### PR TITLE
Fix vmImage to be consistent

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -20,7 +20,7 @@ stages:
   - job: BuildPkg
     displayName: Build Package
     pool:
-      vmImage: windows-latest
+      vmImage: windows-2019
 
     steps:
     - powershell: |
@@ -292,7 +292,7 @@ stages:
   jobs:
   - job: ComplianceJob
     pool:
-      name: Package ES CodeHub Lab E
+      vmImage: windows-2019
     steps:
     - template: compliance.yml
 


### PR DESCRIPTION
Making all agent pool vmImage be the same, 'windows-2019'.