### PR TITLE
Fix cast error

### DIFF
--- a/PowerShellGet.psd1
+++ b/PowerShellGet.psd1
@@ -24,7 +24,7 @@
     AliasesToExport   = @('inmo', 'fimo', 'upmo', 'pumo')
     PrivateData       = @{
         PSData                                 = @{
-            Prerelease = 'beta8'
+            Prerelease = 'beta08'
             Tags         = @('PackageManagement',
                 'PSEdition_Desktop',
                 'PSEdition_Core',

--- a/PowerShellGet.psd1
+++ b/PowerShellGet.psd1
@@ -24,7 +24,7 @@
     AliasesToExport   = @('inmo', 'fimo', 'upmo', 'pumo')
     PrivateData       = @{
         PSData                                 = @{
-            Prerelease = 'beta08'
+            Prerelease = 'beta8'
             Tags         = @('PackageManagement',
                 'PSEdition_Desktop',
                 'PSEdition_Core',

--- a/src/PublishPSResource.cs
+++ b/src/PublishPSResource.cs
@@ -465,7 +465,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             System.Management.Automation.Language.Token[] tokens;
             ParseError[] errors;
-            var ast = Parser.ParseFile(moduleFileInfo.FullName, out tokens, out errors);
+            var ast = Parser.ParseFile(moduleFilePath, out tokens, out errors);
             if (errors.Length == 0)
             {
                 var data = ast.Find(a => a is HashtableAst, false);


### PR DESCRIPTION
This fix attempts to address issue #220 by detecting a returned array and unwrapping it.  It might be better to use LanguagePrimitives.ConvertTo(), but it is not clear to me it will do the unwrapping.  But I will try that in a different PR.