### PR TITLE
Update dependency versions

### DIFF
--- a/src/PowerShellGet.csproj
+++ b/src/PowerShellGet.csproj
@@ -7,21 +7,21 @@
 
   <ItemGroup>
     <PackageReference Include="LinqKit.Core" Version="1.1.17" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.2" />
-    <PackageReference Include="NuGet.Commands" Version="5.6.0-preview.3.6558" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-preview.6.20305.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0-preview.6.20305.6" />
+    <PackageReference Include="NuGet.Commands" Version="5.7.0-rtm.6686" />
     <PackageReference Include="NuGet.Protocol.Catalog" Version="4.2.0-jver-mergemeta-3092366" />
     <PackageReference Include="PowerShellStandard.Library" Version="7.0.0-preview.1" />
-    <PackageReference Include="morelinq" Version="3.2.0" />
-    <PackageReference Include="NuGet.Common" Version="5.6.0-preview.3.6558" />
-    <PackageReference Include="NuGet.Configuration" Version="5.6.0-preview.3.6558" />
-    <PackageReference Include="NuGet.Packaging" Version="5.6.0-preview.3.6558" />
-    <PackageReference Include="NuGet.Protocol" Version="5.6.0-preview.3.6558" />
+    <PackageReference Include="morelinq" Version="3.3.2" />
+    <PackageReference Include="NuGet.Common" Version="5.7.0-rtm.6686" />
+    <PackageReference Include="NuGet.Configuration" Version="5.7.0-rtm.6686" />
+    <PackageReference Include="NuGet.Packaging" Version="5.7.0-rtm.6686" />
+    <PackageReference Include="NuGet.Protocol" Version="5.7.0-rtm.6686" />
     <PackageReference Include="NuGet.Protocol.Core.Types" Version="4.3.0-beta2-2463" />
-    <PackageReference Include="NuGet.Repositories" Version="4.2.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.6.0-preview3.19128.7" />
-    <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.0" />
+    <PackageReference Include="NuGet.Repositories" Version="4.3.0-preview1-3937" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.6.0-preview4.19164.7" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0-preview.6.20305.6" />
+    <PackageReference Include="System.Net.Http" Version="4.4.0-preview1-25218-03" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Updating dependencies to resolve issue with loading assembly when running 'Publish-PSResource':
 ```
Publish-PSResource : Could not load file or assembly 'NuGet.Commands, Version=5.6.0.4,
Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies. The system
cannot find the file specified.
```