### PR TITLE
Fix PSResourceInfo property string types to not be null

### DIFF
--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -769,7 +769,6 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
         #endregion
 
-
         #region Private methods
 
         private PSObject ConvertToCustomObject()
@@ -781,13 +780,13 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             }
 
             var psObject = new PSObject();
-            psObject.Properties.Add(new PSNoteProperty(nameof(Name), Name));
+            psObject.Properties.Add(new PSNoteProperty(nameof(Name), Name ?? string.Empty));
             psObject.Properties.Add(new PSNoteProperty(nameof(Version), ConcatenateVersionWithPrerelease(Version.ToString(), PrereleaseLabel)));
             psObject.Properties.Add(new PSNoteProperty(nameof(Type), Type));
-            psObject.Properties.Add(new PSNoteProperty(nameof(Description), Description));
-            psObject.Properties.Add(new PSNoteProperty(nameof(Author), Author));
-            psObject.Properties.Add(new PSNoteProperty(nameof(CompanyName), CompanyName));
-            psObject.Properties.Add(new PSNoteProperty(nameof(Copyright), Copyright));
+            psObject.Properties.Add(new PSNoteProperty(nameof(Description), Description ?? string.Empty));
+            psObject.Properties.Add(new PSNoteProperty(nameof(Author), Author ?? string.Empty));
+            psObject.Properties.Add(new PSNoteProperty(nameof(CompanyName), CompanyName ?? string.Empty));
+            psObject.Properties.Add(new PSNoteProperty(nameof(Copyright), Copyright ?? string.Empty));
             psObject.Properties.Add(new PSNoteProperty(nameof(PublishedDate), PublishedDate));
             psObject.Properties.Add(new PSNoteProperty(nameof(InstalledDate), InstalledDate));
             psObject.Properties.Add(new PSNoteProperty(nameof(UpdatedDate), UpdatedDate));
@@ -796,14 +795,14 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             psObject.Properties.Add(new PSNoteProperty(nameof(IconUri), IconUri));
             psObject.Properties.Add(new PSNoteProperty(nameof(Tags), Tags));
             psObject.Properties.Add(new PSNoteProperty(nameof(Includes), Includes.ConvertToHashtable()));
-            psObject.Properties.Add(new PSNoteProperty(nameof(PowerShellGetFormatVersion), PowerShellGetFormatVersion));
-            psObject.Properties.Add(new PSNoteProperty(nameof(ReleaseNotes), ReleaseNotes));
+            psObject.Properties.Add(new PSNoteProperty(nameof(PowerShellGetFormatVersion), PowerShellGetFormatVersion ?? string.Empty));
+            psObject.Properties.Add(new PSNoteProperty(nameof(ReleaseNotes), ReleaseNotes ?? string.Empty));
             psObject.Properties.Add(new PSNoteProperty(nameof(Dependencies), Dependencies));
-            psObject.Properties.Add(new PSNoteProperty(nameof(RepositorySourceLocation), RepositorySourceLocation));
-            psObject.Properties.Add(new PSNoteProperty(nameof(Repository), Repository));
-            psObject.Properties.Add(new PSNoteProperty(nameof(PackageManagementProvider), PackageManagementProvider));
+            psObject.Properties.Add(new PSNoteProperty(nameof(RepositorySourceLocation), RepositorySourceLocation ?? string.Empty));
+            psObject.Properties.Add(new PSNoteProperty(nameof(Repository), Repository ?? string.Empty));
+            psObject.Properties.Add(new PSNoteProperty(nameof(PackageManagementProvider), PackageManagementProvider ?? string.Empty));
             psObject.Properties.Add(new PSNoteProperty(nameof(AdditionalMetadata), additionalMetadata));
-            psObject.Properties.Add(new PSNoteProperty(nameof(InstalledLocation), InstalledLocation));
+            psObject.Properties.Add(new PSNoteProperty(nameof(InstalledLocation), InstalledLocation ?? string.Empty));
 
             return psObject;
         }

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -153,7 +153,6 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
     #endregion
 
-
     #region Dependency
 
     public sealed class Dependency
@@ -290,44 +289,42 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                     System.IO.File.ReadAllText(
                         filePath));
 
-
                 var additionalMetadata = GetProperty<Dictionary<string,string>>(nameof(PSResourceInfo.AdditionalMetadata), psObjectInfo);
                 Version version = GetVersionInfo(psObjectInfo, additionalMetadata, out string prereleaseLabel);
 
                 psGetInfo = new PSResourceInfo
                 {
                     AdditionalMetadata = additionalMetadata,
-                    Author = GetProperty<string>(nameof(PSResourceInfo.Author), psObjectInfo),
-                    CompanyName = GetProperty<string>(nameof(PSResourceInfo.CompanyName), psObjectInfo),
-                    Copyright = GetProperty<string>(nameof(PSResourceInfo.Copyright), psObjectInfo),
+                    Author = GetStringProperty(nameof(PSResourceInfo.Author), psObjectInfo),
+                    CompanyName = GetStringProperty(nameof(PSResourceInfo.CompanyName), psObjectInfo),
+                    Copyright = GetStringProperty(nameof(PSResourceInfo.Copyright), psObjectInfo),
                     Dependencies = GetDependencies(GetProperty<ArrayList>(nameof(PSResourceInfo.Dependencies), psObjectInfo)),
-                    Description = GetProperty<string>(nameof(PSResourceInfo.Description), psObjectInfo),
+                    Description = GetStringProperty(nameof(PSResourceInfo.Description), psObjectInfo),
                     IconUri = GetProperty<Uri>(nameof(PSResourceInfo.IconUri), psObjectInfo),
                     Includes = new ResourceIncludes(GetProperty<Hashtable>(nameof(PSResourceInfo.Includes), psObjectInfo)),
                     InstalledDate = GetProperty<DateTime>(nameof(PSResourceInfo.InstalledDate), psObjectInfo),
-                    InstalledLocation = GetProperty<string>(nameof(PSResourceInfo.InstalledLocation), psObjectInfo),
+                    InstalledLocation = GetStringProperty(nameof(PSResourceInfo.InstalledLocation), psObjectInfo),
                     IsPrerelease = GetProperty<bool>(nameof(PSResourceInfo.IsPrerelease), psObjectInfo),
                     LicenseUri = GetProperty<Uri>(nameof(PSResourceInfo.LicenseUri), psObjectInfo),
-                    Name = GetProperty<string>(nameof(PSResourceInfo.Name), psObjectInfo),
-                    PackageManagementProvider = GetProperty<string>(nameof(PSResourceInfo.PackageManagementProvider), psObjectInfo),
-                    PowerShellGetFormatVersion = GetProperty<string>(nameof(PSResourceInfo.PowerShellGetFormatVersion), psObjectInfo),
+                    Name = GetStringProperty(nameof(PSResourceInfo.Name), psObjectInfo),
+                    PackageManagementProvider = GetStringProperty(nameof(PSResourceInfo.PackageManagementProvider), psObjectInfo),
+                    PowerShellGetFormatVersion = GetStringProperty(nameof(PSResourceInfo.PowerShellGetFormatVersion), psObjectInfo),
                     PrereleaseLabel = prereleaseLabel,
                     ProjectUri = GetProperty<Uri>(nameof(PSResourceInfo.ProjectUri), psObjectInfo),
                     PublishedDate = GetProperty<DateTime>(nameof(PSResourceInfo.PublishedDate), psObjectInfo),
-                    ReleaseNotes = GetProperty<string>(nameof(PSResourceInfo.ReleaseNotes), psObjectInfo),
-                    Repository = GetProperty<string>(nameof(PSResourceInfo.Repository), psObjectInfo),
-                    RepositorySourceLocation = GetProperty<string>(nameof(PSResourceInfo.RepositorySourceLocation), psObjectInfo),
+                    ReleaseNotes = GetStringProperty(nameof(PSResourceInfo.ReleaseNotes), psObjectInfo),
+                    Repository = GetStringProperty(nameof(PSResourceInfo.Repository), psObjectInfo),
+                    RepositorySourceLocation = GetStringProperty(nameof(PSResourceInfo.RepositorySourceLocation), psObjectInfo),
                     Tags = Utils.GetStringArray(GetProperty<ArrayList>(nameof(PSResourceInfo.Tags), psObjectInfo)),
                     // try to get the value of PSResourceInfo.Type property, if the value is null use ResourceType.Module as value
                     // this value will be used in Enum.TryParse. If Enum.TryParse returns false, use ResourceType.Module to set Type instead.
                     Type = Enum.TryParse(
                         GetProperty<string>(nameof(PSResourceInfo.Type), psObjectInfo) ?? nameof(ResourceType.Module),
-                        out ResourceType currentReadType)
-                            ? currentReadType : ResourceType.Module,
+                            out ResourceType currentReadType)
+                                ? currentReadType : ResourceType.Module,
                     UpdatedDate = GetProperty<DateTime>(nameof(PSResourceInfo.UpdatedDate), psObjectInfo),
                     Version = version
                 };
-
 
                 return true;
             }
@@ -340,6 +337,13 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
                 return false;
             }
+        }
+
+        private static string GetStringProperty(
+            string name,
+            PSObject psObjectInfo)
+        {
+            return GetProperty<string>(name, psObjectInfo) ?? string.Empty;
         }
 
         private static Version GetVersionInfo(


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes read-from-file PSResourceInfo object string property values to be empty rather than null values.  Also fixes write to xml file to always write empty strings rather than null values.

## PR Context

PSResourceInfo object information is written and read from file using PowerShell serialization. If a string property was not defined it was previously written as a null value.  However, PowerShell reads PSGetModuleInfo.xml files, which are PSResourceInfo objects and assumes string property values are never null, and if null throws an error.  This is a bug in PowerShell, but this change updates the PSResourceInfo object read/write functions to use empty strings for undefined properties.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
