### PR TITLE
Second attempt to fix required modules parsing cast error

### DIFF
--- a/src/PublishPSResource.cs
+++ b/src/PublishPSResource.cs
@@ -658,7 +658,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             //  c. A single hash table of module name and version
             //  d. An array of hash tables of module name and version
 
-            if (LanguagePrimitives.TryConvertTo<string>(requiredModules, out moduleName))
+            if (LanguagePrimitives.TryConvertTo<string>(requiredModules, out string moduleName))
             {
                 return new Hashtable[] {
                     new Hashtable() {
@@ -668,14 +668,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 };
             }
 
-            if (LanguagePrimitives.TryConvertTo<string[]>(requiredModules, out moduleNames))
+            if (LanguagePrimitives.TryConvertTo<string[]>(requiredModules, out string[] moduleNames))
             {
                 var listHashtable = new List<Hashtable>();
-                foreach (var moduleName in moduleNames)
+                foreach (var modName in moduleNames)
                 {
                     listHashtable.Add(
                         new Hashtable() {
-                            { "ModuleName", moduleName },
+                            { "ModuleName", modName },
                             { "ModuleVersion", string.Empty }
                         });
                 }
@@ -683,12 +683,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 return listHashtable.ToArray();
             }
 
-            if (LanguagePrimitives.TryConvertTo<Hashtable>(requiredModules, out module))
+            if (LanguagePrimitives.TryConvertTo<Hashtable>(requiredModules, out Hashtable module))
             {
-                return module;
+                return new Hashtable[] {
+                    module
+                };
             }
 
-            if (LanguagePrimitives.TryConvertTo<Hashtable[]>(requiredModules, out moduleList))
+            if (LanguagePrimitives.TryConvertTo<Hashtable[]>(requiredModules, out Hashtable[] moduleList))
             {
                 return moduleList;
             }

--- a/src/PublishPSResource.cs
+++ b/src/PublishPSResource.cs
@@ -653,19 +653,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             var requiredModules = parsedMetadataHash["requiredmodules"];
         
             // Required modules can be:
-            //  a. A single string module name
-            //  b. A string array of module names
-            //  c. A single hash table of module name and version
-            //  d. An array of hash tables of module name and version
+            //  a. An array of hash tables of module name and version
+            //  b. A single hash table of module name and version
+            //  c. A string array of module names
+            //  d. A single string module name
 
-            if (LanguagePrimitives.TryConvertTo<string>(requiredModules, out string moduleName))
+            if (LanguagePrimitives.TryConvertTo<Hashtable[]>(requiredModules, out Hashtable[] moduleList))
             {
-                return new Hashtable[] {
-                    new Hashtable() {
-                        { "ModuleName", moduleName },
-                        { "ModuleVersion", string.Empty }
-                    }
-                };
+                return moduleList;
             }
 
             if (LanguagePrimitives.TryConvertTo<string[]>(requiredModules, out string[] moduleNames))
@@ -683,21 +678,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 return listHashtable.ToArray();
             }
 
-            if (LanguagePrimitives.TryConvertTo<Hashtable>(requiredModules, out Hashtable module))
-            {
-                return new Hashtable[] {
-                    module
-                };
-            }
-
-            if (LanguagePrimitives.TryConvertTo<Hashtable[]>(requiredModules, out Hashtable[] moduleList))
-            {
-                return moduleList;
-            }
-
             return null;
         }
-
 
         private void ParseScriptMetadata(Hashtable parsedMetadataHash, FileInfo moduleFileInfo)
         {


### PR DESCRIPTION
This uses LanguagePrimitives.TryConverTo() to convert the 'RequiredModules' element into one of four expected types.