### PR TITLE
Publish bug fix

### DIFF
--- a/PowerShellGet.psd1
+++ b/PowerShellGet.psd1
@@ -24,7 +24,7 @@
     AliasesToExport   = @('inmo', 'fimo', 'upmo', 'pumo')
     PrivateData       = @{
         PSData                                 = @{
-            Prerelease = 'beta8'
+            Prerelease = 'beta08'
             Tags         = @('PackageManagement',
                 'PSEdition_Desktop',
                 'PSEdition_Core',

--- a/PowerShellGet.psd1
+++ b/PowerShellGet.psd1
@@ -24,7 +24,7 @@
     AliasesToExport   = @('inmo', 'fimo', 'upmo', 'pumo')
     PrivateData       = @{
         PSData                                 = @{
-            Prerelease = 'beta08'
+            Prerelease = 'beta8'
             Tags         = @('PackageManagement',
                 'PSEdition_Desktop',
                 'PSEdition_Core',

--- a/src/PowerShellGet.csproj
+++ b/src/PowerShellGet.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="NuGet.Packaging" Version="5.7.0-rtm.6702" />
     <PackageReference Include="NuGet.ProjectModel" Version="5.7.0-rtm.6702" />
     <PackageReference Include="NuGet.Protocol" Version="5.7.0-rtm.6702" />
-    <PackageReference Include="NuGet.Protocol.Core.Types" Version="4.3.0-beta2-2463" />
+    <PackageReference Include="NuGet.Protocol.Core.Types" Version="4.3.0-beta1-2418" />
     <PackageReference Include="NuGet.Repositories" Version="4.3.0-beta1-2418" />
     <PackageReference Include="PowerShellStandard.Library" Version="7.0.0-preview.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.6.0-preview3.19128.7" />


### PR DESCRIPTION
-  Fix bug related to error thrown when 'RequiredModules' in .psd1 is parsed as an object array instead of hashtable (see: issue #220 )
- Add error handling for when repository a resource is attempting to publish to does not exist