### PR TITLE
Fix CI to account for removal of bin directory

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -67,10 +67,8 @@ stages:
         Write-Verbose -Verbose "Importing PSPackageProject from: $modPath"
         Import-Module -Name $modPath -Force
         #
-        # First build for netstandard2.0 framework
+        # Build for netstandard2.0 framework
         $(Build.SourcesDirectory)/build.ps1 -Build -Clean -BuildConfiguration Release -BuildFramework 'netstandard2.0'
-        # Next build for net472 framework
-        $(Build.SourcesDirectory)/build.ps1 -Build -BuildConfiguration Release -BuildFramework 'net472'
       displayName: Build and publish artifact
 
     - pwsh: |

--- a/.ci/ci_auto.yml
+++ b/.ci/ci_auto.yml
@@ -73,10 +73,8 @@ stages:
         Write-Verbose -Verbose "Importing PSPackageProject from: $modPath"
         Import-Module -Name $modPath -Force
         #
-        # First build for netstandard2.0 framework
+        # Build for netstandard2.0 framework
         $(Build.SourcesDirectory)/build.ps1 -Build -Clean -BuildConfiguration Release -BuildFramework 'netstandard2.0'
-        # Next build for net472 framework
-        $(Build.SourcesDirectory)/build.ps1 -Build -BuildConfiguration Release -BuildFramework 'net472'
       displayName: Build and publish artifact
 
     - pwsh: |
@@ -111,12 +109,6 @@ stages:
         Copy-Item -Path (Join-Path -Path $srcPath -ChildPath "PSModule.psm1") -Dest $createdSignSrcPath -Force -Verbose
         Copy-Item -Path (Join-Path -Path $srcPath -ChildPath "DscResources") -Dest $createdSignSrcPath -Recurse -Force -Verbose
         Copy-Item -Path (Join-Path -Path $srcPath -ChildPath "Modules") -Dest $createdSignSrcPath -Recurse -Force -Verbose
-
-        $net472Path = Join-Path -Path $createdSignSrcPath -ChildPath "net472"
-        if (! (Test-Path -Path $net472Path)) {
-          $null = New-Item -Path $net472Path -ItemType Directory -Verbose
-        }
-        Copy-Item -Path (Join-Path -Path $srcPath -ChildPath "net472\PowerShellGet.*") -Dest $net472Path -Force -Verbose
 
         $netStandardPath = Join-Path -Path $createdSignSrcPath -ChildPath "netstandard2.0"
         if (! (Test-Path -Path $netStandardPath)) {
@@ -186,21 +178,6 @@ stages:
         if (! (Test-Path -Path $thirdPartySignSrcPath)) {
           $null = New-Item -Path $thirdPartySignSrcPath -ItemType Directory -Verbose
         }
-
-        # Net472 directory
-        $net472Path = Join-Path -Path $thirdPartySignSrcPath -ChildPath "net472"
-        if (! (Test-Path -Path $net472Path)) {
-          $null = New-Item -Path $net472Path -ItemType Directory -Verbose
-        }
-        Get-ChildItem -Path (Join-Path -Path $srcPath -ChildPath "net472") -Filter '*.dll' | Foreach-Object {
-          if ($_.Name -ne 'PowerShellGet.dll') {
-            $sig = Get-AuthenticodeSignature -FilePath $_.FullName
-            if ($sig.Status -ne 'Valid' -or $sig.SignerCertificate.Subject -notlike '*Microsoft*' -or $sig.SignerCertificate.Issuer -notlike '*Microsoft Code Signing PCA*') {
-              # Copy for third party signing
-              Copy-Item -Path $_.FullName -Dest $net472Path -Force -Verbose
-            }
-          }
-        }
         
         # NetStandard directory
         $netStandardPath = Join-Path -Path $thirdPartySignSrcPath -ChildPath "netstandard2.0"
@@ -255,21 +232,6 @@ stages:
 
         # en-US
         Copy-Item -Path (Join-Path -Path $srcPath -ChildPath "en-US") -Dest $signOutPath -Recurse
-
-        # Net472 directory
-        $net472SignedOutPath = Join-Path -Path $signOutPath -ChildPath "net472"
-        if (! (Test-Path -Path $net472SignedOutPath)) {
-          $null = New-Item -Path $net472SignedOutPath -ItemType Directory -Verbose
-        }
-        Get-ChildItem -Path (Join-Path -Path $srcPath -ChildPath "net472") -Filter '*.dll' | Foreach-Object {
-          if ($_.Name -ne 'PowerShellGet.dll') {
-            $sig = Get-AuthenticodeSignature -FilePath $_.FullName
-            if ($sig.Status -eq 'Valid' -and ($sig.SignerCertificate.Subject -like '*Microsoft*' -and $sig.SignerCertificate.Issuer -like '*Microsoft Code Signing PCA*')) {
-              # Copy already signed files directly to output
-              Copy-Item -Path $_.FullName -Dest $net472SignedOutPath -Force -Verbose
-            }
-          }
-        }
 
         # NetStandard directory
         $netStandardSignedOutPath = Join-Path -Path $signOutPath -ChildPath "netstandard2.0"

--- a/.ci/ci_release.yml
+++ b/.ci/ci_release.yml
@@ -72,10 +72,8 @@ stages:
         Write-Verbose -Verbose "Importing PSPackageProject from: $modPath"
         Import-Module -Name $modPath -Force
         #
-        # First build for netstandard2.0 framework
+        # Build for netstandard2.0 framework
         $(Build.SourcesDirectory)/build.ps1 -Build -Clean -BuildConfiguration Release -BuildFramework 'netstandard2.0'
-        # Next build for net472 framework
-        $(Build.SourcesDirectory)/build.ps1 -Build -BuildConfiguration Release -BuildFramework 'net472'
       displayName: Build and publish artifact
 
     - pwsh: |
@@ -110,12 +108,6 @@ stages:
         Copy-Item -Path (Join-Path -Path $srcPath -ChildPath "PSModule.psm1") -Dest $createdSignSrcPath -Force -Verbose
         Copy-Item -Path (Join-Path -Path $srcPath -ChildPath "DscResources") -Dest $createdSignSrcPath -Recurse -Force -Verbose
         Copy-Item -Path (Join-Path -Path $srcPath -ChildPath "Modules") -Dest $createdSignSrcPath -Recurse -Force -Verbose
-
-        $net472Path = Join-Path -Path $createdSignSrcPath -ChildPath "net472"
-        if (! (Test-Path -Path $net472Path)) {
-          $null = New-Item -Path $net472Path -ItemType Directory -Verbose
-        }
-        Copy-Item -Path (Join-Path -Path $srcPath -ChildPath "net472\PowerShellGet.*") -Dest $net472Path -Force -Verbose
 
         $netStandardPath = Join-Path -Path $createdSignSrcPath -ChildPath "netstandard2.0"
         if (! (Test-Path -Path $netStandardPath)) {
@@ -184,21 +176,6 @@ stages:
         if (! (Test-Path -Path $thirdPartySignSrcPath)) {
           $null = New-Item -Path $thirdPartySignSrcPath -ItemType Directory -Verbose
         }
-
-        # Net472 directory
-        $net472Path = Join-Path -Path $thirdPartySignSrcPath -ChildPath "net472"
-        if (! (Test-Path -Path $net472Path)) {
-          $null = New-Item -Path $net472Path -ItemType Directory -Verbose
-        }
-        Get-ChildItem -Path (Join-Path -Path $srcPath -ChildPath "net472") -Filter '*.dll' | Foreach-Object {
-          if ($_.Name -ne 'PowerShellGet.dll') {
-            $sig = Get-AuthenticodeSignature -FilePath $_.FullName
-            if ($sig.Status -ne 'Valid' -or $sig.SignerCertificate.Subject -notlike '*Microsoft*' -or $sig.SignerCertificate.Issuer -notlike '*Microsoft Code Signing PCA*') {
-              # Copy for third party signing
-              Copy-Item -Path $_.FullName -Dest $net472Path -Force -Verbose
-            }
-          }
-        }
         
         # NetStandard directory
         $netStandardPath = Join-Path -Path $thirdPartySignSrcPath -ChildPath "netstandard2.0"
@@ -253,21 +230,6 @@ stages:
 
         # en-US
         Copy-Item -Path (Join-Path -Path $srcPath -ChildPath "en-US") -Dest $signOutPath -Recurse
-
-        # Net472 directory
-        $net472SignedOutPath = Join-Path -Path $signOutPath -ChildPath "net472"
-        if (! (Test-Path -Path $net472SignedOutPath)) {
-          $null = New-Item -Path $net472SignedOutPath -ItemType Directory -Verbose
-        }
-        Get-ChildItem -Path (Join-Path -Path $srcPath -ChildPath "net472") -Filter '*.dll' | Foreach-Object {
-          if ($_.Name -ne 'PowerShellGet.dll') {
-            $sig = Get-AuthenticodeSignature -FilePath $_.FullName
-            if ($sig.Status -eq 'Valid' -and ($sig.SignerCertificate.Subject -like '*Microsoft*' -and $sig.SignerCertificate.Issuer -like '*Microsoft Code Signing PCA*')) {
-              # Copy already signed files directly to output
-              Copy-Item -Path $_.FullName -Dest $net472SignedOutPath -Force -Verbose
-            }
-          }
-        }
 
         # NetStandard directory
         $netStandardSignedOutPath = Join-Path -Path $signOutPath -ChildPath "netstandard2.0"

--- a/doBuild.ps1
+++ b/doBuild.ps1
@@ -20,8 +20,6 @@ function DoBuild
     # Copy module script files
     Write-Verbose -Verbose "Copy-Item ${SrcPath}/${ModuleName}.psd1 to $BuildOutPath"
     Copy-Item -Path "${SrcPath}/${ModuleName}.psd1" -Dest "$BuildOutPath" -Force
-    Write-Verbose -Verbose "Copy Item ${SrcPath}/PSModule.psm1 to $BuildOutPath"
-    Copy-Item -Path "${SrcPath}/PSModule.psm1" -Dest "$BuildOutPath" -Force
 
     #Copy module format ps1xml file
     Write-Verbose -Verbose -Message "Copy-Item ${SrcPath}/${FormatFileName}.ps1xml to $BuildOutPath"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Various changes to CI that account for simpler module bin directory.

## PR Context

This module now builds a single cmdlet binary based on netstandard2.0. And net472 binary is no longer needed.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
