### PR TITLE
Add help docs for unregister, register, get -psresourcerepository 

### DIFF
--- a/help/Get-PSResourceRepository.md
+++ b/help/Get-PSResourceRepository.md
@@ -1,40 +1,81 @@
 ---
 external help file: PowerShellGet.dll-Help.xml
 Module Name: PowerShellGet
-online version: <add>
+online version:
 schema: 2.0.0
 ---
 
 # Get-PSResourceRepository
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Finds and returns registered repository information.
 
 ## SYNTAX
 
 ```
-Get-PSResourceRepository [[-Name] <String[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Get-PSResourceRepository [[-Name] <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+The Get-PSResourceRepository cmdlet replaces the Get-PSRepository cmdlet from V2. It searches for the PowerShell module repositories that are registered for the current user. By default it will return all registered repositories, or if the -Name parameter argument is specified then it wil return the repository which matches that name. It returns PSRepositoryInfo objects which contain information for each repository item found.
 
 ## EXAMPLES
 
 ### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+```
+PS C:\> Get-PSResourceRepository -Name "PSGallery"
+        Name         Url                                        Trusted   Priority
+        ----         ---                                        -------   --------
+        PSGallery    https://www.powershellgallery.com/api/v2     False         50
 ```
 
-{{ Add example description here }}
+This example runs the command with the 'Name' parameter being set to "PSGallery". This repository is registered for the current user so the command returns information on this repository.
+
+### Example 2
+```
+PS C:\> Get-PSResourceRepository -Name "*Gallery"
+        Name             Url                                          Trusted   Priority
+        ----             ---                                          -------   --------
+        PoshTestGallery  https://www.poshtestgallery.com/api/v2          True         40
+        PSGallery        https://www.powershellgallery.com/api/v2       False         50
+
+```
+
+This example runs the command with the 'Name' parameter being set to "*Gallery" which includes a wildcard. The following repositories are registered for the current user and match the name pattern, so the command returns information on these repositories.
+
+### Example 3
+```
+PS C:\> Get-PSResourceRepository -Name "PSGallery","PoshTestGallery"
+        Name             Url                                          Trusted   Priority
+        ----             ---                                          -------   --------
+        PoshTestGallery  https://www.poshtestgallery.com/api/v2          True         40
+        PSGallery        https://www.powershellgallery.com/api/v2       False         50
+
+```
+
+This example runs the command with the 'Name' parameter being set to an array of Strings. Both of the specified repositories are registered for the current user and match the name pattern, so the command returns information on these repositories.
+
+### Example 4
+```
+PS C:\> Get-PSResourceRepository -Name "*"
+        Name             Url                                          Trusted   Priority
+        ----             ---                                          -------   --------
+        PoshTestGallery  https://www.poshtestgallery.com/api/v2          True         40
+        PSGallery        https://www.powershellgallery.com/api/v2       False         50
+        psgettestlocal   file:///c:/code/testdir                         True         50
+
+```
+
+This example runs the command with the 'Name' parameter being set to a single wildcard character. So all the repositories registered for the current user are returned.
+
 
 ## PARAMETERS
 
 ### -Name
-{{ Fill Name Description }}
+This parameter takes a String argument, including wildcard characters, or an array of such String arguments. It is used to search for repository names from the repository store which match the provided name pattern.
 
 ```yaml
-Type: System.String[]
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 
@@ -42,54 +83,19 @@ Required: False
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
-```
-
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-Parameter Sets: (All)
-Aliases: wi
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String[]
-
 ## OUTPUTS
 
-### System.Object
-
+###Microsoft.PowerShell.PowerShellGet.UtilClasses.PSRepositoryInfo
 ## NOTES
+If no value for Name is provided, Get-PSResourceRepository will return information for all registered repositories.
 
 ## RELATED LINKS
-
-[<add>](<add>)
-

--- a/help/Get-PSResourceRepository.md
+++ b/help/Get-PSResourceRepository.md
@@ -68,7 +68,6 @@ PS C:\> Get-PSResourceRepository -Name "*"
 
 This example runs the command with the 'Name' parameter being set to a single wildcard character. So all the repositories registered on this machine are returned.
 
-
 ## PARAMETERS
 
 ### -Name

--- a/help/Get-PSResourceRepository.md
+++ b/help/Get-PSResourceRepository.md
@@ -17,7 +17,7 @@ Get-PSResourceRepository [[-Name] <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Get-PSResourceRepository cmdlet replaces the Get-PSRepository cmdlet from V2. It searches for the PowerShell module repositories that are registered for the current user. By default it will return all registered repositories, or if the -Name parameter argument is specified then it wil return the repository which matches that name. It returns PSRepositoryInfo objects which contain information for each repository item found.
+The Get-PSResourceRepository cmdlet searches for the PowerShell resource repositories that are registered on the machine. By default it will return all registered repositories, or if the -Name parameter argument is specified then it will return the repository which matches that name. It returns PSRepositoryInfo objects which contain information for each repository item found.
 
 ## EXAMPLES
 
@@ -29,7 +29,7 @@ PS C:\> Get-PSResourceRepository -Name "PSGallery"
         PSGallery    https://www.powershellgallery.com/api/v2     False         50
 ```
 
-This example runs the command with the 'Name' parameter being set to "PSGallery". This repository is registered for the current user so the command returns information on this repository.
+This example runs the command with the 'Name' parameter being set to "PSGallery". This repository is registered on this machine so the command returns information on this repository.
 
 ### Example 2
 ```
@@ -41,7 +41,7 @@ PS C:\> Get-PSResourceRepository -Name "*Gallery"
 
 ```
 
-This example runs the command with the 'Name' parameter being set to "*Gallery" which includes a wildcard. The following repositories are registered for the current user and match the name pattern, so the command returns information on these repositories.
+This example runs the command with the 'Name' parameter being set to "*Gallery" which includes a wildcard. The following repositories are registered on this machine and match the name pattern, so the command returns information on these repositories.
 
 ### Example 3
 ```
@@ -53,7 +53,7 @@ PS C:\> Get-PSResourceRepository -Name "PSGallery","PoshTestGallery"
 
 ```
 
-This example runs the command with the 'Name' parameter being set to an array of Strings. Both of the specified repositories are registered for the current user and match the name pattern, so the command returns information on these repositories.
+This example runs the command with the 'Name' parameter being set to an array of Strings. Both of the specified repositories are registered on this machine and match the name pattern, so the command returns information on these repositories.
 
 ### Example 4
 ```
@@ -66,7 +66,7 @@ PS C:\> Get-PSResourceRepository -Name "*"
 
 ```
 
-This example runs the command with the 'Name' parameter being set to a single wildcard character. So all the repositories registered for the current user are returned.
+This example runs the command with the 'Name' parameter being set to a single wildcard character. So all the repositories registered on this machine are returned.
 
 
 ## PARAMETERS

--- a/help/Get-PSResourceRepository.md
+++ b/help/Get-PSResourceRepository.md
@@ -94,7 +94,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ### System.String[]
 ## OUTPUTS
 
-###Microsoft.PowerShell.PowerShellGet.UtilClasses.PSRepositoryInfo
+### Microsoft.PowerShell.PowerShellGet.UtilClasses.PSRepositoryInfo
 ## NOTES
 If no value for Name is provided, Get-PSResourceRepository will return information for all registered repositories.
 

--- a/help/Register-PSResourceRepository.md
+++ b/help/Register-PSResourceRepository.md
@@ -1,69 +1,82 @@
 ---
 external help file: PowerShellGet.dll-Help.xml
 Module Name: PowerShellGet
-online version: <add>
+online version:
 schema: 2.0.0
 ---
 
 # Register-PSResourceRepository
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+The Register-PSResourceRepository cmdlet replaces the Register-PSRepository from V2. It registers a repository for PowerShell modules. The repository is registered to the current user's scope and does not have a system-wide scope.
 
 ## SYNTAX
 
 ### NameParameterSet (Default)
 ```
-Register-PSResourceRepository [-Name] <String> [-URL] <Uri> [-Credential <PSCredential>] [-Trusted]
- [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-Priority <Int32>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Register-PSResourceRepository [-Name] <String> [-URL] <Uri> [-Trusted] [-Priority <Int32>] [-PassThru]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### PSGalleryParameterSet
 ```
-Register-PSResourceRepository [-PSGallery] [-Trusted] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
- [-Priority <Int32>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Register-PSResourceRepository [-PSGallery] [-Trusted] [-Priority <Int32>] [-PassThru] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### RepositoriesParameterSet
 ```
-Register-PSResourceRepository -Repositories <System.Collections.Generic.List`1[System.Collections.Hashtable]>
- [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Register-PSResourceRepository -Repositories <Hashtable[]> [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+The Register-PSResourceRepository cmdlet replaces the Register-PSRepository from V2. It registers a repository for PowerShell modules. The repository is registered to the current user's scope and does not have a system-wide scope.
 
 ## EXAMPLES
-
+These examples assume that the repository we attempt to reigster are not already registered for the current user.
 ### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+```
+PS C:\> Register-PSResourceRepository -Name "PoshTestGallery" -URL "https://www.powershellgallery.com/api/v2"
+PS C:\> Get-PSResourceRepository -Name "PoshTestGallery"
+        Name             Url                                          Trusted   Priority
+        ----             ---                                          -------   --------
+        PoshTestGallery  https://www.poshtestgallery.com/api/v2         False         50
 ```
 
-{{ Add example description here }}
+This example registers the repository with the 'Name' of "PoshtTestGallery" along with the associated 'URL' value for it.
+
+### Example 2
+```
+PS C:\> Register-PSResourceRepository -PSGallery
+PS C:\> Get-PSResourceRepository -Name "PSGallery"
+        Name             Url                                          Trusted   Priority
+        ----             ---                                          -------   --------
+        PSGallery        https://www.powershellgallery.com/api/v2       False         50
+```
+
+This example registers the "PSGallery" repository, with the 'PSGallery' parameter. Unlike the previous example, we cannot use the 'Name' or 'URL' parameters to register the "PSGallery" repository as it is considered Powershell's default repository store and has its own value for URL.
+
+### Example 3
+```
+PS C:\> $arrayOfHashtables = @{Name = "psgettestlocal"; URL = "c:/code/testdir"},@{PSGallery = $True}
+PS C:\> Register-PSResourceRepository -Repositories $arrayOfHashtables
+PS C:\> Get-PSResourceRepository
+        Name             Url                                          Trusted   Priority
+        ----             ---                                          -------   --------
+        PSGallery        https://www.powershellgallery.com/api/v2       False         50
+        psgettestlocal   file:///c:/code/testdir                        False         50
+
+```
+
+This example registers multiple repositories at once. To do so, we use the 'Repositories' parameter and provide an array of hashtables. Each hashtable can only have keys associated with parameters for the NameParameterSet or the PSGalleryParameterSet. Upon running the command we can see that the "psgettestlocal" and "PSGallery" repositories have been succesfully registered.
 
 ## PARAMETERS
 
-### -Credential
-{{ Fill Credential Description }}
-
-```yaml
-Type: System.Management.Automation.PSCredential
-Parameter Sets: NameParameterSet
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
 ### -Name
-{{ Fill Name Description }}
+Name of the repository to be registered.
 
 ```yaml
-Type: System.String
+Type: String
 Parameter Sets: NameParameterSet
 Aliases:
 
@@ -75,100 +88,72 @@ Accept wildcard characters: False
 ```
 
 ### -Priority
-{{ Fill Priority Description }}
+Specifies the priority ranking of the repository.
+Repositories with higher ranking priority are searched before a lower ranking priority one, when searching for a repository item across multiple registered repositories. Valid priority values range from 0 to 50, such that a lower numeric value (i.e 10) corresponds to a higher priority ranking than a higher numeric value (i.e 40). Has default value of 50.
 
 ```yaml
-Type: System.Int32
+Type: Int32
 Parameter Sets: NameParameterSet, PSGalleryParameterSet
 Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 50
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Proxy
-{{ Fill Proxy Description }}
-
-```yaml
-Type: System.Uri
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-### -ProxyCredential
-{{ Fill ProxyCredential Description }}
-
-```yaml
-Type: System.Management.Automation.PSCredential
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
 ### -PSGallery
-{{ Fill PSGallery Description }}
+When specified, registers PSGallery repository.
 
 ```yaml
-Type: System.Management.Automation.SwitchParameter
+Type: SwitchParameter
 Parameter Sets: PSGalleryParameterSet
 Aliases:
 
 Required: True
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Repositories
-{{ Fill Repositories Description }}
+Specifies an array of hashtables of repositories and is used to register multiple repositories at once.
 
 ```yaml
-Type: System.Collections.Generic.List`1[System.Collections.Hashtable]
+Type: Hashtable[]
 Parameter Sets: RepositoriesParameterSet
 Aliases:
 
 Required: True
 Position: Named
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
 ### -Trusted
-{{ Fill Trusted Description }}
+Specifies whether the repository should be trusted.
 
 ```yaml
-Type: System.Management.Automation.SwitchParameter
+Type: SwitchParameter
 Parameter Sets: NameParameterSet, PSGalleryParameterSet
 Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -URL
-{{ Fill URL Description }}
+Specifies the location of the repository to be registered.
+URL can be of the following Uri schemas: HTTPS, HTTP, FTP, file share based.
 
 ```yaml
-Type: System.Uri
+Type: Uri
 Parameter Sets: NameParameterSet
 Aliases:
 
@@ -183,13 +168,13 @@ Accept wildcard characters: False
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: System.Management.Automation.SwitchParameter
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -199,9 +184,24 @@ Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml
-Type: System.Management.Automation.SwitchParameter
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+When specified, displays the succcessfully registered repository and its information.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named
@@ -211,21 +211,17 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
-### System.Management.Automation.PSCredential
-
+### System.String
 ### System.Uri
-
 ## OUTPUTS
 
-### System.Object
-
+### Microsoft.PowerShell.PowerShellGet.UtilClasses.PSRepositoryInfo (if 'PassThru' parameter used)
 ## NOTES
+Repositories are unique by 'Name'. Attempting to register a repository with same 'Name' as an already registered repository will not successfully register.
+Registering the PSGallery repository must be done via the PSGalleryParameterSet (i.e by using the 'PSGallery' parameter instead of 'Name' and 'URL' parameters).
 
 ## RELATED LINKS
-
-[<add>](<add>)
-

--- a/help/Register-PSResourceRepository.md
+++ b/help/Register-PSResourceRepository.md
@@ -119,7 +119,7 @@ Accept wildcard characters: False
 ```
 
 ### -Repositories
-Specifies an array of hashtables that contains repository information and is used to register multiple repositories at once.
+Specifies an array of hashtables which contains repository information and is used to register multiple repositories at once.
 
 ```yaml
 Type: Hashtable[]

--- a/help/Register-PSResourceRepository.md
+++ b/help/Register-PSResourceRepository.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Register-PSResourceRepository
 
 ## SYNOPSIS
-The Register-PSResourceRepository cmdlet replaces the Register-PSRepository from V2. It registers a repository for PowerShell modules. The repository is registered to the current user's scope and does not have a system-wide scope.
+Registers a repository for PowerShell modules.
 
 ## SYNTAX
 

--- a/help/Register-PSResourceRepository.md
+++ b/help/Register-PSResourceRepository.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Register-PSResourceRepository
 
 ## SYNOPSIS
-Registers a repository for PowerShell modules.
+Registers a repository for PowerShell resources.
 
 ## SYNTAX
 

--- a/help/Register-PSResourceRepository.md
+++ b/help/Register-PSResourceRepository.md
@@ -30,10 +30,10 @@ Register-PSResourceRepository -Repositories <Hashtable[]> [-PassThru] [-WhatIf] 
 ```
 
 ## DESCRIPTION
-The Register-PSResourceRepository cmdlet replaces the Register-PSRepository from V2. It registers a repository for PowerShell modules. The repository is registered to the current user's scope and does not have a system-wide scope.
+The Register-PSResourceRepository cmdlet registers a repository for PowerShell resources.
 
 ## EXAMPLES
-These examples assume that the repository we attempt to reigster are not already registered for the current user.
+These examples assume that the repository we attempt to reigster is not already registered on the user's machine.
 ### Example 1
 ```
 PS C:\> Register-PSResourceRepository -Name "PoshTestGallery" -URL "https://www.powershellgallery.com/api/v2"
@@ -43,7 +43,7 @@ PS C:\> Get-PSResourceRepository -Name "PoshTestGallery"
         PoshTestGallery  https://www.poshtestgallery.com/api/v2         False         50
 ```
 
-This example registers the repository with the 'Name' of "PoshtTestGallery" along with the associated 'URL' value for it.
+This example registers the repository with the 'Name' of "PoshTestGallery" along with the associated 'URL' value for it.
 
 ### Example 2
 ```
@@ -119,7 +119,7 @@ Accept wildcard characters: False
 ```
 
 ### -Repositories
-Specifies an array of hashtables of repositories and is used to register multiple repositories at once.
+Specifies an array of hashtables that contains repository information and is used to register multiple repositories at once.
 
 ```yaml
 Type: Hashtable[]
@@ -211,7 +211,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/help/Unregister-PSResourceRepository.md
+++ b/help/Unregister-PSResourceRepository.md
@@ -1,14 +1,14 @@
 ---
 external help file: PowerShellGet.dll-Help.xml
 Module Name: PowerShellGet
-online version: <add>
+online version:
 schema: 2.0.0
 ---
 
 # Unregister-PSResourceRepository
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Un-registers a repository from the repository store for a current user.
 
 ## SYNTAX
 
@@ -17,24 +17,47 @@ Unregister-PSResourceRepository [-Name] <String[]> [-WhatIf] [-Confirm] [<Common
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+The Unregister-PSResourceRepository cmdlet replaces the Unregister-PSRepository cmdlet from V2. It unregisters a repository for the current user.
 
 ## EXAMPLES
 
 ### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+```
+PS C:\> Get-PSResourceRepository -Name "PoshTestGallery"
+PS C:\> Unregister-PSResourceRepository -Name "PoshTestGallery"
+PS C:\> Get-PSResourceRepository -Name "PoshTestGallery"
+PS C:\>
+
 ```
 
-{{ Add example description here }}
+In this example, we assume the repository "PoshTestGallery" has been previously registered for the current user. So when we first run the command to find "PoshTestGallery" it verifies that this repository can be found. Next, we run the command to unregister "PoshTestGallery". Finally, we again run the command to find "PoshTestGallery" but since it was successfully un-registered it cannot be found or retrieved.
+
+### Example 2
+```
+PS C:\> Get-PSResourceRepository
+        Name             Url                                          Trusted   Priority
+        ----             ---                                          -------   --------
+        PoshTestGallery  https://www.poshtestgallery.com/api/v2          True         40
+        PSGallery        https://www.powershellgallery.com/api/v2       False         50
+        psgettestlocal   file:///c:/code/testdir                         True         50
+
+PS C:\> Unregister-PSResourceRepository -Name "PoshTestGallery","psgettestlocal"
+PS C:\> Get-PSResourceRepository
+        Name             Url                                          Trusted   Priority
+        ----             ---                                          -------   --------
+        PSGallery        https://www.powershellgallery.com/api/v2       False         50
+
+```
+
+In this example, the command to find all registered repositories is run and the repositories found are displayed. Next, the command to un-register is run with a list of names ("PoshTestGallery", "psgettestlocal") provided for the 'Name' parameter. Finally, the command to find all registered repositories is run again, but this time we can see that "PoshTestGallery" and "psgettestlocal" are not found and displayed as they have been successfully unregistered.
 
 ## PARAMETERS
 
 ### -Name
-{{ Fill Name Description }}
+This parameter takes a String argument, or an array of String arguments. It is the name of the repository to un-register.
 
 ```yaml
-Type: System.String[]
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 
@@ -49,13 +72,13 @@ Accept wildcard characters: False
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: System.Management.Automation.SwitchParameter
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -65,30 +88,26 @@ Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml
-Type: System.Management.Automation.SwitchParameter
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String[]
-
 ## OUTPUTS
 
-### System.Object
+None
 ## NOTES
 
 ## RELATED LINKS
-
-[<add>](<add>)
-

--- a/help/Unregister-PSResourceRepository.md
+++ b/help/Unregister-PSResourceRepository.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Unregister-PSResourceRepository
 
 ## SYNOPSIS
-Un-registers a repository from the repository store for a current user.
+Un-registers a repository from the repository store.
 
 ## SYNTAX
 
@@ -17,7 +17,7 @@ Unregister-PSResourceRepository [-Name] <String[]> [-WhatIf] [-Confirm] [<Common
 ```
 
 ## DESCRIPTION
-The Unregister-PSResourceRepository cmdlet unregisters a repository for the current user.
+The Unregister-PSResourceRepository cmdlet unregisters a repository.
 
 ## EXAMPLES
 
@@ -30,7 +30,7 @@ PS C:\>
 
 ```
 
-In this example, we assume the repository "PoshTestGallery" has been previously registered for the user. So when we first run the command to find "PoshTestGallery" it verifies that this repository can be found. Next, we run the command to unregister "PoshTestGallery". Finally, we again run the command to find "PoshTestGallery" but since it was successfully un-registered it cannot be found or retrieved.
+In this example, we assume the repository "PoshTestGallery" has been previously registered. So when we first run the command to find "PoshTestGallery" it verifies that this repository can be found. Next, we run the command to unregister "PoshTestGallery". Finally, we again run the command to find "PoshTestGallery" but since it was successfully un-registered it cannot be found or retrieved.
 
 ### Example 2
 ```

--- a/help/Unregister-PSResourceRepository.md
+++ b/help/Unregister-PSResourceRepository.md
@@ -17,7 +17,7 @@ Unregister-PSResourceRepository [-Name] <String[]> [-WhatIf] [-Confirm] [<Common
 ```
 
 ## DESCRIPTION
-The Unregister-PSResourceRepository cmdlet replaces the Unregister-PSRepository cmdlet from V2. It unregisters a repository for the current user.
+The Unregister-PSResourceRepository cmdlet unregisters a repository for the current user.
 
 ## EXAMPLES
 
@@ -30,7 +30,7 @@ PS C:\>
 
 ```
 
-In this example, we assume the repository "PoshTestGallery" has been previously registered for the current user. So when we first run the command to find "PoshTestGallery" it verifies that this repository can be found. Next, we run the command to unregister "PoshTestGallery". Finally, we again run the command to find "PoshTestGallery" but since it was successfully un-registered it cannot be found or retrieved.
+In this example, we assume the repository "PoshTestGallery" has been previously registered for the user. So when we first run the command to find "PoshTestGallery" it verifies that this repository can be found. Next, we run the command to unregister "PoshTestGallery". Finally, we again run the command to find "PoshTestGallery" but since it was successfully un-registered it cannot be found or retrieved.
 
 ### Example 2
 ```
@@ -100,7 +100,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 


### PR DESCRIPTION
Used PlatyPS to update design docs for `Register-PSResourceRepository`, `Get-PSResourceRepository`, and `Unregister-PSResourceRepository`. Filled in the docs.

# PR Summary

Updated design docs for Register, Unregister and Get -PSResourceRepository cmdlets.

## PR Context

updating docs for refactored cmdlets.

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
