### PR TITLE
Fix warnings in build and update build script

### DIFF
--- a/src/GetHelper.cs
+++ b/src/GetHelper.cs
@@ -31,7 +31,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     class GetHelper : PSCmdlet
     {
         private CancellationToken cancellationToken;
-        private readonly bool update;
         private readonly PSCmdlet cmdletPassedIn;
 
 
@@ -164,8 +163,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
 
             List<string> installedPkgsToReturn = new List<string>();
-
-            IEnumerable<string> returnPkgs = null;
 
             //2) use above list to check 
             // if the version specificed is a version range

--- a/src/GetPSResource.cs
+++ b/src/GetPSResource.cs
@@ -88,11 +88,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         */
 
         public static readonly string OsPlatform = System.Runtime.InteropServices.RuntimeInformation.OSDescription;
-        private CancellationToken cancellationToken;
-        private readonly PSCmdlet cmdletPassedIn;
-        private string programFilesPath;
-        private string myDocumentsPath;
-
 
         protected override void ProcessRecord()
         {

--- a/src/InstallHelper.cs
+++ b/src/InstallHelper.cs
@@ -179,7 +179,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 {
                     // TODO:  implement after implementing publish
                     throw new Exception("This feature is not yet implemented");
-                    return;
                 }
                 else if (resolvedReqResourceFile.EndsWith(".json"))
                 {
@@ -193,7 +192,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     {
                         pkgsinJson = JsonConvert.DeserializeObject<Dictionary<string, PkgParams>>(_requiredResourceJson, new JsonSerializerSettings { MaxDepth = 6 });
                     }
-                    catch (Exception e)
+                    catch (Exception)
                     {
                         var exMessage = String.Format("Argument for parameter -RequiredResource is not in proper json format.  Make sure argument is either a hashtable or a json object.");
                         var ex = new ArgumentException(exMessage);
@@ -220,7 +219,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 {
                     jsonString = _requiredResourceHash.ToJson();
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     var exMessage = String.Format("Argument for parameter -RequiredResource is not in proper json format.  Make sure argument is either a hashtable or a json object.");
                     var ex = new ArgumentException(exMessage);
@@ -234,7 +233,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 {
                     pkg = JsonConvert.DeserializeObject<PkgParams>(jsonString, new JsonSerializerSettings { MaxDepth = 6 });
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     var exMessage = String.Format("Argument for parameter -RequiredResource is not in proper json format.  Make sure argument is either a hashtable or a json object.");
                     var ex = new ArgumentException(exMessage);
@@ -256,13 +255,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     {
                         pkgsinJson = JsonConvert.DeserializeObject<Dictionary<string, PkgParams>>(_requiredResourceJson, new JsonSerializerSettings { MaxDepth = 6 });
                     }
-                    catch (Exception e)
+                    catch (Exception)
                     {
                         try
                         {
                             jsonPkgsNameVersion = JsonConvert.DeserializeObject<Dictionary<string, string>>(_requiredResourceJson, new JsonSerializerSettings { MaxDepth = 6 });
                         }
-                        catch (Exception e2)
+                        catch (Exception)
                         {
                             var exMessage = String.Format("Argument for parameter -RequiredResource is not in proper json format.  Make sure argument is either a hashtable or a json object.");
                             var ex = new ArgumentException(exMessage);

--- a/src/InstallHelper.cs
+++ b/src/InstallHelper.cs
@@ -192,9 +192,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     {
                         pkgsinJson = JsonConvert.DeserializeObject<Dictionary<string, PkgParams>>(_requiredResourceJson, new JsonSerializerSettings { MaxDepth = 6 });
                     }
-                    catch (Exception)
+                    catch (Exception e)
                     {
-                        var exMessage = String.Format("Argument for parameter -RequiredResource is not in proper json format.  Make sure argument is either a hashtable or a json object.");
+                        var exMessage = String.Format("Argument for parameter -RequiredResource is not in proper json format.  Make sure argument is either a hashtable or a json object.  Error: {0}", e.Message);
                         var ex = new ArgumentException(exMessage);
                         var RequiredResourceNotInProperJsonFormat = new ErrorRecord(ex, "RequiredResourceNotInProperJsonFormat", ErrorCategory.ObjectNotFound, null);
 
@@ -219,9 +219,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 {
                     jsonString = _requiredResourceHash.ToJson();
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
-                    var exMessage = String.Format("Argument for parameter -RequiredResource is not in proper json format.  Make sure argument is either a hashtable or a json object.");
+                    var exMessage = String.Format("Argument for parameter -RequiredResource is not in proper json format.  Make sure argument is either a hashtable or a json object.  Error: {0}", e.Message);
                     var ex = new ArgumentException(exMessage);
                     var RequiredResourceNotInProperJsonFormat = new ErrorRecord(ex, "RequiredResourceNotInProperJsonFormat", ErrorCategory.ObjectNotFound, null);
 
@@ -233,9 +233,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 {
                     pkg = JsonConvert.DeserializeObject<PkgParams>(jsonString, new JsonSerializerSettings { MaxDepth = 6 });
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
-                    var exMessage = String.Format("Argument for parameter -RequiredResource is not in proper json format.  Make sure argument is either a hashtable or a json object.");
+                    var exMessage = String.Format("Argument for parameter -RequiredResource is not in proper json format.  Make sure argument is either a hashtable or a json object.  Error: {0}", e.Message);
                     var ex = new ArgumentException(exMessage);
                     var RequiredResourceNotInProperJsonFormat = new ErrorRecord(ex, "RequiredResourceNotInProperJsonFormat", ErrorCategory.ObjectNotFound, null);
 
@@ -261,9 +261,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         {
                             jsonPkgsNameVersion = JsonConvert.DeserializeObject<Dictionary<string, string>>(_requiredResourceJson, new JsonSerializerSettings { MaxDepth = 6 });
                         }
-                        catch (Exception)
+                        catch (Exception e)
                         {
-                            var exMessage = String.Format("Argument for parameter -RequiredResource is not in proper json format.  Make sure argument is either a hashtable or a json object.");
+                            var exMessage = String.Format("Argument for parameter -RequiredResource is not in proper json format.  Make sure argument is either a hashtable or a json object.  Error: {0}", e.Message);
                             var ex = new ArgumentException(exMessage);
                             var RequiredResourceNotInProperJsonFormat = new ErrorRecord(ex, "RequiredResourceNotInProperJsonFormat", ErrorCategory.ObjectNotFound, null);
 

--- a/src/PublishPSResource.cs
+++ b/src/PublishPSResource.cs
@@ -474,7 +474,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     MSBuildProjectFactory.ProjectCreator,
                     builder);
 
-            runner.BuildPackage();
+            runner.RunPackageBuild();
 
             
             // Push the nupkg to the appropriate repository 
@@ -805,7 +805,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         {
                             parsedMetadataHash.Add(key, value);
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             var message = String.Format("Failed to add key '{0}' and value '{1}' to hashtable", key, value);
                             var ex = new ArgumentException(message);

--- a/src/PublishPSResource.cs
+++ b/src/PublishPSResource.cs
@@ -805,9 +805,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         {
                             parsedMetadataHash.Add(key, value);
                         }
-                        catch (Exception)
+                        catch (Exception e)
                         {
-                            var message = String.Format("Failed to add key '{0}' and value '{1}' to hashtable", key, value);
+                            var message = String.Format("Failed to add key '{0}' and value '{1}' to hashtable.  Error: {2}", key, value, e.Message);
                             var ex = new ArgumentException(message);
                             var metadataCannotBeAdded = new ErrorRecord(ex, "metadataCannotBeAdded", ErrorCategory.MetadataError, null);
 

--- a/src/SavePSResource.cs
+++ b/src/SavePSResource.cs
@@ -481,14 +481,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                             // Create XMLs
                             using (StreamWriter sw = new StreamWriter(fullinstallPath))
                             {
-                                var psModule = "PSModule";
-
                                 var tags = p.Tags.Split(' ');
-
 
                                 var module = tags.Contains("PSModule") ? "Module" : null;
                                 var script = tags.Contains("PSScript") ? "Script" : null;
-
 
                                 List<string> includesDscResource = new List<string>();
                                 List<string> includesCommand = new List<string>();
@@ -500,8 +496,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                                 var psCommand = "PSCommand_";
                                 var psFunction = "PSFunction_";
                                 var psRoleCapability = "PSRoleCapability_";
-
-
 
                                 foreach (var tag in tags)
                                 {

--- a/src/UninstallPSResource.cs
+++ b/src/UninstallPSResource.cs
@@ -92,12 +92,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         public static readonly string OsPlatform = System.Runtime.InteropServices.RuntimeInformation.OSDescription;
         private string programFilesPath;
         private string myDocumentsPath;
-
-        private string psPath;
-        private string psModulesPath;
-        private string psScriptsPath;
-        private List<string> psModulesPathAllDirs;
-        private List<string> psScriptsPathAllFiles;
         List<string> dirsToDelete;
 
         private CancellationTokenSource source;
@@ -125,14 +119,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
 
             var consoleIsElevated = false;
-            var isWindowsPS = true;
 
 #if NET472
             // WindowsPS
             var id = System.Security.Principal.WindowsIdentity.GetCurrent();
             consoleIsElevated = (id.Owner != id.User);
-            isWindowsPS = true;
-
             myDocumentsPath = Path.Combine(Environment.GetFolderPath(SpecialFolder.MyDocuments), "WindowsPowerShell");
             programFilesPath = Path.Combine(Environment.GetFolderPath(SpecialFolder.ProgramFiles), "WindowsPowerShell");
 #else

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -5,9 +5,14 @@ param(
     [ValidateSet("Debug", "Release")]
     [string]$Configuration = "Debug",
 
+    [switch]$Clean,
+
     [switch]$EmbedProviderManifest
 )
 
+if ($Clean) {
+    git clean -fdx
+}
 Function Test-DotNetRestore {
     param(
         [string] $projectPath
@@ -96,9 +101,10 @@ $destinationDirBinaries = "$destinationDir/$currentFramework"
 
 try {
     Push-Location $solutionPath
-    dotnet restore
-    dotnet build --configuration $Configuration
-    dotnet publish --framework $framework --configuration $Configuration
+    dotnet publish --framework $framework --configuration $Configuration -warnaserror
+    if ($LASTEXITCODE -ne 0) {
+        throw "Build failed"
+    }
 }
 finally {
     Pop-Location


### PR DESCRIPTION
Fix all warnings
Update build script to treat warnings as errors
Fix build script to fail early if build fails
Add `-Clean` switch to build script

`dotnet publish` will do a restore and build so those individual steps aren't needed