### PR TITLE
Install bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ New Feature
 Bug Fixes
 * Improved experience when loading module for diffent frameworks
 * Bug fix for assembly loading error in Publish-PSResource
+* Allow for relative paths when registering psrepository
 * Improved error handling for Install-PSResource and Update-PSResource
 
 ### 3.0.0-beta6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Bug Fixes
 * Bug fix for assembly loading error in Publish-PSResource
 * Allow for relative paths when registering psrepository
 * Improved error handling for Install-PSResource and Update-PSResource
+* Remove prerelease tag from module version directory
+* Fix error getting thrown from paths with incorrectly formatted module versions
 
 ### 3.0.0-beta6
 New Feature 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+### 3.0.0-beta7
+New Feature 
+* Completed functionality for Update-PSResource
+* Input-Object parameter for Install-PSResource
+
+Bug Fixes
+* Improved experience when loading module for diffent frameworks
+* Bug fix for assembly loading error in Publish-PSResource
+* Improved error handling for Install-PSResource and Update-PSResource
+
 ### 3.0.0-beta6
 New Feature 
 * Implement functionality for Publish-PSResource

--- a/PowerShellGet.psd1
+++ b/PowerShellGet.psd1
@@ -24,7 +24,7 @@
     AliasesToExport   = @('inmo', 'fimo', 'upmo', 'pumo')
     PrivateData       = @{
         PSData                                 = @{
-            Prerelease = 'beta6'
+            Prerelease = 'beta7'
             Tags         = @('PackageManagement',
                 'PSEdition_Desktop',
                 'PSEdition_Core',
@@ -34,6 +34,16 @@
             ProjectUri   = 'https://go.microsoft.com/fwlink/?LinkId=828955'
             LicenseUri   = 'https://go.microsoft.com/fwlink/?LinkId=829061'
             ReleaseNotes = @'
+### 3.0.0-beta7
+New Feature 
+* Completed functionality for Update-PSResource
+* Input-Object parameter for Install-PSResource
+
+Bug Fixes
+* Improved experience when loading module for diffent frameworks
+* Bug fix for assembly loading error in Publish-PSResource
+* Improved error handling for Install-PSResource and Update-PSResource
+
 ### 3.0.0-beta6
 New Feature 
 * Implement functionality for Publish-PSResource

--- a/PowerShellGet.psd1
+++ b/PowerShellGet.psd1
@@ -44,6 +44,8 @@ Bug Fixes
 * Bug fix for assembly loading error in Publish-PSResource
 * Allow for relative paths when registering psrepository
 * Improved error handling for Install-PSResource and Update-PSResource
+* Remove prerelease tag from module version directory
+* Fix error getting thrown from paths with incorrectly formatted module versions
 
 ### 3.0.0-beta6
 New Feature 

--- a/PowerShellGet.psd1
+++ b/PowerShellGet.psd1
@@ -42,6 +42,7 @@ New Feature
 Bug Fixes
 * Improved experience when loading module for diffent frameworks
 * Bug fix for assembly loading error in Publish-PSResource
+* Allow for relative paths when registering psrepository
 * Improved error handling for Install-PSResource and Update-PSResource
 
 ### 3.0.0-beta6

--- a/src/InstallPSResource.cs
+++ b/src/InstallPSResource.cs
@@ -242,7 +242,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             CancellationToken cancellationToken = source.Token;
 
             // If PSModuleInfo object 
-            if (_inputObject[0] != null && _inputObject[0].GetType().Name.Equals("PSModuleInfo"))
+            if (_inputObject != null && _inputObject[0].GetType().Name.Equals("PSModuleInfo"))
             {
                 foreach (PSModuleInfo pkg in _inputObject)
                 {
@@ -266,7 +266,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     installHelp.ProcessInstallParams(new[] { pkg.Name }, pkg.Version.ToString(), prerelease, _repository, _scope, _acceptLicense, _quiet, _reinstall, _force: false, _trustRepository, _noClobber, _credential, _requiredResourceFile, _requiredResourceJson, _requiredResourceHash);
                 }
             }
-            else if (_inputObject[0].GetType().Name.Equals("PSObject"))
+            else if (_inputObject != null && _inputObject[0].GetType().Name.Equals("PSObject"))
             {
                 // If PSObject 
                 foreach (PSObject pkg in _inputObject)


### PR DESCRIPTION
- Fix bug with InputObject
- Remove prerelease tag from module version directory
- Ignore and silently continue instead of throwing error for paths with incorrectly formatted module versions 
- Update changelog