### PR TITLE
Add -RequiredResource and -RequiredResource file functionality

### DIFF
--- a/src/InstallPSResource.cs
+++ b/src/InstallPSResource.cs
@@ -1086,7 +1086,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                     // may need to modify due to capitalization
                     var dirNameVersion = Path.Combine(tempInstallPath, p.Identity.Id, p.Identity.Version.ToNormalizedString());
-                    var nupkgMetadataToDelete = Path.Combine(dirNameVersion, ".nupkg.metadata");
+                    var nupkgMetadataToDelete = Path.Combine(dirNameVersion, (p.Identity.ToString() + p.Identity.Version.ToNormalizedString() + ".nupkg").ToLower());
                     var nupkgToDelete = Path.Combine(dirNameVersion, (p.Identity.ToString() + ".nupkg").ToLower());
                     var nupkgSHAToDelete = Path.Combine(dirNameVersion, (p.Identity.ToString() + ".nupkg.sha512").ToLower());
                     var nuspecToDelete = Path.Combine(dirNameVersion, (p.Identity.Id + ".nuspec").ToLower());

--- a/src/InstallPSResource.cs
+++ b/src/InstallPSResource.cs
@@ -439,10 +439,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 }
             }
 
-
-
-
-
             if (_requiredResourceHash != null)
             {
                 try

--- a/src/InstallPkgParams.cs
+++ b/src/InstallPkgParams.cs
@@ -1,0 +1,18 @@
+﻿
+using System.Management.Automation;
+
+public class PkgParams
+{
+    public string Name { get; set; }
+    public string Version { get; set; }
+    public string Repository { get; set; }
+    public PSCredential Credential { get; set; }
+    public bool AcceptLicense { get; set; } 
+    public bool Prerelease { get; set; }
+    public string Scope { get; set; }
+    public bool Quiet { get; set; }
+    public bool Reinstall { get; set; }
+    public bool Force { get; set; }
+    public bool TrustRepository { get; set; }
+    public bool NoClobber { get; set; }
+}

--- a/src/RepositorySettings.cs
+++ b/src/RepositorySettings.cs
@@ -247,7 +247,7 @@ namespace Microsoft.PowerShell.PowerShellGet.RepositorySettings
             XDocument doc = XDocument.Load(DefaultFullRepositoryPath);
 
             var foundRepos = new List<PSObject>();
-            if (repoNames == null || !repoNames.Any() || string.Equals(repoNames[0], "*"))
+            if (repoNames == null || !repoNames.Any() || string.Equals(repoNames[0], "*") || repoNames[0] == null)
             {
                 // array is null and we will list all repositories
                 // iterate through the doc

--- a/test/Pester.RequiredResourceTests.ps1
+++ b/test/Pester.RequiredResourceTests.ps1
@@ -1,0 +1,140 @@
+# This is a Pester test suite to validate Register-PSResourceRepository, Unregister-PSResourceRepository, Get-PSResourceRepository, and Set-PSResourceRepository.
+#
+# Copyright (c) Microsoft Corporation, 2019
+
+# Import-Module "$PSScriptRoot\PSGetTestUtils.psm1" -WarningAction SilentlyContinue
+import-module "C:\code\PowerShellGet\src\bin\Debug\netstandard2.0\publish\PowerShellGet.dll" -force
+
+$PSGalleryName = 'PSGallery'
+$PSGalleryLocation = 'https://www.powershellgallery.com/api/v2'
+
+$TestLocalDirectory = 'TestLocalDirectory'
+$tmpdir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath $TestLocalDirectory
+
+
+
+if (-not (Test-Path -LiteralPath $tmpdir)) {
+    New-Item -Path $tmpdir -ItemType Directory > $null
+}
+Write-Host $tmpdir
+
+
+############################################
+### Install-PSResource -RequiredResource ###
+############################################
+
+Describe 'Test Install-PSResource using the RequiredResource parameter set' -tags 'BVT' {
+
+	AfterEach {
+        $null = uninstall-psresource 'CertificateDsc' -ErrorAction SilentlyContinue
+    }
+
+    ### Installing using -RequiredResource and a json argument
+    It 'Should install the resource specified in the json (with specified parameters)' {
+        $json = 
+        "{
+            'CertificateDsc': {
+              'version': '[4.0.0,4.2.0]',
+              'repository': 'PSGallery',
+              'Prerelease': true
+            }
+        }"
+
+        $ret = Install-PSResource -RequiredResource $json
+        $ret | Should -BeNullOrEmpty
+
+        $pkg = get-psresource 'CertificateDsc' -Version '[4.0.0.0,4.2.0.0]'
+        $pkg.Name | Should -Be 'CertificateDsc'
+        $pkg.Version.ToString() | Should -BeGreaterOrEqual 4.0.0.0
+        $pkg.Version.ToString() | Should -BeLessOrEqual 4.2.0.0
+    }
+
+
+    It 'Should install multiple resources specified in the json' {
+        $json = 
+        "{
+            'CertificateDsc': {
+              'version': '[4.0.0,4.2.0]',
+              'repository': 'PSGallery',
+              'Prerelease': true
+            },
+            'WSManDsc': {
+              'repository': 'PSGallery',
+              'Prerelease': true
+            }
+        }"
+
+        $ret = Install-PSResource -RequiredResource $json
+        $ret | Should -BeNullOrEmpty
+
+        $pkg = get-psresource 'CertificateDsc' -Version '[4.0.0.0,4.2.0.0]'
+        $pkg.Name | Should -Be 'CertificateDsc'
+        $pkg.Version.ToString() | Should -BeGreaterOrEqual 4.0.0.0
+        $pkg.Version.ToString() | Should -BeLessOrEqual 4.2.0.0
+
+        $pkg2 = get-psresource 'WSManDsc' -Version '3.1.2-preview0001'
+        $pkg2.Name | Should -Be 'WSManDsc'
+        $pkg2.Version.ToString() | Should -Be '3.1.2-preview0001'
+    }
+
+
+    ### Installing using -RequiredResource and a hashtable argument
+    It 'Should install the resource specified in the hashtable' {
+        $hash = 
+        @{
+            “name” = “CertificateDsc”
+            "trustrepository" = "true"
+            “version” = "[4.0.0,4.2.0]”
+            "Prerelease" = "true"
+        }
+
+        $ret = Install-PSResource -RequiredResource $hash
+        $ret | Should -BeNullOrEmpty
+
+        $pkg = get-psresource 'CertificateDsc' -Version '[4.0.0.0,4.2.0.0]'
+        $pkg.Name | Should -Be 'CertificateDsc'
+        $pkg.Version.ToString() | Should -BeGreaterOrEqual 4.0.0.0
+        $pkg.Version.ToString() | Should -BeLessOrEqual 4.2.0.0
+    }
+}
+
+
+
+
+################################################
+### Install-PSResource -RequiredResourceFile ###
+################################################
+
+Describe 'Test Install-PSResource using the RequiredResource parameter set' -tags 'BVT' {
+
+    ### Installing using -RequiredResource and a json file
+    It 'Should install the resource specified in the json file' {
+        $json = 
+        "{
+            'CertificateDsc': {
+              'version': '[4.0.0,4.2.0]',
+              'repository': 'PSGallery',
+              'Prerelease': true
+            }
+        }"
+
+        $tmpJsonFile = Join-Path -Path $tmpdir -ChildPath "TestJsonFile.json"
+
+        New-Item -Path $tmpJsonFile -ItemType File
+        $json | Write-File $tmpJsonFile
+
+        if ($tmpJsonFile -ne $null)
+        {
+            $ret = Install-PSResource -RequiredResourceFile $tmpJsonFile
+        }
+        Remove-Item $tmpJsonFile
+        
+        $ret | Should -BeNullOrEmpty
+
+        $pkg = get-psresource 'CertificateDsc' -Version '[4.0.0.0,4.2.0.0]'
+        $pkg.Name | Should -Be 'CertificateDsc'
+        $pkg.Version.ToString() | Should -BeGreaterOrEqual 4.0.0.0
+        $pkg.Version.ToString() | Should -BeLessOrEqual 4.2.0.0
+    }
+}
+


### PR DESCRIPTION
Adding -RequiredResource parameter to Install-PSResource, which will take a json for hashtable as input and install the specified modules or scripts. 

-RequiredResourceFile takes a .json as input and installs the specified modules or scripts.  

See [RFC](https://github.com/PowerShell/PowerShell-RFC/blob/2171bd358ab159fc8bd29d1435b5456d06f8ad5a/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md#dependencies-and-version-management) for more details of formatting of input.

Note:  this PR does not include taking a .psd1 as input.  I'm waiting to implement publish functionality before including that into the repo.