### PR TITLE
Fixes Issue 217

### DIFF
--- a/src/GetHelper.cs
+++ b/src/GetHelper.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 // PSModules path
                 var psModulePath = Environment.GetEnvironmentVariable("PSModulePath");
-                var modulePaths = psModulePath.Split(';');
+                var modulePaths = psModulePath.Split(';').Where(d => Directory.Exists(d));
 
 
 #if NET472
@@ -86,7 +86,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                 foreach (var modulePath in modulePaths)
                 {
-                    dirsToSearch.AddRange(Directory.GetDirectories(modulePath).ToList());
+                    if (Directory.Exists(modulePath))
+                    {
+                        dirsToSearch.AddRange(Directory.GetDirectories(modulePath).ToList());
+                    }
                 }
 
 

--- a/src/GetHelper.cs
+++ b/src/GetHelper.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 // PSModules path
                 var psModulePath = Environment.GetEnvironmentVariable("PSModulePath");
-                var modulePaths = psModulePath.Split(';').Where(d => Directory.Exists(d));
+                var modulePaths = psModulePath.Split(';');
 
 
 #if NET472


### PR DESCRIPTION
This fixes the error that occurs when a PSModulePath directory is not present on the system when running Get-PSResource mentioned in #217 