### PR TITLE
Fix Register-PSResourceRepository to accept a non-Windows filesystem path

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/src/RegisterPSResourceRepository.cs
+++ b/src/RegisterPSResourceRepository.cs
@@ -59,7 +59,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 if (!Uri.TryCreate(value, string.Empty, out url))
                 {
                     // Try the URL as a file path
-                    var resolvedPath = string.Format(CultureInfo.InvariantCulture, "file://{0}", SessionState.Path.GetResolvedPSPathFromPSPath(value.ToString()).FirstOrDefault().Path);
+                    var resolvedPath = string.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", Uri.UriSchemeFile, Uri.SchemeDelimiter, SessionState.Path.GetResolvedPSPathFromPSPath(value.ToString()).FirstOrDefault().Path);
                     if (!Uri.TryCreate(resolvedPath, UriKind.Absolute, out url))
                     {
                         var message = string.Format(CultureInfo.InvariantCulture, "The URL provided is not valid: {0}", value);

--- a/src/RegisterPSResourceRepository.cs
+++ b/src/RegisterPSResourceRepository.cs
@@ -56,16 +56,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             set
             {
                 Uri url;
-                Uri.TryCreate(value, string.Empty, out url);
-
-                if (url == null)
+                if (!Uri.TryCreate(value, string.Empty, out url))
                 {
                     // Try the URL as a file path
-                    var resolvedPath = string.Format("file://{0}", SessionState.Path.GetResolvedPSPathFromPSPath(value.ToString()).FirstOrDefault().Path);
-                    Uri.TryCreate(resolvedPath, UriKind.Absolute, out url);
-                    if (url == null)
+                    var resolvedPath = string.Format(CultureInfo.InvariantCulture, "file://{0}", SessionState.Path.GetResolvedPSPathFromPSPath(value.ToString()).FirstOrDefault().Path);
+                    if (!Uri.TryCreate(resolvedPath, UriKind.Absolute, out url))
                     {
-                        var message = String.Format("The URL provided is not valid: {0}", value);
+                        var message = string.Format(CultureInfo.InvariantCulture, "The URL provided is not valid: {0}", value);
                         var ex = new ArgumentException(message);
                         var moduleManifestNotFound = new ErrorRecord(ex, "InvalidUrl", ErrorCategory.InvalidArgument, null);
                         ThrowTerminatingError(moduleManifestNotFound);

--- a/src/RegisterPSResourceRepository.cs
+++ b/src/RegisterPSResourceRepository.cs
@@ -60,8 +60,16 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                 if (url == null)
                 {
-                    var resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(value.ToString()).FirstOrDefault().Path;
-                    Uri.TryCreate(value, resolvedPath, out url);
+                    // Try the URL as a file path
+                    var resolvedPath = string.Format("file://{0}", SessionState.Path.GetResolvedPSPathFromPSPath(value.ToString()).FirstOrDefault().Path);
+                    Uri.TryCreate(resolvedPath, UriKind.Absolute, out url);
+                    if (url == null)
+                    {
+                        var message = String.Format("The URL provided is not valid: {0}", value);
+                        var ex = new ArgumentException(message);
+                        var moduleManifestNotFound = new ErrorRecord(ex, "InvalidUrl", ErrorCategory.InvalidArgument, null);
+                        ThrowTerminatingError(moduleManifestNotFound);
+                    }
                 }
 
                 _url = url;


### PR DESCRIPTION
Unix file paths don't start with a drive letter, so the Url API fails.  Fix is to use an appropriate URL scheme which is `file://` in this case denoting it as a filesystem path.  This will work on both Windows and Unix systems.

No added test for this as I'm fixing the Register-PSRepository tests in a separate PR which requires more extensive changes.

Also added a luanch.json file so that VSCode can attach the pwsh process to debug PowerShellGet.dll