### PR TITLE
Change version of Pester to 5.x

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -75,8 +75,8 @@ stages:
         Save-Module -Name "platyPS" -Path $modulePath -Force
         Write-Verbose -Verbose "Install PSScriptAnalyzer to temp module path"
         Save-Module -Name "PSScriptAnalyzer" -Path $modulePath -RequiredVersion 1.18.0 -Force
-        Write-Verbose -Verbose "Install Pester 4.X to temp module path"
-        Save-Module -Name "Pester" -MaximumVersion 4.99 -Path $modulePath -Force
+        Write-Verbose -Verbose "Install Pester 5.X to temp module path"
+        Save-Module -Name "Pester" -MinimumVersion 5.0 -Path $modulePath -Repository PSGallery -Force
         Write-Verbose -Verbose "Install PSPackageProject to temp module path"
         Save-Module -Name PSPackageProject -Path $modulePath -Force
       displayName: Install PSPackageProject and dependencies

--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -42,8 +42,8 @@ jobs:
       Save-Module -Name "platyPS" -Path $modulePath -Force
       Write-Verbose -Verbose "Install PSScriptAnalyzer to temp module path"
       Save-Module -Name "PSScriptAnalyzer" -Path $modulePath -RequiredVersion 1.18.0 -Force
-      Write-Verbose -Verbose "Install Pester 4.X to temp module path"
-      Save-Module -Name "Pester" -MaximumVersion 4.99 -Path $modulePath -Force
+      Write-Verbose -Verbose "Install Pester 5.X to temp module path"
+      Save-Module -Name "Pester" -MinimumVersion 5.0 -Path $modulePath -Repository PSGallery -Force
       Write-Verbose -Verbose "Install PSPackageProject to temp module path"
       Save-Module -Name PSPackageProject -Path $modulePath -Force
     displayName: Install PSPackageProject and dependencies


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR changes the Pester for CI tests to 5.x.

## PR Context

We want to standardize Pester 5.x for our new tests.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
