### PR TITLE
Fix for package pathname one off error

### DIFF
--- a/src/PublishPSResource.cs
+++ b/src/PublishPSResource.cs
@@ -415,12 +415,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 // Create subdirectory structure in temp folder
                 foreach (string dir in System.IO.Directory.GetDirectories(_path, "*", System.IO.SearchOption.AllDirectories))
                 {
-                    System.IO.Directory.CreateDirectory(System.IO.Path.Combine(outputDir, dir.Substring(_path.Length + 1)));
+                    System.IO.Directory.CreateDirectory(System.IO.Path.Combine(outputDir, dir.Substring(_path.Length)));
                 }
                 // Copy files over to temp folder
                 foreach (string file_name in System.IO.Directory.GetFiles(_path, "*", System.IO.SearchOption.AllDirectories))
                 {
-                    System.IO.File.Copy(file_name, System.IO.Path.Combine(outputDir, file_name.Substring(_path.Length + 1)));
+                    System.IO.File.Copy(file_name, System.IO.Path.Combine(outputDir, file_name.Substring(_path.Length)));
                 }
             }
 


### PR DESCRIPTION
Package file names had their first character missing.  Fix simple one off error in copy.