### PR TITLE
Fix Get-InstalledPSResource resource name and path resolution.

### DIFF
--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -18,22 +18,33 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// </summary>
     internal class GetHelper
     {
-        private CancellationToken _cancellationToken;
-        private readonly PSCmdlet _cmdletPassedIn;
-        private Dictionary<string, PSResourceInfo> _scriptDictionary;
+        #region Members
 
-        public GetHelper(CancellationToken cancellationToken, PSCmdlet cmdletPassedIn)
+        private readonly PSCmdlet _cmdletPassedIn;
+        private readonly Dictionary<string, PSResourceInfo> _scriptDictionary;
+
+        #endregion
+
+        #region Constructors
+
+        public GetHelper(PSCmdlet cmdletPassedIn)
         {
-            _cancellationToken = cancellationToken;
             _cmdletPassedIn = cmdletPassedIn;
             _scriptDictionary = new Dictionary<string, PSResourceInfo>();
         }
 
-        public IEnumerable<PSResourceInfo> ProcessGetParams(string[] name, VersionRange versionRange, List<string> pathsToSearch)
-        {
-            List<string> filteredPathsToSearch = FilterPkgPathsByName(name, pathsToSearch);
+        #endregion
 
-            foreach (string pkgPath in FilterPkgPathsByVersion(versionRange, filteredPathsToSearch))
+        #region Public methods
+
+        public IEnumerable<PSResourceInfo> FilterPkgPaths(
+            string[] name,
+            VersionRange versionRange,
+            List<string> pathsToSearch)
+        {
+            List<string> pgkPathsByName = FilterPkgPathsByName(name, pathsToSearch);
+
+            foreach (string pkgPath in FilterPkgPathsByVersion(versionRange, pgkPathsByName))
             {
                 yield return OutputPackageObject(pkgPath, _scriptDictionary);
             }
@@ -54,11 +65,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 WildcardPattern nameWildCardPattern = new WildcardPattern(name, WildcardOptions.IgnoreCase);
 
-                // ./Modules/Test-Module
-                // ./Scripts/Test-Script.ps1
                 wildCardDirsToSearch.AddRange(dirsToSearch.FindAll(
-                    p => nameWildCardPattern.IsMatch(
-                        System.IO.Path.GetFileNameWithoutExtension((new DirectoryInfo(p).Name)))));
+                    path => nameWildCardPattern.IsMatch(
+                        GetResourceNameFromPath(path))));
             }
             _cmdletPassedIn.WriteDebug(wildCardDirsToSearch.Any().ToString());
 
@@ -167,7 +176,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         // Create package object for each found resource directory
         public PSResourceInfo OutputPackageObject(string pkgPath, Dictionary<string,PSResourceInfo> scriptDictionary)
         {
-            string xmlFilePath = string.Empty;
+            string xmlFilePath;
             var parentDir = new DirectoryInfo(pkgPath).Parent;
 
             // find package name
@@ -204,5 +213,23 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             return null;
         }
+
+        #endregion
+    
+        #region Private methods
+
+        private static string GetResourceNameFromPath(string path)
+        {
+            // Resource paths may end in a directory or script file name.
+            // Directory name is the same as the resource name.
+            // Script file name is the resource name without the file extension.
+            // ./Modules/Microsoft.PowerShell.Test-Module     : Microsoft.PowerShell.Test-Module
+            // ./Scripts/Microsoft.PowerShell.Test-Script.ps1 : Microsoft.PowerShell.Test-Script
+            var resourceName = Path.GetFileName(path);
+            return Path.GetExtension(resourceName).Equals(".ps1", StringComparison.OrdinalIgnoreCase) 
+                ? Path.GetFileNameWithoutExtension(resourceName) : resourceName;
+        }
+
+        #endregion
     }
 }

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -50,8 +50,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         private const string NameParameterSet = "NameParameterSet";
         private const string InputObjectSet = "InputObjectSet";
         public static readonly string OsPlatform = System.Runtime.InteropServices.RuntimeInformation.OSDescription;
-        private CancellationTokenSource _source;
-        private CancellationToken _cancellationToken;
         VersionRange _versionRange;
         List<string> _pathsToSearch = new List<string>();
         #endregion
@@ -59,9 +57,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         #region Methods
         protected override void BeginProcessing()
         {
-            _source = new CancellationTokenSource();
-            _cancellationToken = _source.Token;
-
             // validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
             // an exact version will be formatted into a version range.
             if (ParameterSetName.Equals("NameParameterSet") && Version != null && !Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
@@ -128,7 +123,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             var successfullyUninstalled = false;
 
-            GetHelper getHelper = new GetHelper(_cancellationToken, this);
+            GetHelper getHelper = new GetHelper(this);
             List<string>  dirsToDelete = getHelper.FilterPkgPathsByName(Name, _pathsToSearch);
 
             // Checking if module or script


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes resource names with '.' characters and Path argument resolution.  Also removes unneeded cancel and source tokens.

## PR Context

Previously Get-InstalledPSResource would remove any file extension in the installed path, but that ends up breaking a name that has '.' charcters, such as 'Microsoft.PowerShell.SecretStore'.

Path argument resolution was using ToString() to get resolved path, but that returns the collection type name.

Source and cancel token variables are not used and so were removed.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
