### PR TITLE
Update PSResourceInfo type to have correct default property values

### DIFF
--- a/src/PowerShellGet.psd1
+++ b/src/PowerShellGet.psd1
@@ -27,7 +27,7 @@
     AliasesToExport = @('inmo', 'fimo', 'upmo', 'pumo')
     PrivateData = @{
         PSData = @{
-            Prerelease = 'beta10'
+            Prerelease = 'beta11'
             Tags = @('PackageManagement',
                 'PSEdition_Desktop',
                 'PSEdition_Core',

--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -93,15 +93,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     // ./Modules/Test-Module/2.0.0
                     _cmdletPassedIn.WriteDebug(string.Format("Searching through package path: '{0}'", pkgPath));
 
-                    string[] versionsDirs = new string[] { };
-                    try
+                    string[] versionsDirs = Utils.GetSubDirectories(pkgPath);
+                    if (versionsDirs.Length == 0)
                     {
-                        versionsDirs = Directory.GetDirectories(pkgPath);
-                    }
-                    catch (Exception e){
-                        _cmdletPassedIn.WriteVerbose(string.Format("Error retreiving directories from path '{0}': '{1}'", pkgPath, e.Message));
-
-                        // skip to next iteration of the loop
+                        _cmdletPassedIn.WriteVerbose(
+                            $"No version subdirectories found for path: {pkgPath}");
                         continue;
                     }
 

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -87,17 +87,19 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 var resolvedPath = resolvedPaths[0].Path;
                 WriteDebug(string.Format("Provided resolved path is '{0}'", resolvedPath));
 
-                try
+                var versionPaths = Utils.GetSubDirectories(resolvedPath);
+                if (versionPaths.Length == 0)
                 {
-                    _pathsToSearch.AddRange(Directory.GetDirectories(resolvedPath));
+                    ThrowTerminatingError(
+                        new ErrorRecord(
+                            exception: new PSInvalidOperationException(
+                                $"Error cannot find expected subdirectories in provided path: {Path}"),
+                            "PathMissingExpectedSubdirectories",
+                            ErrorCategory.InvalidOperation,
+                            targetObject: null));
                 }
-                catch (Exception e)
-                {
-                    var exMessage = String.Format("Error retrieving directories from provided path '{0}': '{1}'.", Path, e.Message);
-                    var ex = new ArgumentException(exMessage);
-                    var ErrorRetrievingDirectories = new ErrorRecord(ex, "ErrorRetrievingDirectories", ErrorCategory.ResourceUnavailable, null);
-                    ThrowTerminatingError(ErrorRetrievingDirectories);
-                }
+
+                _pathsToSearch.AddRange(versionPaths);
             }
             else
             {

--- a/src/code/GetPSResourceRepository.cs
+++ b/src/code/GetPSResourceRepository.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         [Parameter(Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [ArgumentCompleter(typeof(RepositoryNameCompleter))]
         [ValidateNotNullOrEmpty]
-        public string[] Name { get; set; } = new string[0];
+        public string[] Name { get; set; } = Utils.EmptyStrArray;
 
         #endregion
 

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -226,7 +226,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             // ./InstallPackagePath3/PackageD
             foreach (var path in _pathsToInstallPkg)
             {
-                _pathsToSearch.AddRange(Directory.GetDirectories(path));
+                _pathsToSearch.AddRange(Utils.GetSubDirectories(path));
             }
 
             IEnumerable<PSResourceInfo> pkgsAlreadyInstalled = getHelper.FilterPkgPaths(pkgNames.ToArray(), _versionRange, _pathsToSearch);

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         ///     Value: ArrayList of Workflow name strings
         /// </summary>
         /// <param name="includes">Hashtable of PSGet includes</param>
-        public ResourceIncludes(Hashtable includes)
+        internal ResourceIncludes(Hashtable includes)
         {
             if (includes == null) { return; }
 
@@ -116,6 +116,16 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             Function = GetHashTableItem(includes, nameof(Function));
             RoleCapability = GetHashTableItem(includes, nameof(RoleCapability));
             Workflow = GetHashTableItem(includes, nameof(Workflow));
+        }
+
+        internal ResourceIncludes()
+        {
+            Cmdlet = Utils.EmptyStrArray;
+            Command = Utils.EmptyStrArray;
+            DscResource = Utils.EmptyStrArray;
+            Function = Utils.EmptyStrArray;
+            RoleCapability = Utils.EmptyStrArray;
+            Workflow = Utils.EmptyStrArray;
         }
 
         #endregion
@@ -195,35 +205,92 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
     {
         #region Properties
 
-        public Dictionary<string, string> AdditionalMetadata { get; set; }
-        public string Author { get; set; }
-        public string CompanyName { get; set; }
-        public string Copyright { get; set; }
-        public Dependency[] Dependencies { get; set; }
-        public string Description { get; set; }
-        public Uri IconUri { get; set; }
-        public ResourceIncludes Includes { get; set; }
-        public DateTime? InstalledDate { get; set; }
-        public string InstalledLocation { get; set; }
-        public bool IsPrerelease { get; set; }
-        public Uri LicenseUri { get; set; }
-        public string Name { get; set; }
-        public string PackageManagementProvider { get; set; }
-        public string PowerShellGetFormatVersion { get; set; }
-        public string PrereleaseLabel { get; set; }
-        public Uri ProjectUri { get; set; }
-        public DateTime? PublishedDate { get; set; }
-        public string ReleaseNotes { get; set; }
-        public string Repository { get; set; }
-        public string RepositorySourceLocation { get; set; }
-        public string[] Tags { get; set; }
-        public ResourceType Type { get; set; }
-        public DateTime? UpdatedDate { get; set; }
-        public Version Version { get; set; }
+        public Dictionary<string, string> AdditionalMetadata { get; }
+        public string Author { get; }
+        public string CompanyName { get; }
+        public string Copyright { get; }
+        public Dependency[] Dependencies { get; }
+        public string Description { get; }
+        public Uri IconUri { get; }
+        public ResourceIncludes Includes { get; }
+        public DateTime? InstalledDate { get; internal set; }
+        public string InstalledLocation { get; internal set; }
+        public bool IsPrerelease { get; }
+        public Uri LicenseUri { get; }
+        public string Name { get; }
+        public string PackageManagementProvider { get; }
+        public string PowerShellGetFormatVersion { get; }
+        public string PrereleaseLabel { get; }
+        public Uri ProjectUri { get; }
+        public DateTime? PublishedDate { get; }
+        public string ReleaseNotes { get; }
+        public string Repository { get; }
+        public string RepositorySourceLocation { get; }
+        public string[] Tags { get; }
+        public ResourceType Type { get; }
+        public DateTime? UpdatedDate { get; }
+        public Version Version { get; }
 
         #endregion
 
-        #region Constructor
+        #region Constructors
+
+        private PSResourceInfo() { }
+
+        private PSResourceInfo(
+            Dictionary<string, string> additionalMetadata,
+            string author,
+            string companyName,
+            string copyright,
+            Dependency[] dependencies,
+            string description,
+            Uri iconUri,
+            ResourceIncludes includes,
+            DateTime? installedDate,
+            string installedLocation,
+            bool isPrelease,
+            Uri licenseUri,
+            string name,
+            string packageManagementProvider,
+            string powershellGetFormatVersion,
+            string prereleaseLabel,
+            Uri projectUri,
+            DateTime? publishedDate,
+            string releaseNotes,
+            string repository,
+            string repositorySourceLocation,
+            string[] tags,
+            ResourceType type,
+            DateTime? updatedDate,
+            Version version)
+        {
+            AdditionalMetadata = additionalMetadata ?? new Dictionary<string, string>();
+            Author = author ?? string.Empty;
+            CompanyName = companyName ?? string.Empty;
+            Copyright = copyright ?? string.Empty;
+            Dependencies = dependencies ?? new Dependency[0];
+            Description = description ?? string.Empty;
+            IconUri = iconUri;
+            Includes = includes ?? new ResourceIncludes();
+            InstalledDate = installedDate;
+            InstalledLocation = installedLocation ?? string.Empty;
+            IsPrerelease = isPrelease;
+            LicenseUri = licenseUri;
+            Name = name ?? string.Empty;
+            PackageManagementProvider = packageManagementProvider ?? string.Empty;
+            PowerShellGetFormatVersion = powershellGetFormatVersion ?? string.Empty;
+            PrereleaseLabel = prereleaseLabel ?? string.Empty;
+            ProjectUri = projectUri;
+            PublishedDate = publishedDate;
+            ReleaseNotes = releaseNotes ?? string.Empty;
+            Repository = repository ?? string.Empty;
+            RepositorySourceLocation = repositorySourceLocation ?? string.Empty;
+            Tags = tags ?? Utils.EmptyStrArray;
+            Type = type;
+            UpdatedDate = updatedDate;
+            Version = version ?? new Version();
+        }
+
         #endregion
 
         #region Private fields
@@ -301,39 +368,35 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 var additionalMetadata = GetProperty<Dictionary<string,string>>(nameof(PSResourceInfo.AdditionalMetadata), psObjectInfo);
                 Version version = GetVersionInfo(psObjectInfo, additionalMetadata, out string prereleaseLabel);
 
-                psGetInfo = new PSResourceInfo
-                {
-                    AdditionalMetadata = additionalMetadata,
-                    Author = GetStringProperty(nameof(PSResourceInfo.Author), psObjectInfo),
-                    CompanyName = GetStringProperty(nameof(PSResourceInfo.CompanyName), psObjectInfo),
-                    Copyright = GetStringProperty(nameof(PSResourceInfo.Copyright), psObjectInfo),
-                    Dependencies = GetDependencies(GetProperty<ArrayList>(nameof(PSResourceInfo.Dependencies), psObjectInfo)),
-                    Description = GetStringProperty(nameof(PSResourceInfo.Description), psObjectInfo),
-                    IconUri = GetProperty<Uri>(nameof(PSResourceInfo.IconUri), psObjectInfo),
-                    Includes = new ResourceIncludes(GetProperty<Hashtable>(nameof(PSResourceInfo.Includes), psObjectInfo)),
-                    InstalledDate = GetProperty<DateTime>(nameof(PSResourceInfo.InstalledDate), psObjectInfo),
-                    InstalledLocation = GetStringProperty(nameof(PSResourceInfo.InstalledLocation), psObjectInfo),
-                    IsPrerelease = GetProperty<bool>(nameof(PSResourceInfo.IsPrerelease), psObjectInfo),
-                    LicenseUri = GetProperty<Uri>(nameof(PSResourceInfo.LicenseUri), psObjectInfo),
-                    Name = GetStringProperty(nameof(PSResourceInfo.Name), psObjectInfo),
-                    PackageManagementProvider = GetStringProperty(nameof(PSResourceInfo.PackageManagementProvider), psObjectInfo),
-                    PowerShellGetFormatVersion = GetStringProperty(nameof(PSResourceInfo.PowerShellGetFormatVersion), psObjectInfo),
-                    PrereleaseLabel = prereleaseLabel,
-                    ProjectUri = GetProperty<Uri>(nameof(PSResourceInfo.ProjectUri), psObjectInfo),
-                    PublishedDate = GetProperty<DateTime>(nameof(PSResourceInfo.PublishedDate), psObjectInfo),
-                    ReleaseNotes = GetStringProperty(nameof(PSResourceInfo.ReleaseNotes), psObjectInfo),
-                    Repository = GetStringProperty(nameof(PSResourceInfo.Repository), psObjectInfo),
-                    RepositorySourceLocation = GetStringProperty(nameof(PSResourceInfo.RepositorySourceLocation), psObjectInfo),
-                    Tags = Utils.GetStringArray(GetProperty<ArrayList>(nameof(PSResourceInfo.Tags), psObjectInfo)),
-                    // try to get the value of PSResourceInfo.Type property, if the value is null use ResourceType.Module as value
-                    // this value will be used in Enum.TryParse. If Enum.TryParse returns false, use ResourceType.Module to set Type instead.
-                    Type = Enum.TryParse(
-                        GetProperty<string>(nameof(PSResourceInfo.Type), psObjectInfo) ?? nameof(ResourceType.Module),
-                            out ResourceType currentReadType)
-                                ? currentReadType : ResourceType.Module,
-                    UpdatedDate = GetProperty<DateTime>(nameof(PSResourceInfo.UpdatedDate), psObjectInfo),
-                    Version = version
-                };
+                psGetInfo = new PSResourceInfo(
+                    additionalMetadata: additionalMetadata,
+                    author: GetStringProperty(nameof(PSResourceInfo.Author), psObjectInfo),
+                    companyName: GetStringProperty(nameof(PSResourceInfo.CompanyName), psObjectInfo),
+                    copyright: GetStringProperty(nameof(PSResourceInfo.Copyright), psObjectInfo),
+                    dependencies: GetDependencies(GetProperty<ArrayList>(nameof(PSResourceInfo.Dependencies), psObjectInfo)),
+                    description: GetStringProperty(nameof(PSResourceInfo.Description), psObjectInfo),
+                    iconUri: GetProperty<Uri>(nameof(PSResourceInfo.IconUri), psObjectInfo),
+                    includes: new ResourceIncludes(GetProperty<Hashtable>(nameof(PSResourceInfo.Includes), psObjectInfo)),
+                    installedDate: GetProperty<DateTime>(nameof(PSResourceInfo.InstalledDate), psObjectInfo),
+                    installedLocation: GetStringProperty(nameof(PSResourceInfo.InstalledLocation), psObjectInfo),
+                    isPrelease: GetProperty<bool>(nameof(PSResourceInfo.IsPrerelease), psObjectInfo),
+                    licenseUri: GetProperty<Uri>(nameof(PSResourceInfo.LicenseUri), psObjectInfo),
+                    name: GetStringProperty(nameof(PSResourceInfo.Name), psObjectInfo),
+                    packageManagementProvider: GetStringProperty(nameof(PSResourceInfo.PackageManagementProvider), psObjectInfo),
+                    powershellGetFormatVersion: GetStringProperty(nameof(PSResourceInfo.PowerShellGetFormatVersion), psObjectInfo),
+                    prereleaseLabel: prereleaseLabel,
+                    projectUri: GetProperty<Uri>(nameof(PSResourceInfo.ProjectUri), psObjectInfo),
+                    publishedDate: GetProperty<DateTime>(nameof(PSResourceInfo.PublishedDate), psObjectInfo),
+                    releaseNotes: GetStringProperty(nameof(PSResourceInfo.ReleaseNotes), psObjectInfo),
+                    repository: GetStringProperty(nameof(PSResourceInfo.Repository), psObjectInfo),
+                    repositorySourceLocation: GetStringProperty(nameof(PSResourceInfo.RepositorySourceLocation), psObjectInfo),
+                    tags: Utils.GetStringArray(GetProperty<ArrayList>(nameof(PSResourceInfo.Tags), psObjectInfo)),
+                    type: Enum.TryParse(
+                            GetProperty<string>(nameof(PSResourceInfo.Type), psObjectInfo) ?? nameof(ResourceType.Module),
+                                out ResourceType currentReadType)
+                                    ? currentReadType : ResourceType.Module,
+                    updatedDate: GetProperty<DateTime>(nameof(PSResourceInfo.UpdatedDate), psObjectInfo),
+                    version: version);
 
                 return true;
             }
@@ -423,24 +486,32 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
             try
             {
-                psGetInfo = new PSResourceInfo
-                {
-                    // not all of the properties of PSResourceInfo are filled as they are not there in metadata returned for Find-PSResource.
-                    Author = ParseMetadataAuthor(metadataToParse),
-                    Dependencies = ParseMetadataDependencies(metadataToParse),
-                    Description = ParseMetadataDescription(metadataToParse),
-                    IconUri = ParseMetadataIconUri(metadataToParse),
-                    IsPrerelease = ParseMetadataIsPrerelease(metadataToParse),
-                    LicenseUri = ParseMetadataLicenseUri(metadataToParse),
-                    Name = ParseMetadataName(metadataToParse),
-                    PrereleaseLabel = ParsePrerelease(metadataToParse),
-                    ProjectUri = ParseMetadataProjectUri(metadataToParse),
-                    PublishedDate = ParseMetadataPublishedDate(metadataToParse),
-                    Repository = repositoryName,
-                    Tags = ParseMetadataTags(metadataToParse),
-                    Type = ParseMetadataType(metadataToParse, repositoryName, type),
-                    Version = ParseMetadataVersion(metadataToParse)
-                };
+                psGetInfo = new PSResourceInfo(
+                    additionalMetadata: null,
+                    author: ParseMetadataAuthor(metadataToParse),
+                    companyName: null,
+                    copyright: null,
+                    dependencies: ParseMetadataDependencies(metadataToParse),
+                    description: ParseMetadataDescription(metadataToParse),
+                    iconUri: ParseMetadataIconUri(metadataToParse),
+                    includes: null,
+                    installedDate: null,
+                    installedLocation: null,
+                    isPrelease: ParseMetadataIsPrerelease(metadataToParse),
+                    licenseUri: ParseMetadataLicenseUri(metadataToParse),
+                    name: ParseMetadataName(metadataToParse),
+                    packageManagementProvider: null,
+                    powershellGetFormatVersion: null,
+                    prereleaseLabel: ParsePrerelease(metadataToParse),
+                    projectUri: ParseMetadataProjectUri(metadataToParse),
+                    publishedDate: ParseMetadataPublishedDate(metadataToParse),
+                    releaseNotes: null,
+                    repository: repositoryName,
+                    repositorySourceLocation: null,
+                    tags: ParseMetadataTags(metadataToParse),
+                    type: ParseMetadataType(metadataToParse, repositoryName, type),
+                    updatedDate: null,
+                    version: ParseMetadataVersion(metadataToParse));
 
                 return true;
             }
@@ -802,11 +873,6 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
             var additionalMetadata = new PSObject();
 
-            if (AdditionalMetadata == null)
-            {
-                AdditionalMetadata = new Dictionary<string, string>();
-            }
-
             if (!AdditionalMetadata.ContainsKey(nameof(IsPrerelease)))
             {
                 AdditionalMetadata.Add(nameof(IsPrerelease), IsPrerelease.ToString());
@@ -832,13 +898,13 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             }
 
             var psObject = new PSObject();
-            psObject.Properties.Add(new PSNoteProperty(nameof(Name), Name ?? string.Empty));
+            psObject.Properties.Add(new PSNoteProperty(nameof(Name), Name));
             psObject.Properties.Add(new PSNoteProperty(nameof(Version), NormalizedVersion));
             psObject.Properties.Add(new PSNoteProperty(nameof(Type), Type));
-            psObject.Properties.Add(new PSNoteProperty(nameof(Description), Description ?? string.Empty));
-            psObject.Properties.Add(new PSNoteProperty(nameof(Author), Author ?? string.Empty));
-            psObject.Properties.Add(new PSNoteProperty(nameof(CompanyName), CompanyName ?? string.Empty));
-            psObject.Properties.Add(new PSNoteProperty(nameof(Copyright), Copyright ?? string.Empty));
+            psObject.Properties.Add(new PSNoteProperty(nameof(Description), Description));
+            psObject.Properties.Add(new PSNoteProperty(nameof(Author), Author));
+            psObject.Properties.Add(new PSNoteProperty(nameof(CompanyName), CompanyName));
+            psObject.Properties.Add(new PSNoteProperty(nameof(Copyright), Copyright));
             psObject.Properties.Add(new PSNoteProperty(nameof(PublishedDate), PublishedDate));
             psObject.Properties.Add(new PSNoteProperty(nameof(InstalledDate), InstalledDate));
             psObject.Properties.Add(new PSNoteProperty(nameof(IsPrerelease), IsPrerelease));
@@ -847,15 +913,15 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             psObject.Properties.Add(new PSNoteProperty(nameof(ProjectUri), ProjectUri));
             psObject.Properties.Add(new PSNoteProperty(nameof(IconUri), IconUri));
             psObject.Properties.Add(new PSNoteProperty(nameof(Tags), Tags));
-            psObject.Properties.Add(new PSNoteProperty(nameof(Includes), Includes != null ? Includes.ConvertToHashtable() : null));
-            psObject.Properties.Add(new PSNoteProperty(nameof(PowerShellGetFormatVersion), PowerShellGetFormatVersion ?? string.Empty));
-            psObject.Properties.Add(new PSNoteProperty(nameof(ReleaseNotes), ReleaseNotes ?? string.Empty));
+            psObject.Properties.Add(new PSNoteProperty(nameof(Includes), Includes.ConvertToHashtable()));
+            psObject.Properties.Add(new PSNoteProperty(nameof(PowerShellGetFormatVersion), PowerShellGetFormatVersion));
+            psObject.Properties.Add(new PSNoteProperty(nameof(ReleaseNotes), ReleaseNotes));
             psObject.Properties.Add(new PSNoteProperty(nameof(Dependencies), Dependencies));
-            psObject.Properties.Add(new PSNoteProperty(nameof(RepositorySourceLocation), RepositorySourceLocation ?? string.Empty));
-            psObject.Properties.Add(new PSNoteProperty(nameof(Repository), Repository ?? string.Empty));
-            psObject.Properties.Add(new PSNoteProperty(nameof(PackageManagementProvider), PackageManagementProvider ?? string.Empty));
+            psObject.Properties.Add(new PSNoteProperty(nameof(RepositorySourceLocation), RepositorySourceLocation));
+            psObject.Properties.Add(new PSNoteProperty(nameof(Repository), Repository));
+            psObject.Properties.Add(new PSNoteProperty(nameof(PackageManagementProvider), PackageManagementProvider));
             psObject.Properties.Add(new PSNoteProperty(nameof(AdditionalMetadata), additionalMetadata));
-            psObject.Properties.Add(new PSNoteProperty(nameof(InstalledLocation), InstalledLocation ?? string.Empty));
+            psObject.Properties.Add(new PSNoteProperty(nameof(InstalledLocation), InstalledLocation));
 
             return psObject;
         }

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -201,7 +201,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 // finally: check to see if there's anything left in the parent directory, if not, delete that as well
                 try
                 {
-                    if (Directory.GetDirectories(dir.Parent.FullName).Length == 0)
+                    if (Utils.GetSubDirectories(dir.Parent.FullName).Length == 0)
                     {
                         Directory.Delete(dir.Parent.FullName, true);
                     }

--- a/src/code/UnregisterPSResourceRepository.cs
+++ b/src/code/UnregisterPSResourceRepository.cs
@@ -29,7 +29,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             ValueFromPipelineByPropertyName = true)]
         [ArgumentCompleter(typeof(RepositoryNameCompleter))]
         [ValidateNotNullOrEmpty]
-        public string[] Name { get; set; } = new string[0];
+        public string[] Name { get; set; } = Utils.EmptyStrArray;
 
         #endregion
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix PSResourceInfo type so that it is always constructed with expected default property values.

## PR Context

This PR makes a number of small changes:

- Update PSResourceInfo construction
- Bump module version to 'beta11'
- Create GetSubDirectories and GetDirectorFiles helper functions
- Avoid allocations by using Array.Empty<>()
- Add #region origanization to Utils.cs file

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
