### PR TITLE
change WriteDebug in catch to WriteVerbose -Verbose

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -191,7 +191,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 resourceMetadata = repository.GetResourceAsync<PackageMetadataResource>().GetAwaiter().GetResult();
             }
             catch (Exception e){
-                _cmdletPassedIn.WriteDebug("Error retrieving resource from repository: " + e.Message);
+                Utils.WriteVerboseOnCmdlet(_cmdletPassedIn, "Error retrieving resource from repository: " + e.Message);
             }
 
             if (resourceSearch == null || resourceMetadata == null)
@@ -271,16 +271,16 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 }
                 catch (HttpRequestException ex)
                 {
+                    Utils.WriteVerboseOnCmdlet(_cmdletPassedIn, "FindHelper MetadataAsync()- error receiving package: " + ex.Message);
                     if ((String.Equals(repositoryName, _psGalleryRepoName, StringComparison.InvariantCultureIgnoreCase) ||
                         String.Equals(repositoryName, _psGalleryScriptsRepoName, StringComparison.InvariantCultureIgnoreCase)))
                     {
-                        _cmdletPassedIn.WriteDebug(String.Format("Error receiving package from PSGallery. To check if this is due to a PSGallery outage check: https://aka.ms/psgallerystatus . Specific error: {0}", ex.Message));
-                        yield break;
+                        _cmdletPassedIn.WriteWarning(String.Format("Error receiving package from PSGallery. To check if this is due to a PSGallery outage check: https://aka.ms/psgallerystatus . Specific error: {0}", ex.Message));
                     }
                 }
                 catch (Exception e)
                 {
-                    _cmdletPassedIn.WriteDebug(String.Format("Exception retrieving package {0} due to {1}.", pkgName, e.Message));
+                    Utils.WriteVerboseOnCmdlet(_cmdletPassedIn, "FindHelper MetadataAsync()- error receiving package: " + e.Message);
                 }
 
                 if (retrievedPkgs == null || retrievedPkgs.Count() == 0)
@@ -330,16 +330,17 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 }
                 catch (HttpRequestException ex)
                 {
+                    Utils.WriteVerboseOnCmdlet(_cmdletPassedIn, "FindHelper SearchAsync()- error receiving package: " + ex.Message);
                     if ((String.Equals(repositoryName, _psGalleryRepoName, StringComparison.InvariantCultureIgnoreCase) ||
                         String.Equals(repositoryName, _psGalleryScriptsRepoName, StringComparison.InvariantCultureIgnoreCase)))
                     {
-                        _cmdletPassedIn.WriteDebug(String.Format("Error receiving package from PSGallery. To check if this is due to a PSGallery outage check: https://aka.ms/psgallerystatus . Specific error: {0}", ex.Message));
+                        _cmdletPassedIn.WriteWarning(String.Format("Error receiving package from PSGallery. To check if this is due to a PSGallery outage check: https://aka.ms/psgallerystatus . Specific error: {0}", ex.Message));
                     }
                     yield break;
                 }
                 catch (Exception e)
                 {
-                    _cmdletPassedIn.WriteDebug(String.Format("Exception retrieving package {0} due to {1}.", pkgName, e.Message));
+                    Utils.WriteVerboseOnCmdlet(_cmdletPassedIn, "FindHelper SearchAsync()- error receiving package: " + e.Message);
                     yield break;
                 }
 

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -16,6 +16,18 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 {
     internal static class Utils
     {
+        public static void WriteVerboseOnCmdlet(
+            PSCmdlet cmdlet,
+            string message)
+        {
+            cmdlet.InvokeCommand.InvokeScript(
+                script: $"Write-Verbose -Verbose -Message {message}",
+                useNewScope: true,
+                writeToPipeline: System.Management.Automation.Runspaces.PipelineResultTypes.None,
+                input: null,
+                args: null);
+        }
+
         public static string[] FilterOutWildcardNames(
             string[] pkgNames,
             out string[] errorMsgs)


### PR DESCRIPTION

# PR Summary

Use Write-Verbose -Verbose instead of Write-Debug for caught exceptions so that they appear in the CI system datastream.

## PR Context

So we can get more clarity for errors failing in CI.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
