### PR TITLE
Get helper null fix

### DIFF
--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -35,7 +35,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             foreach (string pkgPath in FilterPkgPathsByVersion(versionRange, filteredPathsToSearch))
             {
-                yield return OutputPackageObject(pkgPath, _scriptDictionary);
+                PSResourceInfo pkg = OutputPackageObject(pkgPath, _scriptDictionary);
+                if (pkg != null)
+                {
+                    yield return pkg;
+                }
             }
         }
 
@@ -174,7 +178,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             string pkgName = Utils.GetInstalledPackageName(pkgPath);
             _cmdletPassedIn.WriteDebug(string.Format("OutputPackageObject:: package name is {0}.", pkgName));
             // Find xml file
-            // if the package path is in the deserialized script dictionary, just return that 
+            // if the package path is in the deserialized script dictionary, just return that
             if (scriptDictionary.ContainsKey(pkgPath))
             {
                 return scriptDictionary[pkgPath];
@@ -184,12 +188,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 xmlFilePath = System.IO.Path.Combine(parentDir.ToString(), "InstalledScriptInfos", pkgName + "_InstalledScriptInfo.xml");
             }
-            // else we assume it's a module, and look for the xml path that way 
+            // else we assume it's a module, and look for the xml path that way
             else
             {
                 xmlFilePath = System.IO.Path.Combine(pkgPath, "PSGetModuleInfo.xml");
             }
-            
+
             // Read metadata from XML and parse into PSResourceInfo object
             _cmdletPassedIn.WriteVerbose(string.Format("Reading package metadata from: '{0}'", xmlFilePath));
             if (!TryRead(xmlFilePath, out PSResourceInfo psGetInfo, out string errorMsg))

--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -194,6 +194,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 xmlFilePath = System.IO.Path.Combine(pkgPath, "PSGetModuleInfo.xml");
             }
 
+
             // Read metadata from XML and parse into PSResourceInfo object
             _cmdletPassedIn.WriteVerbose(string.Format("Reading package metadata from: '{0}'", xmlFilePath));
             if (!TryRead(xmlFilePath, out PSResourceInfo psGetInfo, out string errorMsg))

--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -194,7 +194,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 xmlFilePath = System.IO.Path.Combine(pkgPath, "PSGetModuleInfo.xml");
             }
 
-
             // Read metadata from XML and parse into PSResourceInfo object
             _cmdletPassedIn.WriteVerbose(string.Format("Reading package metadata from: '{0}'", xmlFilePath));
             if (!TryRead(xmlFilePath, out PSResourceInfo psGetInfo, out string errorMsg))


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add check to ProcessGetParams, to see if package found is not null before yield return.

## PR Context

This was throwing an exception for me in Update-PSResource for some modules that aren't installed by PSGet, so they don't have a PSModuleInfo.xml file and thus cannot be retrieved by GetHelper and have a value of null. Null objects should not be returned by the helper in this case.

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
