### PR TITLE
Add TryPSGetInfo utility function to read resource installation file data

### DIFF
--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -116,7 +116,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
         public Hashtable ConvertToHashtable()
         {
-            var hashtable = new Hashtable()
+            var hashtable = new Hashtable
             {
                 { nameof(Cmdlet), Cmdlet },
                 { nameof(Command), Command },

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -58,9 +58,9 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         #endregion
     }
 
-    #region PSGetInfo classes
+    #region PSGetResourceInfo classes
 
-    internal sealed class PSGetInclude
+    internal sealed class PSGetIncludes
     {
         #region Properties
 
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         ///     Value: ArrayList of Workflow name strings
         /// </summary>
         /// <param name="includes">Hashtable of PSGet includes</param>
-        public PSGetInclude(Hashtable includes)
+        public PSGetIncludes(Hashtable includes)
         {
             if (includes == null) { return; }
 
@@ -149,7 +149,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         #endregion
     }
 
-    internal sealed class PSGetInfo
+    internal sealed class PSGetResourceInfo
     {
         #region Properties
 
@@ -167,7 +167,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
         public Uri IconUri { get; set; }
 
-        public PSGetInclude Includes { get; set; }
+        public PSGetIncludes Includes { get; set; }
 
         public DateTime InstalledDate { get; set; }
 
@@ -204,11 +204,11 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         #region Public static methods
 
         /// <summary>
-        /// Writes the PSGetInfo properties to the specified file path as a 
+        /// Writes the PSGetResourceInfo properties to the specified file path as a 
         /// PowerShell serialized xml file, maintaining compatibility with 
         /// PowerShellGet v2 file format.
         /// </summary>
-        public bool TryWritePSGetInfo(
+        public bool TryWrite(
             string filePath,
             out string errorMsg)
         {
@@ -244,12 +244,12 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         }
 
         /// <summary>
-        /// Reads a 'PSGetModuleInfo.xml' PowerShell serialized file and returns
-        /// a PSGetInfo object containing the file contents.
+        /// Reads a PSGet resource xml (PowerShell serialized) file and returns
+        /// a PSGetResourceInfo object containing the file contents.
         /// </summary>
-        public static bool TryReadPSGetInfo(
+        public static bool TryRead(
             string filePath,
-            out PSGetInfo psGetInfo,
+            out PSGetResourceInfo psGetInfo,
             out string errorMsg)
         {
             psGetInfo = null;
@@ -268,31 +268,31 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                     System.IO.File.ReadAllText(
                         filePath));
 
-                psGetInfo = new PSGetInfo
+                psGetInfo = new PSGetResourceInfo
                 {
-                    AdditionalMetadata = GetProperty<Dictionary<string,string>>(nameof(PSGetInfo.AdditionalMetadata), psObjectInfo),
-                    Author = GetProperty<string>(nameof(PSGetInfo.Author), psObjectInfo),
-                    CompanyName = GetProperty<string>(nameof(PSGetInfo.CompanyName), psObjectInfo),
-                    Copyright = GetProperty<string>(nameof(PSGetInfo.Copyright), psObjectInfo),
-                    Dependencies = Utils.GetStringArray(GetProperty<ArrayList>(nameof(PSGetInfo.Dependencies), psObjectInfo)),
-                    Description = GetProperty<string>(nameof(PSGetInfo.Description), psObjectInfo),
-                    IconUri = GetProperty<Uri>(nameof(PSGetInfo.IconUri), psObjectInfo),
-                    Includes = new PSGetInclude(GetProperty<Hashtable>(nameof(PSGetInfo.Includes), psObjectInfo)),
-                    InstalledDate = GetProperty<DateTime>(nameof(PSGetInfo.InstalledDate), psObjectInfo),
-                    InstalledLocation = GetProperty<string>(nameof(PSGetInfo.InstalledLocation), psObjectInfo),
-                    LicenseUri = GetProperty<Uri>(nameof(PSGetInfo.LicenseUri), psObjectInfo),
-                    Name = GetProperty<string>(nameof(PSGetInfo.Name), psObjectInfo),
-                    PackageManagementProvider = GetProperty<string>(nameof(PSGetInfo.PackageManagementProvider), psObjectInfo),
-                    PowerShellGetFormatVersion = GetProperty<string>(nameof(PSGetInfo.PowerShellGetFormatVersion), psObjectInfo),
-                    ProjectUri = GetProperty<Uri>(nameof(PSGetInfo.ProjectUri), psObjectInfo),
-                    PublishedDate = GetProperty<DateTime>(nameof(PSGetInfo.PublishedDate), psObjectInfo),
-                    ReleaseNotes = GetProperty<string>(nameof(PSGetInfo.ReleaseNotes), psObjectInfo),
-                    Repository = GetProperty<string>(nameof(PSGetInfo.Repository), psObjectInfo),
-                    RepositorySourceLocation = GetProperty<string>(nameof(PSGetInfo.RepositorySourceLocation), psObjectInfo),
-                    Tags = Utils.GetStringArray(GetProperty<ArrayList>(nameof(PSGetInfo.Tags), psObjectInfo)),
-                    Type = GetProperty<string>(nameof(PSGetInfo.Type), psObjectInfo),
-                    UpdatedDate = GetProperty<DateTime>(nameof(PSGetInfo.UpdatedDate), psObjectInfo),
-                    Version = GetProperty<Version>(nameof(PSGetInfo.Version), psObjectInfo)
+                    AdditionalMetadata = GetProperty<Dictionary<string,string>>(nameof(PSGetResourceInfo.AdditionalMetadata), psObjectInfo),
+                    Author = GetProperty<string>(nameof(PSGetResourceInfo.Author), psObjectInfo),
+                    CompanyName = GetProperty<string>(nameof(PSGetResourceInfo.CompanyName), psObjectInfo),
+                    Copyright = GetProperty<string>(nameof(PSGetResourceInfo.Copyright), psObjectInfo),
+                    Dependencies = Utils.GetStringArray(GetProperty<ArrayList>(nameof(PSGetResourceInfo.Dependencies), psObjectInfo)),
+                    Description = GetProperty<string>(nameof(PSGetResourceInfo.Description), psObjectInfo),
+                    IconUri = GetProperty<Uri>(nameof(PSGetResourceInfo.IconUri), psObjectInfo),
+                    Includes = new PSGetIncludes(GetProperty<Hashtable>(nameof(PSGetResourceInfo.Includes), psObjectInfo)),
+                    InstalledDate = GetProperty<DateTime>(nameof(PSGetResourceInfo.InstalledDate), psObjectInfo),
+                    InstalledLocation = GetProperty<string>(nameof(PSGetResourceInfo.InstalledLocation), psObjectInfo),
+                    LicenseUri = GetProperty<Uri>(nameof(PSGetResourceInfo.LicenseUri), psObjectInfo),
+                    Name = GetProperty<string>(nameof(PSGetResourceInfo.Name), psObjectInfo),
+                    PackageManagementProvider = GetProperty<string>(nameof(PSGetResourceInfo.PackageManagementProvider), psObjectInfo),
+                    PowerShellGetFormatVersion = GetProperty<string>(nameof(PSGetResourceInfo.PowerShellGetFormatVersion), psObjectInfo),
+                    ProjectUri = GetProperty<Uri>(nameof(PSGetResourceInfo.ProjectUri), psObjectInfo),
+                    PublishedDate = GetProperty<DateTime>(nameof(PSGetResourceInfo.PublishedDate), psObjectInfo),
+                    ReleaseNotes = GetProperty<string>(nameof(PSGetResourceInfo.ReleaseNotes), psObjectInfo),
+                    Repository = GetProperty<string>(nameof(PSGetResourceInfo.Repository), psObjectInfo),
+                    RepositorySourceLocation = GetProperty<string>(nameof(PSGetResourceInfo.RepositorySourceLocation), psObjectInfo),
+                    Tags = Utils.GetStringArray(GetProperty<ArrayList>(nameof(PSGetResourceInfo.Tags), psObjectInfo)),
+                    Type = GetProperty<string>(nameof(PSGetResourceInfo.Type), psObjectInfo),
+                    UpdatedDate = GetProperty<DateTime>(nameof(PSGetResourceInfo.UpdatedDate), psObjectInfo),
+                    Version = GetProperty<Version>(nameof(PSGetResourceInfo.Version), psObjectInfo)
                 };
 
                 return true;
@@ -413,9 +413,9 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
     public static class TestHooks
     {
-        public static PSObject ReadPSGetInfo(string filePath)
+        public static PSObject ReadPSGetResourceInfo(string filePath)
         {
-            if (PSGetInfo.TryReadPSGetInfo(filePath, out PSGetInfo psGetInfo, out string errorMsg))
+            if (PSGetResourceInfo.TryRead(filePath, out PSGetResourceInfo psGetInfo, out string errorMsg))
             {
                 return PSObject.AsPSObject(psGetInfo);
             }
@@ -423,13 +423,13 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             throw new PSInvalidOperationException(errorMsg);
         }
 
-        public static void WritePSGetInfo(
+        public static void WritePSGetResourceInfo(
             string filePath,
             PSObject psObjectGetInfo)
         {
-            if (psObjectGetInfo.BaseObject is PSGetInfo psGetInfo)
+            if (psObjectGetInfo.BaseObject is PSGetResourceInfo psGetInfo)
             {
-                if (! psGetInfo.TryWritePSGetInfo(filePath, out string errorMsg))
+                if (! psGetInfo.TryWrite(filePath, out string errorMsg))
                 {
                     throw new PSInvalidOperationException(errorMsg);
                 }
@@ -437,7 +437,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 return;
             }
 
-            throw new PSArgumentException("psObjectGetInfo argument is not a PSGetInfo type.");
+            throw new PSArgumentException("psObjectGetInfo argument is not a PSGetResourceInfo type.");
         }
     }
 

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         /// Reads a 'PSGetModuleInfo.xml' PowerShell serialized file and returns
         /// a PSGetInfo object containing the file contents.
         /// </summary>
-        public static bool TryGetPSGetInfo(
+        public static bool TryReadPSGetInfo(
             string filePath,
             out PSGetInfo psGetInfo,
             out string errorMsg)
@@ -312,7 +312,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
     {
         public static PSObject ReadPSGetInfo(string filePath)
         {
-            if (Utils.TryGetPSGetInfo(filePath, out PSGetInfo psGetInfo, out string errorMsg))
+            if (Utils.TryReadPSGetInfo(filePath, out PSGetInfo psGetInfo, out string errorMsg))
             {
                 return PSObject.AsPSObject(psGetInfo);
             }

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                     System.IO.File.ReadAllText(
                         filePath));
 
-                psGetInfo = new PSGetInfo()
+                psGetInfo = new PSGetInfo
                 {
                     AdditionalMetadata = GetProperty<Dictionary<string,string>>(nameof(PSGetInfo.AdditionalMetadata), psObjectInfo),
                     Author = GetProperty<string>(nameof(PSGetInfo.Author), psObjectInfo),
@@ -308,7 +308,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
     #region Test Hooks
 
-    public sealed class TestHooks
+    public static class TestHooks
     {
         public static PSObject ReadPSGetInfo(string filePath)
         {

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -419,10 +419,8 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             {
                 return PSObject.AsPSObject(psGetInfo);
             }
-            else
-            {
-                throw new PSInvalidOperationException(errorMsg);
-            }
+
+            throw new PSInvalidOperationException(errorMsg);
         }
 
         public static void WritePSGetInfo(
@@ -435,11 +433,11 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 {
                     throw new PSInvalidOperationException(errorMsg);
                 }
+
+                return;
             }
-            else
-            {
-                throw new PSArgumentException("psObjectGetInfo argument is not a PSGetInfo type.");
-            }
+
+            throw new PSArgumentException("psObjectGetInfo argument is not a PSGetInfo type.");
         }
     }
 

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -2,15 +2,17 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Management.Automation;
 using System.Management.Automation.Language;
 
 namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 {
-    #region Utils
-
     internal static class Utils
     {
-        #region Members
+        #region Public methods
 
         public static string TrimQuotes(string name)
         {
@@ -37,7 +39,288 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             return "'" + CodeGeneration.EscapeSingleQuotedStringContent(name) + "'";
         }
 
+        /// <summary>
+        /// Reads a 'PSGetModuleInfo.xml' PowerShell serialized file and returns
+        /// a PSGetInfo object containing the file contents.
+        /// </summary>
+        public static bool TryGetPSGetInfo(
+            string filePath,
+            out PSGetInfo psGetInfo,
+            out string errorMsg)
+        {
+            psGetInfo = null;
+            errorMsg = string.Empty;
+
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                errorMsg = "GetPSGetInfo: Invalid file path. Filepath cannot be empty or whitespace.";
+                return false;
+            }
+
+            try
+            {
+                // Read and deserialize information xml file.
+                var psObjectInfo = (PSObject) PSSerializer.Deserialize(
+                    System.IO.File.ReadAllText(
+                        filePath));
+
+                psGetInfo = new PSGetInfo()
+                {
+                    AdditionalMetadata = GetProperty<Dictionary<string,string>>(nameof(PSGetInfo.AdditionalMetadata), psObjectInfo),
+                    Author = GetProperty<string>(nameof(PSGetInfo.Author), psObjectInfo),
+                    CompanyName = GetProperty<string>(nameof(PSGetInfo.CompanyName), psObjectInfo),
+                    Copyright = GetProperty<string>(nameof(PSGetInfo.Copyright), psObjectInfo),
+                    Dependencies = GetStringArray(GetProperty<ArrayList>(nameof(PSGetInfo.Dependencies), psObjectInfo)),
+                    Description = GetProperty<string>(nameof(PSGetInfo.Description), psObjectInfo),
+                    IconUri = GetProperty<Uri>(nameof(PSGetInfo.IconUri), psObjectInfo),
+                    Includes = new PSGetInclude(GetProperty<Hashtable>(nameof(PSGetInfo.Includes), psObjectInfo)),
+                    InstalledDate = GetProperty<DateTime>(nameof(PSGetInfo.InstalledDate), psObjectInfo),
+                    InstalledLocation = GetProperty<string>(nameof(PSGetInfo.InstalledLocation), psObjectInfo),
+                    LicenseUri = GetProperty<Uri>(nameof(PSGetInfo.LicenseUri), psObjectInfo),
+                    Name = GetProperty<string>(nameof(PSGetInfo.Name), psObjectInfo),
+                    PackageManagementProvider = GetProperty<string>(nameof(PSGetInfo.PackageManagementProvider), psObjectInfo),
+                    PowerShellGetFormatVersion = GetProperty<string>(nameof(PSGetInfo.PowerShellGetFormatVersion), psObjectInfo),
+                    ProjectUri = GetProperty<Uri>(nameof(PSGetInfo.ProjectUri), psObjectInfo),
+                    PublishedDate = GetProperty<DateTime>(nameof(PSGetInfo.PublishedDate), psObjectInfo),
+                    ReleaseNotes = GetProperty<string>(nameof(PSGetInfo.ReleaseNotes), psObjectInfo),
+                    Repository = GetProperty<string>(nameof(PSGetInfo.Repository), psObjectInfo),
+                    RepositorySourceLocation = GetProperty<string>(nameof(PSGetInfo.RepositorySourceLocation), psObjectInfo),
+                    Tags = GetStringArray(GetProperty<ArrayList>(nameof(PSGetInfo.Tags), psObjectInfo)),
+                    Type = GetProperty<string>(nameof(PSGetInfo.Type), psObjectInfo),
+                    UpdatedDate = GetProperty<DateTime>(nameof(PSGetInfo.UpdatedDate), psObjectInfo),
+                    Version = GetProperty<Version>(nameof(PSGetInfo.Version), psObjectInfo)
+                };
+
+                return true;
+            }
+            catch(Exception ex)
+            {
+                errorMsg = string.Format(
+                    CultureInfo.InvariantCulture,
+                    @"GetPSGetInfo: Cannot read the PowerShellGet information file with error: {0}",
+                    ex.Message);
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Converts an ArrayList of object types to a string array.
+        /// </summary>
+        public static string[] GetStringArray(ArrayList list)
+        {
+            if (list == null) { return null; }
+
+            var strArray = new string[list.Count];
+            for (int i=0; i<list.Count; i++)
+            {
+                strArray[i] = list[i] as string;
+            }
+
+            return strArray;
+        }
+
         #endregion
+
+        #region Private methods
+
+        private static T ConvertToType<T>(PSObject psObject)
+        {
+            // We only convert Dictionary<string, string> types.
+            if (typeof(T) != typeof(Dictionary<string, string>))
+            {
+                return default(T);
+            }
+
+            var dict = new Dictionary<string, string>();
+            foreach (var prop in psObject.Properties)
+            {
+                dict.Add(prop.Name, prop.Value.ToString());
+            }
+
+            return (T)Convert.ChangeType(dict, typeof(T));
+        }
+
+        private static T GetProperty<T>(
+            string Name,
+            PSObject psObjectInfo)
+        {
+            var val = psObjectInfo.Properties[Name]?.Value;
+            if (val == null)
+            {
+                return default(T);
+            }
+
+            switch (val)
+            {
+                case T valType:
+                    return valType;
+
+                case PSObject valPSObject:
+                    switch (valPSObject.BaseObject)
+                    {
+                        case T valBase:
+                            return valBase;
+
+                        case PSCustomObject _:
+                            // A base object of PSCustomObject means this is additional metadata
+                            // and type T should be Dictionary<string,string>.
+                            return ConvertToType<T>(valPSObject);
+
+                        default:
+                            return default(T);
+                    }
+
+                default:
+                    return default(T);
+            }
+        }
+
+        #endregion
+    }
+
+    #region PSGetInfo classes
+
+    internal sealed class PSGetInclude
+    {
+        #region Properties
+
+        public string[] Cmdlet { get; }
+
+        public string[] Command { get; }
+
+        public string[] DscResource { get; }
+
+        public string[] Function { get; }
+
+        public string[] RoleCapability { get; }
+
+        public string[] Workflow { get; }
+
+        #endregion
+
+        #region Constructor
+
+        /// <summary>
+        /// Constructor
+        /// 
+        /// Provided hashtable has form:
+        ///     Key: Cmdlet
+        ///     Value: ArrayList of Cmdlet name strings
+        ///     Key: Command
+        ///     Value: ArrayList of Command name strings
+        ///     Key: DscResource
+        ///     Value: ArrayList of DscResource name strings
+        ///     Key: Function
+        ///     Value: ArrayList of Function name strings
+        ///     Key: RoleCapability (deprecated for PSGetV3)
+        ///     Value: ArrayList of RoleCapability name strings
+        ///     Key: Workflow (deprecated for PSGetV3)
+        ///     Value: ArrayList of Workflow name strings
+        /// </summary>
+        /// <param name="includes">Hashtable of PSGet includes</param>
+        public PSGetInclude(Hashtable includes)
+        {
+            if (includes == null) { return; }
+
+            Cmdlet = GetHashTableItem(includes, nameof(Cmdlet));
+            Command = GetHashTableItem(includes, nameof(Command));
+            DscResource = GetHashTableItem(includes, nameof(DscResource));
+            Function = GetHashTableItem(includes, nameof(Function));
+            RoleCapability = GetHashTableItem(includes, nameof(RoleCapability));
+            Workflow = GetHashTableItem(includes, nameof(Workflow));
+        }
+
+        #endregion
+
+        #region Private methods
+
+        private string[] GetHashTableItem(
+            Hashtable table,
+            string name)
+        {
+            if (table.ContainsKey(name) &&
+                table[name] is PSObject psObjectItem)
+            {
+                return Utils.GetStringArray(psObjectItem.BaseObject as ArrayList);
+            }
+
+            return null;
+        }
+
+        #endregion
+    }
+
+    internal sealed class PSGetInfo
+    {
+        #region Properties
+
+        public Dictionary<string, string> AdditionalMetadata { get; set; }
+
+        public string Author { get; set; }
+
+        public string CompanyName { get; set; }
+
+        public string Copyright { get; set; }
+
+        public string[] Dependencies { get; set; }
+
+        public string Description { get; set; }
+
+        public Uri IconUri { get; set; }
+
+        public PSGetInclude Includes { get; set; }
+
+        public DateTime InstalledDate { get; set; }
+
+        public string InstalledLocation { get; set; }
+
+        public Uri LicenseUri { get; set; }
+
+        public string Name { get; set; }
+
+        public string PackageManagementProvider { get; set; }
+
+        public string PowerShellGetFormatVersion { get; set; }
+
+        public Uri ProjectUri { get; set; }
+
+        public DateTime PublishedDate { get; set; }
+
+        public string ReleaseNotes { get; set; }
+
+        public string Repository { get; set; }
+
+        public string RepositorySourceLocation { get; set; }
+
+        public string[] Tags { get; set; }
+
+        public string Type { get; set; }
+
+        public DateTime UpdatedDate { get; set; }
+
+        public Version Version { get; set; }
+
+        #endregion
+    }
+
+    #endregion
+
+    #region Test Hooks
+
+    public sealed class TestHooks
+    {
+        public static PSObject ReadPSGetInfo(string filePath)
+        {
+            if (Utils.TryGetPSGetInfo(filePath, out PSGetInfo psGetInfo, out string errorMsg))
+            {
+                return PSObject.AsPSObject(psGetInfo);
+            }
+            else
+            {
+                throw new PSInvalidOperationException(errorMsg);
+            }
+        }
     }
 
     #endregion

--- a/test/PSGetInfo.Tests.ps1
+++ b/test/PSGetInfo.Tests.ps1
@@ -35,20 +35,20 @@ Describe "Read PSGetModuleInfo xml file" -tags CI {
         $psGetInfo.IconUri | Should -BeNullOrEmpty
         $psGetInfo.Includes.Cmdlet | Should -HaveCount 10
         $psGetInfo.Includes.Cmdlet[0] | Should -BeExactly 'Register-SecretVault'
-        $psGetInfo.InstalledDate.Ticks | Should -BeExactly 637522675617662015
+        $psGetInfo.InstalledDate.Year | Should -BeExactly 2021
         $psGetInfo.InstalledLocation | Should -BeLike 'C:\Users\*'
         $psGetInfo.LicenseUri | Should -BeExactly 'https://github.com/PowerShell/SecretManagement/blob/master/LICENSE'
         $psGetInfo.Name | Should -BeExactly 'Microsoft.PowerShell.SecretManagement'
         $psGetInfo.PackageManagementProvider | Should -BeExactly 'NuGet'
         $psGetInfo.PowerShellGetFormatVersion | Should -BeNullOrEmpty
         $psGetInfo.ProjectUri | Should -BeExactly 'https://github.com/powershell/secretmanagement'
-        $psGetInfo.PublishedDate.Ticks | Should -BeExactly 637522924900000000
+        $psGetInfo.PublishedDate.Year | Should -BeExactly 2021
         $psGetInfo.ReleasedNotes | Should -BeNullOrEmpty
         $psGetInfo.Repository | Should -BeExactly 'PSGallery'
         $psGetInfo.RepositorySourceLocation | Should -BeExactly 'https://www.powershellgallery.com/api/v2'
         $psGetInfo.Tags | Should -BeExactly @('PSModule', 'PSEdition_Core')
         $psGetInfo.Type | Should -BeExactly 'Module'
-        $psGetInfo.UpdatedDate.Ticks | Should -BeExactly 0
+        $psGetInfo.UpdatedDate.Year | Should -BeExactly 1
         $psGetInfo.Version.ToString() | Should -BeExactly '1.0.0'
     }
 }

--- a/test/PSGetInfo.Tests.ps1
+++ b/test/PSGetInfo.Tests.ps1
@@ -35,20 +35,20 @@ Describe "Read PSGetModuleInfo xml file" -tags CI {
         $psGetInfo.IconUri | Should -BeNullOrEmpty
         $psGetInfo.Includes.Cmdlet | Should -HaveCount 10
         $psGetInfo.Includes.Cmdlet[0] | Should -BeExactly 'Register-SecretVault'
-        $psGetInfo.InstalledDate.ToLongDateString() | Should -BeExactly 'Thursday, March 25, 2021'
+        $psGetInfo.InstalledDate.Ticks | Should -BeExactly 637522675617662015
         $psGetInfo.InstalledLocation | Should -BeLike 'C:\Users\*'
         $psGetInfo.LicenseUri | Should -BeExactly 'https://github.com/PowerShell/SecretManagement/blob/master/LICENSE'
         $psGetInfo.Name | Should -BeExactly 'Microsoft.PowerShell.SecretManagement'
         $psGetInfo.PackageManagementProvider | Should -BeExactly 'NuGet'
         $psGetInfo.PowerShellGetFormatVersion | Should -BeNullOrEmpty
         $psGetInfo.ProjectUri | Should -BeExactly 'https://github.com/powershell/secretmanagement'
-        $psGetInfo.PublishedDate.ToLongDateString() | Should -BeExactly 'Thursday, March 25, 2021'
+        $psGetInfo.PublishedDate.Ticks | Should -BeExactly 637522924900000000
         $psGetInfo.ReleasedNotes | Should -BeNullOrEmpty
         $psGetInfo.Repository | Should -BeExactly 'PSGallery'
         $psGetInfo.RepositorySourceLocation | Should -BeExactly 'https://www.powershellgallery.com/api/v2'
         $psGetInfo.Tags | Should -BeExactly @('PSModule', 'PSEdition_Core')
         $psGetInfo.Type | Should -BeExactly 'Module'
-        $psGetInfo.UpdatedDate.ToLongDateString() | Should -BeExactly 'Monday, January 1, 0001'
+        $psGetInfo.UpdatedDate.Ticks | Should -BeExactly 0
         $psGetInfo.Version.ToString() | Should -BeExactly '1.0.0'
     }
 }

--- a/test/PSGetInfo.Tests.ps1
+++ b/test/PSGetInfo.Tests.ps1
@@ -1,0 +1,54 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+$psGetMod = Get-Module -Name PowerShellGet
+if ((! $psGetMod) -or (($psGetMod | Select-Object Version) -lt 3.0.0))
+{
+    Write-Verbose -Message "Importing PowerShellGet 3.0.0 for test" -Verbose
+    Import-Module -Name PowerShellGet -MinimumVersion 3.0.0 -Force
+}
+
+Describe "Read PSGetModuleInfo xml file" -tags CI {
+
+    It "Verifies expected error with null path" {
+        { [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::ReadPSGetInfo($null) } | Should -Throw -ErrorId 'PSInvalidOperationException'
+    }
+
+    It "Verifies expected error with invalid file path" {
+        { [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::ReadPSGetInfo('nonePath') } | Should -Throw -ErrorId 'PSInvalidOperationException'
+    }
+
+    It "Verifies PSGetModuleInfo.xml file is read successfully" {
+        $fileToRead = Join-Path -Path $PSScriptRoot -ChildPath "PSGetModuleInfo.xml"
+        $psGetInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::ReadPSGetInfo($fileToRead)
+        #
+        $psGetInfo.AdditionalMetadata.Keys | Should -HaveCount 22
+        $psGetInfo.AdditionalMetadata['copyright'] | Should -BeExactly '(c) Microsoft Corporation. All rights reserved.'
+        $psGetInfo.AdditionalMetadata['tags'] | Should -BeLike 'PSModule PSEdition_Core*'
+        $psGetInfo.AdditionalMetadata['ItemType'] | Should -BeExactly 'Module'
+        #
+        $psGetInfo.Author | Should -BeExactly 'Microsoft Corporation'
+        $psGetInfo.CompanyName | Should -BeExactly 'Microsoft Corporation'
+        $psGetInfo.Copyright | Should -BeExactly '(c) Microsoft Corporation. All rights reserved.'
+        $psGetInfo.Dependencies | Should -HaveCount 0
+        $psGetInfo.Description | Should -BeLike 'This module provides a convenient way for a user to store*'
+        $psGetInfo.IconUri | Should -BeNullOrEmpty
+        $psGetInfo.Includes.Cmdlet | Should -HaveCount 10
+        $psGetInfo.Includes.Cmdlet[0] | Should -BeExactly 'Register-SecretVault'
+        $psGetInfo.InstalledDate.ToString() | Should -BeExactly '3/25/2021 11:12:41 AM'
+        $psGetInfo.InstalledLocation | Should -BeLike 'C:\Users\*'
+        $psGetInfo.LicenseUri | Should -BeExactly 'https://github.com/PowerShell/SecretManagement/blob/master/LICENSE'
+        $psGetInfo.Name | Should -BeExactly 'Microsoft.PowerShell.SecretManagement'
+        $psGetInfo.PackageManagementProvider | Should -BeExactly 'NuGet'
+        $psGetInfo.PowerShellGetFormatVersion | Should -BeNullOrEmpty
+        $psGetInfo.ProjectUri | Should -BeExactly 'https://github.com/powershell/secretmanagement'
+        $psGetInfo.PublishedDate.ToString() | Should -BeExactly '3/25/2021 6:08:10 PM'
+        $psGetInfo.ReleasedNotes | Should -BeNullOrEmpty
+        $psGetInfo.Repository | Should -BeExactly 'PSGallery'
+        $psGetInfo.RepositorySourceLocation | Should -BeExactly 'https://www.powershellgallery.com/api/v2'
+        $psGetInfo.Tags | Should -BeExactly @('PSModule', 'PSEdition_Core')
+        $psGetInfo.Type | Should -BeExactly 'Module'
+        $psGetInfo.UpdatedDate.ToString() | Should -BeExactly '1/1/0001 12:00:00 AM'
+        $psGetInfo.Version.ToString() | Should -BeExactly '1.0.0'
+    }
+}

--- a/test/PSGetInfo.Tests.ps1
+++ b/test/PSGetInfo.Tests.ps1
@@ -35,20 +35,20 @@ Describe "Read PSGetModuleInfo xml file" -tags CI {
         $psGetInfo.IconUri | Should -BeNullOrEmpty
         $psGetInfo.Includes.Cmdlet | Should -HaveCount 10
         $psGetInfo.Includes.Cmdlet[0] | Should -BeExactly 'Register-SecretVault'
-        $psGetInfo.InstalledDate.ToString() | Should -BeExactly '3/25/2021 11:12:41 AM'
+        $psGetInfo.InstalledDate.ToLongDateString() | Should -BeExactly 'Thursday, March 25, 2021'
         $psGetInfo.InstalledLocation | Should -BeLike 'C:\Users\*'
         $psGetInfo.LicenseUri | Should -BeExactly 'https://github.com/PowerShell/SecretManagement/blob/master/LICENSE'
         $psGetInfo.Name | Should -BeExactly 'Microsoft.PowerShell.SecretManagement'
         $psGetInfo.PackageManagementProvider | Should -BeExactly 'NuGet'
         $psGetInfo.PowerShellGetFormatVersion | Should -BeNullOrEmpty
         $psGetInfo.ProjectUri | Should -BeExactly 'https://github.com/powershell/secretmanagement'
-        $psGetInfo.PublishedDate.ToString() | Should -BeExactly '3/25/2021 6:08:10 PM'
+        $psGetInfo.PublishedDate.ToLongDateString() | Should -BeExactly 'Thursday, March 25, 2021'
         $psGetInfo.ReleasedNotes | Should -BeNullOrEmpty
         $psGetInfo.Repository | Should -BeExactly 'PSGallery'
         $psGetInfo.RepositorySourceLocation | Should -BeExactly 'https://www.powershellgallery.com/api/v2'
         $psGetInfo.Tags | Should -BeExactly @('PSModule', 'PSEdition_Core')
         $psGetInfo.Type | Should -BeExactly 'Module'
-        $psGetInfo.UpdatedDate.ToString() | Should -BeExactly '1/1/0001 12:00:00 AM'
+        $psGetInfo.UpdatedDate.ToLongDateString() | Should -BeExactly 'Monday, January 1, 0001'
         $psGetInfo.Version.ToString() | Should -BeExactly '1.0.0'
     }
 }

--- a/test/PSGetModuleInfo.xml
+++ b/test/PSGetModuleInfo.xml
@@ -1,0 +1,152 @@
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.PSRepositoryItemInfo</T>
+      <T>System.Management.Automation.PSCustomObject</T>
+      <T>System.Object</T>
+    </TN>
+    <MS>
+      <S N="Name">Microsoft.PowerShell.SecretManagement</S>
+      <Version N="Version">1.0.0</Version>
+      <S N="Type">Module</S>
+      <S N="Description">This module provides a convenient way for a user to store and retrieve secrets. The secrets are_x000D__x000A_stored in registered extension vaults. An extension vault can store secrets locally or remotely._x000D__x000A_SecretManagement coordinates access to the secrets through the registered vaults._x000D__x000A__x000D__x000A_Go to GitHub for more information about the module and to submit issues:_x000D__x000A_https://github.com/powershell/SecretManagement</S>
+      <S N="Author">Microsoft Corporation</S>
+      <S N="CompanyName">Microsoft Corporation</S>
+      <S N="Copyright">(c) Microsoft Corporation. All rights reserved.</S>
+      <DT N="PublishedDate">2021-03-25T18:08:10-07:00</DT>
+      <Obj N="InstalledDate" RefId="1">
+        <DT>2021-03-25T11:12:41.7662015-07:00</DT>
+        <MS>
+          <Obj N="DisplayHint" RefId="2">
+            <TN RefId="1">
+              <T>Microsoft.PowerShell.Commands.DisplayHintType</T>
+              <T>System.Enum</T>
+              <T>System.ValueType</T>
+              <T>System.Object</T>
+            </TN>
+            <ToString>DateTime</ToString>
+            <I32>2</I32>
+          </Obj>
+        </MS>
+      </Obj>
+      <Nil N="UpdatedDate" />
+      <URI N="LicenseUri">https://github.com/PowerShell/SecretManagement/blob/master/LICENSE</URI>
+      <URI N="ProjectUri">https://github.com/powershell/secretmanagement</URI>
+      <Nil N="IconUri" />
+      <Obj N="Tags" RefId="3">
+        <TN RefId="2">
+          <T>System.Object[]</T>
+          <T>System.Array</T>
+          <T>System.Object</T>
+        </TN>
+        <LST>
+          <S>PSModule</S>
+          <S>PSEdition_Core</S>
+        </LST>
+      </Obj>
+      <Obj N="Includes" RefId="4">
+        <TN RefId="3">
+          <T>System.Collections.Hashtable</T>
+          <T>System.Object</T>
+        </TN>
+        <DCT>
+          <En>
+            <S N="Key">DscResource</S>
+            <Obj N="Value" RefId="5">
+              <TNRef RefId="2" />
+              <LST />
+            </Obj>
+          </En>
+          <En>
+            <S N="Key">RoleCapability</S>
+            <Ref N="Value" RefId="5" />
+          </En>
+          <En>
+            <S N="Key">Function</S>
+            <Ref N="Value" RefId="5" />
+          </En>
+          <En>
+            <S N="Key">Cmdlet</S>
+            <Obj N="Value" RefId="6">
+              <TNRef RefId="2" />
+              <LST>
+                <S>Register-SecretVault</S>
+                <S>Unregister-SecretVault</S>
+                <S>Get-SecretVault</S>
+                <S>Set-SecretVaultDefault</S>
+                <S>Test-SecretVault</S>
+                <S>Set-Secret</S>
+                <S>Set-SecretInfo</S>
+                <S>Get-Secret</S>
+                <S>Get-SecretInfo</S>
+                <S>Remove-Secret</S>
+              </LST>
+            </Obj>
+          </En>
+          <En>
+            <S N="Key">Command</S>
+            <Obj N="Value" RefId="7">
+              <TNRef RefId="2" />
+              <LST>
+                <S>Register-SecretVault</S>
+                <S>Unregister-SecretVault</S>
+                <S>Get-SecretVault</S>
+                <S>Set-SecretVaultDefault</S>
+                <S>Test-SecretVault</S>
+                <S>Set-Secret</S>
+                <S>Set-SecretInfo</S>
+                <S>Get-Secret</S>
+                <S>Get-SecretInfo</S>
+                <S>Remove-Secret</S>
+              </LST>
+            </Obj>
+          </En>
+          <En>
+            <S N="Key">Workflow</S>
+            <Ref N="Value" RefId="5" />
+          </En>
+        </DCT>
+      </Obj>
+      <Nil N="PowerShellGetFormatVersion" />
+      <Nil N="ReleaseNotes" />
+      <Obj N="Dependencies" RefId="8">
+        <TNRef RefId="2" />
+        <LST />
+      </Obj>
+      <S N="RepositorySourceLocation">https://www.powershellgallery.com/api/v2</S>
+      <S N="Repository">PSGallery</S>
+      <S N="PackageManagementProvider">NuGet</S>
+      <Obj N="AdditionalMetadata" RefId="9">
+        <TN RefId="4">
+          <T>System.Management.Automation.PSCustomObject</T>
+          <T>System.Object</T>
+        </TN>
+        <MS>
+          <S N="copyright">(c) Microsoft Corporation. All rights reserved.</S>
+          <S N="description">This module provides a convenient way for a user to store and retrieve secrets. The secrets are_x000D__x000A_stored in registered extension vaults. An extension vault can store secrets locally or remotely._x000D__x000A_SecretManagement coordinates access to the secrets through the registered vaults._x000D__x000A__x000D__x000A_Go to GitHub for more information about the module and to submit issues:_x000D__x000A_https://github.com/powershell/SecretManagement</S>
+          <S N="requireLicenseAcceptance">False</S>
+          <S N="isLatestVersion">True</S>
+          <S N="isAbsoluteLatestVersion">True</S>
+          <S N="versionDownloadCount">0</S>
+          <S N="downloadCount">15034</S>
+          <S N="packageSize">55046</S>
+          <S N="published">3/25/2021 6:08:10 PM -07:00</S>
+          <S N="created">3/25/2021 6:08:10 PM -07:00</S>
+          <S N="lastUpdated">3/25/2021 6:08:10 PM -07:00</S>
+          <S N="tags">PSModule PSEdition_Core PSCmdlet_Register-SecretVault PSCommand_Register-SecretVault PSCmdlet_Unregister-SecretVault PSCommand_Unregister-SecretVault PSCmdlet_Get-SecretVault PSCommand_Get-SecretVault PSCmdlet_Set-SecretVaultDefault PSCommand_Set-SecretVaultDefault PSCmdlet_Test-SecretVault PSCommand_Test-SecretVault PSCmdlet_Set-Secret PSCommand_Set-Secret PSCmdlet_Set-SecretInfo PSCommand_Set-SecretInfo PSCmdlet_Get-Secret PSCommand_Get-Secret PSCmdlet_Get-SecretInfo PSCommand_Get-SecretInfo PSCmdlet_Remove-Secret PSCommand_Remove-Secret PSIncludes_Cmdlet</S>
+          <S N="developmentDependency">False</S>
+          <S N="updated">2021-03-25T18:08:10Z</S>
+          <S N="NormalizedVersion">1.0.0</S>
+          <S N="Authors">Microsoft Corporation</S>
+          <S N="IsPrerelease">false</S>
+          <S N="ItemType">Module</S>
+          <S N="FileList">Microsoft.PowerShell.SecretManagement.nuspec|Microsoft.PowerShell.SecretManagement.dll|Microsoft.PowerShell.SecretManagement.format.ps1xml|Microsoft.PowerShell.SecretManagement.psd1|en-US\about_Microsoft.PowerShell.SecretManagement.help.txt|en-US\Microsoft.PowerShell.SecretManagement.dll-Help.xml</S>
+          <S N="GUID">a5c858f6-4a8e-41f1-b1ee-0ff8f6ad69d3</S>
+          <S N="PowerShellVersion">5.1</S>
+          <S N="CompanyName">Microsoft Corporation</S>
+        </MS>
+      </Obj>
+      <S N="InstalledLocation">C:\Users\paulhi\OneDrive - Microsoft\Documents\PowerShell\Modules\Microsoft.PowerShell.SecretManagement\1.0.0</S>
+    </MS>
+  </Obj>
+</Objs>

--- a/test/PSGetResourceInfo.Tests.ps1
+++ b/test/PSGetResourceInfo.Tests.ps1
@@ -17,15 +17,15 @@ Describe "Read PSGetModuleInfo xml file" -tags 'CI' {
     }
 
     It "Verifies expected error with null path" {
-        { [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::ReadPSGetInfo($null) } | Should -Throw -ErrorId 'PSInvalidOperationException'
+        { [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::ReadPSGetResourceInfo($null) } | Should -Throw -ErrorId 'PSInvalidOperationException'
     }
 
     It "Verifies expected error with invalid file path" {
-        { [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::ReadPSGetInfo('nonePath') } | Should -Throw -ErrorId 'PSInvalidOperationException'
+        { [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::ReadPSGetResourceInfo('nonePath') } | Should -Throw -ErrorId 'PSInvalidOperationException'
     }
 
     It "Verifies PSGetModuleInfo.xml file is read successfully" {
-        $psGetInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::ReadPSGetInfo($fileToRead)
+        $psGetInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::ReadPSGetResourceInfo($fileToRead)
         CheckForExpectedPSGetInfo $psGetInfo
     }
 }
@@ -38,17 +38,17 @@ Describe "Write PSGetModuleInfo xml file" -tags 'CI' {
     }
 
     It "Verifies expected error with null path" {
-        $psGetInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::ReadPSGetInfo($fileToRead)
-        { [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::WritePSGetInfo($null, $psGetInfo) } | Should -Throw -ErrorId 'PSInvalidOperationException'
+        $psGetInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::ReadPSGetResourceInfo($fileToRead)
+        { [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::WritePSGetResourceInfo($null, $psGetInfo) } | Should -Throw -ErrorId 'PSInvalidOperationException'
     }
 
     It "Verifies file write is successful" {
-        $psGetInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::ReadPSGetInfo($fileToRead)
-        { [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::WritePSGetInfo($fileToWrite, $psGetInfo) } | Should -Not -Throw
+        $psGetInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::ReadPSGetResourceInfo($fileToRead)
+        { [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::WritePSGetResourceInfo($fileToWrite, $psGetInfo) } | Should -Not -Throw
     }
 
     It "Verifes written file can be read successfully" {
-        $newGetInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::ReadPSGetInfo($fileToWrite)
+        $newGetInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.TestHooks]::ReadPSGetResourceInfo($fileToWrite)
         CheckForExpectedPSGetInfo $newGetInfo
     }
 }

--- a/test/PSGetTestUtils.psm1
+++ b/test/PSGetTestUtils.psm1
@@ -445,3 +445,60 @@ $($ReleaseNotes -join "`r`n")
         return $PSScriptInfoString
     }
 }
+
+<#
+Checks that provided PSGetInfo object contents match the expected data
+from the test information file: PSGetModuleInfo.xml
+#>
+function CheckForExpectedPSGetInfo
+{
+    param ($psGetInfo)
+
+    $psGetInfo.AdditionalMetadata.Keys | Should -HaveCount 22
+    $psGetInfo.AdditionalMetadata['copyright'] | Should -BeExactly '(c) Microsoft Corporation. All rights reserved.'
+    $psGetInfo.AdditionalMetadata['description'] | Should -BeLike 'This module provides a convenient way for a user to store and retrieve secrets*'
+    $psGetInfo.AdditionalMetadata['requireLicenseAcceptance'] | Should -BeExactly 'False'
+    $psGetInfo.AdditionalMetadata['isLatestVersion'] | Should -BeExactly 'True'
+    $psGetInfo.AdditionalMetadata['isAbsoluteLatestVersion'] | Should -BeExactly 'True'
+    $psGetInfo.AdditionalMetadata['versionDownloadCount'] | Should -BeExactly '0'
+    $psGetInfo.AdditionalMetadata['downloadCount'] | Should -BeExactly '15034'
+    $psGetInfo.AdditionalMetadata['packageSize'] | Should -BeExactly '55046'
+    $psGetInfo.AdditionalMetadata['published'] | Should -BeExactly '3/25/2021 6:08:10 PM -07:00'
+    $psGetInfo.AdditionalMetadata['created'] | Should -BeExactly '3/25/2021 6:08:10 PM -07:00'
+    $psGetInfo.AdditionalMetadata['lastUpdated'] | Should -BeExactly '3/25/2021 6:08:10 PM -07:00'
+    $psGetInfo.AdditionalMetadata['tags'] | Should -BeLike 'PSModule PSEdition_Core PSCmdlet_Register-SecretVault*'
+    $psGetInfo.AdditionalMetadata['developmentDependency'] | Should -BeExactly 'False'
+    $psGetInfo.AdditionalMetadata['updated'] | Should -BeExactly '2021-03-25T18:08:10Z'
+    $psGetInfo.AdditionalMetadata['NormalizedVersion'] | Should -BeExactly '1.0.0'
+    $psGetInfo.AdditionalMetadata['Authors'] | Should -BeExactly 'Microsoft Corporation'
+    $psGetInfo.AdditionalMetadata['IsPrerelease'] | Should -BeExactly 'false'
+    $psGetInfo.AdditionalMetadata['ItemType'] | Should -BeExactly 'Module'
+    $psGetInfo.AdditionalMetadata['FileList'] | Should -BeLike 'Microsoft.PowerShell.SecretManagement.nuspec|Microsoft.PowerShell.SecretManagement.dll*'
+    $psGetInfo.AdditionalMetadata['GUID'] | Should -BeExactly 'a5c858f6-4a8e-41f1-b1ee-0ff8f6ad69d3'
+    $psGetInfo.AdditionalMetadata['PowerShellVersion'] | Should -BeExactly '5.1'
+    $psGetInfo.AdditionalMetadata['CompanyName'] | Should -BeExactly 'Microsoft Corporation'
+    #
+    $psGetInfo.Author | Should -BeExactly 'Microsoft Corporation'
+    $psGetInfo.CompanyName | Should -BeExactly 'Microsoft Corporation'
+    $psGetInfo.Copyright | Should -BeExactly '(c) Microsoft Corporation. All rights reserved.'
+    $psGetInfo.Dependencies | Should -HaveCount 0
+    $psGetInfo.Description | Should -BeLike 'This module provides a convenient way for a user to store*'
+    $psGetInfo.IconUri | Should -BeNullOrEmpty
+    $psGetInfo.Includes.Cmdlet | Should -HaveCount 10
+    $psGetInfo.Includes.Cmdlet[0] | Should -BeExactly 'Register-SecretVault'
+    $psGetInfo.InstalledDate.Year | Should -BeExactly 2021
+    $psGetInfo.InstalledLocation | Should -BeLike 'C:\Users\*'
+    $psGetInfo.LicenseUri | Should -BeExactly 'https://github.com/PowerShell/SecretManagement/blob/master/LICENSE'
+    $psGetInfo.Name | Should -BeExactly 'Microsoft.PowerShell.SecretManagement'
+    $psGetInfo.PackageManagementProvider | Should -BeExactly 'NuGet'
+    $psGetInfo.PowerShellGetFormatVersion | Should -BeNullOrEmpty
+    $psGetInfo.ProjectUri | Should -BeExactly 'https://github.com/powershell/secretmanagement'
+    $psGetInfo.PublishedDate.Year | Should -BeExactly 2021
+    $psGetInfo.ReleasedNotes | Should -BeNullOrEmpty
+    $psGetInfo.Repository | Should -BeExactly 'PSGallery'
+    $psGetInfo.RepositorySourceLocation | Should -BeExactly 'https://www.powershellgallery.com/api/v2'
+    $psGetInfo.Tags | Should -BeExactly @('PSModule', 'PSEdition_Core')
+    $psGetInfo.Type | Should -BeExactly 'Module'
+    $psGetInfo.UpdatedDate.Year | Should -BeExactly 1
+    $psGetInfo.Version.ToString() | Should -BeExactly '1.0.0'
+}

--- a/test/PSGetTestUtils.psm1
+++ b/test/PSGetTestUtils.psm1
@@ -1,10 +1,5 @@
-<#####################################################################################
- # File: PSGetTestUtils.psm1
- #
- # Copyright (c) Microsoft Corporation, 2020
- #####################################################################################>
-
-#."$PSScriptRoot\uiproxy.ps1"
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 $psGetMod = Get-Module -Name PowerShellGet
 if ((! $psGetMod) -or (($psGetMod | Select-Object Version) -lt 3.0.0))


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR adds a new `TryPSGetInfo` utility method to read a `PSGetModuleInfo.xml` file.

## PR Context

The `PSGetModuleInfo.xml` file is a PowerShell serialization file that contains information about an installed module or other resource type.  The format of the install information is inconsistent but appears to be the same for all installed resources.  This method can be modified as needed to accommodate other resource types if needed.

Testing adds an example xml file for now, but eventually should be expanded to include writing this installation information and then reading it.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
