### PR TITLE
Fixes to git and build environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+src/bin
+src/obj
+src/out
+src/dotnet-install.sh
+src/dotnet-uninstall-pkgs.sh

--- a/src/PowerShellGet.csproj
+++ b/src/PowerShellGet.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="NuGet.Packaging" Version="5.7.0-rtm.6702" />
     <PackageReference Include="NuGet.ProjectModel" Version="5.7.0-rtm.6702" />
     <PackageReference Include="NuGet.Protocol" Version="5.7.0-rtm.6702" />
-    <PackageReference Include="NuGet.Protocol.Core.Types" Version="4.3.0-beta2-2463" />
     <PackageReference Include="NuGet.Repositories" Version="4.3.0-beta1-2418" />
     <PackageReference Include="PowerShellStandard.Library" Version="7.0.0-preview.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.6.0-preview3.19128.7" />

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -81,7 +81,8 @@ $assemblyNames = @(
 $itemsToCopyBinaries = $assemblyNames | % { "$solutionDir\$_\bin\$Configuration\$currentFramework\$_.dll" }
 $itemsToCopyPdbs = $assemblyNames | % { "$solutionDir\$_\bin\$Configuration\$currentFramework\$_.pdb" }
 
-$itemsToCopyCommon = @("$solutionDir\PowerShellGet.psd1")
+$projectPath = Split-Path $solutionDir -Parent
+$itemsToCopyCommon = @("$projectPath/PowerShellGet.psd1","$projectPath/PSModule.psm1")
 
 $destinationDir = "$solutionDir/out/PowerShellGet"
 
@@ -95,16 +96,13 @@ try {
 finally {
 }
 
-
 CopyToDestinationDir $itemsToCopyCommon $destinationDir
-
 
 if (-not (CopyBinariesToDestinationDir $assemblyNames $destinationDirBinaries $currentFramework $Configuration '.dll' $solutionDir)) {
     throw 'Build failed'
 }
 
 CopyBinariesToDestinationDir $assemblyNames $destinationDirBinaries $currentFramework $Configuration '.pdb' $solutionDir
-
 
 #Packing
 $sourcePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($destinationDir)

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -41,11 +41,8 @@ Function CopyBinariesToDestinationDir($itemsToCopy, $destination, $framework, $c
 
         Write-Host("item to copy is: $file")
 
-        $fullPath = Join-Path -Path $solutionDir -ChildPath 'bin' | Join-Path -ChildPath $configuration | Join-Path -ChildPath $framework | Join-Path -ChildPath "$file$ext"
-        Write-Host("Full path is: $fullPath")
-
-        $fullPathWithPlatform = Join-Path -Path $solutionDir -ChildPath 'bin' | Join-Path -ChildPath $platform | Join-Path -ChildPath $configuration | Join-Path -ChildPath $framework | Join-Path -ChildPath "$file$ext"
-        Write-Host("Full path with platform is: $fullPathWithPlatform")
+        $fullPath = Join-Path -Path $solutionDir -ChildPath 'bin' -AdditionalChildPath $configuration, $framework, "publish", "$file$ext"
+        $fullPathWithPlatform = Join-Path -Path $solutionDir -ChildPath 'bin' -AdditionalChildPath $platform, $configuration, $framework, "publish", "$file$ext"
 
         if (Test-Path $fullPath) {
             Write-Host("In full path, copying item over to:  $(Join-Path $destination "$file$ext")")
@@ -74,12 +71,18 @@ write-host ("solutionDir: $($solutionDir)")
 
 $assemblyNames = @(
     "PowerShellGet"
+    'Microsoft.Extensions.Logging.Abstractions'
+    'MoreLinq'
+    'NuGet.Commands'
+    'NuGet.Common'
+    'NuGet.Configuration'
+    'NuGet.Frameworks'
+    'NuGet.Packaging'
+    'NuGet.ProjectModel'
+    'NuGet.Protocol'
+    'NuGet.Repositories'
+    'NuGet.Versioning'
 )
-
-
-
-$itemsToCopyBinaries = $assemblyNames | % { "$solutionDir\$_\bin\$Configuration\$currentFramework\$_.dll" }
-$itemsToCopyPdbs = $assemblyNames | % { "$solutionDir\$_\bin\$Configuration\$currentFramework\$_.pdb" }
 
 $projectPath = Split-Path $solutionDir -Parent
 $itemsToCopyCommon = @("$projectPath/PowerShellGet.psd1","$projectPath/PSModule.psm1")

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -89,11 +89,13 @@ $destinationDir = "$solutionDir/out/PowerShellGet"
 $destinationDirBinaries = "$destinationDir/$currentFramework"
 
 try {
+    Push-Location $solutionPath
     dotnet restore
     dotnet build --configuration $Configuration
     dotnet publish --framework $framework --configuration $Configuration
 }
 finally {
+    Pop-Location
 }
 
 CopyToDestinationDir $itemsToCopyCommon $destinationDir

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -85,7 +85,10 @@ $assemblyNames = @(
 )
 
 $projectPath = Split-Path $solutionDir -Parent
-$itemsToCopyCommon = @("$projectPath/PowerShellGet.psd1","$projectPath/PSModule.psm1")
+$itemsToCopyCommon = @(
+    (Join-Path $projectPath "PowerShellGet.psd1")
+    (Join-Path $projectPath "PSModule.psm1")
+)
 
 $destinationDir = "$solutionDir/out/PowerShellGet"
 


### PR DESCRIPTION
add .gitignore file for bootstrapping and built files
update csproj to not use deprecated nupkg
fix build.ps1 to correctly copy psd1 and psm1 to output folder