### PR TITLE
Add Publish functionality

### DIFF
--- a/SignConfig.xml
+++ b/SignConfig.xml
@@ -4,20 +4,20 @@
 <SignConfigXML>
   <!-- AnyCPU Release sign job -->
   <job platform="AnyCPU" configuration="Release" dest="__OUTPATHROOT__\signed" jobname="PowerShellGet" approvers="vigarg;gstolt">
-    <file src="__INPATHROOT__\PowerShellGet\PowerShellGet.psd1" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\PowerShellGet.psd1" />
-    <file src="__INPATHROOT__\PowerShellGet\PSModule.psm1" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\PSModule.psm1" />
-    <file src="__INPATHROOT__\PowerShellGet\PowerShellGet.dll" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\netstandard2.0\PowerShellGet.dll" />
+    <file src="__INPATHROOT__\PowerShellGet.psd1" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\PowerShellGet.psd1" />
+    <file src="__INPATHROOT__\PSModule.psm1" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\PSModule.psm1" />
+    <file src="__INPATHROOT__\PowerShellGet.dll" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\PowerShellGet.dll" />
 
-    <file src="__INPATHROOT__\PowerShellGet\Microsoft.Extensions.Logging.Abstractions.dll" signType="ThirdParty" dest="__OUTPATHROOT__\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll" />
-    <file src="__INPATHROOT__\PowerShellGet\MoreLinq.dll" signType="ThirdParty" dest="__OUTPATHROOT__\netstandard2.0\MoreLinq.dll" />
-    <file src="__INPATHROOT__\PowerShellGet\NuGet.Common.dll" signType="ThirdParty" dest="__OUTPATHROOT__\netstandard2.0\NuGet.Common.dll" />
-    <file src="__INPATHROOT__\PowerShellGet\NuGet.Configuration.dll" signType="ThirdParty" dest="__OUTPATHROOT__\netstandard2.0\NuGet.Configuration.dll" />
-    <file src="__INPATHROOT__\PowerShellGet\NuGet.Frameworks.dll" signType="ThirdParty" dest="__OUTPATHROOT__\netstandard2.0\NuGet.Frameworks.dll" />
-    <file src="__INPATHROOT__\PowerShellGet\NuGet.Packaging.dll" signType="ThirdParty" dest="__OUTPATHROOT__\netstandard2.0\NuGet.Packaging.dll" />
-    <file src="__INPATHROOT__\PowerShellGet\NuGet.Protocol.Catalog.dll" signType="ThirdParty" dest="__OUTPATHROOT__\netstandard2.0\NuGet.Protocol.Catalog.dll" />
-    <file src="__INPATHROOT__\PowerShellGet\NuGet.Protocol.Core.Types.dll" signType="ThirdParty" dest="__OUTPATHROOT__\netstandard2.0\NuGet.Protocol.Core.Types.dll" />
-    <file src="__INPATHROOT__\PowerShellGet\NuGet.Protocol.dll" signType="ThirdParty" dest="__OUTPATHROOT__\netstandard2.0\NuGet.Protocol.dll" />
-    <file src="__INPATHROOT__\PowerShellGet\NuGet.Repositories.dll" signType="ThirdParty" dest="__OUTPATHROOT__\netstandard2.0\NuGet.Repositories.dll" />
-    <file src="__INPATHROOT__\PowerShellGet\NuGet.Versioning.dll" signType="ThirdParty" dest="__OUTPATHROOT__\netstandard2.0\NuGet.Versioning.dll" />
+    <file src="__INPATHROOT__\Microsoft.Extensions.Logging.Abstractions.dll" signType="ThirdParty" dest="__OUTPATHROOT__\Microsoft.Extensions.Logging.Abstractions.dll" />
+    <file src="__INPATHROOT__\MoreLinq.dll" signType="ThirdParty" dest="__OUTPATHROOT__\MoreLinq.dll" />
+    <file src="__INPATHROOT__\NuGet.Common.dll" signType="ThirdParty" dest="__OUTPATHROOT__\NuGet.Common.dll" />
+    <file src="__INPATHROOT__\NuGet.Configuration.dll" signType="ThirdParty" dest="__OUTPATHROOT__\NuGet.Configuration.dll" />
+    <file src="__INPATHROOT__\NuGet.Frameworks.dll" signType="ThirdParty" dest="__OUTPATHROOT__\NuGet.Frameworks.dll" />
+    <file src="__INPATHROOT__\NuGet.Packaging.dll" signType="ThirdParty" dest="__OUTPATHROOT__\NuGet.Packaging.dll" />
+    <file src="__INPATHROOT__\NuGet.Protocol.Catalog.dll" signType="ThirdParty" dest="__OUTPATHROOT__\NuGet.Protocol.Catalog.dll" />
+    <file src="__INPATHROOT__\NuGet.Protocol.Core.Types.dll" signType="ThirdParty" dest="__OUTPATHROOT__\NuGet.Protocol.Core.Types.dll" />
+    <file src="__INPATHROOT__\NuGet.Protocol.dll" signType="ThirdParty" dest="__OUTPATHROOT__\NuGet.Protocol.dll" />
+    <file src="__INPATHROOT__\NuGet.Repositories.dll" signType="ThirdParty" dest="__OUTPATHROOT__\NuGet.Repositories.dll" />
+    <file src="__INPATHROOT__\NuGet.Versioning.dll" signType="ThirdParty" dest="__OUTPATHROOT__\NuGet.Versioning.dll" />
   </job>
 </SignConfigXML>

--- a/src/FindHelper.cs
+++ b/src/FindHelper.cs
@@ -1,0 +1,1325 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+
+using System;
+using System.Management.Automation;
+using System.Collections.Generic;
+using NuGet.Configuration;
+using NuGet.Common;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using System.Threading;
+using LinqKit;
+using MoreLinq.Extensions;
+using NuGet.Versioning;
+using System.Data;
+using System.Linq;
+using System.Net;
+using Microsoft.PowerShell.PowerShellGet.RepositorySettings;
+using System.Net.Http;
+using NuGet.Protocol.Catalog;
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using static System.Environment;
+
+
+namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
+{
+
+    /// <summary>
+    /// Find helper class
+    /// </summary>
+    class FindHelper : PSCmdlet
+    {
+        // This will be a list of all the repository caches
+        public static readonly List<string> RepoCacheFileName = new List<string>();
+        // Temporarily store cache in this path for testing purposes
+        public static readonly string RepositoryCacheDir = Path.Combine(Environment.GetFolderPath(SpecialFolder.LocalApplicationData), "PowerShellGet", "RepositoryCache");
+        //public static readonly string RepositoryCacheDir = @"%APPDATA%/PowerShellGet/repositorycache";//@"%APPDTA%\NuGet";
+        //private readonly object p;
+
+        // Define the cancellation token.
+        CancellationTokenSource source;
+        CancellationToken cancellationToken;
+        List<string> pkgsLeftToFind;
+        private const string CursorFileName = "cursor.json";
+
+        string[] _name;
+        string[] _type;
+        string _version;
+        bool _prerelease = false;
+        string _moduleName;
+        string[] _tags;
+        string[] _repository;
+        PSCredential _credential;
+        SwitchParameter _includeDependencies;
+
+        public FindHelper()
+        { }
+
+        /// <summary>
+        /// </summary>
+        public List<PSObject> beginFindHelper(string[] _name, string[] _type, string _version, bool _prerelease, string _moduleName, string[] _tags, string[] _repository, PSCredential _credential, SwitchParameter _includeDependencies, bool writeToConsole)
+        {
+            this._name = _name;
+            this._type = _type;
+            this._version = _version;
+            this._prerelease = _prerelease;
+            this._moduleName = _moduleName;
+            this._tags = _tags;
+            this._repository = _repository;
+            this._credential = _credential;
+            this._includeDependencies = _includeDependencies;
+       
+
+                source = new CancellationTokenSource();
+            cancellationToken = source.Token;
+
+
+
+            var r = new RespositorySettings();
+            var listOfRepositories = r.Read(_repository);
+
+            var returnedPkgsFound = new List<IEnumerable<IPackageSearchMetadata>>();
+            pkgsLeftToFind = _name.ToList();
+            List<PSObject> returnedPSObjects = new List<PSObject>();
+            foreach (var repoName in listOfRepositories)
+            {
+
+                // We'll need to use the catalog reader when enumerating through all packages under v3 protocol.
+                // if using v3 endpoint and there's no exact name specified (ie no name specified or a name with a wildcard is specified)
+                if (repoName.Properties["Url"].Value.ToString().EndsWith("/v3/index.json") &&
+                    (_name.Length == 0 || _name.Any(n => n.Contains("*"))))//_name.Contains("*")))  /// TEST THIS!!!!!!!
+                {
+                    // right now you can use wildcards with an array of names, ie -name "Az*", "PS*", "*Get", will take a hit performance wise, though.
+                    // TODO:  add wildcard condition here
+                    ProcessCatalogReader(repoName.Properties["Name"].Value.ToString(), repoName.Properties["Url"].Value.ToString());
+                }
+
+
+
+                // if it can't find the pkg in one repository, it'll look in the next one in the list
+                // returns any pkgs found, and any pkgs that weren't found
+                returnedPkgsFound.AddRange(FindPackagesFromSource(repoName.Properties["Url"].Value.ToString(), cancellationToken));
+
+
+                // Flatten returned pkgs before displaying output returnedPkgsFound.Flatten().ToList()[0]
+                var flattenedPkgs = returnedPkgsFound.Flatten();
+                // flattenedPkgs.ToList();
+
+
+                if (flattenedPkgs.Any() && flattenedPkgs.First() != null)
+                {
+                    foreach (IPackageSearchMetadata pkg in flattenedPkgs)
+                    {
+                        //WriteObject(pkg);
+
+
+                        PSObject pkgAsPSObject = new PSObject();
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Name", pkg.Identity.Id));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Version", pkg.Identity.Version));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Repository", repoName.Properties["Name"].Value.ToString()));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Description", pkg.Description));
+
+                        if (writeToConsole)
+                        {
+                            WriteObject(pkgAsPSObject);
+                        }
+                        else {
+                            returnedPSObjects.Add(pkgAsPSObject);
+                        }
+                    }
+                }
+
+                // reset found packages
+                returnedPkgsFound.Clear();
+
+                // if we need to search all repositories, we'll continue, otherwise we'll just return
+                if (!pkgsLeftToFind.Any())
+                {
+                    break;
+                }
+
+
+
+            } // end of foreach
+
+            return returnedPSObjects;
+
+        }
+
+
+        public void ProcessCatalogReader(string repoName, string sourceUrl)
+        {
+
+            // test initalizing a cursor see: https://docs.microsoft.com/en-us/nuget/guides/api/query-for-all-published-packages
+            // we want all packages published from the beginning of time
+            //       DateTime cursor = DateTime.MinValue;
+
+
+
+            // Define a lower time bound for leaves to fetch. This exclusive minimum time bound is called the cursor.
+            //var cursor = DateTime.MinValue;   /// come back to this GetCursor();
+            var cursor = GetCursor();     // come back to this
+
+            // Discover the catalog index URL from the service index.
+            var catalogIndexUrl = GetCatalogIndexUrlAsync(sourceUrl).GetAwaiter().GetResult();
+
+
+            var httpClient = new HttpClient();
+
+            // Download the catalog index and deserialize it.
+            var indexString = httpClient.GetStringAsync(catalogIndexUrl).GetAwaiter().GetResult();
+            Console.WriteLine($"Fetched catalog index {catalogIndexUrl}.");
+            var index = JsonConvert.DeserializeObject<CatalogIndex>(indexString);
+
+            // Find all pages in the catalog index that meet the time bound.
+
+            var pageItems = index
+                .Items
+                .Where(x => x.CommitTimestamp > cursor);
+
+            var allLeafItems = new List<CatalogLeafItem>();
+
+
+            foreach (var pageItem in pageItems)  /// need to process one page at a time
+            {
+                // Download the catalog page and deserialize it.
+                var pageString = httpClient.GetStringAsync(pageItem.Url).GetAwaiter().GetResult();
+                Console.WriteLine($"Fetched catalog page {pageItem.Url}.");
+                var page = JsonConvert.DeserializeObject<CatalogPage>(pageString);
+
+                // Find all leaves in the catalog page that meet the time bound.
+                var pageLeafItems = page
+                    .Items
+                    .Where(x => x.CommitTimestamp > cursor);
+
+                allLeafItems.AddRange(pageLeafItems);
+
+
+                // local
+                FindLocalPackagesResourceV2 localResource = new FindLocalPackagesResourceV2(sourceUrl);
+
+                LocalPackageSearchResource localResourceSearch = new LocalPackageSearchResource(localResource);
+                LocalPackageMetadataResource localResourceMetadata = new LocalPackageMetadataResource(localResource);
+
+                SearchFilter filter = new SearchFilter(_prerelease);
+                SourceCacheContext context = new SourceCacheContext();
+
+
+
+                // url
+                PackageSource source = new PackageSource(sourceUrl);
+                if (_credential != null)
+                {
+                    string password = new NetworkCredential(string.Empty, _credential.Password).Password;
+                    source.Credentials = PackageSourceCredential.FromUserInput(sourceUrl, _credential.UserName, password, true, null);
+                }
+                var provider = FactoryExtensionsV3.GetCoreV3(NuGet.Protocol.Core.Types.Repository.Provider);
+
+                SourceRepository repository = new SourceRepository(source, provider);
+                PackageSearchResource resourceSearch = repository.GetResourceAsync<PackageSearchResource>().GetAwaiter().GetResult();
+                PackageMetadataResource resourceMetadata = repository.GetResourceAsync<PackageMetadataResource>().GetAwaiter().GetResult();
+
+
+
+
+                // Process all of the catalog leaf items.
+                Console.WriteLine($"Processing {allLeafItems.Count} catalog leaves.");
+                foreach (var leafItem in allLeafItems)
+                {
+                    _version = leafItem.PackageVersion;
+
+                    IEnumerable<IPackageSearchMetadata> foundPkgs;
+                    if (sourceUrl.StartsWith("file://"))
+                    {
+                        foundPkgs = FindPackagesFromSourceHelper(sourceUrl, leafItem.PackageId, localResourceSearch, localResourceMetadata, filter, context).FirstOrDefault();
+                    }
+                    else
+                    {
+                        foundPkgs = FindPackagesFromSourceHelper(sourceUrl, leafItem.PackageId, resourceSearch, resourceMetadata, filter, context).FirstOrDefault();
+                    }
+
+                    // var foundPkgsFlattened = foundPkgs.Flatten();
+                    foreach (var pkg in foundPkgs)
+                    {
+                        // First or default to convert the ienumeraable object into just an IPackageSearchmetadata object
+                        // var pkgToOutput = foundPkgs.FirstOrDefault();//foundPkgs.Cast<IPackageSearchMetadata>();
+                        PSObject pkgAsPSObject = new PSObject();
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Name", pkg.Identity.Id));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Version", pkg.Identity.Version));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Repository", repoName));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Description", pkg.Description));
+
+                        WriteObject(pkgAsPSObject);
+                    }
+
+                }
+
+            }
+
+        }
+
+        //
+        public List<IEnumerable<IPackageSearchMetadata>> FindPackagesFromSource(string repositoryUrl, CancellationToken cancellationToken)
+        {
+            List<IEnumerable<IPackageSearchMetadata>> returnedPkgs = new List<IEnumerable<IPackageSearchMetadata>>();
+
+            if (repositoryUrl.StartsWith("file://"))
+            {
+
+                FindLocalPackagesResourceV2 localResource = new FindLocalPackagesResourceV2(repositoryUrl);
+
+                LocalPackageSearchResource resourceSearch = new LocalPackageSearchResource(localResource);
+                LocalPackageMetadataResource resourceMetadata = new LocalPackageMetadataResource(localResource);
+
+                SearchFilter filter = new SearchFilter(_prerelease);
+                SourceCacheContext context = new SourceCacheContext();
+
+
+                if ((_name == null) || (_name.Length == 0))
+                {
+                    returnedPkgs.AddRange(FindPackagesFromSourceHelper(repositoryUrl, null, resourceSearch, resourceMetadata, filter, context));
+                }
+
+                foreach (var n in _name)
+                {
+                    returnedPkgs.AddRange(FindPackagesFromSourceHelper(repositoryUrl, n, resourceSearch, resourceMetadata, filter, context));
+                }
+            }
+            else
+            {
+
+
+
+                PackageSource source = new PackageSource(repositoryUrl);
+                if (_credential != null)
+                {
+                    string password = new NetworkCredential(string.Empty, _credential.Password).Password;
+                    source.Credentials = PackageSourceCredential.FromUserInput(repositoryUrl, _credential.UserName, password, true, null);
+                }
+
+
+
+                var provider = FactoryExtensionsV3.GetCoreV3(NuGet.Protocol.Core.Types.Repository.Provider);
+
+                SourceRepository repository = new SourceRepository(source, provider);
+
+
+                PackageSearchResource resourceSearch = null;
+                PackageMetadataResource resourceMetadata = null;
+                try
+                {
+                    resourceSearch = repository.GetResourceAsync<PackageSearchResource>().GetAwaiter().GetResult();
+                    resourceMetadata = repository.GetResourceAsync<PackageMetadataResource>().GetAwaiter().GetResult();
+                }
+                catch (Exception e)
+                {
+                    WriteDebug("Error retrieving resource from repository: " + e.Message);
+                    return returnedPkgs;
+                }
+
+                SearchFilter filter = new SearchFilter(_prerelease);
+                SourceCacheContext context = new SourceCacheContext();
+
+                if ((_name == null) || (_name.Length == 0))
+                {
+                    returnedPkgs.AddRange(FindPackagesFromSourceHelper(repositoryUrl, null, resourceSearch, resourceMetadata, filter, context));
+                }
+
+                foreach (var n in _name)
+                {
+                    if (pkgsLeftToFind.Any())
+                    {
+                        var foundPkgs = FindPackagesFromSourceHelper(repositoryUrl, n, resourceSearch, resourceMetadata, filter, context);
+                        if (foundPkgs.Any() && foundPkgs.FirstOrDefault() != null)
+                        {
+                            returnedPkgs.AddRange(foundPkgs);
+
+
+                            // if the repository is not specified or the repository is specified (but it's not '*'), then we can stop continuing to search for the package
+                            if (_repository == null || !_repository[0].Equals("*"))
+                            {
+                                pkgsLeftToFind.Remove(n);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return returnedPkgs;
+        }
+
+
+        private IEnumerable<DataRow> FindPackageFromCache(string repositoryName)
+        {
+            DataSet cachetables = new CacheSettings().CreateDataTable(repositoryName);
+
+            return FindPackageFromCacheHelper(cachetables, repositoryName);
+        }
+
+
+        private IEnumerable<DataRow> FindPackageFromCacheHelper(DataSet cachetables, string repositoryName)
+        {
+            DataTable metadataTable = cachetables.Tables[0];
+            DataTable tagsTable = cachetables.Tables[1];
+            DataTable dependenciesTable = cachetables.Tables[2];
+            DataTable commandsTable = cachetables.Tables[3];
+            DataTable dscResourceTable = cachetables.Tables[4];
+            DataTable roleCapabilityTable = cachetables.Tables[5];
+
+            DataTable queryTable = new DataTable();
+            var predicate = PredicateBuilder.New<DataRow>(true);
+
+
+            if ((_tags != null) && (_tags.Length != 0))
+            {
+
+                var tagResults = from t0 in metadataTable.AsEnumerable()
+                                 join t1 in tagsTable.AsEnumerable()
+                                 on t0.Field<string>("Key") equals t1.Field<string>("Key")
+                                 select new PackageMetadataAllTables
+                                 {
+                                     Key = t0["Key"],
+                                     Name = t0["Name"],
+                                     Version = t0["Version"],
+                                     Type = (string)t0["Type"],
+                                     Description = t0["Description"],
+                                     Author = t0["Author"],
+                                     Copyright = t0["Copyright"],
+                                     PublishedDate = t0["PublishedDate"],
+                                     InstalledDate = t0["InstalledDate"],
+                                     UpdatedDate = t0["UpdatedDate"],
+                                     LicenseUri = t0["LicenseUri"],
+                                     ProjectUri = t0["ProjectUri"],
+                                     IconUri = t0["IconUri"],
+                                     PowerShellGetFormatVersion = t0["PowerShellGetFormatVersion"],
+                                     ReleaseNotes = t0["ReleaseNotes"],
+                                     RepositorySourceLocation = t0["RepositorySourceLocation"],
+                                     Repository = t0["Repository"],
+                                     IsPrerelease = t0["IsPrerelease"],
+                                     Tags = t1["Tags"],
+                                 };
+
+                DataTable joinedTagsTable = tagResults.ToDataTable();
+
+                var tagsPredicate = PredicateBuilder.New<DataRow>(true);
+
+                // Build predicate by combining tag searches with 'or'
+                foreach (string t in _tags)
+                {
+                    tagsPredicate = tagsPredicate.Or(pkg => pkg.Field<string>("Tags").Equals(t));
+                }
+
+
+                // final results -- All the appropriate pkgs with these tags
+                var tagsRowCollection = joinedTagsTable.AsEnumerable().Where(tagsPredicate).Select(p => p);
+
+                // Add row collection to final table to be queried
+                queryTable.Merge(tagsRowCollection.ToDataTable());
+            }
+
+            if (_type != null)
+            {
+                if (_type.Contains("Command", StringComparer.OrdinalIgnoreCase))
+                {
+
+                    var commandResults = from t0 in metadataTable.AsEnumerable()
+                                         join t1 in commandsTable.AsEnumerable()
+                                         on t0.Field<string>("Key") equals t1.Field<string>("Key")
+                                         select new PackageMetadataAllTables
+                                         {
+                                             Key = t0["Key"],
+                                             Name = t0["Name"],
+                                             Version = t0["Version"],
+                                             Type = (string)t0["Type"],
+                                             Description = t0["Description"],
+                                             Author = t0["Author"],
+                                             Copyright = t0["Copyright"],
+                                             PublishedDate = t0["PublishedDate"],
+                                             InstalledDate = t0["InstalledDate"],
+                                             UpdatedDate = t0["UpdatedDate"],
+                                             LicenseUri = t0["LicenseUri"],
+                                             ProjectUri = t0["ProjectUri"],
+                                             IconUri = t0["IconUri"],
+                                             PowerShellGetFormatVersion = t0["PowerShellGetFormatVersion"],
+                                             ReleaseNotes = t0["ReleaseNotes"],
+                                             RepositorySourceLocation = t0["RepositorySourceLocation"],
+                                             Repository = t0["Repository"],
+                                             IsPrerelease = t0["IsPrerelease"],
+                                             Commands = t1["Commands"],
+                                         };
+
+                    DataTable joinedCommandTable = commandResults.ToDataTable();
+
+                    var commandPredicate = PredicateBuilder.New<DataRow>(true);
+
+                    // Build predicate by combining names of commands searches with 'or'
+                    // if no name is specified, we'll return all (?)
+                    foreach (string n in _name)
+                    {
+                        commandPredicate = commandPredicate.Or(pkg => pkg.Field<string>("Commands").Equals(n));
+                    }
+
+                    // final results -- All the appropriate pkgs with these tags
+                    var commandsRowCollection = joinedCommandTable.AsEnumerable().Where(commandPredicate).Select(p => p);
+
+                    // Add row collection to final table to be queried
+                    queryTable.Merge(commandsRowCollection.ToDataTable());
+                }
+
+
+                if (_type.Contains("DscResource", StringComparer.OrdinalIgnoreCase))
+                {
+
+                    var dscResourceResults = from t0 in metadataTable.AsEnumerable()
+                                             join t1 in dscResourceTable.AsEnumerable()
+                                             on t0.Field<string>("Key") equals t1.Field<string>("Key")
+                                             select new PackageMetadataAllTables
+                                             {
+                                                 Key = t0["Key"],
+                                                 Name = t0["Name"],
+                                                 Version = t0["Version"],
+                                                 Type = (string)t0["Type"],
+                                                 Description = t0["Description"],
+                                                 Author = t0["Author"],
+                                                 Copyright = t0["Copyright"],
+                                                 PublishedDate = t0["PublishedDate"],
+                                                 InstalledDate = t0["InstalledDate"],
+                                                 UpdatedDate = t0["UpdatedDate"],
+                                                 LicenseUri = t0["LicenseUri"],
+                                                 ProjectUri = t0["ProjectUri"],
+                                                 IconUri = t0["IconUri"],
+                                                 PowerShellGetFormatVersion = t0["PowerShellGetFormatVersion"],
+                                                 ReleaseNotes = t0["ReleaseNotes"],
+                                                 RepositorySourceLocation = t0["RepositorySourceLocation"],
+                                                 Repository = t0["Repository"],
+                                                 IsPrerelease = t0["IsPrerelease"],
+                                                 DscResources = t1["DscResources"],
+                                             };
+
+                    var dscResourcePredicate = PredicateBuilder.New<DataRow>(true);
+
+                    DataTable joinedDscResourceTable = dscResourceResults.ToDataTable();
+
+                    // Build predicate by combining names of commands searches with 'or'
+                    // if no name is specified, we'll return all (?)
+                    foreach (string n in _name)
+                    {
+                        dscResourcePredicate = dscResourcePredicate.Or(pkg => pkg.Field<string>("DscResources").Equals(n));
+                    }
+
+                    // final results -- All the appropriate pkgs with these tags
+                    var dscResourcesRowCollection = joinedDscResourceTable.AsEnumerable().Where(dscResourcePredicate).Select(p => p);
+
+                    // Add row collection to final table to be queried
+                    queryTable.Merge(dscResourcesRowCollection.ToDataTable());
+                }
+
+                if (_type.Contains("RoleCapability", StringComparer.OrdinalIgnoreCase))
+                {
+
+                    var roleCapabilityResults = from t0 in metadataTable.AsEnumerable()
+                                                join t1 in roleCapabilityTable.AsEnumerable()
+                                                on t0.Field<string>("Key") equals t1.Field<string>("Key")
+                                                select new PackageMetadataAllTables
+                                                {
+                                                    Key = t0["Key"],
+                                                    Name = t0["Name"],
+                                                    Version = t0["Version"],
+                                                    Type = (string)t0["Type"],
+                                                    Description = t0["Description"],
+                                                    Author = t0["Author"],
+                                                    Copyright = t0["Copyright"],
+                                                    PublishedDate = t0["PublishedDate"],
+                                                    InstalledDate = t0["InstalledDate"],
+                                                    UpdatedDate = t0["UpdatedDate"],
+                                                    LicenseUri = t0["LicenseUri"],
+                                                    ProjectUri = t0["ProjectUri"],
+                                                    IconUri = t0["IconUri"],
+                                                    PowerShellGetFormatVersion = t0["PowerShellGetFormatVersion"],
+                                                    ReleaseNotes = t0["ReleaseNotes"],
+                                                    RepositorySourceLocation = t0["RepositorySourceLocation"],
+                                                    Repository = t0["Repository"],
+                                                    IsPrerelease = t0["IsPrerelease"],
+                                                    RoleCapability = t1["RoleCapability"],
+                                                };
+
+                    var roleCapabilityPredicate = PredicateBuilder.New<DataRow>(true);
+
+                    DataTable joinedRoleCapabilityTable = roleCapabilityResults.ToDataTable();
+
+                    // Build predicate by combining names of commands searches with 'or'
+                    // if no name is specified, we'll return all (?)
+                    foreach (string n in _name)
+                    {
+                        roleCapabilityPredicate = roleCapabilityPredicate.Or(pkg => pkg.Field<string>("RoleCapability").Equals(n));
+                    }
+
+                    // final results -- All the appropriate pkgs with these tags
+                    var roleCapabilitiesRowCollection = joinedRoleCapabilityTable.AsEnumerable().Where(roleCapabilityPredicate).Select(p => p);
+
+                    // Add row collection to final table to be queried
+                    queryTable.Merge(roleCapabilitiesRowCollection.ToDataTable());
+                }
+            }
+
+
+
+            // We'll build the rest of the predicate-- ie the portions of the predicate that do not rely on datatables
+            predicate = predicate.Or(BuildPredicate(repositoryName));
+
+
+            // we want to uniquely add datarows into the table
+            // if queryTable is empty, we'll just query upon the metadata table
+            if (queryTable == null || queryTable.Rows.Count == 0)
+            {
+                queryTable = metadataTable;
+            }
+
+            // final results -- All the appropriate pkgs with these tags
+            var queryTableRowCollection = queryTable.AsEnumerable().Where(predicate).Select(p => p);
+
+            // ensure distinct by key
+            var finalQueryResults = queryTableRowCollection.AsEnumerable().DistinctBy(pkg => pkg.Field<string>("Key"));
+
+            // Add row collection to final table to be queried
+            // queryTable.Merge(distinctQueryTableRowCollection.ToDataTable());
+
+
+
+            /// ignore-- testing.
+            //if ((queryTable == null) || (queryTable.Rows.Count == 0) && (((_type == null) || (_type.Contains("Module", StringComparer.OrdinalIgnoreCase) || _type.Contains("Script", StringComparer.OrdinalIgnoreCase))) && ((_tags == null) || (_tags.Length == 0))))
+            //{
+            //    queryTable = metadataTable;
+            //}
+
+
+            List<IEnumerable<DataRow>> allFoundPkgs = new List<IEnumerable<DataRow>>();
+            allFoundPkgs.Add(finalQueryResults);
+
+            // Need to handle includeDependencies
+            if (_includeDependencies)
+            {
+                foreach (var pkg in finalQueryResults)
+                {
+                    //allFoundPkgs.Add(DependencyFinder(finalQueryResults, dependenciesTable));
+                }
+            }
+
+            IEnumerable<DataRow> flattenedFoundPkgs = (IEnumerable<DataRow>)allFoundPkgs.Flatten();
+
+            // (IEnumerable<DataRow>)
+            return flattenedFoundPkgs;
+        }
+
+
+
+
+        /*********************** come back to this
+        private IEnumerable<DataRow> DependencyFinder(IEnumerable<DataRow> finalQueryResults, DataTable dependenciesTable )
+        {
+            List<IEnumerable<PackageMetadataAllTables>> foundDependencies = new List<IEnumerable<IPackageSearchMetadata>>();
+
+            var queryResultsDT = finalQueryResults.ToDataTable();
+
+            //var dependencyResults = from t0 in metadataTable.AsEnumerable()
+            var dependencyResults = from t0 in queryResultsDT.AsEnumerable()
+                                    join t1 in dependenciesTable.AsEnumerable()
+                                    on t0.Field<string>("Key") equals t1.Field<string>("Key")
+                                    select new PackageMetadataAllTables
+                                    {
+                                        Key = t0["Key"],
+                                        Name = t0["Name"],
+                                        Version = t0["Version"],
+                                        Type = (string)t0["Type"],
+                                        Description = t0["Description"],
+                                        Author = t0["Author"],
+                                        Copyright = t0["Copyright"],
+                                        PublishedDate = t0["PublishedDate"],
+                                        InstalledDate = t0["InstalledDate"],
+                                        UpdatedDate = t0["UpdatedDate"],
+                                        LicenseUri = t0["LicenseUri"],
+                                        ProjectUri = t0["ProjectUri"],
+                                        IconUri = t0["IconUri"],
+                                        PowerShellGetFormatVersion = t0["PowerShellGetFormatVersion"],
+                                        ReleaseNotes = t0["ReleaseNotes"],
+                                        RepositorySourceLocation = t0["RepositorySourceLocation"],
+                                        Repository = t0["Repository"],
+                                        IsPrerelease = t0["IsPrerelease"],
+                                        Dependencies = (Dependency)t1["Dependencies"],
+                                    };
+
+            var dependencyPredicate = PredicateBuilder.New<DataRow>(true);
+
+            DataTable joinedDependencyTable = dependencyResults.ToDataTable();
+
+            // Build predicate by combining names of dependencies searches with 'or'
+
+            // public string Name { get; set; }
+            // public string MinimumVersion { get; set; }
+            // public string MaximumVersion { get; set; }
+
+
+
+            // for each pkg that was found, check to see if it has a dep
+            foreach (var pkg in dependencyResults)
+            {
+                // because it's an ienumerable, we need to pull out the pkg itself to access its properties, but there is only a 'default' option
+                if (!string.IsNullOrEmpty(pkg.Dependencies.Name))
+                {
+                    // you could just add the data row
+                    foundDependencies.Add((IEnumerable<PackageMetadataAllTables>) pkg);
+                }
+
+                // and then check to make sure dep name/version exists within the cache (via the metadata table)
+                // call helper recursively
+                // (IEnumerable<DataRow> finalQueryResults, DataTable dependenciesTable )
+                DependencyFinder(pkg, dependencyResults, dependenciesTable)
+
+                var roleCapabilityPredicate = PredicateBuilder.New<DataRow>(true);
+
+                DataTable joinedRoleCapabilityTable = roleCapabilityResults.ToDataTable();
+
+                // Build predicate by combining names of commands searches with 'or'
+                // if no name is specified, we'll return all (?)
+                foreach (string n in _name)
+                {
+                    roleCapabilityPredicate = roleCapabilityPredicate.Or(pkg => pkg.Field<string>("RoleCapability").Equals(n));
+                }
+
+                // final results -- All the appropriate pkgs with these tags
+                var roleCapabilitiesRowCollection = joinedRoleCapabilityTable.AsEnumerable().Where(roleCapabilityPredicate).Select(p => p);
+
+                // Add row collection to final table to be queried
+                queryTable.Merge(roleCapabilitiesRowCollection.ToDataTable());
+            }
+
+            // final results -- All the
+            var dependencies = joinedDependencyTable.AsEnumerable().Where(dependencyPredicate).Select(p => p);
+
+            return
+        }
+        ***************/
+
+
+        private ExpressionStarter<DataRow> BuildPredicate(string repository)
+        {
+            //NuGetVersion nugetVersion0;
+            var predicate = PredicateBuilder.New<DataRow>(true);
+
+            if (_type != null)
+            {
+                var typePredicate = PredicateBuilder.New<DataRow>(true);
+
+                if (_type.Contains("Script", StringComparer.OrdinalIgnoreCase))
+                {
+                    typePredicate = typePredicate.Or(pkg => pkg.Field<string>("Type").Equals("Script"));
+                }
+                if (_type.Contains("Module", StringComparer.OrdinalIgnoreCase))
+                {
+                    typePredicate = typePredicate.Or(pkg => pkg.Field<string>("Type").Equals("Module"));
+                }
+                predicate.And(typePredicate);
+
+            }
+
+            ExpressionStarter<DataRow> starter2 = PredicateBuilder.New<DataRow>(true);
+            if (_moduleName != null)
+            {
+                predicate = predicate.And(pkg => pkg.Field<string>("Name").Equals(_moduleName));
+            }
+
+            if ((_type == null) || ((_type.Length == 0) || !(_type.Contains("Module", StringComparer.OrdinalIgnoreCase) || _type.Contains("Script", StringComparer.OrdinalIgnoreCase))))
+            {
+                var typeNamePredicate = PredicateBuilder.New<DataRow>(true);
+                foreach (string name in _name)
+                {
+
+                    //// ?
+                    typeNamePredicate = typeNamePredicate.Or(pkg => pkg.Field<string>("Type").Equals("Script"));
+                }
+            }
+
+
+            // cache will only contain the latest stable and latest prerelease of each package
+            if (_version != null)
+            {
+
+                NuGetVersion nugetVersion;
+
+                //VersionRange versionRange = VersionRange.Parse(version);
+
+                if (NuGetVersion.TryParse(_version, out nugetVersion))
+                {
+                    predicate = predicate.And(pkg => pkg.Field<string>("Version").Equals(nugetVersion));
+                }
+
+
+
+
+            }
+            if (!_prerelease)
+            {
+                predicate = predicate.And(pkg => pkg.Field<string>("IsPrerelease").Equals("false"));  // consider checking if it IS prerelease
+            }
+            return predicate;
+        }
+
+
+
+
+
+
+
+
+
+        private List<IEnumerable<IPackageSearchMetadata>> FindPackagesFromSourceHelper(string repositoryUrl, string name, PackageSearchResource pkgSearchResource, PackageMetadataResource pkgMetadataResource, SearchFilter searchFilter, SourceCacheContext srcContext)
+        {
+
+            List<IEnumerable<IPackageSearchMetadata>> foundPackages = new List<IEnumerable<IPackageSearchMetadata>>();
+            //IEnumerable<IPackageSearchMetadata> foundPackages;
+            List<IEnumerable<IPackageSearchMetadata>> filteredFoundPkgs = new List<IEnumerable<IPackageSearchMetadata>>();
+
+            // If module name is specified, use that as the name for the pkg to search for
+            if (_moduleName != null)
+            {
+                // may need to take 1
+                foundPackages.Add(pkgMetadataResource.GetMetadataAsync(_moduleName, _prerelease, false, srcContext, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult());
+                //foundPackages = pkgMetadataResource.GetMetadataAsync(_moduleName, _prerelease, false, srcContext, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult();
+            }
+            else if (name != null)
+            {
+                // If a resource name is specified, search for that particular pkg name
+                // search for specific pkg name
+                if (!name.Contains("*"))
+                {
+                    foundPackages.Add(pkgMetadataResource.GetMetadataAsync(name, _prerelease, false, srcContext, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult());
+                    //foundPackages = pkgMetadataResource.GetMetadataAsync(name, _prerelease, false, srcContext, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult();
+                }
+                // search for range of pkg names
+                else
+                {
+                    // TODO:  follow up on this
+                    //foundPackages.Add(pkgSearchResource.SearchAsync(name, searchFilter, 0, 6000, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult());
+
+                    name = name.Equals("*") ? "" : name;   // can't use * in v3 protocol
+                    var wildcardPkgs = pkgSearchResource.SearchAsync(name, searchFilter, 0, 6000, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult();
+
+                    // If not searching for *all* packages
+                    if (!name.Equals("") && !name[0].Equals('*'))
+                    {
+                        char[] wildcardDelimiter = new char[] { '*' };
+                        var tokenizedName = name.Split(wildcardDelimiter, StringSplitOptions.RemoveEmptyEntries);
+
+                        //var startsWithWildcard = name[0].Equals('*') ? true : false;
+                        //var endsWithWildcard = name[name.Length-1].Equals('*') ? true : false;
+
+                        // 1)  *owershellge*
+                        if (name.StartsWith("*") && name.EndsWith("*"))
+                        {
+                            // filter results
+                            foundPackages.Add(wildcardPkgs.Where(p => p.Identity.Id.Contains(tokenizedName[0])));
+
+                            if (foundPackages.Flatten().Any())
+                            {
+                                pkgsLeftToFind.Remove(name);
+                            }
+                            // .Where(p => versionRange.Satisfies(p.Identity.Version))
+                            // .OrderByDescending(p => p.Identity.Version, VersionComparer.VersionRelease));
+
+                        }
+                        // 2)  *erShellGet
+                        else if (name.StartsWith("*"))
+                        {
+                            // filter results
+                            foundPackages.Add(wildcardPkgs.Where(p => p.Identity.Id.EndsWith(tokenizedName[0])));
+
+                            if (foundPackages.Flatten().Any())
+                            {
+                                pkgsLeftToFind.Remove(name);
+                            }
+                        }
+                        // if 1)  PowerShellG*
+                        else if (name.EndsWith("*"))
+                        {
+                            // filter results
+                            foundPackages.Add(wildcardPkgs.Where(p => p.Identity.Id.StartsWith(tokenizedName[0])));
+
+                            if (foundPackages.Flatten().Any())
+                            {
+                                pkgsLeftToFind.Remove(name);
+                            }
+                        }
+                        // 3)  Power*Get
+                        else if (tokenizedName.Length == 2)
+                        {
+                            // filter results
+                            foundPackages.Add(wildcardPkgs.Where(p => p.Identity.Id.StartsWith(tokenizedName[0]) && p.Identity.Id.EndsWith(tokenizedName[1])));
+
+                            if (foundPackages.Flatten().Any())
+                            {
+                                pkgsLeftToFind.Remove("*");
+                            }
+                        }
+                    }
+                    else
+                    {
+                        foundPackages.Add(wildcardPkgs);
+                        pkgsLeftToFind.Remove("*");
+                    }
+
+
+                }
+            }
+            else
+            {
+                /* can probably get rid of this */
+                foundPackages.Add(pkgSearchResource.SearchAsync("", searchFilter, 0, 6000, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult());
+                //foundPackages = pkgSearchResource.SearchAsync("", searchFilter, 0, 6000, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult();
+            }
+
+
+
+
+            // Check version first to narrow down the number of pkgs before potential searching through tags
+            if (_version != null)
+            {
+
+                if (_version.Equals("*"))
+                {
+                    // this is all that's needed if version == "*" (I think)
+                    /*
+                     if (repositoryUrl.Contains("api.nuget.org") || repositoryUrl.StartsWith("file:///"))
+                     {
+                         // need to reverse the order of the informaiton returned when using nuget.org v3 protocol
+                         filteredFoundPkgs.Add(pkgMetadataResource.GetMetadataAsync(name, _prerelease, false, srcContext, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult().Reverse());
+                     }
+                     else
+                     {
+                         filteredFoundPkgs.Add(pkgMetadataResource.GetMetadataAsync(name, _prerelease, false, srcContext, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult());
+                     }
+                     */
+                    // ensure that the latst version is returned first (the ordering of versions differ
+                    filteredFoundPkgs.Add(pkgMetadataResource.GetMetadataAsync(name, _prerelease, false, srcContext, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult().OrderByDescending(p => p.Identity.Version, VersionComparer.VersionRelease));
+                }
+                else
+                {
+                    // try to parse into a singular NuGet version
+                    NuGetVersion specificVersion;
+                    NuGetVersion.TryParse(_version, out specificVersion);
+
+                    foundPackages.RemoveAll(p => true);
+                    VersionRange versionRange = null;
+
+                    if (specificVersion != null)
+                    {
+                        // exact version
+                        versionRange = new VersionRange(specificVersion, true, specificVersion, true, null, null);
+                    }
+                    else
+                    {
+                        // maybe try catch this
+                        // check if version range
+                        versionRange = VersionRange.Parse(_version);
+
+                    }
+
+
+
+                    // Search for packages within a version range
+                    // ensure that the latst version is returned first (the ordering of versions differ
+                    // test wth  Find-PSResource 'Carbon' -Version '[,2.4.0)'
+                    foundPackages.Add(pkgMetadataResource.GetMetadataAsync(name, _prerelease, false, srcContext, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult()
+                        .Where(p => versionRange.Satisfies(p.Identity.Version))
+                        .OrderByDescending(p => p.Identity.Version, VersionComparer.VersionRelease));
+
+                    // TODO:  TEST AFTER CHANGES
+                    // choose the most recent version -- it's not doing this right now
+                    //int toRemove = foundPackages.First().Count() - 1;
+                    //var singlePkg = (System.Linq.Enumerable.SkipLast(foundPackages.FirstOrDefault(), toRemove));
+                    var pkgList = foundPackages.FirstOrDefault();
+                    var singlePkg = Enumerable.Repeat(pkgList.FirstOrDefault(), 1);
+
+                    filteredFoundPkgs.Add(singlePkg);
+                }
+            }
+            else // version is null
+            {
+                // if version is null, but there we want to return multiple packages (muliple names), skip over this step of removing all but the lastest package/version:
+                if ((name != null && !name.Contains("*")) || _moduleName != null)
+                {
+                    // choose the most recent version -- it's not doing this right now
+                    int toRemove = foundPackages.First().Count() - 1;
+
+                    // var result = ((IEnumerable)firstPkg).Cast<IPackageSearchMetadata>();
+                    // var bleh = foundPackages.FirstOrDefault().(System.Linq.Enumerable.SkipLast(foundPackages.FirstOrDefault(), 20));
+                    var pkgList = foundPackages.FirstOrDefault();
+                    var singlePkg = Enumerable.Repeat(pkgList.FirstOrDefault(), 1);
+
+
+                    filteredFoundPkgs.Add(singlePkg);
+                }
+                else
+                {
+                    filteredFoundPkgs = foundPackages;
+                }
+            }
+
+
+
+
+            // TAGS
+            /// should move this to the last thing that gets filtered
+            char[] delimiter = new char[] { ' ', ',' };
+            var flattenedPkgs = filteredFoundPkgs.Flatten().ToList();
+            if (_tags != null)
+            {
+                // clear filteredfoundPkgs because we'll just be adding back the pkgs we we
+                filteredFoundPkgs.RemoveAll(p => true);
+                var pkgsFilteredByTags = new List<IPackageSearchMetadata>();
+
+                foreach (IPackageSearchMetadata p in flattenedPkgs)
+                {
+                    // Enumerable.ElementAt(0)
+                    var tagArray = p.Tags.Split(delimiter, StringSplitOptions.RemoveEmptyEntries);
+
+                    foreach (string t in _tags)
+                    {
+                        // if the pkg contains one of the tags we're searching for
+                        if (tagArray.Contains(t, StringComparer.OrdinalIgnoreCase))
+                        {
+                            pkgsFilteredByTags.Add(p);
+                        }
+                    }
+                }
+                // make sure just adding one pkg if not * versions
+                if (_version != "*")
+                {
+                    filteredFoundPkgs.Add(pkgsFilteredByTags.DistinctBy(p => p.Identity.Id));
+                }
+                else
+                {
+                    // if we want all version, make sure there's only one package id/version in the returned list.
+                    filteredFoundPkgs.Add(pkgsFilteredByTags.DistinctBy(p => p.Identity.Version));
+                }
+            }
+
+
+
+
+            // optimizes searcching by 
+            if ((_type != null || !filteredFoundPkgs.Flatten().Any()) && pkgsLeftToFind.Any() && !_name.Contains("*"))
+            {
+                //if ((_type.Contains("Module") || _type.Contains("Script")) && !_type.Contains("DscResource") && !_type.Contains("Command") && !_type.Contains("RoleCapability"))
+                if (_type == null || _type.Contains("DscResource") || _type.Contains("Command") || _type.Contains("RoleCapability"))
+                {
+
+                    if (!filteredFoundPkgs.Flatten().Any())
+                    {
+                        filteredFoundPkgs.Add(pkgSearchResource.SearchAsync("", searchFilter, 0, 6000, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult());
+                    }
+
+                    var tempList = (FilterPkgsByResourceType(filteredFoundPkgs));
+                    filteredFoundPkgs.RemoveAll(p => true);
+
+                    filteredFoundPkgs.Add(tempList);
+                }
+
+            }
+            // else type == null
+
+
+
+
+
+
+
+            // Search for dependencies
+            if (_includeDependencies && filteredFoundPkgs.Any())
+            {
+                List<IEnumerable<IPackageSearchMetadata>> foundDependencies = new List<IEnumerable<IPackageSearchMetadata>>();
+
+                // need to parse the depenency and version and such
+                var filteredFoundPkgsFlattened = filteredFoundPkgs.Flatten();
+                foreach (IPackageSearchMetadata pkg in filteredFoundPkgsFlattened)
+                {
+                    // need to improve this later
+                    // this function recursively finds all dependencies
+                    // change into an ieunumerable (helpful for the finddependenciesfromsource function)
+
+                    foundDependencies.AddRange(FindDependenciesFromSource(Enumerable.Repeat(pkg, 1), pkgMetadataResource, srcContext));
+                }
+
+                filteredFoundPkgs.AddRange(foundDependencies);
+            }
+
+            // return foundPackages;
+            return filteredFoundPkgs;
+        }
+
+
+
+
+        private List<IEnumerable<IPackageSearchMetadata>> FindDependenciesFromSource(IEnumerable<IPackageSearchMetadata> pkg, PackageMetadataResource pkgMetadataResource, SourceCacheContext srcContext)
+        {
+            /// dependency resolver
+            ///
+            /// this function will be recursively called
+            ///
+            /// call the findpackages from source helper (potentially generalize this so it's finding packages from source or cache)
+            ///
+            List<IEnumerable<IPackageSearchMetadata>> foundDependencies = new List<IEnumerable<IPackageSearchMetadata>>();
+
+            // 1)  check the dependencies of this pkg
+            // 2) for each dependency group, search for the appropriate name and version
+            // a dependency group are all the dependencies for a particular framework
+            // first or default because we need this pkg to be an ienumerable (so we don't need to be doing strange object conversions)
+            foreach (var dependencyGroup in pkg.FirstOrDefault().DependencySets)
+            {
+
+                //dependencyGroup.TargetFramework
+                //dependencyGroup.
+
+                foreach (var pkgDependency in dependencyGroup.Packages)
+                {
+
+                    // 2.1) check that the appropriate pkg dependencies exist
+                    // returns all versions from a single package id.
+                    var dependencies = pkgMetadataResource.GetMetadataAsync(pkgDependency.Id, _prerelease, true, srcContext, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult();
+
+                    // then 2.2) check if the appropriate verion range exists  (if version exists, then add it to the list to return)
+
+                    VersionRange versionRange = null;
+                    try
+                    {
+                        versionRange = VersionRange.Parse(pkgDependency.VersionRange.OriginalString);
+                    }
+                    catch
+                    {
+                        Console.WriteLine("Error parsing version range");
+                    }
+
+
+
+                    // choose the most recent version
+                    int toRemove = dependencies.Count() - 1;
+
+                    // if no version/version range is specified the we just return the latest version
+                    var depPkgToReturn = (versionRange == null ?
+                        dependencies.FirstOrDefault() :
+                        dependencies.Where(v => versionRange.Satisfies(v.Identity.Version)).FirstOrDefault());
+
+
+
+                    // using the repeat function to convert the IPackageSearchMetadata object into an enumerable.
+                    foundDependencies.Add(Enumerable.Repeat(depPkgToReturn, 1));
+
+                    // 3) search for any dependencies the pkg has
+                    foundDependencies.AddRange(FindDependenciesFromSource(Enumerable.Repeat(depPkgToReturn, 1), pkgMetadataResource, srcContext));
+                }
+            }
+
+            // flatten after returning
+            return foundDependencies;
+        }
+
+
+
+
+
+
+
+
+
+
+        private List<IPackageSearchMetadata> FilterPkgsByResourceType(List<IEnumerable<IPackageSearchMetadata>> filteredFoundPkgs)
+        {
+
+
+            char[] delimiter = new char[] { ' ', ',' };
+
+            // If there are any packages that were filtered by tags, we'll continue to filter on those packages, otherwise, we'll filter on all the packages returned from the search
+            var flattenedPkgs = filteredFoundPkgs.Flatten();
+
+            var pkgsFilteredByResource = new List<IPackageSearchMetadata>();
+
+            // if the type is null, we'll set it to check for everything except modules and scripts, since those types were already checked.
+            _type = _type == null ? new string[] { "DscResource", "RoleCapability", "Command" } : _type;
+            string[] pkgsToFind = new string[5];
+            pkgsLeftToFind.CopyTo(pkgsToFind);
+
+            foreach (IPackageSearchMetadata pkg in flattenedPkgs)
+            {
+                // Enumerable.ElementAt(0)
+                var tagArray = pkg.Tags.Split(delimiter, StringSplitOptions.RemoveEmptyEntries);
+
+
+                // check modules and scripts here ??
+
+                foreach (var tag in tagArray)
+                {
+
+
+                    // iterate through type array
+                    foreach (var resourceType in _type)
+                    {
+
+                        switch (resourceType)
+                        {
+                            case "Module":
+                                if (tag.Equals("PSModule"))
+                                {
+                                    pkgsFilteredByResource.Add(pkg);
+                                }
+                                break;
+
+                            case "Script":
+                                if (tag.Equals("PSScript"))
+                                {
+                                    pkgsFilteredByResource.Add(pkg);
+                                }
+                                break;
+
+                            case "Command":
+                                if (tag.StartsWith("PSCommand_"))
+                                {
+                                    foreach (var resourceName in pkgsToFind)
+                                    {
+                                        if (tag.Equals("PSCommand_" + resourceName, StringComparison.OrdinalIgnoreCase))
+                                        {
+                                            pkgsFilteredByResource.Add(pkg);
+                                            pkgsLeftToFind.Remove(resourceName);
+
+                                        }
+                                    }
+                                }
+                                break;
+
+                            case "DscResource":
+                                if (tag.StartsWith("PSDscResource_"))
+                                {
+                                    foreach (var resourceName in pkgsToFind)
+                                    {
+                                        if (tag.Equals("PSDscResource_" + resourceName, StringComparison.OrdinalIgnoreCase))
+                                        {
+                                            pkgsFilteredByResource.Add(pkg);
+                                            pkgsLeftToFind.Remove(resourceName);
+                                        }
+                                    }
+                                }
+                                break;
+
+                            case "RoleCapability":
+                                if (tag.StartsWith("PSRoleCapability_"))
+                                {
+                                    foreach (var resourceName in pkgsToFind)
+                                    {
+                                        if (tag.Equals("PSRoleCapability_" + resourceName, StringComparison.OrdinalIgnoreCase))
+                                        {
+                                            pkgsFilteredByResource.Add(pkg);
+                                            pkgsLeftToFind.Remove(resourceName);
+                                        }
+                                    }
+                                }
+                                break;
+                        }
+
+                    }
+                }
+            }
+
+
+
+            return pkgsFilteredByResource.DistinctBy(p => p.Identity.Id).ToList();
+
+        }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        private static async Task<Uri> GetCatalogIndexUrlAsync(string sourceUrl)
+        {
+            // This code uses the NuGet client SDK, which are the libraries used internally by the official
+            // NuGet client.
+            var sourceRepository = NuGet.Protocol.Core.Types.Repository.Factory.GetCoreV3(sourceUrl);
+            var serviceIndex = await sourceRepository.GetResourceAsync<ServiceIndexResourceV3>();
+            var catalogIndexUrl = serviceIndex.GetServiceEntryUri("Catalog/3.0.0");
+
+
+
+            return catalogIndexUrl;
+        }
+
+
+
+        ///  Modified this
+        private static DateTime GetCursor()
+        {
+            /*
+            try
+            {
+                var cursorString = File.ReadAllText(CursorFileName);
+                var cursor = JsonConvert.DeserializeObject<FileCursor>(cursorString);
+                var cursorValue = cursor.GetAsync().GetAwaiter().GetResult().GetValueOrDefault();
+                DateTime cursorValueDateTime = DateTime.MinValue;
+                if (cursorValue != null)
+                {
+                    cursorValueDateTime = cursorValue.DateTime;
+                }
+                Console.WriteLine($"Read cursor value: {cursorValueDateTime}.");
+                return cursorValueDateTime;
+            }
+            catch (FileNotFoundException)
+            {
+            */
+            var value = DateTime.MinValue;
+            Console.WriteLine($"No cursor found. Defaulting to {value}.");
+            return value;
+            // }
+        }
+
+
+        private static void ProcessCatalogLeaf(CatalogLeafItem leaf)
+        {
+            // Here, you can do whatever you want with each catalog item. If you want the full metadata about
+            // the catalog leaf, you can use the leafItem.Url property to fetch the full leaf document. In this case,
+            // we'll just keep it simple and output the details about the leaf that are included in the catalog page.
+            // example: Console.WriteLine($"{leaf.CommitTimeStamp}: {leaf.Id} {leaf.Version} (type is {leaf.Type})");
+
+            Console.WriteLine($"{leaf.CommitTimestamp}: {leaf.PackageId} {leaf.PackageVersion} (type is {leaf.Type})");
+        }
+
+        private static void SetCursor(DateTime value)
+        {
+            Console.WriteLine($"Writing cursor value: {value}.");
+            var cursorString = JsonConvert.SerializeObject(new Cursor { Value = value });
+            File.WriteAllText(CursorFileName, cursorString);
+        }
+
+
+
+
+
+    }
+
+    /*
+    public class Cursor
+    {
+        [JsonProperty("value")]
+        public DateTime Value { get; set; }
+    }
+    */
+}

--- a/src/NuGetLogger.cs
+++ b/src/NuGetLogger.cs
@@ -1,0 +1,196 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using NuGet.Common;
+
+
+public class NuGetLogger : ILogger
+{
+    private readonly ITestOutputHelper _output;
+
+    public NuGetLogger()
+    {
+    }
+
+    public NuGetLogger(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    /// <summary>
+    /// Logged messages
+    /// </summary>
+    public ConcurrentQueue<string> Messages { get; } = new ConcurrentQueue<string>();
+    public ConcurrentQueue<string> DebugMessages { get; } = new ConcurrentQueue<string>();
+    public ConcurrentQueue<string> VerboseMessages { get; } = new ConcurrentQueue<string>();
+    public ConcurrentQueue<string> MinimalMessages { get; } = new ConcurrentQueue<string>();
+    public ConcurrentQueue<string> ErrorMessages { get; } = new ConcurrentQueue<string>();
+    public ConcurrentQueue<string> WarningMessages { get; } = new ConcurrentQueue<string>();
+    public ConcurrentQueue<ILogMessage> LogMessages { get; } = new ConcurrentQueue<ILogMessage>();
+    public int Errors { get; set; }
+    public int Warnings { get; set; }
+
+    public void LogDebug(string data)
+    {
+        Messages.Enqueue(data);
+        DebugMessages.Enqueue(data);
+        DumpMessage("DEBUG", data);
+    }
+
+    public void LogError(string data)
+    {
+        Errors++;
+        Messages.Enqueue(data);
+        ErrorMessages.Enqueue(data);
+        DumpMessage("ERROR", data);
+    }
+
+    public void LogInformation(string data)
+    {
+        Messages.Enqueue(data);
+        DumpMessage("INFO ", data);
+    }
+
+    public void LogMinimal(string data)
+    {
+        Messages.Enqueue(data);
+        MinimalMessages.Enqueue(data);
+        DumpMessage("LOG  ", data);
+    }
+
+    public void LogVerbose(string data)
+    {
+        Messages.Enqueue(data);
+        VerboseMessages.Enqueue(data);
+        DumpMessage("TRACE", data);
+    }
+
+    public void LogWarning(string data)
+    {
+        Warnings++;
+        Messages.Enqueue(data);
+        WarningMessages.Enqueue(data);
+        DumpMessage("WARN ", data);
+    }
+
+    public void LogInformationSummary(string data)
+    {
+        Messages.Enqueue(data);
+        DumpMessage("ISMRY", data);
+    }
+
+    private void DumpMessage(string level, string data)
+    {
+        _output?.WriteLine($"{level}: {data}");
+    }
+
+    public void Clear()
+    {
+        string msg;
+        while (Messages.TryDequeue(out msg))
+        {
+            // do nothing
+        }
+    }
+
+    public string ShowErrors()
+    {
+        return string.Join(Environment.NewLine, ErrorMessages);
+    }
+
+    public string ShowWarnings()
+    {
+        return string.Join(Environment.NewLine, WarningMessages);
+    }
+
+    public string ShowMessages()
+    {
+        return string.Join(Environment.NewLine, Messages);
+    }
+
+    public void Log(LogLevel level, string data)
+    {
+        switch (level)
+        {
+            case LogLevel.Debug:
+                {
+                    LogDebug(data);
+                    break;
+                }
+
+            case LogLevel.Error:
+                {
+                    LogError(data);
+                    break;
+                }
+
+            case LogLevel.Information:
+                {
+                    LogInformation(data);
+                    break;
+                }
+
+            case LogLevel.Minimal:
+                {
+                    LogMinimal(data);
+                    break;
+                }
+
+            case LogLevel.Verbose:
+                {
+                    LogVerbose(data);
+                    break;
+                }
+
+            case LogLevel.Warning:
+                {
+                    LogWarning(data);
+                    break;
+                }
+        }
+    }
+
+    public Task LogAsync(LogLevel level, string data)
+    {
+        Log(level, data);
+
+        return Task.FromResult(0);
+    }
+
+    public void Log(ILogMessage message)
+    {
+        LogMessages.Enqueue(message);
+
+        Log(message.Level, message.Message);
+    }
+
+    public async Task LogAsync(ILogMessage message)
+    {
+        LogMessages.Enqueue(message);
+
+        await LogAsync(message.Level, message.Message);
+    }
+}
+
+    // Summary:
+    //     Represents a class which can be used to provide test output.
+    public interface ITestOutputHelper
+    {
+        // Summary:
+        //     Adds a line of text to the output.
+        // Parameters:
+        //   message:
+        //     The message
+        void WriteLine(string message);
+        // Summary:
+        //     Formats a line of text and adds it to the output.
+        // Parameters:
+        //   format:
+        //     The message format
+        //   args:
+        //     The format arguments
+        void WriteLine(string format, params object[] args);
+    }

--- a/src/PublishPSResource.cs
+++ b/src/PublishPSResource.cs
@@ -298,7 +298,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         private Hashtable dependencies = new Hashtable();
         private NuGetVersion pkgVersion = null;
         private bool isScript;
-        private FileInfo moduleFileInfo;
         private string pkgName;
 
         protected override void ProcessRecord()
@@ -328,6 +327,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 pkgName = pkgFileOrDir.Name;
             }
 
+            FileInfo moduleFileInfo;
             moduleFileInfo = new FileInfo(moduleManifestOrScriptPath);
             // if there's no specified destination path to publish the nupkg, we'll just create a temp folder and delete it later
             string outputDir = !string.IsNullOrEmpty(_destinationPath) ? _destinationPath : System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -352,7 +352,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                 if (version == null)
                 {
-                    var message = String.Format("Version is not specified in the .nuspec provided. Please provide a valid version in the .nuspec.");
+                    var message = "Version is not specified in the .nuspec provided. Please provide a valid version in the .nuspec.";
                     var ex = new ArgumentException(message);
                     var versionNotFound = new ErrorRecord(ex, "versionNotFound", ErrorCategory.NotSpecified, null);
 
@@ -738,7 +738,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 }
                 catch
                 {
-                    var message = String.Format("Error parsing metadata for script.");
+                    var message = "Error parsing metadata for script.";
                     var ex = new ArgumentException(message);
                     var errorParsingScriptMetadata = new ErrorRecord(ex, "errorParsingScriptMetadata", ErrorCategory.ParserError, null);
 
@@ -796,7 +796,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 }
                 catch
                 {
-                    var message = String.Format("Error parsing metadata for script");
+                    var message = "Error parsing metadata for script";
                     var ex = new ArgumentException(message);
                     var errorParsingScriptMetadata = new ErrorRecord(ex, "errorParsingScriptMetadata", ErrorCategory.ParserError, null);
 

--- a/src/PublishPSResource.cs
+++ b/src/PublishPSResource.cs
@@ -334,8 +334,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                 // ex: <version>2.2.1</version>
                 var versionNode = doc.Descendants("version");
-                NuGetVersion version;
-                NuGetVersion.TryParse(versionNode.FirstOrDefault().Value, out version);
+                NuGetVersion.TryParse(versionNode.FirstOrDefault().Value, out NuGetVersion version);
 
                 // ex: <dependency id="Carbon" version="2.9.2" /> 
                 var dependencyNode = doc.Descendants("dependency");

--- a/src/PublishPSResource.cs
+++ b/src/PublishPSResource.cs
@@ -10,11 +10,13 @@ using System.Management.Automation;
 using System.Management.Automation.Language;
 using System.Xml;
 using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.PowerShellGet.RepositorySettings;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Packaging;
+using NuGet.Test.Utility;
 using NuGet.Versioning;
 
 
@@ -422,7 +424,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             var publishLocation = repoURL.EndsWith("/v2", StringComparison.OrdinalIgnoreCase) ? repoURL + "/package" : repoURL;
 
             var settings = NuGet.Configuration.Settings.LoadDefaultSettings(null, null, null);
-            ILogger log = new TestLogger();
+            NuGet.Common.ILogger log = new NuGetLogger();
             PushRunner.Run(
                     Settings.LoadDefaultSettings(null, null, null),
                     new PackageSourceProvider(settings), 

--- a/src/PublishPSResource.cs
+++ b/src/PublishPSResource.cs
@@ -1,0 +1,1008 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+using System.Xml;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Packaging;
+using NuGet.Versioning;
+
+
+
+namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
+{
+    /// <summary>
+    /// It retrieves a resource that was installEd with Install-PSResource
+    /// Returns a single resource or multiple resource.
+    /// </summary>
+    [Cmdlet(VerbsData.Publish, "PSResource", SupportsShouldProcess = true,
+        HelpUri = "<add>", RemotingCapability = RemotingCapability.None)]
+    public sealed
+    class PublishPSResource : PSCmdlet
+    {
+        /// <summary>
+        /// Specifies the name of the resource to be published.
+        /// </summary>
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "NameParameterSet")]
+        [ValidateNotNullOrEmpty]
+        public string Name
+        {
+            get
+            { return _name; }
+
+            set
+            { _name = value; }
+        }
+        private string _name;
+
+
+        /// <summary>
+        /// Specifies the API key that you want to use to publish a module to the online gallery.
+        /// </summary>
+        [Parameter()]
+        [ValidateNotNullOrEmpty]
+        public string APIKey
+        {
+            get
+            { return _APIKey; }
+
+            set
+            { _APIKey = value; }
+        }
+        private string _APIKey;
+
+
+        /// <summary>
+        /// Specifies the repository to publish to.
+        /// </summary>
+        [Parameter()]
+        [ValidateNotNullOrEmpty]
+        public string Repository
+        {
+            get
+            { return _repository; }
+
+            set
+            { _repository = value; }
+        }
+        private string _repository;
+
+
+
+        /// <summary>
+        /// Can be used to publish the a nupkg locally.
+        /// </summary>
+        [Parameter()]
+        [ValidateNotNullOrEmpty]
+        public string DestinationPath
+        {
+            get
+            { return _destinationPath; }
+
+            set
+            { _destinationPath = value; }
+        }
+        private string _destinationPath;
+
+
+
+        /// TODO 
+        /// <summary>
+        /// Specifies the path to the resource that you want to publish. This parameter accepts the path to the folder that contains the resource.
+        /// Specifies a path to one or more locations. Wildcards are permitted. The default location is the current directory (.).
+        /// </summary>
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "PathsParameterSet")]
+        [ValidateNotNullOrEmpty]
+        public string Path
+        {
+            get
+            { return _path; }
+
+            set
+            { _path = value; }
+        }
+        private string _path;
+        
+
+
+        /// TODO
+        /// <summary>
+        /// Specifies a path to one or more locations. Unlike the Path parameter, the value of the LiteralPath parameter is used exactly as entered.
+        /// No characters are interpreted as wildcards. If the path includes escape characters, enclose them in single quotation marks.
+        /// Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+        /// </summary>
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "PathLiteralParameterSet")]
+        [ValidateNotNullOrEmpty]
+        //   [Alias('PSPath')]
+        public string LiteralPath
+        {
+         get
+         { return _literalPath; }
+
+         set
+         { _literalPath = value; }
+        }
+        private string _literalPath;
+
+
+        /// TODO
+        /// <summary>
+        ///  Specifies the exact version of a single resource to publish.
+        /// </summary>
+        [Parameter(ParameterSetName = "NameParameterSet")]
+        [ValidateNotNullOrEmpty]
+        public string RequiredVersion
+        {
+            get
+            { return _requiredVersion; }
+
+            set
+            { _requiredVersion = value; }
+        }
+        private string _requiredVersion;
+
+
+        // TODO
+        /// <summary>
+        /// Allows resources marked as prerelease to be published.
+        /// </summary>
+        [Parameter(ParameterSetName = "NameParameterSet")]
+        [ValidateNotNullOrEmpty]
+        public SwitchParameter Prerelease
+        {
+            get
+            { return _prerelease; }
+
+            set
+            { _prerelease = value; }
+        }
+        private bool _prerelease;
+
+
+
+
+
+
+
+
+
+        /// <summary>
+        /// Specifies a user account that has rights to a specific repository (used for finding dependencies).
+        /// </summary>
+        [Parameter()]
+        [ValidateNotNullOrEmpty]
+        public PSCredential Credential
+        {
+            get
+            { return _credential; }
+
+            set
+            { _credential = value; }
+        }
+        private PSCredential _credential;
+
+        /*
+         # Forces the command to run without asking for user confirmation.
+         [Parameter()]
+         [switch]
+         $Force,
+         */
+
+        /// <summary>
+        /// Bypasses the default check that all dependencies are present.
+        /// </summary>
+        [Parameter()]
+        [ValidateNotNullOrEmpty]
+        public SwitchParameter SkipDependenciesCheck
+        {
+            get
+            { return _skipDependenciesCheck; }
+
+            set
+            { _skipDependenciesCheck = value; }
+        }
+        private bool _skipDependenciesCheck;
+
+
+
+      
+
+
+    
+
+        /// TODO:   (should this be parsed form the psd1??)   >>>  consider removing
+        /// <summary>
+        ///  Specifies a string containing release notes or comments that you want to be available to users of this version of the resource.
+        ///  Note-- this applies only to the nuspec.
+        /// </summary>
+        [Parameter()]
+        [ValidateNotNullOrEmpty]
+        public string ReleaseNotes
+        {
+            get
+            { return _releaseNotes; }
+
+            set
+            { _releaseNotes = value; }
+        }
+        private string _releaseNotes;
+
+
+
+
+        /// TODO:   (should this be parsed form the psd1??)   >>>  consider removing
+        /// <summary>
+        ///  Adds one or more tags to the resource that you are publishing.
+        ///  Note-- this applies only to the nuspec.
+        /// </summary>
+        [Parameter()]
+        [ValidateNotNullOrEmpty]
+        public string[] Tags
+        {
+            get
+            { return _tags; }
+
+            set
+            { _tags = value; }
+        }
+        private string[] _tags;
+
+
+
+
+
+
+        /// TODO:   (should this be parsed form the psd1??)   >>>  consider removing
+        /// <summary>
+        ///  Specifies the URL of licensing terms for the resource you want to publish.
+        ///  Note-- this applies only to the nuspec.
+        /// </summary>
+        [Parameter()]
+        [ValidateNotNullOrEmpty]
+        public string LicenseUrl
+        {
+            get
+            { return _licenseUrl; }
+
+            set
+            { _licenseUrl = value; }
+        }
+        private string _licenseUrl;
+
+
+
+
+        /// TODO:   (should this be parsed form the psd1??)   >>>  consider removing
+        /// <summary>
+        ///  Specifies the URL of an icon for the resource.
+        ///  Note-- this applies only to the nuspec.
+        /// </summary>
+        [Parameter()]
+        [ValidateNotNullOrEmpty]
+        public string IconUrl
+        {
+            get
+            { return _iconUrl; }
+
+            set
+            { _iconUrl = value; }
+        }
+        private string _iconUrl;
+
+
+        /// TODO:   (should this be parsed form the psd1??)  >>>  consider removing 
+        /// <summary>
+        /// Specifies the URL of a webpage about this project.
+        /// Note-- this applies only to the nuspec.
+        /// </summary>
+        [Parameter()]
+        [ValidateNotNullOrEmpty]
+        public string ProjectUrl
+        {
+            get
+            { return _projectUrl; }
+
+            set
+            { _projectUrl = value; }
+        }
+        private string _projectUrl;
+
+        // done
+        [Parameter(ParameterSetName = "ModuleNameParameterSet")]
+        /// <summary>
+        /// Excludes files from a nuspec
+        /// </summary>
+        [Parameter()]
+        [ValidateNotNullOrEmpty]
+        public string[] Exclude
+        {
+            get
+            { return _exclude; }
+
+            set
+            { _exclude = value; }
+        }
+        private string[] _exclude = System.Array.Empty<string>();
+
+        // done
+        /// <summary>
+        /// Specifies a nuspec file rather than relying on this module to produce one.
+        /// </summary>
+        [Parameter()]
+        [ValidateNotNullOrEmpty]
+        public string Nuspec
+        {
+            get
+            { return _nuspec; }
+
+            set
+            { _nuspec = value; }
+        }
+        private string _nuspec;
+
+
+        Hashtable dependencies = new Hashtable();
+
+
+
+
+        /// <summary>
+        /// </summary>
+        protected override void ProcessRecord()
+        {
+
+            string resolvedPath = "";
+            if (!string.IsNullOrEmpty(_name))
+            {
+                // name parameterset
+
+                // should return path to the module or script
+                resolvedPath = publishNameParamSet();
+
+            }
+            else {
+                // one of the paths parameter set 
+
+                // resolve path 
+
+                // this should be path:
+                //"C:\\Users\\americks\\Desktop\\newpsgettestmodule.2.0.0", //"C:\\code\\TestPackage1",
+                 
+                if (!string.IsNullOrEmpty(_literalPath))
+                {
+                    resolvedPath = _literalPath;
+                }
+                else if (!string.IsNullOrEmpty(_path))
+                { 
+                    resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(_path).FirstOrDefault().Path;
+
+                }
+
+                if (string.IsNullOrEmpty(resolvedPath))
+                {
+                    //sThrowTerminatingError();
+                }
+
+            }
+
+
+
+            // first do modules, then do scripts  (could be module or script)
+            // get the psd1 file or .ps1 file
+            string dirName = new DirectoryInfo(resolvedPath).Name;
+
+            string moduleFile = "";
+            if (File.Exists(System.IO.Path.Combine(resolvedPath, dirName + ".psd1")))
+            {
+                // if a module
+                moduleFile = System.IO.Path.Combine(resolvedPath, dirName + ".psd1");
+            }
+            else if (File.Exists(resolvedPath) && resolvedPath.EndsWith(".ps1"))
+            {
+                // if a script
+                moduleFile = resolvedPath;
+            }
+            else {
+                  //ThrowTerminatingError(); // .psd1 or .ps1 does not exist           
+            }
+
+
+
+
+            string outputDir = "";
+            // if there's no specified destination path to publish the nupkg, we'll just create a temp folder and delete it later
+            if (!string.IsNullOrEmpty(_destinationPath))
+            {
+                // check if there's an extenssion... the directory should be passed in
+                outputDir = SessionState.Path.GetResolvedPSPathFromPSPath(_destinationPath).FirstOrDefault().Path;
+            }
+            else
+            {
+                // TODO: create temp directory 
+                outputDir = "C:\\code\\testdirectory";
+            }
+
+
+
+            // _nuspec = "C:\\code\\testmodule99\\testmodule99.nuspec";
+
+            // if user specifies they want to use a nuspec they've created
+            if (string.IsNullOrEmpty(_nuspec))
+            {
+                _nuspec = createNuspec(outputDir, moduleFile, dirName);
+
+                // check if nuspec gets created successfully
+            }
+            else
+            {
+                // read the nuspec passed in to pull out the dependency information
+
+                using (StreamReader sr = File.OpenText(_nuspec))
+                {
+                    string str = String.Empty;
+
+                    // read until the beginning of the dependency metadata is hit
+                    while ((str = sr.ReadLine()) != null)
+                    {
+                        if (str.Trim().StartsWith("<dependency "))
+                        {
+                            // <dependency id="PackageManagement" version="1.4.4" />  1 ,  3
+                            var splitStr = str.Split('"');
+
+                            var moduleName = splitStr[1];
+                            var moduleVersion = splitStr[3];
+
+                            //var hash = new Hashtable();
+                            //hash.Add(moduleName, moduleVersion);
+
+                            dependencies.Add(moduleName, moduleVersion);
+                        }
+                    }
+
+
+                }
+            }
+
+
+            if (!_skipDependenciesCheck)
+            {
+                /// check to see that all dependencies are in the repository 
+                ///  For each dependency that's located in the dependency hash 
+                ///     * if we created the nuspec we should have a list of dependencies and versions
+                ///     * if the nuspec was provided, we'll check if there are any dependencies and versions
+
+                var findHelper = new FindHelper();
+
+                foreach (var dependency in dependencies.Keys)
+                {
+                    // need to make individual calls since we have version numbers 
+                    // make a call to find the dep in the repo...
+                    var depName = new[] { (string)dependency };
+                    var depVersion = (string)dependencies[dependency];
+                    var type = new[] { "module", "script" };
+                    var repository = new[] { _repository };
+
+                   
+                    var dependencyFound = findHelper.beginFindHelper(depName, type, depVersion, true, null, null, repository, _credential, false, false);
+
+                    if (!dependencyFound.Any())
+                    {
+                        var message = String.Format("Dependency {0} was not found in repository {1}.  Make sure the dependency is published to the repository before publishing this module.", depName, _repository);
+                        var ex = new ArgumentException(message);  // System.ArgumentException vs PSArgumentException
+
+                        var dependencyNotFound = new ErrorRecord(ex, "DependencyNotFound", ErrorCategory.ResourceUnavailable, null);
+
+                        this.ThrowTerminatingError(dependencyNotFound);
+                    }
+                }
+            }
+
+
+
+
+
+
+            ///////   PACK INTO A NUPKG GIVEN A NUSPEC
+            var builder = new PackageBuilder();
+                var runner = new PackCommandRunner(
+                    new PackArgs
+                    {
+                        CurrentDirectory = resolvedPath,
+                        OutputDirectory = outputDir,  // make temp directory for this
+                        Path = _nuspec, //"NewpsGetTestModule.nuspec",
+                        Exclude = _exclude,
+                        Symbols = false,
+                        Logger = NullLogger.Instance
+                    },
+                    MSBuildProjectFactory.ProjectCreator,
+                    builder);;
+
+                runner.BuildPackage();
+            ///// END PACK
+
+
+
+            //////  PUSH
+
+            var fullNupkgPath = System.IO.Path.Combine(outputDir, "testmodule99.0.0.3.nupkg");
+            // check if nupkg successfully installed, if so continue on, if not throw error
+
+
+            var settings = NuGet.Configuration.Settings.LoadDefaultSettings(null, null, null);
+
+            if (_repository.Equals("poshtest", StringComparison.OrdinalIgnoreCase))
+            {
+                _repository = "https://www.poshtestgallery.com/api/v2/package";
+            }
+
+            if (_repository.Equals("psgallery", StringComparison.OrdinalIgnoreCase))
+            {
+                _repository = "https://www.powershellgallery.com/api/v2/package";
+            }
+
+            ILogger log = new TestLogger();
+            PushRunner.Run(
+                    Settings.LoadDefaultSettings(null, null, null),
+                    new PackageSourceProvider(settings), 
+                    fullNupkgPath, //packagePath ////packageInfo.FullName,   
+                    _repository, //"https://www.poshtestgallery.com/api/v2/", // packagePushDest.FullName,  
+                    _APIKey, // api key
+                    null, // symbols source
+                    null, // symbols api key
+                    0, // timeout
+                    false, // disable buffering
+                    false, // no symbols,
+                    false, // no skip duplicate
+                    false, // enable server endpoint
+                    log).GetAwaiter().GetResult();
+
+        }
+
+
+
+
+
+
+
+
+
+
+
+
+        private string publishNameParamSet()
+        {
+            var modulePath = "";
+            // 1) run get-module to find the right package version
+            // _name, _requiredVersion, _prerelease
+
+
+            NuGetVersion nugetVersion;
+
+            // parse version,
+            // throw if version is in incorrect format
+            if (!string.IsNullOrEmpty(_requiredVersion))
+            {
+                // check if exact version
+
+                //VersionRange versionRange = VersionRange.Parse(version);
+                NuGetVersion.TryParse(_requiredVersion, out nugetVersion);
+
+                // if the version didn't parse correctly, throw error 
+                if (string.IsNullOrEmpty(nugetVersion.ToNormalizedString()))
+                {
+                    var message = $"-RequiredVersion is not in a proper package version.  Please specify a version number, for example: '2.0.0'";
+                    var ex = new ArgumentException(message);  // System.ArgumentException vs PSArgumentException
+
+                    var requiredVersionError = new ErrorRecord(ex, "RequiredVersionError", ErrorCategory.InvalidArgument, null);
+
+                    this.ThrowTerminatingError(requiredVersionError);
+                }
+            }
+
+            if (_prerelease)
+            { 
+                // add prerelease flag    
+            }
+
+            // return the full path 
+            return modulePath;
+        }
+
+
+        private string createNuspec(string outputDir, string moduleFile, string pkgName)
+        {
+            /////////////////// create a nuspec 
+            WriteVerbose("Creating new nuspec file.");
+
+            Hashtable parsedMetadataHash = new Hashtable();
+
+            if (moduleFile.EndsWith(".psd1"))
+            {
+                //FileStream fs = File.Open(moduleFile, FileMode.Open, FileAccess.Read);
+
+                System.Management.Automation.Language.Token[] tokens;
+                ParseError[] errors;
+                var ast = Parser.ParseFile(moduleFile, out tokens, out errors);
+
+                if (errors.Length > 0)
+                {
+                    // WriteInvalidDataFileError(resolved, "CouldNotParseAsPowerShellDataFile");
+                    WriteDebug("Could not parse '" + moduleFile + "' as a powershell data file.");
+                }
+                else
+                {
+                    var data = ast.Find(a => a is HashtableAst, false);
+                    if (data != null)
+                    {
+                        // WriteObject(data.SafeGetValue());
+                        parsedMetadataHash = (Hashtable) data.SafeGetValue();
+                    }
+                    else
+                    {
+                        WriteDebug("Could not parse as PowerShell data file-- no hashtable root for file '" + moduleFile + "'");
+                    }
+                }
+
+              
+            }
+            else if (moduleFile.EndsWith(".ps1"))
+            {
+
+                /// parse .ps1  
+                /* <#PSScriptInfo
+                    .VERSION 1.6
+                    .GUID ebf446a3 - 3362 - 4774 - 83c0 - b7299410b63f
+                    .AUTHOR Michael Niehaus
+                    .COMPANYNAME Microsoft
+                    .COPYRIGHT
+                    .TAGS Windows AutoPilot
+                    .LICENSEURI
+                    .PROJECTURI
+                    .ICONURI
+                    .EXTERNALMODULEDEPENDENCIES
+                    .REQUIREDSCRIPTS
+                    .EXTERNALSCRIPTDEPENDENCIES
+                    .RELEASENOTES
+                    #>
+
+                    <#
+                    .SYNOPSIS
+                     Synopsis description here
+                    .DESCRIPTION
+                     Description here
+                    .PARAMETER Name
+                     Parameter description here
+                    .PARAMETER Credential
+                     Parameter description here
+                    .PARAMETER Partner
+                     Parameter description here2
+                    .EXAMPLE
+                     Example cmdlet here
+                    #>
+                */
+
+                pkgName = pkgName.Remove(pkgName.Length - 4);
+
+                using (StreamReader sr = File.OpenText(moduleFile))
+                {
+                   // StringBuilder sb = new StringBuilder();
+                    //Hashtable parsedMetadataHash = new Hashtable();
+
+
+                    string endOfMetadata = "#>";
+
+                    // metadata for scripts are divided into two parts
+                    string str = String.Empty;
+
+                    // read until the beginning of the metadata is hit "<#PSScriptInfo"
+                    do
+                    {
+                        str = sr.ReadLine().Trim();
+                    }
+                    while (str != "<#PSScriptInfo");
+
+                    string key = String.Empty;
+                    string value;
+                    // Then start reading metadata
+                    do
+                    {
+                        str = sr.ReadLine().Trim();
+                        value = String.Empty;
+
+                        if (str.StartsWith("."))
+                        {
+                            // create new key
+                            if (str.IndexOf(" ") > 0)
+                            {
+                                key = str.Substring(1, str.IndexOf(" ")-1).ToLower();
+                                var startIndex = str.IndexOf(" ") + 1;
+                                value = str.Substring(startIndex, str.Length - startIndex);
+                            }
+                            else { 
+                                key = str.Substring(1, str.Length-1).ToLower();
+                            }
+                            
+
+                            try
+                            {
+                                parsedMetadataHash.Add(key, value);
+                            }
+                            catch (Exception e)
+                            {
+                                WriteDebug(String.Format("Failed to add key '{0}' and value '{1}' to hashtable", key, value));
+                            }
+                        }
+                        else 
+                        {
+                            if (!String.IsNullOrEmpty(key))
+                            {
+                                // append to existing key/value
+                                parsedMetadataHash[key] = parsedMetadataHash[key] + " " + str;
+                            }
+                        }
+                        //sb.Append(str);
+                    }
+                    while (str != endOfMetadata);
+
+                    WriteObject(parsedMetadataHash.ToString());
+                    // read until the beginning of the next metadata section
+                    // Note there may only be one metadata section
+                    do
+                    {
+                        str = sr.ReadLine().Trim();
+                    }
+                    while (str != "<#");
+
+                    // Then start reading metadata again.
+                    str = String.Empty;
+                    key = String.Empty;
+
+                    do
+                    {
+                        str = sr.ReadLine().Trim();
+                        value = String.Empty;
+
+                        if (str.StartsWith("."))
+                        {
+
+                            // create new key
+                            if (str.IndexOf(" ") > 0)
+                            {
+                                key = str.Substring(1, str.IndexOf(" ") - 1).ToLower();
+                                var startIndex = str.IndexOf(" ") + 1;
+                                value = str.Substring(startIndex, str.Length - startIndex);
+                            }
+                            else
+                            {
+                                key = str.Substring(1, str.Length - 1).ToLower();
+                            }
+
+
+                            try
+                            {
+                                parsedMetadataHash.Add(key, value);
+                            }
+                            catch (Exception e)
+                            {
+                                WriteDebug(String.Format("Failed to add key '{0}' and value '{1}' to hashtable", key, value));
+                            }
+                        }
+                        else
+                        {
+                            // append to existing key/value
+                            if (!String.IsNullOrEmpty(key))
+                            {
+                                parsedMetadataHash[key] = parsedMetadataHash[key] + " " + str;
+                            }
+                        }
+                        //sb.Append(str);
+                    }
+                    while (str != endOfMetadata);
+
+                    WriteObject("here");
+                    WriteObject(parsedMetadataHash);
+                    
+                }
+
+            }
+            else {
+                WriteDebug("File to be parsed does not have a .psd1 or .ps1 extension.");
+            }
+
+
+
+
+
+            // safeData;
+
+            WriteObject(parsedMetadataHash);
+
+            WriteObject("-----------------------");
+
+            
+            /// now we have parsedMetadatahash to fill out the nuspec information
+
+
+            var nameSpaceUri = "http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd";
+            var doc = new XmlDocument();
+
+            // xml declaration is recommended, but not mandatory
+            XmlDeclaration xmlDeclaration = doc.CreateXmlDeclaration("1.0", "utf-8", null);
+            XmlElement root = doc.DocumentElement;
+            doc.InsertBefore(xmlDeclaration, root);
+
+            // create top-level elements
+            XmlElement packageElement = doc.CreateElement("package", nameSpaceUri);
+            XmlElement metadataElement = doc.CreateElement("metadata", nameSpaceUri);
+
+            //using (StreamWriter sw = new StreamWriter(fullinstallPath))
+
+            Dictionary<string, string> metadataElementsDictionary = new Dictionary<string, string>();
+
+
+       
+            // id is mandatory
+            metadataElementsDictionary.Add("id", pkgName);
+
+
+            string version = String.Empty;
+            if (parsedMetadataHash.ContainsKey("moduleversion"))
+            {
+                version = parsedMetadataHash["moduleversion"].ToString();
+            }
+            else if (parsedMetadataHash.ContainsKey("version"))
+            {
+                version = parsedMetadataHash["version"].ToString();
+            }
+            else 
+            {
+                 // no version is specified for the nuspec
+            }
+            NuGetVersion nugetVersion;
+            NuGetVersion.TryParse(version, out nugetVersion);
+
+            metadataElementsDictionary.Add("version", nugetVersion.ToFullString());
+
+
+            if (parsedMetadataHash.ContainsKey("author"))
+            {
+                metadataElementsDictionary.Add("author", parsedMetadataHash["author"].ToString().Trim());
+            }
+
+
+            if (parsedMetadataHash.ContainsKey("companyname"))
+            {
+                metadataElementsDictionary.Add("owners", parsedMetadataHash["companyname"].ToString().Trim());
+            }
+
+
+
+            // defaults to false
+            var requireLicenseAcceptance = parsedMetadataHash.ContainsKey("requirelicenseacceptance") ? parsedMetadataHash["requirelicenseacceptance"].ToString().ToLower().Trim()
+                : "false";
+            metadataElementsDictionary.Add("requireLicenseAcceptance", requireLicenseAcceptance); 
+           
+
+
+            if (parsedMetadataHash.ContainsKey("description"))
+            {
+                metadataElementsDictionary.Add("description", parsedMetadataHash["description"].ToString().Trim());
+            }
+
+
+
+           if (parsedMetadataHash.ContainsKey("releasenotes") || !String.IsNullOrEmpty(_releaseNotes))
+            {
+                var releaseNotes = string.IsNullOrEmpty(_releaseNotes) ? parsedMetadataHash["releasenotes"].ToString().Trim() : _releaseNotes;
+                metadataElementsDictionary.Add("releaseNotes", releaseNotes);
+            }
+
+
+            if (parsedMetadataHash.ContainsKey("copyright"))
+            {
+                metadataElementsDictionary.Add("copyright", parsedMetadataHash["copyright"].ToString().Trim());
+            }
+
+            string tags = string.Empty;
+            if (parsedMetadataHash.ContainsKey("tags") || _tags != null)
+            {
+                tags = _tags == null ? (parsedMetadataHash["tags"].ToString().Trim() + " ") : (_tags.ToString().Trim() + " ");   ///////////    ??????????
+            }
+            tags += moduleFile.EndsWith(".psd1") ? "PSModule" : "PSScript";
+            metadataElementsDictionary.Add("tags", tags);
+
+
+            if (parsedMetadataHash.ContainsKey("licenseurl") || !String.IsNullOrEmpty(_licenseUrl))
+            {
+                var licenseUrl = string.IsNullOrEmpty(_licenseUrl) ? parsedMetadataHash["licenseurl"].ToString().Trim() : _licenseUrl;
+                metadataElementsDictionary.Add("licenseUrl", licenseUrl);
+            }
+
+            if (parsedMetadataHash.ContainsKey("projecturl") || !String.IsNullOrEmpty(_projectUrl))
+            {
+                var projectUrl = string.IsNullOrEmpty(_projectUrl) ? parsedMetadataHash["projecturl"].ToString().Trim() : _projectUrl;
+                metadataElementsDictionary.Add("projectUrl", projectUrl);
+            }
+
+            if (parsedMetadataHash.ContainsKey("iconurl") || !String.IsNullOrEmpty(_iconUrl))
+            {
+                var iconUrl = string.IsNullOrEmpty(_iconUrl) ? parsedMetadataHash["iconurl"].ToString().Trim() : _iconUrl;
+                metadataElementsDictionary.Add("iconUrl", iconUrl);
+            }
+
+       
+            ///// TUESDAY:  1)  test the above nuspec additions
+            //  2) check dependencies below 
+            // 3) look into what exactly needs to be passed in for file stuff 
+
+            foreach (var key in metadataElementsDictionary.Keys)
+            {
+                XmlElement element = doc.CreateElement(key, nameSpaceUri);
+
+                string elementInnerText;
+                metadataElementsDictionary.TryGetValue(key, out elementInnerText);
+                element.InnerText = elementInnerText;
+
+                metadataElement.AppendChild(element);
+            }
+
+
+
+            ////// CREATE DEPENDENCY TABLE HERE
+            ///
+            if (parsedMetadataHash.ContainsKey("requiredmodules"))
+            {
+                dependencies = (Hashtable)parsedMetadataHash["requiredmodules"];
+
+                if (dependencies != null)
+                {
+                    XmlElement dependenciesElement = doc.CreateElement("dependencies", nameSpaceUri);
+
+                    foreach (Hashtable dependency in dependencies)
+                    {
+                        XmlElement element = doc.CreateElement("dependency", nameSpaceUri);
+
+                        element.SetAttribute("id", dependency["ModuleName"].ToString());  /// may need to be lower case
+                        if (!string.IsNullOrEmpty(dependency["ModuleVersion"].ToString()))
+                        {
+                            element.SetAttribute("version", dependency["ModuleVersion"].ToString());
+                        }
+
+                        dependenciesElement.AppendChild(element);
+                    }
+                    metadataElement.AppendChild(dependenciesElement);
+                }
+
+            }
+            
+
+          
+            packageElement.AppendChild(metadataElement);
+            
+            doc.AppendChild(packageElement);
+
+
+
+            var nuspecFullName = System.IO.Path.Combine(outputDir, pkgName + ".nuspec");
+            doc.Save(nuspecFullName);
+
+            this.WriteVerbose("The newly created nuspec is: " + nuspecFullName);
+
+            return nuspecFullName;
+            //  done creating nuspec 
+        }
+    }
+}
+
+
+
+
+

--- a/src/PublishPSResource.cs
+++ b/src/PublishPSResource.cs
@@ -16,7 +16,6 @@ using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Packaging;
-using NuGet.Test.Utility;
 using NuGet.Versioning;
 
 
@@ -321,7 +320,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 // create temp directory 
                 outputDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString());
-                var dir = Directory.CreateDirectory(outputDir);
             }
 
             // if user does not specify that they want to use a nuspec they've created, we'll create a nuspec
@@ -474,9 +472,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             else if (moduleFileInfo.Extension.Equals(".ps1", StringComparison.OrdinalIgnoreCase))
             {
                 // parse script metadata
-                pkgName = pkgName.Remove(pkgName.Length - 4);
-
-                ParseScriptMetadata(parsedMetadataHash, pkgName, moduleFileInfo);
+                ParseScriptMetadata(parsedMetadataHash, moduleFileInfo);
             }
             else {
                 WriteDebug("File to be parsed does not have a .psd1 or .ps1 extension.");
@@ -512,7 +508,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             else 
             {
                 // no version is specified for the nuspec
-                var message = String.Format("There is no package version specified. Please specify a verison before publishing.");
+                var message = "There is no package version specified. Please specify a verison before publishing.";
                 var ex = new ArgumentException(message);  
                 var NoVersionFound = new ErrorRecord(ex, "NoVersionFound", ErrorCategory.InvalidArgument, null);
 
@@ -628,7 +624,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         }
 
 
-        private void ParseScriptMetadata(Hashtable parsedMetadataHash, string pkgName, FileInfo moduleFileInfo)
+        private void ParseScriptMetadata(Hashtable parsedMetadataHash, FileInfo moduleFileInfo)
         {
             // parse .ps1 - example .ps1 metadata:
             /* <#PSScriptInfo

--- a/src/PublishPSResource.cs
+++ b/src/PublishPSResource.cs
@@ -298,7 +298,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 // Pkg to publish is a module
                 moduleFile = System.IO.Path.Combine(resolvedPath, dirName + ".psd1");
             }
-            else if (File.Exists(resolvedPath) && resolvedPath.EndsWith(".ps1"))
+            else if (File.Exists(resolvedPath) && resolvedPath.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase))
             {
                 // Pkg to publish is a script
                 moduleFile = resolvedPath;
@@ -341,14 +341,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     // read until the beginning of the dependency metadata is hit
                     while ((str = sr.ReadLine()) != null)
                     {
-                        if (str.Trim().StartsWith("<version>"))
+                        if (str.Trim().StartsWith("<version>", StringComparison.OrdinalIgnoreCase))
                         {
                             // ex: <version>2.2.1</version>
                             var splitStr = str.Split('<','>');
 
                             NuGetVersion.TryParse(splitStr[2], out pkgVersion);
                         }
-                        if (str.Trim().StartsWith("<dependency "))
+                        if (str.Trim().StartsWith("<dependency ", StringComparison.OrdinalIgnoreCase))
                         {
                             // ex: <dependency id="Carbon" version="2.9.2" /> 
                             var splitStr = str.Split('"');
@@ -394,10 +394,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 }
             }
 
-            var pkgName = dirName.EndsWith(".ps1") ? dirName.Remove(dirName.Length - 4) : dirName;
+            var pkgName = dirName.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase) ? dirName.Remove(dirName.Length - 4) : dirName;
             if (isScript)
             {
-                File.Copy(resolvedPath, System.IO.Path.Combine(outputDir, pkgName + ".ps1" ), true);
+                File.Copy(resolvedPath, System.IO.Path.Combine(outputDir, pkgName + ".ps1"), true);
             }
             else 
             {
@@ -411,7 +411,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             var outputDirectory = System.IO.Path.Combine(outputDir, "nupkg");
             // Pack the module or script into a nupkg given a nuspec.
             var builder = new PackageBuilder();
-                var runner = new PackCommandRunner(
+            var runner = new PackCommandRunner(
                     new PackArgs
                     {
                         CurrentDirectory = outputDir,
@@ -436,7 +436,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             var fullNupkgPath = System.IO.Path.Combine(outputDirectory, pkgName + "." + pkgVersion.ToNormalizedString() + ".nupkg" );
 
             var repoURL = repositoryUrl.FirstOrDefault().Properties["Url"].Value.ToString();
-            var publishLocation = repoURL.EndsWith("/v2") ? repoURL + "/package" : repoURL;
+            var publishLocation = repoURL.EndsWith("/v2", StringComparison.OrdinalIgnoreCase) ? repoURL + "/package" : repoURL;
 
             var settings = NuGet.Configuration.Settings.LoadDefaultSettings(null, null, null);
             ILogger log = new TestLogger();
@@ -463,7 +463,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             Hashtable parsedMetadataHash = new Hashtable();
 
-            if (moduleFile.EndsWith(".psd1"))
+            if (moduleFile.EndsWith(".psd1", StringComparison.OrdinalIgnoreCase))
             {
                 System.Management.Automation.Language.Token[] tokens;
                 ParseError[] errors;
@@ -486,7 +486,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     }
                 }
             }
-            else if (moduleFile.EndsWith(".ps1"))
+            else if (moduleFile.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase))
             {
                 // parse .ps1 - example .ps1 metadata:
                 /* <#PSScriptInfo
@@ -533,7 +533,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         str = sr.ReadLine().Trim();
                         value = String.Empty;
 
-                        if (str.StartsWith("."))
+                        if (str.StartsWith(".", StringComparison.OrdinalIgnoreCase))
                         {
                             // Create new key
                             if (str.IndexOf(" ") > 0)
@@ -596,7 +596,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                             str = sr.ReadLine().Trim();
                             value = String.Empty;
 
-                            if (str.StartsWith("."))
+                            if (str.StartsWith(".", StringComparison.OrdinalIgnoreCase))
                             {
 
                                 // create new key
@@ -718,7 +718,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 tags = _tags == null ? (parsedMetadataHash["tags"].ToString().Trim() + " ") : (_tags.ToString().Trim() + " ");
             }
-            tags += moduleFile.EndsWith(".psd1") ? "PSModule" : "PSScript";
+            tags += moduleFile.EndsWith(".psd1", StringComparison.OrdinalIgnoreCase) ? "PSModule" : "PSScript";
             metadataElementsDictionary.Add("tags", tags);
 
             if (parsedMetadataHash.ContainsKey("licenseurl") || !String.IsNullOrEmpty(_licenseUrl))

--- a/src/PublishPSResource.cs
+++ b/src/PublishPSResource.cs
@@ -523,7 +523,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     {
                         str = sr.ReadLine().Trim();
                     }
-                    while (str != "<#PSScriptInfo");
+                    while (!string.Equals(str, "<#PSScriptInfo", StringComparison.OrdinalIgnoreCase));
 
                     string key = String.Empty;
                     string value;

--- a/test/PSGetTestUtils.psm1
+++ b/test/PSGetTestUtils.psm1
@@ -1,0 +1,250 @@
+<#####################################################################################
+ # File: PSGetTestUtils.psm1
+ #
+ # Copyright (c) Microsoft Corporation, 2020
+ #####################################################################################>
+
+#."$PSScriptRoot\uiproxy.ps1"
+
+$script:DotnetCommandPath = @()
+$script:EnvironmentVariableTarget = @{ Process = 0; User = 1; Machine = 2 }
+$script:EnvPATHValueBackup = $null
+
+$script:PowerShellGet = 'PowerShellGet'
+$script:IsInbox = $PSHOME.EndsWith('\WindowsPowerShell\v1.0', [System.StringComparison]::OrdinalIgnoreCase)
+$script:IsWindows = (-not (Get-Variable -Name IsWindows -ErrorAction Ignore)) -or $IsWindows
+$script:IsLinux = (Get-Variable -Name IsLinux -ErrorAction Ignore) -and $IsLinux
+$script:IsMacOS = (Get-Variable -Name IsMacOS -ErrorAction Ignore) -and $IsMacOS
+$script:IsCoreCLR = $PSVersionTable.ContainsKey('PSEdition') -and $PSVersionTable.PSEdition -eq 'Core'
+
+if($script:IsInbox)
+{
+    $script:ProgramFilesPSPath = Microsoft.PowerShell.Management\Join-Path -Path $env:ProgramFiles -ChildPath "WindowsPowerShell"
+}
+elseif($script:IsCoreCLR){
+    if($script:IsWindows) {
+        $script:ProgramFilesPSPath = Microsoft.PowerShell.Management\Join-Path -Path $env:ProgramFiles -ChildPath 'PowerShell'
+    }
+    else {
+        $script:ProgramFilesPSPath = Split-Path -Path ([System.Management.Automation.Platform]::SelectProductNameForDirectory('SHARED_MODULES')) -Parent
+    }
+}
+
+try
+{
+    $script:MyDocumentsFolderPath = [Environment]::GetFolderPath("MyDocuments")
+}
+catch
+{
+    $script:MyDocumentsFolderPath = $null
+}
+
+if($script:IsInbox)
+{
+    $script:MyDocumentsPSPath = if($script:MyDocumentsFolderPath)
+                                {
+                                    Microsoft.PowerShell.Management\Join-Path -Path $script:MyDocumentsFolderPath -ChildPath "WindowsPowerShell"
+                                }
+                                else
+                                {
+                                    Microsoft.PowerShell.Management\Join-Path -Path $env:USERPROFILE -ChildPath "Documents\WindowsPowerShell"
+                                }
+}
+elseif($script:IsCoreCLR) {
+    if($script:IsWindows)
+    {
+        $script:MyDocumentsPSPath = if($script:MyDocumentsFolderPath)
+        {
+            Microsoft.PowerShell.Management\Join-Path -Path $script:MyDocumentsFolderPath -ChildPath 'PowerShell'
+        }
+        else
+        {
+            Microsoft.PowerShell.Management\Join-Path -Path $HOME -ChildPath "Documents\PowerShell"
+        }
+    }
+    else
+    {
+        $script:MyDocumentsPSPath = Split-Path -Path ([System.Management.Automation.Platform]::SelectProductNameForDirectory('USER_MODULES')) -Parent
+    }
+}
+
+$script:ProgramFilesModulesPath = Microsoft.PowerShell.Management\Join-Path -Path $script:ProgramFilesPSPath -ChildPath 'Modules'
+$script:MyDocumentsModulesPath = Microsoft.PowerShell.Management\Join-Path -Path $script:MyDocumentsPSPath -ChildPath 'Modules'
+$script:ProgramFilesScriptsPath = Microsoft.PowerShell.Management\Join-Path -Path $script:ProgramFilesPSPath -ChildPath 'Scripts'
+$script:MyDocumentsScriptsPath = Microsoft.PowerShell.Management\Join-Path -Path $script:MyDocumentsPSPath -ChildPath 'Scripts'
+$script:TempPath = [System.IO.Path]::GetTempPath()
+
+if($script:IsWindows) {
+    $script:PSGetProgramDataPath = Microsoft.PowerShell.Management\Join-Path -Path $env:ProgramData -ChildPath 'Microsoft\Windows\PowerShell\PowerShellGet\'
+    $script:PSGetAppLocalPath = Microsoft.PowerShell.Management\Join-Path -Path $env:LOCALAPPDATA -ChildPath 'Microsoft\Windows\PowerShell\PowerShellGet\'
+} else {
+    $script:PSGetProgramDataPath = Join-Path -Path ([System.Management.Automation.Platform]::SelectProductNameForDirectory('CONFIG')) -ChildPath 'PowerShellGet'
+    $script:PSGetAppLocalPath = Join-Path -Path ([System.Management.Automation.Platform]::SelectProductNameForDirectory('CACHE')) -ChildPath 'PowerShellGet'
+}
+
+$script:ProgramDataExePath = Microsoft.PowerShell.Management\Join-Path -Path $script:PSGetProgramDataPath -ChildPath $script:NuGetExeName
+$script:ApplocalDataExePath = Microsoft.PowerShell.Management\Join-Path -Path $script:PSGetAppLocalPath -ChildPath $script:NuGetExeName
+$script:moduleSourcesFilePath = Microsoft.PowerShell.Management\Join-Path -Path $script:PSGetAppLocalPath -ChildPath 'PSRepositories.xml'
+
+# PowerShellGetFormatVersion will be incremented when we change the .nupkg format structure.
+# PowerShellGetFormatVersion is in the form of Major.Minor.
+# Minor is incremented for the backward compatible format change.
+# Major is incremented for the breaking change.
+$script:CurrentPSGetFormatVersion = "1.0"
+$script:PSGetFormatVersionPrefix = "PowerShellGetFormatVersion_"
+
+function Get-AllUsersModulesPath {
+    return $script:ProgramFilesModulesPath
+}
+
+function Get-CurrentUserModulesPath {
+    return $script:MyDocumentsModulesPath
+}
+
+function Get-AllUsersScriptsPath {
+    return $script:ProgramFilesScriptsPath
+}
+
+function Get-CurrentUserScriptsPath {
+    return $script:MyDocumentsScriptsPath
+}
+
+function Get-TempPath {
+    return $script:TempPath
+}
+
+function Get-PSGetLocalAppDataPath {
+    return $script:PSGetAppLocalPath
+}
+
+
+
+
+
+function RemoveItem
+{
+    Param(
+        [string]
+        $path
+    )
+
+    if($path -and (Test-Path $path))
+    {
+        Remove-Item $path -Force -Recurse -ErrorAction SilentlyContinue
+    }
+}
+
+
+function Create-PSScriptMetadata
+{
+    [CmdletBinding(PositionalBinding=$false,
+    SupportsShouldProcess=$true)]
+
+    Param
+    (
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Version,
+
+        [Parameter()]
+        #[ValidateNotNullOrEmpty()]
+        [Guid]
+        $Guid,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Author,
+
+        [Parameter()]
+        [String]
+        $CompanyName,
+
+        [Parameter()]
+        [string]
+        $Copyright,
+
+        [Parameter()]
+        [string]
+        $Description,
+
+        [Parameter()]
+        [String[]]
+        $ExternalModuleDependencies,
+
+        [Parameter()]
+        [string[]]
+        $RequiredScripts,
+
+        [Parameter()]
+        [String[]]
+        $ExternalScriptDependencies,
+
+        [Parameter()]
+        [string[]]
+        $Tags,
+
+        [Parameter()]
+        [Uri]
+        $ProjectUri,
+
+        [Parameter()]
+        [Uri]
+        $LicenseUri,
+
+        [Parameter()]
+        [Uri]
+        $IconUri,
+
+        [Parameter()]
+        [string[]]
+        $ReleaseNotes,
+
+		[Parameter()]
+        [string]
+        $PrivateData
+    )
+
+    Process
+    {
+        $PSScriptInfoString = @"
+
+<#PSScriptInfo
+
+.VERSION$(if ($Version) {" $Version"})
+
+.GUID$(if ($Guid) {" $Guid"})
+
+.AUTHOR$(if ($Author) {" $Author"})
+
+.COMPANYNAME$(if ($CompanyName) {" $CompanyName"})
+
+.COPYRIGHT$(if ($Copyright) {" $Copyright"})
+
+.DESCRIPTION$(if ($Description) {" $Description"})
+
+.TAGS$(if ($Tags) {" $Tags"})
+
+.LICENSEURI$(if ($LicenseUri) {" $LicenseUri"})
+
+.PROJECTURI$(if ($ProjectUri) {" $ProjectUri"})
+
+.ICONURI$(if ($IconUri) {" $IconUri"})
+
+.EXTERNALMODULEDEPENDENCIES$(if ($ExternalModuleDependencies) {" $($ExternalModuleDependencies -join ',')"}) 
+
+.REQUIREDSCRIPTS$(if ($RequiredScripts) {" $($RequiredScripts -join ',')"})
+
+.EXTERNALSCRIPTDEPENDENCIES$(if ($ExternalScriptDependencies) {" $($ExternalScriptDependencies -join ',')"})
+
+.RELEASENOTES
+$($ReleaseNotes -join "`r`n")
+
+.PRIVATEDATA$(if ($PrivateData) {" $PrivateData"})
+
+#>
+"@
+        return $PSScriptInfoString
+    }
+}

--- a/test/PSGetTestUtils.psm1
+++ b/test/PSGetTestUtils.psm1
@@ -137,6 +137,7 @@ function RemoveItem
 
 function Create-PSScriptMetadata
 {
+    [OutputType([String])]
     [CmdletBinding(PositionalBinding=$false,
     SupportsShouldProcess=$true)]
 

--- a/test/Pester.PublishResourceTests.ps1
+++ b/test/Pester.PublishResourceTests.ps1
@@ -1,0 +1,97 @@
+# This is a Pester test suite to validate Register-PSResourceRepository, Unregister-PSResourceRepository, Get-PSResourceRepository, and Set-PSResourceRepository.
+#
+# Copyright (c) Microsoft Corporation, 2019
+
+Import-Module "$psscriptroot\PSGetTestUtils.psm1" -WarningAction SilentlyContinue -force
+import-module "C:\code\PowerShellGet\src\bin\Debug\netstandard2.0\publish\PowerShellGet.dll" -force
+
+$PSGalleryName = 'PSGallery'
+$PSGalleryLocation = 'https://www.powershellgallery.com/api/v2'
+
+$TestLocalDirectory = 'TestLocalDirectory'
+$tmpdir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath $TestLocalDirectory
+
+
+
+if (-not (Test-Path -LiteralPath $tmpdir)) {
+    New-Item -Path $tmpdir -ItemType Directory > $null
+}
+Write-Host $tmpdir
+
+
+##########################
+### Publish-PSResource ###
+##########################
+
+
+Describe 'Test Publish-PSResource' -tags 'BVT' {
+
+    BeforeAll {
+
+        Register-PSResourceRepository -Name psgettestlocal -URL "c:\code\testdir"
+
+        # Create temp module to be published
+        $script:TempModulesPath = Join-Path -Path $tmpdir -ChildPath "PSGet_$(Get-Random)"
+        $null = New-Item -Path $script:TempModulesPath -ItemType Directory -Force
+        Write-Host("script:TempModulesPath is: " + $script:TempModulesPath)
+        $script:PublishModuleName = "TestPublishModule"
+        $script:PublishModuleBase = Join-Path $script:TempModulesPath $script:PublishModuleName
+        $null = New-Item -Path $script:PublishModuleBase -ItemType Directory -Force
+        Write-Host("script:TempModulesPath is: " + $script:PublishModuleBase)
+
+    }
+	AfterAll {
+        if($tempdir -and (Test-Path $tempdir))
+        {
+            Remove-Item $tempdir -Force -Recurse -ErrorAction SilentlyContinue
+        }
+    }
+
+    ### Publish a script
+    It 'Should publish a script' {
+
+        $Name = 'TestScriptName'
+        $scriptFilePath = Join-Path -Path $script:TempModulesPath -ChildPath "$Name.ps1"
+        write-host ("scriptFilePath is: " + $scriptFilePath)
+        $null = New-Item -Path $scriptFilePath -ItemType File -Force
+
+        $version = "1.0.0"
+        $params = @{
+                    #Path = $scriptFilePath
+                    Version = $version
+                    #GUID = 
+                    Author = 'Jane'
+                    CompanyName = 'Microsoft Corporation'
+                    Copyright = '(c) 2020 Microsoft Corporation. All rights reserved.'
+                    Description = "Description for the $Name script"
+                    LicenseUri = "https://$Name.com/license"
+                    IconUri = "https://$Name.com/icon"
+                    ProjectUri = "https://$Name.com"
+                    Tags = @('Tag1','Tag2', "Tag-$Name-$version")
+                    ReleaseNotes = "$Name release notes"
+                    }
+    
+
+        $scriptMetadata = Create-PSScriptMetadata @params
+        Set-Content -Path $scriptFilePath -Value $scriptMetadata
+
+        Publish-PSResource -path $scriptFilePath -Repository psgettestlocal
+    }
+
+
+
+
+    It 'Should publish a module' {
+       
+        $PublishModuleBase = Join-Path $script:TempModulesPath $script:PublishModuleName
+
+        $version = "1.0"
+        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"  -NestedModules "$script:PublishModuleName.psm1"
+        write-host ($script:PublishModuleBase)
+
+        Publish-PSResource -path  $script:PublishModuleBase -Repository psgettestlocal
+    }
+
+}
+
+

--- a/test/Pester.PublishResourceTests.ps1
+++ b/test/Pester.PublishResourceTests.ps1
@@ -16,14 +16,11 @@ $tmpdir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath $TestLoca
 if (-not (Test-Path -LiteralPath $tmpdir)) {
     New-Item -Path $tmpdir -ItemType Directory > $null
 }
-Write-Host $tmpdir
 
 
 ##########################
 ### Publish-PSResource ###
 ##########################
-
-
 Describe 'Test Publish-PSResource' -tags 'BVT' {
 
     BeforeAll {
@@ -33,11 +30,10 @@ Describe 'Test Publish-PSResource' -tags 'BVT' {
         # Create temp module to be published
         $script:TempModulesPath = Join-Path -Path $tmpdir -ChildPath "PSGet_$(Get-Random)"
         $null = New-Item -Path $script:TempModulesPath -ItemType Directory -Force
-        Write-Host("script:TempModulesPath is: " + $script:TempModulesPath)
+
         $script:PublishModuleName = "TestPublishModule"
         $script:PublishModuleBase = Join-Path $script:TempModulesPath $script:PublishModuleName
         $null = New-Item -Path $script:PublishModuleBase -ItemType Directory -Force
-        Write-Host("script:TempModulesPath is: " + $script:PublishModuleBase)
 
     }
 	AfterAll {
@@ -48,11 +44,11 @@ Describe 'Test Publish-PSResource' -tags 'BVT' {
     }
 
     ### Publish a script
-    It 'Should publish a script' {
+    It 'Should publish a script'
+    {
 
         $Name = 'TestScriptName'
         $scriptFilePath = Join-Path -Path $script:TempModulesPath -ChildPath "$Name.ps1"
-        write-host ("scriptFilePath is: " + $scriptFilePath)
         $null = New-Item -Path $scriptFilePath -ItemType File -Force
 
         $version = "1.0.0"
@@ -70,7 +66,6 @@ Describe 'Test Publish-PSResource' -tags 'BVT' {
                     Tags = @('Tag1','Tag2', "Tag-$Name-$version")
                     ReleaseNotes = "$Name release notes"
                     }
-    
 
         $scriptMetadata = Create-PSScriptMetadata @params
         Set-Content -Path $scriptFilePath -Value $scriptMetadata
@@ -79,19 +74,15 @@ Describe 'Test Publish-PSResource' -tags 'BVT' {
     }
 
 
-
-
-    It 'Should publish a module' {
-       
+    It 'Should publish a module'
+    {
         $PublishModuleBase = Join-Path $script:TempModulesPath $script:PublishModuleName
 
         $version = "1.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"  -NestedModules "$script:PublishModuleName.psm1"
-        write-host ($script:PublishModuleBase)
 
         Publish-PSResource -path  $script:PublishModuleBase -Repository psgettestlocal
     }
-
 }
 
 


### PR DESCRIPTION
Adding functionality for Publish-PSResource.

FinderHelper class is pulled directly from Find-PSResource.  I'm going to have Find-PSResource call into this class, but am separating out the PRs to make it easier to read through.

**Note**:  FindHelper is a WIP.  I'm primarily seeking out feedback on PublishPSResource, though feedback on the logic within all files is welcome.


Bare bones publish specs in the RFC for reference: [PSGet RFC](https://github.com/SteveL-MSFT/PowerShell-RFC/blob/08bc32943beeaad9b10a67225bb4bcd90867d80d/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md#publishing-resources)