### PR TITLE
Bug fixes in install, uninstall, and get

### DIFF
--- a/src/InstallPSResource.cs
+++ b/src/InstallPSResource.cs
@@ -54,6 +54,21 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         private object[] _inputObject;
 
         /// <summary>
+        /// Specifies to allow installation of prerelease versions
+        /// </summary>
+        [Parameter(ParameterSetName = "NameParameterSet")]
+        [Parameter(ParameterSetName = "RequiredResourceFileParameterSet")]
+        public string[] Type
+        {
+            get
+            { return _type; }
+
+            set
+            { _type = value; }
+        }
+        private string[] _type;
+
+        /// <summary>
         /// Specifies the version or version range of the package to be installed
         /// </summary>
         [Parameter(ParameterSetName = "NameParameterSet")]

--- a/src/PowerShellGet.csproj
+++ b/src/PowerShellGet.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="LinqKit.Core" Version="1.1.17" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-preview.7.20364.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0-preview.7.20364.11" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="3.1.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="NuGet.Commands" Version="5.7.0-rtm.6702" />
     <PackageReference Include="NuGet.Common" Version="5.7.0-rtm.6702" />
@@ -22,7 +23,6 @@
     <PackageReference Include="PowerShellStandard.Library" Version="7.0.0-preview.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.6.0-preview3.19128.7" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0-preview.7.20364.11" Condition="'$(TargetFramework)' == 'net472'" />
   </ItemGroup>
 
 


### PR DESCRIPTION
- Fix bug with retrieving installed scripts in Get-PSResource
- Fix bug with AllUsers scope in Windows in Install-PSResource 
- Fix bug with Uninstall-PSResource sometimes not fully uninstalling
- Change installed file paths to contain original version number instead of normalized version 

- Add Type parameter to Install-PSResource
- Add 'sudo' check for admin privileges in Unix in Install-PSResource
