### PR TITLE
Addressing range of open issues 

### DIFF
--- a/PSModule.psm1
+++ b/PSModule.psm1
@@ -35,10 +35,3 @@ if (Test-Path $FrameworkToRemovePath)
 
 # NOW LOAD THE APPROPRIATE ASSEMBLY
 $ImportedPSGetModule = Import-Module -Name $pathToAssembly -PassThru
-
-if($ImportedPSGetModule)
-{
-    $script:PSModule.OnRemove = {
-        Remove-Module -ModuleInfo $ImportedPSGetModule
-    }
-}

--- a/src/FindPSResource.cs
+++ b/src/FindPSResource.cs
@@ -236,7 +236,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                         PSObject pkgAsPSObject = new PSObject();
                         pkgAsPSObject.Members.Add(new PSNoteProperty("Name", pkg.Identity.Id));
-                        pkgAsPSObject.Members.Add(new PSNoteProperty("Version", pkg.Identity.Version));
+                        // Version.Version ensures type is System.Version instead of type NuGetVersion
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Version", pkg.Identity.Version.Version));
                         pkgAsPSObject.Members.Add(new PSNoteProperty("Repository", repoName.Properties["Name"].Value.ToString()));
                         pkgAsPSObject.Members.Add(new PSNoteProperty("Description", pkg.Description));
 

--- a/src/GetHelper.cs
+++ b/src/GetHelper.cs
@@ -84,15 +84,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 cmdletPassedIn.WriteDebug(string.Format("All users scope path: '{0}'", programFilesPath));
 
                 /*** Will search first in PSModulePath, then will search in default paths ***/
-                try
+
+                foreach (var modulePath in modulePaths)
                 {
-                    foreach (var modulePath in modulePaths)
-                    {
-                        dirsToSearch.AddRange(Directory.GetDirectories(modulePath).ToList());
-                    }
-                    cmdletPassedIn.WriteDebug(string.Format("PSModulePath directories: '{0}'", dirsToSearch.ToString()));
+                    dirsToSearch.AddRange(Directory.GetDirectories(modulePath).ToList());
                 }
-                catch { }
+
 
                 var pfModulesPath = System.IO.Path.Combine(programFilesPath, "Modules");
                 if (Directory.Exists(pfModulesPath))
@@ -137,19 +134,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 Array.ForEach(name, n => nameLowerCased.Add(n.ToLower()));
                 Array.ForEach(name, n => scriptXMLnames.Add((n + "_InstalledScriptInfo.xml").ToLower()));
 
-                /* 
-                foreach (var name in nameLowerCased)
-                {
-                    cmdletPassedIn.WriteDebug(string.Format("Name in nameLowerCased: '{0}'", name));
-                }
-                
-
-
-                foreach (var dir in dirsToSearch)
-                {
-                    cmdletPassedIn.WriteDebug((System.IO.Path.GetFileNameWithoutExtension(dir)).ToLower());
-                }
-                */
                 dirsToSearch = dirsToSearch.FindAll(p => (nameLowerCased.Contains(new DirectoryInfo(p).Name.ToLower())
                     || scriptXMLnames.Contains((System.IO.Path.GetFileName(p)).ToLower())));
 
@@ -182,8 +166,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             List<string> installedPkgsToReturn = new List<string>();
 
             IEnumerable<string> returnPkgs = null;
-            var versionDirs = new List<string>();
-
 
             //2) use above list to check 
             // if the version specificed is a version range
@@ -240,7 +222,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
             else
             {
-                cmdletPassedIn.WriteDebug(string.Format("No version provided-- check each path for the requested package"));
+                cmdletPassedIn.WriteDebug("No version provided-- check each path for the requested package");
                 // if no version is specified, just get the latest version
                 foreach (var pkgPath in dirsToSearch)
                 {
@@ -279,18 +261,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
 
             // Flatten returned pkgs before displaying output returnedPkgsFound.Flatten().ToList()[0]
-            // update this
             var flattenedPkgs = installedPkgsToReturn.Flatten();
-
-            //  return flattenedPkgs;
-
-
-
 
 
 
             List<PSObject> foundInstalledPkgs = new List<PSObject>();
-
 
             foreach (string xmlFilePath in flattenedPkgs)
             {
@@ -323,7 +298,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     ReadOnlyPSMemberInfoCollection<PSPropertyInfo> installedLocationInfo;
 
 
-                    var isPrelease = false;
+                    //var isPrelease = false;
                     using (StreamReader sr = new StreamReader(xmlFilePath))
                     {
 
@@ -345,42 +320,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         iconUriInfo = deserializedObj.Properties.Match("IconUri");
                         tagsInfo = deserializedObj.Properties.Match("Tags");
                         includesInfo = deserializedObj.Properties.Match("Includes");
-
-                       // var types = includesInfo.FirstOrDefault().Value;
-                        foreach (var type in includesInfo) 
-                        {
-                            Console.WriteLine(type + "\n");
-
-                            PSObject psObj = (PSObject)type.Value;
-
-                            //var dscResource = psObj.Properties.Match("DscResource");
-
-                            ArrayList baseObj = (ArrayList)psObj.ImmediateBaseObject;
-
-
-
-                            foreach (PSObject item in baseObj)
-                            {
-                                Console.WriteLine("YES1");
-
-                            }
-
-
-                            var deserializedObj2 = PSSerializer.DeserializeAsList(text);
-                            foreach (PSObject item2 in deserializedObj2)
-                            {
-                                Console.WriteLine("YES1");
-
-                            }
-
-
-
-                            if (type.Name.Equals("DSCResources"))
-                            {
-                                Console.WriteLine("YES");
-                            }
-                        }
-
                         powerShellGetFormatVersionInfo = deserializedObj.Properties.Match("PowerShellGetFormatVersion");
                         releaseNotesInfo = deserializedObj.Properties.Match("ReleaseNotes");
                         dependenciesInfo = deserializedObj.Properties.Match("Dependencies");

--- a/src/GetHelper.cs
+++ b/src/GetHelper.cs
@@ -1,0 +1,453 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using static System.Environment;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using System.Net;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Threading;
+using Microsoft.PowerShell.PowerShellGet.RepositorySettings;
+using MoreLinq.Extensions;
+using Newtonsoft.Json;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
+{
+    /// <summary>
+    /// Find helper class
+    /// </summary>
+    class GetHelper : PSCmdlet
+    {
+        private CancellationToken cancellationToken;
+        private readonly bool update;
+        private readonly PSCmdlet cmdletPassedIn;
+
+
+        public static readonly string OsPlatform = System.Runtime.InteropServices.RuntimeInformation.OSDescription;
+
+        private string programFilesPath;
+        private string myDocumentsPath;
+
+        public GetHelper(CancellationToken cancellationToken, PSCmdlet cmdletPassedIn)
+        {
+            this.cancellationToken = cancellationToken;
+            this.cmdletPassedIn = cmdletPassedIn;
+        }
+
+        public List<PSObject> ProcessGetParams(string[] name, string version, bool prerelease, string path)
+        {
+            var dirsToSearch = new List<string>();
+
+            if (path != null)
+            {
+                cmdletPassedIn.WriteDebug(string.Format("Provided path is: '{0}'", path));
+                dirsToSearch.AddRange(Directory.GetDirectories(path).ToList());
+            }
+            else
+            {
+                // PSModules path
+                var psModulePath = Environment.GetEnvironmentVariable("PSModulePath");
+                var modulePaths = psModulePath.Split(';');
+
+
+#if NET472
+                programFilesPath = System.IO.Path.Combine(Environment.GetFolderPath(SpecialFolder.ProgramFiles), "WindowsPowerShell");
+                myDocumentsPath = System.IO.Path.Combine(Environment.GetFolderPath(SpecialFolder.MyDocuments), "WindowsPowerShell");
+
+#else
+                // If PS6+ on Windows
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    myDocumentsPath = System.IO.Path.Combine(Environment.GetFolderPath(SpecialFolder.MyDocuments), "PowerShell");
+                    programFilesPath = System.IO.Path.Combine(Environment.GetFolderPath(SpecialFolder.ProgramFiles), "PowerShell");
+                }
+                else
+                {
+                    // Paths are the same for both Linux and MacOS
+                    myDocumentsPath = System.IO.Path.Combine(Environment.GetFolderPath(SpecialFolder.LocalApplicationData), "powershell");
+                    programFilesPath = System.IO.Path.Combine("/usr", "local", "share", "powershell");
+                }
+#endif
+                cmdletPassedIn.WriteDebug(string.Format("Current user scope path: '{0}'", myDocumentsPath));
+                cmdletPassedIn.WriteDebug(string.Format("All users scope path: '{0}'", programFilesPath));
+
+                /*** Will search first in PSModulePath, then will search in default paths ***/
+                try
+                {
+                    foreach (var modulePath in modulePaths)
+                    {
+                        dirsToSearch.AddRange(Directory.GetDirectories(modulePath).ToList());
+                    }
+                    cmdletPassedIn.WriteDebug(string.Format("PSModulePath directories: '{0}'", dirsToSearch.ToString()));
+                }
+                catch { }
+
+                var pfModulesPath = System.IO.Path.Combine(programFilesPath, "Modules");
+                if (Directory.Exists(pfModulesPath))
+                {
+                    dirsToSearch.AddRange(Directory.GetDirectories(pfModulesPath).ToList());
+                }
+
+                var mdModulesPath = System.IO.Path.Combine(myDocumentsPath, "Modules");
+                if (Directory.Exists(mdModulesPath))
+                {
+                    dirsToSearch.AddRange(Directory.GetDirectories(mdModulesPath).ToList());
+                }
+
+
+                var pfScriptsPath = System.IO.Path.Combine(programFilesPath, "Scripts", "InstalledScriptInfos");
+                if (Directory.Exists(pfScriptsPath))
+                {
+                    dirsToSearch.AddRange(Directory.GetFiles(pfScriptsPath).ToList());
+                }
+
+                var mdScriptsPath = System.IO.Path.Combine(myDocumentsPath, "Scripts", "InstalledScriptInfos");
+                if (Directory.Exists(mdScriptsPath))
+                {
+                    dirsToSearch.AddRange(Directory.GetFiles(mdScriptsPath).ToList());
+                }
+
+
+                // uniqueify 
+                dirsToSearch = dirsToSearch.Distinct().ToList();
+            }
+
+            foreach (var dir in dirsToSearch)
+            {
+                cmdletPassedIn.WriteDebug(string.Format("All directories to search: '{0}'", dir));
+            }
+
+            // Or a list of the passed in names
+            if (name != null && !name[0].Equals("*"))
+            {
+                var nameLowerCased = new List<string>();
+                var scriptXMLnames = new List<string>();
+                Array.ForEach(name, n => nameLowerCased.Add(n.ToLower()));
+                Array.ForEach(name, n => scriptXMLnames.Add((n + "_InstalledScriptInfo.xml").ToLower()));
+
+                /* 
+                foreach (var name in nameLowerCased)
+                {
+                    cmdletPassedIn.WriteDebug(string.Format("Name in nameLowerCased: '{0}'", name));
+                }
+                
+
+
+                foreach (var dir in dirsToSearch)
+                {
+                    cmdletPassedIn.WriteDebug((System.IO.Path.GetFileNameWithoutExtension(dir)).ToLower());
+                }
+                */
+                dirsToSearch = dirsToSearch.FindAll(p => (nameLowerCased.Contains(new DirectoryInfo(p).Name.ToLower())
+                    || scriptXMLnames.Contains((System.IO.Path.GetFileName(p)).ToLower())));
+
+                cmdletPassedIn.WriteDebug(dirsToSearch.Any().ToString());
+            }
+
+            // try to parse into a specific NuGet version
+            VersionRange versionRange = null;
+            if (version != null)
+            {
+                NuGetVersion specificVersion;
+                NuGetVersion.TryParse(version, out specificVersion);
+
+                if (specificVersion != null)
+                {
+                    // exact version
+                    versionRange = new VersionRange(specificVersion, true, specificVersion, true, null, null);
+                    cmdletPassedIn.WriteDebug(string.Format("A specific version, '{0}', is specified", versionRange.ToString()));
+
+                }
+                else
+                {
+                    // check if version range
+                    versionRange = VersionRange.Parse(version);
+                    cmdletPassedIn.WriteDebug(string.Format("A version range, '{0}', is specified", versionRange.ToString()));
+
+                }
+            }
+
+            List<string> installedPkgsToReturn = new List<string>();
+
+            IEnumerable<string> returnPkgs = null;
+            var versionDirs = new List<string>();
+
+
+            //2) use above list to check 
+            // if the version specificed is a version range
+            if (versionRange != null)
+            {
+                foreach (var pkgPath in dirsToSearch)
+                {
+                    cmdletPassedIn.WriteDebug(string.Format("Searching through package path: '{0}'", pkgPath));
+                    var versionsDirs = Directory.GetDirectories(pkgPath);
+
+                    foreach (var versionPath in versionsDirs)
+                    {
+                        cmdletPassedIn.WriteDebug(string.Format("Searching through package version path: '{0}'", versionPath));
+                        NuGetVersion dirAsNugetVersion;
+                        var dirInfo = new DirectoryInfo(versionPath);
+                        NuGetVersion.TryParse(dirInfo.Name, out dirAsNugetVersion);
+                        cmdletPassedIn.WriteDebug(string.Format("Directory parsed as NuGet version: '{0}'", dirAsNugetVersion));
+
+                        if (versionRange.Satisfies(dirAsNugetVersion))
+                        {
+                            // just search scripts paths
+                            if (pkgPath.ToLower().Contains("Scripts"))
+                            {
+                                if (File.Exists(pkgPath))
+                                {
+                                    installedPkgsToReturn.Add(pkgPath);
+                                }
+                            }
+                            else
+                            {
+                                // modules paths
+                                versionsDirs = Directory.GetDirectories(pkgPath);
+                                cmdletPassedIn.WriteDebug(string.Format("Getting sub directories from : '{0}'", pkgPath));
+
+                                // Check if the pkg path actually has version sub directories.
+                                if (versionsDirs.Length != 0)
+                                {
+                                    Array.Sort(versionsDirs, StringComparer.OrdinalIgnoreCase);
+                                    Array.Reverse(versionsDirs);
+
+                                    var pkgXmlFilePath = System.IO.Path.Combine(versionsDirs.First(), "PSGetModuleInfo.xml");
+
+                                    // TODO:  check if this xml file exists, if it doesn't check if it exists in a previous version
+                                    cmdletPassedIn.WriteDebug(string.Format("Found module XML: '{0}'", pkgXmlFilePath));
+
+                                    installedPkgsToReturn.Add(pkgXmlFilePath);
+                                }
+                            }
+
+                            installedPkgsToReturn.Add(versionPath);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                cmdletPassedIn.WriteDebug(string.Format("No version provided-- check each path for the requested package"));
+                // if no version is specified, just get the latest version
+                foreach (var pkgPath in dirsToSearch)
+                {
+                    cmdletPassedIn.WriteDebug(string.Format("Searching through package path: '{0}'", pkgPath));
+
+                    // just search scripts paths
+                    if (pkgPath.ToLower().Contains("scripts"))
+                    {
+                        if (File.Exists(pkgPath))   //check to make sure properly formatted
+                        {
+                            installedPkgsToReturn.Add(pkgPath);
+                        }
+                    }
+                    else
+                    {
+                        // modules paths
+                        string[] versionsDirs = new string[0];
+
+                        versionsDirs = Directory.GetDirectories(pkgPath);
+
+                        // Check if the pkg path actually has version sub directories.
+                        if (versionsDirs.Length != 0)
+                        {
+                            Array.Sort(versionsDirs, StringComparer.OrdinalIgnoreCase);
+                            Array.Reverse(versionsDirs);
+
+                            var pkgXmlFilePath = System.IO.Path.Combine(versionsDirs.First(), "PSGetModuleInfo.xml");
+
+                            // TODO:  check if this xml file exists, if it doesn't check if it exists in a previous version
+                            cmdletPassedIn.WriteDebug(string.Format("Found package XML: '{0}'", pkgXmlFilePath));
+                            installedPkgsToReturn.Add(pkgXmlFilePath);
+                        }
+                    }
+                }
+            }
+
+
+            // Flatten returned pkgs before displaying output returnedPkgsFound.Flatten().ToList()[0]
+            // update this
+            var flattenedPkgs = installedPkgsToReturn.Flatten();
+
+            //  return flattenedPkgs;
+
+
+
+
+
+
+            List<PSObject> foundInstalledPkgs = new List<PSObject>();
+
+
+            foreach (string xmlFilePath in flattenedPkgs)
+            {
+                cmdletPassedIn.WriteDebug(string.Format("Reading package metadata from: '{0}'", xmlFilePath));
+
+                // Open xml and read metadata from it     
+                if (File.Exists(xmlFilePath))
+                {
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> nameInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> versionInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> typeInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> descriptionInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> authorInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> companyNameInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> copyrightInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> publishedDateInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> installedDateInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> updatedDateInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> licenseUriInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> projectUriInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> iconUriInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> tagsInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> includesInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> powerShellGetFormatVersionInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> releaseNotesInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> dependenciesInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> repositorySourceLocationInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> repositoryInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> additionalMetadataInfo;
+                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> installedLocationInfo;
+
+
+                    var isPrelease = false;
+                    using (StreamReader sr = new StreamReader(xmlFilePath))
+                    {
+
+                        string text = sr.ReadToEnd();
+                        var deserializedObj = (PSObject)PSSerializer.Deserialize(text);
+
+                        nameInfo = deserializedObj.Properties.Match("Name");
+                        versionInfo = deserializedObj.Properties.Match("Version");
+                        typeInfo = deserializedObj.Properties.Match("Type");
+                        descriptionInfo = deserializedObj.Properties.Match("Description");
+                        authorInfo = deserializedObj.Properties.Match("Author");
+                        companyNameInfo = deserializedObj.Properties.Match("CompanyName");
+                        copyrightInfo = deserializedObj.Properties.Match("Copyright");
+                        publishedDateInfo = deserializedObj.Properties.Match("PublishedDate");
+                        installedDateInfo = deserializedObj.Properties.Match("InstalledDate");
+                        updatedDateInfo = deserializedObj.Properties.Match("UpdatedDate");
+                        licenseUriInfo = deserializedObj.Properties.Match("LicenseUri");
+                        projectUriInfo = deserializedObj.Properties.Match("ProjectUri");
+                        iconUriInfo = deserializedObj.Properties.Match("IconUri");
+                        tagsInfo = deserializedObj.Properties.Match("Tags");
+                        includesInfo = deserializedObj.Properties.Match("Includes");
+
+                       // var types = includesInfo.FirstOrDefault().Value;
+                        foreach (var type in includesInfo) 
+                        {
+                            Console.WriteLine(type + "\n");
+
+                            PSObject psObj = (PSObject)type.Value;
+
+                            //var dscResource = psObj.Properties.Match("DscResource");
+
+                            ArrayList baseObj = (ArrayList)psObj.ImmediateBaseObject;
+
+
+
+                            foreach (PSObject item in baseObj)
+                            {
+                                Console.WriteLine("YES1");
+
+                            }
+
+
+                            var deserializedObj2 = PSSerializer.DeserializeAsList(text);
+                            foreach (PSObject item2 in deserializedObj2)
+                            {
+                                Console.WriteLine("YES1");
+
+                            }
+
+
+
+                            if (type.Name.Equals("DSCResources"))
+                            {
+                                Console.WriteLine("YES");
+                            }
+                        }
+
+                        powerShellGetFormatVersionInfo = deserializedObj.Properties.Match("PowerShellGetFormatVersion");
+                        releaseNotesInfo = deserializedObj.Properties.Match("ReleaseNotes");
+                        dependenciesInfo = deserializedObj.Properties.Match("Dependencies");
+                        repositorySourceLocationInfo = deserializedObj.Properties.Match("RepositorySourceLocation");
+                        repositoryInfo = deserializedObj.Properties.Match("Repository");
+                        additionalMetadataInfo = deserializedObj.Properties.Match("AdditionalMetadata");
+                        installedLocationInfo = deserializedObj.Properties.Match("InstalledLocation");
+
+
+                        /* // testing adding prerelease parameter
+                        additionalMetadataInfo = deserializedObj.Properties.Match("AdditionalMetadata");
+                        if (additionalMetadataInfo.Any())
+                        {
+                            isPrelease = additionalMetadataInfo.FirstOrDefault().Value.ToString().Contains("IsPrerelease=true");
+                            if ((isPrelease == true) && _prerelease) // find a stable version of the pkg {}
+                        }
+                        */
+
+
+                    };
+
+                    // if -Prerelease is not passed in as a parameter, don't allow prerelease pkgs to be returned,
+                    // we still want all pkgs to be returned if -Prerelease is passed in as a param
+                    //if ((_prerelease == false && isPrelease == false) || _prerelease == true)
+                    //{
+
+                    //var foundPkgs = List<PSObject>();
+                    
+                    PSObject pkgAsPSObject = new PSObject();
+                    try
+                    {
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Name", nameInfo.Any()? nameInfo.FirstOrDefault().Value : string.Empty)); 
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Version", versionInfo.Any()? versionInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Type", typeInfo.Any()? typeInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Description", descriptionInfo.Any()? descriptionInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Author", authorInfo.Any()? authorInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("CompanyName", companyNameInfo.Any()? companyNameInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Copyright", copyrightInfo.Any()? copyrightInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("PublishedDate", publishedDateInfo.Any()? publishedDateInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("InstalledDate", installedDateInfo.Any()? installedDateInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("UpdatedDate", updatedDateInfo.Any()? updatedDateInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("LicenseUri", licenseUriInfo.Any()? licenseUriInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("ProjectUri", projectUriInfo.Any()? projectUriInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("IconUri", iconUriInfo.Any()? iconUriInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Tags", tagsInfo.Any()? tagsInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Includes", includesInfo.Any()? includesInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("PowerShellGetFormatVersion", powerShellGetFormatVersionInfo.Any()? powerShellGetFormatVersionInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("ReleaseNotes", releaseNotesInfo.Any()? releaseNotesInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Dependencies", dependenciesInfo.Any()? dependenciesInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("RepositorySourceLocation", repositorySourceLocationInfo.Any()? repositorySourceLocationInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("Repository", repositoryInfo.Any()? repositoryInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("AdditionalMetadata", additionalMetadataInfo.Any()? additionalMetadataInfo.FirstOrDefault().Value : string.Empty));
+                        pkgAsPSObject.Members.Add(new PSNoteProperty("InstalledLocation", installedLocationInfo.Any()? installedLocationInfo.FirstOrDefault().Value : string.Empty));
+
+
+                        // verify that this works, then add the object to a list and return it
+                        //WriteObject(pkgAsPSObject);
+                        foundInstalledPkgs.Add(pkgAsPSObject);
+
+                    }
+                    catch { }
+                    
+                }
+            }
+
+            // return here 
+            return foundInstalledPkgs;
+        }
+    }
+}

--- a/src/GetPSResource.cs
+++ b/src/GetPSResource.cs
@@ -96,8 +96,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void ProcessRecord()
         {
-            WriteDebug("Entering GetPSResource");
+            // Define the cancellation token.
+            CancellationTokenSource source = new CancellationTokenSource();
+            CancellationToken cancellationToken = source.Token;
 
+            WriteDebug("Entering GetPSResource");
 
             // Flatten returned pkgs before displaying output returnedPkgsFound.Flatten().ToList()[0]
             GetHelper getHelper = new GetHelper(cancellationToken, this);

--- a/src/GetPSResource.cs
+++ b/src/GetPSResource.cs
@@ -10,6 +10,7 @@ using System.Management.Automation;
 using static System.Environment;
 using MoreLinq;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 {
@@ -87,7 +88,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         */
 
         public static readonly string OsPlatform = System.Runtime.InteropServices.RuntimeInformation.OSDescription;
-      
+        private CancellationToken cancellationToken;
+        private readonly PSCmdlet cmdletPassedIn;
         private string programFilesPath;
         private string myDocumentsPath;
 
@@ -95,294 +97,16 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         protected override void ProcessRecord()
         {
             WriteDebug("Entering GetPSResource");
-            var dirsToSearch = new List<string>();
-
-            if (_path != null)
-            {
-                WriteDebug(string.Format("Provided path is: '{0}'", _path));
-                dirsToSearch.AddRange(Directory.GetDirectories(_path).ToList());
-            }
-            else
-            { 
-                var isWindows = OsPlatform.ToLower().Contains("windows");
-
-                // PSModules path
-                var psModulePath = Environment.GetEnvironmentVariable("PSModulePath");
-                var modulePaths = psModulePath.Split(';');
-
-
-#if NET472
-                programFilesPath = System.IO.Path.Combine(Environment.GetFolderPath(SpecialFolder.ProgramFiles), "WindowsPowerShell");
-                myDocumentsPath = System.IO.Path.Combine(Environment.GetFolderPath(SpecialFolder.MyDocuments), "WindowsPowerShell");
-#else
-                // If PS6+ on Windows
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    myDocumentsPath = System.IO.Path.Combine(Environment.GetFolderPath(SpecialFolder.MyDocuments), "PowerShell");
-                    programFilesPath = System.IO.Path.Combine(Environment.GetFolderPath(SpecialFolder.ProgramFiles), "PowerShell");
-                }
-                else
-                {
-                    // Paths are the same for both Linux and MacOS
-                    myDocumentsPath = System.IO.Path.Combine(Environment.GetFolderPath(SpecialFolder.LocalApplicationData), "powershell");
-                    programFilesPath = System.IO.Path.Combine("/usr", "local", "share", "powershell");
-                }
-#endif
-                WriteDebug(string.Format("Current user scope path: '{0}'", myDocumentsPath));
-                WriteDebug(string.Format("All users scope path: '{0}'", programFilesPath));
-
-                /*** Will search first in PSModulePath, then will search in default paths ***/
-                try
-                {
-                    foreach (var path in modulePaths)
-                    {
-                        dirsToSearch.AddRange(Directory.GetDirectories(path).ToList());
-                    }
-                    WriteDebug(string.Format("PSModulePath directories: '{0}'", dirsToSearch.ToString()));
-                }
-                catch { }
-
-                var pfModulesPath = System.IO.Path.Combine(programFilesPath, "Modules");
-                if (Directory.Exists(pfModulesPath))
-                {
-                    dirsToSearch.AddRange(Directory.GetDirectories(pfModulesPath).ToList());
-                }
-
-                var mdModulesPath = System.IO.Path.Combine(myDocumentsPath, "Modules");
-                if (Directory.Exists(mdModulesPath))
-                {
-                    dirsToSearch.AddRange(Directory.GetDirectories(mdModulesPath).ToList());
-                }
-
-
-                var pfScriptsPath = System.IO.Path.Combine(programFilesPath, "Scripts", "InstalledScriptInfos");
-                if (Directory.Exists(pfScriptsPath))
-                {
-                    dirsToSearch.AddRange(Directory.GetFiles(pfScriptsPath).ToList());
-                }
-
-                var mdScriptsPath = System.IO.Path.Combine(myDocumentsPath, "Scripts", "InstalledScriptInfos");
-                if (Directory.Exists(mdScriptsPath))
-                {
-                    dirsToSearch.AddRange(Directory.GetFiles(mdScriptsPath).ToList());
-                }
-
-
-                // uniqueify 
-                dirsToSearch = dirsToSearch.Distinct().ToList();
-            }
-
-            foreach (var dir in dirsToSearch)
-            {
-                WriteDebug(string.Format("All directories to search: '{0}'", dir));
-            }
-
-            // Or a list of the passed in names
-            if (_name != null && !_name[0].Equals("*"))
-            {
-                var nameLowerCased = new List<string>();
-                var scriptXMLnames = new List<string>();
-                Array.ForEach(_name, n => nameLowerCased.Add(n.ToLower()));
-                Array.ForEach(_name, n => scriptXMLnames.Add((n + "_InstalledScriptInfo.xml").ToLower()));
-
-                /* 
-                foreach (var name in nameLowerCased)
-                {
-                    WriteDebug(string.Format("Name in nameLowerCased: '{0}'", name));
-                }
-                
-
-
-                foreach (var dir in dirsToSearch)
-                {
-                    WriteDebug((System.IO.Path.GetFileNameWithoutExtension(dir)).ToLower());
-                }
-                */
-                dirsToSearch = dirsToSearch.FindAll(p => (nameLowerCased.Contains(new DirectoryInfo(p).Name.ToLower())
-                    || scriptXMLnames.Contains((System.IO.Path.GetFileName(p)).ToLower())));
-                    
-                WriteDebug(dirsToSearch.Any().ToString());
-            }
-
-            // try to parse into a specific NuGet version
-            VersionRange versionRange = null;
-            if (_version != null)
-            {
-                NuGetVersion specificVersion;
-                NuGetVersion.TryParse(_version, out specificVersion);
-
-                if (specificVersion != null)
-                {
-                    // exact version
-                    versionRange = new VersionRange(specificVersion, true, specificVersion, true, null, null);
-                    WriteDebug(string.Format("A specific version, '{0}', is specified", versionRange.ToString()));
-
-                }
-                else
-                {
-                    // check if version range
-                    versionRange = VersionRange.Parse(_version);
-                    WriteDebug(string.Format("A version range, '{0}', is specified", versionRange.ToString()));
-
-                }
-            }
-
-            List<string> installedPkgsToReturn = new List<string>();
-
-            IEnumerable<string> returnPkgs = null;
-            var versionDirs = new List<string>();
-
-
-            //2) use above list to check 
-            // if the version specificed is a version range
-            if (versionRange != null)
-            {
-                foreach (var pkgPath in dirsToSearch)
-                {
-                    WriteDebug(string.Format("Searching through package path: '{0}'", pkgPath));
-                    var versionsDirs = Directory.GetDirectories(pkgPath);
-
-                    foreach (var versionPath in versionsDirs)
-                    {
-                        WriteDebug(string.Format("Searching through package version path: '{0}'", versionPath));
-                        NuGetVersion dirAsNugetVersion;
-                        var dirInfo = new DirectoryInfo(versionPath);
-                        NuGetVersion.TryParse(dirInfo.Name, out dirAsNugetVersion);
-                        WriteDebug(string.Format("Directory parsed as NuGet version: '{0}'", dirAsNugetVersion));
-
-                        if (versionRange.Satisfies(dirAsNugetVersion))
-                        {
-                            // just search scripts paths
-                            if (pkgPath.ToLower().Contains("Scripts"))
-                            {
-                                if (File.Exists(pkgPath))
-                                {
-                                    installedPkgsToReturn.Add(pkgPath);
-                                }
-                            }
-                            else
-                            {
-                                // modules paths
-                                versionsDirs = Directory.GetDirectories(pkgPath);
-                                WriteDebug(string.Format("Getting sub directories from : '{0}'", pkgPath));
-
-                                // Check if the pkg path actually has version sub directories.
-                                if (versionsDirs.Length != 0)
-                                {
-                                    Array.Sort(versionsDirs, StringComparer.OrdinalIgnoreCase);
-                                    Array.Reverse(versionsDirs);
-
-                                    var pkgXmlFilePath = System.IO.Path.Combine(versionsDirs.First(), "PSGetModuleInfo.xml");
-
-                                    // TODO:  check if this xml file exists, if it doesn't check if it exists in a previous version
-                                    WriteDebug(string.Format("Found module XML: '{0}'", pkgXmlFilePath));
-
-                                    installedPkgsToReturn.Add(pkgXmlFilePath);
-                                }
-                            }
-
-                            installedPkgsToReturn.Add(versionPath);
-                        }
-                    }  
-                }
-            }
-            else
-            {
-                WriteDebug(string.Format("No version provided-- check each path for the requested package"));
-                // if no version is specified, just get the latest version
-                foreach (var pkgPath in dirsToSearch)
-                {
-                    WriteDebug(string.Format("Searching through package path: '{0}'", pkgPath));
-
-                    // just search scripts paths
-                    if (pkgPath.ToLower().Contains("scripts"))
-                    {
-                        if (File.Exists(pkgPath))   //check to make sure properly formatted
-                        {
-                            installedPkgsToReturn.Add(pkgPath);
-                        }
-                    }
-                    else
-                    {
-                        // modules paths
-                        string[] versionsDirs = new string[0];
-                       
-                        versionsDirs = Directory.GetDirectories(pkgPath);
-
-                        // Check if the pkg path actually has version sub directories.
-                        if (versionsDirs.Length != 0)
-                        {
-                            Array.Sort(versionsDirs, StringComparer.OrdinalIgnoreCase);
-                            Array.Reverse(versionsDirs);
-
-                            var pkgXmlFilePath = System.IO.Path.Combine(versionsDirs.First(), "PSGetModuleInfo.xml");
-
-                            // TODO:  check if this xml file exists, if it doesn't check if it exists in a previous version
-                            WriteDebug(string.Format("Found package XML: '{0}'", pkgXmlFilePath));
-                            installedPkgsToReturn.Add(pkgXmlFilePath);
-                        }
-                    }
-                }
-            }
 
 
             // Flatten returned pkgs before displaying output returnedPkgsFound.Flatten().ToList()[0]
-            var flattenedPkgs = installedPkgsToReturn.Flatten();
+            GetHelper getHelper = new GetHelper(cancellationToken, this);
+            List<PSObject> flattenedPkgs = getHelper.ProcessGetParams(_name, _version, prerelease:false, _path);
 
-            foreach (string xmlFilePath in flattenedPkgs)
+            foreach (PSObject psObject in flattenedPkgs)
             {
-                WriteDebug(string.Format("Reading package metadata from: '{0}'", xmlFilePath));
+                WriteObject(psObject);
 
-                // Open xml and read metadata from it     
-                if (File.Exists(xmlFilePath))
-                {
-                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> nameInfo;
-                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> versionInfo;
-                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> additionalMetadataInfo;
-                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> psDataInfo;
-                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> repositoryInfo;
-                    ReadOnlyPSMemberInfoCollection<PSPropertyInfo> descriptionversionInfo;
-
-                    var isPrelease = false;
-                    using (StreamReader sr = new StreamReader(xmlFilePath))
-                    {
-
-                        string text = sr.ReadToEnd();
-                        var deserializedObj = (PSObject)PSSerializer.Deserialize(text);
-
-                        nameInfo = deserializedObj.Properties.Match("Name");
-
-                        /* // testing adding prerelease parameter
-                        additionalMetadataInfo = deserializedObj.Properties.Match("AdditionalMetadata");
-                        if (additionalMetadataInfo.Any())
-                        {
-                            isPrelease = additionalMetadataInfo.FirstOrDefault().Value.ToString().Contains("IsPrerelease=true");
-                            if ((isPrelease == true) && _prerelease) // find a stable version of the pkg {}
-                        }
-                        */
-
-                        versionInfo = deserializedObj.Properties.Match("Version");
-                        repositoryInfo = deserializedObj.Properties.Match("Repository");
-                        descriptionversionInfo = deserializedObj.Properties.Match("Description");
-
-                    };
-
-                    // if -Prerelease is not passed in as a parameter, don't allow prerelease pkgs to be returned,
-                    // we still want all pkgs to be returned if -Prerelease is passed in as a param
-                    //if ((_prerelease == false && isPrelease == false) || _prerelease == true)
-                    //{
-                    PSObject pkgAsPSObject = new PSObject();
-                    try
-                    {
-                        pkgAsPSObject.Members.Add(new PSNoteProperty("Name", nameInfo.FirstOrDefault().Value));   // need to fix output
-                        pkgAsPSObject.Members.Add(new PSNoteProperty("Version", versionInfo.FirstOrDefault().Value));
-                        pkgAsPSObject.Members.Add(new PSNoteProperty("Repository", repositoryInfo.FirstOrDefault().Value));
-                        pkgAsPSObject.Members.Add(new PSNoteProperty("Description", descriptionversionInfo.FirstOrDefault().Value));
-                        WriteObject(pkgAsPSObject);
-                    }
-                    catch { }
-                    //}
-                }
             }
         }
     }

--- a/src/GetPSResource.cs
+++ b/src/GetPSResource.cs
@@ -108,8 +108,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             foreach (PSObject psObject in flattenedPkgs)
             {
-                WriteObject(psObject);
+                // Temporary PSObject for output purposes
+                PSObject temp = new PSObject();
 
+                temp.Members.Add(new PSNoteProperty("Name", psObject.Properties["Name"].ToString()));
+                temp.Members.Add(new PSNoteProperty("Version", psObject.Properties["Version"].ToString()));
+                temp.Members.Add(new PSNoteProperty("Repository", psObject.Properties["Repository"].ToString()));
+                temp.Members.Add(new PSNoteProperty("Description", psObject.Properties["Description"].ToString()));
+                WriteObject(temp);
             }
         }
     }

--- a/src/InstallHelper.cs
+++ b/src/InstallHelper.cs
@@ -759,25 +759,22 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         // If NoClobber is specified, ensure command clobbering does not happen
                         if (noClobber)
                         {
-
-                            
                             // This is a primitive implementation  
                             // 1) get all possible paths
                             // 2) search all modules and compare
                             /// Cannot uninstall a module if another module is dependent on it 
 
-                            //using (System.Management.Automation.PowerShell pwsh = System.Management.Automation.PowerShell.Create())
-                           // {
+                            using (System.Management.Automation.PowerShell pwsh = System.Management.Automation.PowerShell.Create())
+                            {
                                 // Get all modules
-                                //var results = pwsh.AddCommand("Get-Module").AddParameter("ListAvailable").Invoke();
+                                var results = pwsh.AddCommand("Get-Module").AddParameter("ListAvailable").Invoke();
 
                                 // Structure of LINQ call:
                                 // Results is a collection of PSModuleInfo objects that contain a property listing module commands, "ExportedCommands".
                                 // ExportedCommands is collection of PSModuleInfo objects that need to be iterated through to see if any of them are the command we're trying to install
                                 // If anything from the final call gets returned, there is a command clobber with this pkg.
 
-                               // List<IEnumerable<PSObject>> pkgsWithCommandClobber = new List<IEnumerable<PSObject>>();
-                               /*
+                                List<IEnumerable<PSObject>> pkgsWithCommandClobber = new List<IEnumerable<PSObject>>();
                                 foreach (string command in includesCommand)
                                 {
                                     pkgsWithCommandClobber.Add(results.Where(pkg => ((ReadOnlyCollection<PSModuleInfo>)pkg.Properties["ExportedCommands"].Value).Where(ec => ec.Name.Equals(command, StringComparison.InvariantCultureIgnoreCase)).Any()));
@@ -789,19 +786,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                                     throw new System.ArgumentException(string.Format(CultureInfo.InvariantCulture, "Command(s) with name(s) '{0}' is already available on this system. Installing '{1}' may override the existing command. If you still want to install '{1}', remove the -NoClobber parameter.", strUniqueCommandNames, p.Identity.Id));
                                 }
-                                */
-                            //}
-                            
-                            GetHelper getHelper = new GetHelper(cancellationToken, this);
-                            List<PSObject> results = getHelper.ProcessGetParams(name:null, version:"", prerelease:false, path:"");
-
-                            List<IEnumerable<PSObject>> pkgsWithCommandClobber = new List<IEnumerable<PSObject>>();
-
-                            foreach (string command in includesCommand)
-                            {
-                                pkgsWithCommandClobber.Add(results.Where(pkg => ((ReadOnlyCollection<PSModuleInfo>)pkg.Properties["ExportedCommands"].Value).Where(ec => ec.Name.Equals(command, StringComparison.InvariantCultureIgnoreCase)).Any()));
                             }
-
                         }
 
                         Dictionary<string, List<string>> includes = new Dictionary<string, List<string>> {
@@ -1032,4 +1017,3 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         }
     }
 }
-

--- a/src/InstallHelper.cs
+++ b/src/InstallHelper.cs
@@ -300,18 +300,21 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             var repositoryIsNotTrusted = "Untrusted repository";
             var queryInstallUntrustedPackage = "You are installing the modules from an untrusted repository. If you trust this repository, change its Trusted value by running the Set-PSResourceRepository cmdlet. Are you sure you want to install the PSresource from '{0}' ?";
 
-            foreach (var repoName in listOfRepositories)
+            foreach (var repo in listOfRepositories)
             {
                 var sourceTrusted = false;
 
-                if (string.Equals(repoName.Properties["Trusted"].Value.ToString(), "false", StringComparison.InvariantCultureIgnoreCase) && !trustRepository && !force)
+                string repoName = repo.Properties["Name"].Value.ToString();
+
+                cmdletPassedIn.WriteDebug(string.Format("Attempting to search for packages in '{0}'", repoName));
+                if (string.Equals(repo.Properties["Trusted"].Value.ToString(), "false", StringComparison.InvariantCultureIgnoreCase) && !trustRepository && !force)
                 {
                     cmdletPassedIn.WriteDebug("Checking if untrusted repository should be used");
 
                     if (!(yesToAll || noToAll))
                     {
                         // Prompt for installation of package from untrusted repository
-                        var message = string.Format(CultureInfo.InvariantCulture, queryInstallUntrustedPackage, repoName.Properties["Name"].Value.ToString());
+                        var message = string.Format(CultureInfo.InvariantCulture, queryInstallUntrustedPackage, repoName);
                         sourceTrusted = cmdletPassedIn.ShouldContinue(message, repositoryIsNotTrusted, true, ref yesToAll, ref noToAll);
                     }
                 }
@@ -325,7 +328,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     cmdletPassedIn.WriteDebug("Untrusted repository accepted as trusted source.");
                     // Try to install-- returns any pkgs that weren't found
                     // If it can't find the pkg in one repository, it'll look for it in the next repo in the list
-                    var returnedPkgsNotInstalled = InstallPkgs(repoName.Properties["Url"].Value.ToString(), pkgsLeftToInstall, packageNames, version, prerelease, scope, acceptLicense, quiet, reinstall, force, trustRepository, noClobber, credential);
+                    var returnedPkgsNotInstalled = InstallPkgs(repoName, repo.Properties["Url"].Value.ToString(), pkgsLeftToInstall, packageNames, version, prerelease, scope, acceptLicense, quiet, reinstall, force, trustRepository, noClobber, credential);
                     if (!pkgsLeftToInstall.Any())
                     {
                         return;
@@ -339,7 +342,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         // Package and its dependencies will be saved into a tmp folder
         // and will only be properly installed if all dependencies are found successfully.
         // Once package is installed, we want to resolve and install all dependencies.
-        public List<string> InstallPkgs(string repositoryUrl, List<string> pkgsLeftToInstall, string[] packageNames, string version, bool prerelease, string scope, bool acceptLicense, bool quiet, bool reinstall, bool force, bool trustRepository, bool noClobber, PSCredential credential)
+        public List<string> InstallPkgs(string repositoryName, string repositoryUrl, List<string> pkgsLeftToInstall, string[] packageNames, string version, bool prerelease, string scope, bool acceptLicense, bool quiet, bool reinstall, bool force, bool trustRepository, bool noClobber, PSCredential credential)
         {
             PackageSource source = new PackageSource(repositoryUrl);
 
@@ -362,14 +365,15 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
             catch
             {
-                var exMessage = String.Format("Error retreiving repository resource");
-                var ex = new ArgumentException(exMessage);
-                var ErrorCreatingRepositoryResource = new ErrorRecord(ex, "ErrorCreatingRepositoryResource", ErrorCategory.ObjectNotFound, null);
+            }
+            if (resourceMetadata == null)
+            {
+              cmdletPassedIn.WriteVerbose(string.Format("Error retreiving resource repository from '{0}'. Try running command again with -Credential", repositoryName));
 
-                cmdletPassedIn.ThrowTerminatingError(ErrorCreatingRepositoryResource);
+                return pkgsLeftToInstall;
             }
 
-            foreach (var n in packageNames)
+            foreach (var pkgName in packageNames)
             {
                 IPackageSearchMetadata filteredFoundPkgs = null;
 
@@ -380,7 +384,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     // TODO: proper error handling
                     try
                     {
-                        filteredFoundPkgs = (resourceMetadata.GetMetadataAsync(n, prerelease, false, context, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult()
+                        filteredFoundPkgs = (resourceMetadata.GetMetadataAsync(pkgName, prerelease, false, context, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult()
                             .OrderByDescending(p => p.Identity.Version, VersionComparer.VersionRelease)
                             .FirstOrDefault());
 
@@ -395,11 +399,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     }
                     catch
                     {
-                        var exMessage = String.Format("Could not find package {0}", n);
-                        var ex = new ArgumentException(exMessage);
-                        var ErrorCreatingRepositoryResource = new ErrorRecord(ex, "ErrorCreatingRepositoryResource", ErrorCategory.ObjectNotFound, null);
+                    }
 
-                        cmdletPassedIn.ThrowTerminatingError(ErrorCreatingRepositoryResource);
+                    if (filteredFoundPkgs == null)
+                    {
+                        cmdletPassedIn.WriteVerbose(String.Format("Could not find package '{0}' in repository '{1}'", pkgName, repositoryName));
+
+                        return pkgsLeftToInstall;
                     }
                 }
                 else
@@ -422,7 +428,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                     // Search for packages within a version range
                     // ensure that the latest version is returned first (the ordering of versions differ
-                    filteredFoundPkgs = (resourceMetadata.GetMetadataAsync(n, prerelease, false, context, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult()
+                    filteredFoundPkgs = (resourceMetadata.GetMetadataAsync(pkgName, prerelease, false, context, NullLogger.Instance, cancellationToken).GetAwaiter().GetResult()
                         .Where(p => versionRange.Satisfies(p.Identity.Version))
                         .OrderByDescending(p => p.Identity.Version, VersionComparer.VersionRelease)
                         .FirstOrDefault());
@@ -860,7 +866,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                             File.Delete(Path.Combine(newPath, p.Identity.Id + ".ps1"));
                         }
 
-             
+
                         cmdletPassedIn.WriteDebug(string.Format("Moving '{0}' to '{1}'", Path.Combine(dirNameVersion, scriptXML), Path.Combine(psScriptsPath, "InstalledScriptInfos", scriptXML)));
                         File.Move(Path.Combine(dirNameVersion, scriptXML), Path.Combine(psScriptsPath, "InstalledScriptInfos", scriptXML));
 
@@ -928,7 +934,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         throw new Exception(e.Message);
                     }
 
-                    pkgsLeftToInstall.Remove(n);
+                    pkgsLeftToInstall.Remove(pkgName);
                 }
             }
 

--- a/src/InstallPSResource.cs
+++ b/src/InstallPSResource.cs
@@ -54,21 +54,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         private object[] _inputObject;
 
         /// <summary>
-        /// Specifies to allow installation of prerelease versions
-        /// </summary>
-        [Parameter(ParameterSetName = "NameParameterSet")]
-        [Parameter(ParameterSetName = "RequiredResourceFileParameterSet")]
-        public string[] Type
-        {
-            get
-            { return _type; }
-
-            set
-            { _type = value; }
-        }
-        private string[] _type;
-
-        /// <summary>
         /// Specifies the version or version range of the package to be installed
         /// </summary>
         [Parameter(ParameterSetName = "NameParameterSet")]

--- a/src/PublishPSResource.cs
+++ b/src/PublishPSResource.cs
@@ -294,6 +294,36 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         }
         private string _nuspec;
 
+
+        /// <summary>
+        /// Specifies a proxy server for the request, rather than a direct connection to the internet resource.
+        /// </summary>
+        [Parameter(ValueFromPipelineByPropertyName = true)]
+        [ValidateNotNullOrEmpty]
+        public Uri Proxy
+        {
+            get
+            { return _proxy; }
+
+            set
+            { _proxy = value; }
+        }
+        private Uri _proxy;
+
+        /// <summary>
+        /// Specifies a user account that has permission to use the proxy server that is specified by the Proxy parameter.
+        /// </summary>
+        [Parameter(ValueFromPipelineByPropertyName = true)]
+        public PSCredential ProxyCredential
+        {
+            get
+            { return _proxyCredential; }
+
+            set
+            { _proxyCredential = value; }
+        }
+        private PSCredential _proxyCredential;
+
         private NuGetVersion pkgVersion = null;
         private bool isScript;
         private string pkgName;


### PR DESCRIPTION
* Return 'System.Version' instead of 'NuGet.Version' (in Find-PSResource)
* Have Install output verbose message on successful installation (error for unsuccessful installation)
* Ensure that not passing credentials does not throw an error if searching through multiple repositories
* Delete attempt to remove loaded assemblies in psm1