### PR TITLE
Fix save psresource tests by using TestDrive

### DIFF
--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -16,7 +16,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// It returns PSResourceInfo objects which describe each resource item found.
     /// Other parameters allow the returned results to be filtered by item Type and Tag.
     /// </summary>
-
     [Cmdlet(VerbsCommon.Find,
         "PSResource",
         DefaultParameterSetName = ResourceNameParameterSet,
@@ -25,6 +24,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     public sealed class FindPSResource : PSCmdlet
     {
         #region Members
+        
         private const string ResourceNameParameterSet = "ResourceNameParameterSet";
         private const string CommandNameParameterSet = "CommandNameParameterSet";
         private const string DscResourceNameParameterSet = "DscResourceNameParameterSet";

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -418,7 +418,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     
                     MoveFilesIntoInstallPath(p, isScript, isLocalRepo, tempDirNameVersion, tempInstallPath, installPath, newVersion, moduleManifestVersion, normalizedVersionNoPrereleaseLabel, version4digitNoPrerelease, scriptPath);
                     
-                    _cmdletPassedIn.WriteVerbose(String.Format("Successfully installed package '{0}'", p.Name));
+                    _cmdletPassedIn.WriteVerbose(String.Format("Successfully installed package '{0}' to location '{1}'", p.Name, installPath));
                     pkgsSuccessfullyInstalled.Add(p.Name);
                 }
                 catch (Exception e)

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -19,7 +19,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     public sealed
     class InstallPSResource : PSCmdlet
     {
-        #region parameters 
+        #region Parameters 
+
         /// <summary>
         /// Specifies the exact names of resources to install from a repository.
         /// A comma-separated list of module names is accepted. The resource name must match the resource name in the repository.
@@ -85,17 +86,21 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// </summary>
         [Parameter(ParameterSetName = NameParameterSet)]
         public SwitchParameter AcceptLicense { get; set; }
+
         #endregion
 
-        #region members
+        #region Members
+
         private const string NameParameterSet = "NameParameterSet";
         private const string RequiredResourceFileParameterSet = "RequiredResourceFileParameterSet";
         private const string RequiredResourceParameterSet = "RequiredResourceParameterSet";
         List<string> _pathsToInstallPkg;
         VersionRange _versionRange;
+
         #endregion
 
-        #region Methods
+        #region Method overrides
+
         protected override void BeginProcessing()
         {
             // validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
@@ -165,6 +170,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     break;
             }
         }
+        
         #endregion
     }
 }

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -25,10 +25,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// <summary>
     /// Publishes a module, script, or nupkg to a designated repository.
     /// </summary>
-    [Cmdlet(VerbsData.Publish, "PSResource", SupportsShouldProcess = true,
-        HelpUri = "<add>")]
-    public sealed
-    class PublishPSResource : PSCmdlet
+    [Cmdlet(VerbsData.Publish, "PSResource", SupportsShouldProcess = true)]
+    public sealed class PublishPSResource : PSCmdlet
     {
         #region Parameters
 
@@ -44,6 +42,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// </summary>
         [Parameter()]
         [ValidateNotNullOrEmpty]
+        [ArgumentCompleter(typeof(RepositoryNameCompleter))]
         public string Repository { get; set; }
 
         /// <summary>
@@ -168,11 +167,15 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         #endregion
 
-        #region members
+        #region Members
+
         private NuGetVersion _pkgVersion;
         private string _pkgName;
         private static char[] _PathSeparators = new [] { System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar };
+        
         #endregion
+
+        #region Method overrides
 
         protected override void ProcessRecord()
         {
@@ -318,7 +321,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                 string repositoryUrl = repository.Url.AbsoluteUri;
 
-
                 // Check if dependencies already exist within the repo if:
                 // 1) the resource to publish has dependencies and 
                 // 2) the -SkipDependenciesCheck flag is not passed in
@@ -389,6 +391,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 Directory.Delete(outputDir, recursive:true);
             }
         }
+
+        #endregion
+
+        #region Private methods
 
         private bool IsValidModuleManifest(string moduleManifestPath)
         {
@@ -608,7 +614,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 <icon>Powershell_black_64.png</icon>
                 <projectUrl>https://github.com/PowerShell/PowerShell</projectUrl>
                 <description>Example description here</description>
-                <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+                <copyright>Copyright (c) Microsoft Corporation. All rights reserved.</copyright>
                 <language>en-US</language>
                 <tags>PowerShell</tags>
                 <dependencies>
@@ -923,4 +929,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }            
         }
     }
+
+    #endregion
 }

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -16,12 +16,18 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// The Save-PSResource cmdlet saves a resource to a machine.
     /// It returns nothing.
     /// </summary>
-
-    [Cmdlet(VerbsData.Save, "PSResource", DefaultParameterSetName = "NameParameterSet", SupportsShouldProcess = true, HelpUri = "<add>")]
-    public sealed
-    class SavePSResource : PSCmdlet
+    [Cmdlet(VerbsData.Save, "PSResource", DefaultParameterSetName = "NameParameterSet", SupportsShouldProcess = true)]
+    public sealed class SavePSResource : PSCmdlet
     {
-        #region parameters 
+        #region Members
+
+        private const string NameParameterSet = "NameParameterSet";
+        private const string InputObjectSet = "InputObjectSet";
+        VersionRange _versionRange;
+        
+        #endregion
+
+        #region Parameters 
 
         /// <summary>
         /// Specifies the exact names of resources to save from a repository.
@@ -50,6 +56,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         [Parameter(ParameterSetName = NameParameterSet)]
         // todo: add tab completion (look at get-psresourcerepository at the name parameter)
         [ValidateNotNullOrEmpty]
+        [ArgumentCompleter(typeof(RepositoryNameCompleter))]
         public string[] Repository { get; set; }
 
         /// <summary>
@@ -108,23 +115,21 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// <summary>
         /// Used for pipeline input.
         /// </summary>
-        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "InputObjectSet")]
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, ParameterSetName = InputObjectSet)]
         [ValidateNotNullOrEmpty]
         public object[] InputObject { set; get; }
+
         #endregion
 
-        #region members
-        private const string NameParameterSet = "NameParameterSet";
-        private const string InputObjectSet = "InputObjectSet";
-        VersionRange _versionRange;
-        #endregion
+        #region Method overrides
 
-        #region Methods
         protected override void BeginProcessing()
         {
             // validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
             // an exact version will be formatted into a version range.
-            if (ParameterSetName.Equals("NameParameterSet") && Version != null && !Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
+            if (ParameterSetName.Equals("NameParameterSet") && 
+                Version != null && 
+                !Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
             {
                 var exMessage = "Argument for -Version parameter is not in the proper format.";
                 var ex = new ArgumentException(exMessage);
@@ -176,6 +181,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     break;
             }
         }
+
         #endregion
     }
 }

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -188,12 +188,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
             
             DirectoryInfo dir = new DirectoryInfo(pkgPath);
-            dir.Attributes = dir.Attributes & ~FileAttributes.ReadOnly;
+            dir.Attributes &= ~FileAttributes.ReadOnly;
 
             try
             {
                 // delete recursively
-                dir.Delete(true);
+                Directory.Delete(pkgPath, recursive: true);
                 WriteVerbose(string.Format("Successfully uninstalled '{0}' from path '{1}'", pkgName, dir.FullName));
 
                 successfullyUninstalledPkg = true;

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Test Install-PSResource for Module' {
 
     AfterEach {
         Uninstall-PSResource "TestModule", "TestModule99", "myTestModule", "myTestModule2", "testModulePrerelease", 
-            "testModuleWithlicense","PSGetTestModule", "PSGetTestDependency1", "TestFindModule"
+            "testModuleWithlicense","PSGetTestModule", "PSGetTestDependency1", "TestFindModule" -Force -ErrorAction SilentlyContinue
     }
 
     AfterAll {

--- a/test/PSGetTestUtils.psm1
+++ b/test/PSGetTestUtils.psm1
@@ -166,13 +166,6 @@ function Get-RemoveTestDirs {
     }
 }
 
-function Create-TemporaryDirectory {
-    $path = [System.IO.Path]::GetTempPath()
-    $child = [System.Guid]::NewGuid()
-
-    return New-Item -ItemType Directory -Path (Join-Path $path $child) 
-}
-
 function Get-NewPSResourceRepositoryFile {
     # register our own repositories with desired priority
     $powerShellGetPath = Join-Path -Path ([Environment]::GetFolderPath([System.Environment+SpecialFolder]::LocalApplicationData)) -ChildPath "PowerShellGet"

--- a/test/SavePSResource.Tests.ps1
+++ b/test/SavePSResource.Tests.ps1
@@ -12,17 +12,13 @@ Describe 'Test Save-PSResource for PSResources' {
         Get-NewPSResourceRepositoryFile
         Register-LocalRepos
 
-       $TempDir = Create-TemporaryDirectory 
+       $SaveDir = Join-Path $TestDrive 'SavedResources'
+       New-Item -Item Directory $SaveDir -Force
     }
 
     AfterEach {
-        # Delete all files and subdirectories in $Tempdir, but keep the directory $Tempdir
-        try {
-            Get-ChildItem -Path $TempDir -Force | foreach { $_.Delete($true)}
-        }
-        catch {
-            Get-ChildItem -Path $TempDir -Force | foreach { $_.Delete()}
-        }
+        # Delte contents of save directory
+        Remove-Item -Path (Join-Path $SaveDir '*') -Recurse -Force -ErrorAction SilentlyContinue
     }
 
     AfterAll {
@@ -30,37 +26,37 @@ Describe 'Test Save-PSResource for PSResources' {
     }
 
     It "Save specific module resource by name" {
-        Save-PSResource -Name "TestModule" -Repository $TestGalleryName -Path $TempDir
-        $pkg = Get-ChildItem $TempDir
+        Save-PSResource -Name "TestModule" -Repository $TestGalleryName -Path $SaveDir
+        $pkg = Get-ChildItem $SaveDir
         $pkg.Name | Should -Be "TestModule" 
         (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
     }
 
     It "Save specific script resource by name" {
-        Save-PSResource -Name "TestTestScript" -Repository $TestGalleryName -Path $TempDir
-        $pkg = Get-ChildItem $TempDir
+        Save-PSResource -Name "TestTestScript" -Repository $TestGalleryName -Path $SaveDir
+        $pkg = Get-ChildItem $SaveDir
         $pkg.Name | Should -Be "TestTestScript.ps1" 
         (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
     }
 
     It "Save multiple resources by name" {
         $pkgNames = @("TestModule","TestModule99")
-        Save-PSResource -Name $pkgNames -Repository $TestGalleryName -Path $TempDir
-        $pkg = Get-ChildItem $TempDir
+        Save-PSResource -Name $pkgNames -Repository $TestGalleryName -Path $SaveDir
+        $pkg = Get-ChildItem $SaveDir
         $pkg.Name | Should -Be @("TestModule","TestModule99") 
         (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
     }
 
     It "Should not save resource given nonexistant name" {
-        Save-PSResource -Name NonExistantModule -Repository $TestGalleryName -Path $TempDir
-        $pkg = Get-ChildItem $TempDir
+        Save-PSResource -Name NonExistantModule -Repository $TestGalleryName -Path $SaveDir
+        $pkg = Get-ChildItem $SaveDir
         $pkg.Name | Should -BeNullOrEmpty
     }
 
     # Do some version testing, but Find-PSResource should be doing thorough testing
     It "Should save resource given name and exact version" {
-        Save-PSResource -Name "TestModule" -Version "1.2.0" -Repository $TestGalleryName -Path $TempDir
-        $pkg = Get-ChildItem $TempDir
+        Save-PSResource -Name "TestModule" -Version "1.2.0" -Repository $TestGalleryName -Path $SaveDir
+        $pkg = Get-ChildItem $SaveDir
         $pkg.Name | Should -Be "TestModule" 
         (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
         $pkgVersion = Get-ChildItem $pkg
@@ -68,8 +64,8 @@ Describe 'Test Save-PSResource for PSResources' {
     }
 
     It "Should save resource given name and exact version with bracket syntax" {
-        Save-PSResource -Name "TestModule" -Version "[1.2.0]" -Repository $TestGalleryName -Path $TempDir
-        $pkg = Get-ChildItem $TempDir
+        Save-PSResource -Name "TestModule" -Version "[1.2.0]" -Repository $TestGalleryName -Path $SaveDir
+        $pkg = Get-ChildItem $SaveDir
         $pkg.Name | Should -Be "TestModule" 
         (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
         $pkgVersion = Get-ChildItem $pkg
@@ -77,8 +73,8 @@ Describe 'Test Save-PSResource for PSResources' {
     }
 
     It "Should save resource given name and exact range inclusive [1.0.0, 1.1.1]" {
-        Save-PSResource -Name "TestModule" -Version "[1.0.0, 1.1.1]" -Repository $TestGalleryName -Path $TempDir
-        $pkg = Get-ChildItem $TempDir
+        Save-PSResource -Name "TestModule" -Version "[1.0.0, 1.1.1]" -Repository $TestGalleryName -Path $SaveDir
+        $pkg = Get-ChildItem $SaveDir
         $pkg.Name | Should -Be "TestModule" 
         (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
         $pkgVersion = Get-ChildItem $pkg
@@ -86,8 +82,8 @@ Describe 'Test Save-PSResource for PSResources' {
     }
 
     It "Should save resource given name and exact range exclusive (1.0.0, 1.1.1)" {
-        Save-PSResource -Name "TestModule" -Version "(1.0.0, 1.1.1)" -Repository $TestGalleryName -Path $TempDir
-        $pkg = Get-ChildItem $TempDir
+        Save-PSResource -Name "TestModule" -Version "(1.0.0, 1.1.1)" -Repository $TestGalleryName -Path $SaveDir
+        $pkg = Get-ChildItem $SaveDir
         $pkg.Name | Should -Be "TestModule" 
         (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
         $pkgVersion = Get-ChildItem $pkg
@@ -100,14 +96,14 @@ Describe 'Test Save-PSResource for PSResources' {
     ) {
         param($Version, $Description)
 
-        Save-PSResource -Name "TestModule" -Version $Version -Repository $TestGalleryName -Path $TempDir
-        $res = Get-ChildItem $TempDir
+        Save-PSResource -Name "TestModule" -Version $Version -Repository $TestGalleryName -Path $SaveDir
+        $res = Get-ChildItem $SaveDir
         $res | Should -BeNullOrEmpty
     }
 
     It "Save resource when given Name, Version '*', should install the latest version" {
-        Save-PSResource -Name "TestModule" -Version "*" -Repository $TestGalleryName -Path $TempDir
-        $pkg = Get-ChildItem $TempDir
+        Save-PSResource -Name "TestModule" -Version "*" -Repository $TestGalleryName -Path $SaveDir
+        $pkg = Get-ChildItem $SaveDir
         $pkg.Name | Should -Be "TestModule" 
         (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
         $pkgVersion = Get-ChildItem $pkg
@@ -115,8 +111,8 @@ Describe 'Test Save-PSResource for PSResources' {
     }
 
     It "Save resource with latest (including prerelease) version given Prerelease parameter" {
-        Save-PSResource -Name "TestModulePrerelease" -Prerelease -Repository $TestGalleryName -Path $TempDir
-        $pkg = Get-ChildItem $TempDir
+        Save-PSResource -Name "TestModulePrerelease" -Prerelease -Repository $TestGalleryName -Path $SaveDir
+        $pkg = Get-ChildItem $SaveDir
         $pkg.Name | Should -Be "TestModulePrerelease" 
         (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
         $pkgVersion = Get-ChildItem $pkg
@@ -124,15 +120,15 @@ Describe 'Test Save-PSResource for PSResources' {
     }
 
     It "Save a module with a dependency" {
-        Save-PSResource -Name "PSGetTestModule" -Prerelease -Repository $TestGalleryName -Path $TempDir
-        $pkg = Get-ChildItem $TempDir
+        Save-PSResource -Name "PSGetTestModule" -Prerelease -Repository $TestGalleryName -Path $SaveDir
+        $pkg = Get-ChildItem $SaveDir
         $pkg.Name | Should -Be @("PSGetTestDependency1","PSGetTestModule") 
         (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
     }
 
     It "Save resource via InputObject by piping from Find-PSresource" {
-        Find-PSResource -Name "TestModule" -Repository $TestGalleryName | Save-PSResource -Path $TempDir
-        $pkg = Get-ChildItem $TempDir
+        Find-PSResource -Name "TestModule" -Repository $TestGalleryName | Save-PSResource -Path $SaveDir
+        $pkg = Get-ChildItem $SaveDir
         $pkg.Name | Should -Be "TestModule" 
         (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
         $pkgVersion = Get-ChildItem $pkg
@@ -142,8 +138,8 @@ Describe 'Test Save-PSResource for PSResources' {
     It "Save resource should not prompt 'trust repository' if repository is not trusted but -TrustRepository is used" {
         Set-PSResourceRepository PoshTestGallery -Trusted:$false
 
-        Save-PSResource -Name "TestModule" -Repository $TestGalleryName -TrustRepository -Path $TempDir
-        $pkg = Get-ChildItem $TempDir
+        Save-PSResource -Name "TestModule" -Repository $TestGalleryName -TrustRepository -Path $SaveDir
+        $pkg = Get-ChildItem $SaveDir
         $pkg.Name | Should -Be "TestModule" 
         (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
         $pkgVersion = Get-ChildItem $pkg
@@ -158,8 +154,8 @@ Describe 'Test Save-PSResource for PSResources' {
         Get-ModuleResourcePublishedToLocalRepoTestDrive $publishModuleName $repoName
         Set-PSResourceRepository "psgettestlocal" -Trusted:$true
 
-        Save-PSResource -Name $publishModuleName -Repository $repoName -Path $TempDir
-        $pkg = Get-ChildItem $TempDir
+        Save-PSResource -Name $publishModuleName -Repository $repoName -Path $SaveDir
+        $pkg = Get-ChildItem $SaveDir
         $pkg.Name | Should -Be $publishModuleName 
         (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
     }
@@ -169,8 +165,8 @@ Describe 'Test Save-PSResource for PSResources' {
         Set-PSResourceRepository "PSGallery" -Trusted:$True
         Set-PSResourceRepository "psgettestlocal2" -Trusted:$True
 
-        Save-PSResource -Name "TestModule" -Path $TempDir
-        $pkg = Get-ChildItem $TempDir
+        Save-PSResource -Name "TestModule" -Path $SaveDir
+        $pkg = Get-ChildItem $SaveDir
         $pkg.Name | Should -Be "TestModule" 
         (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
     }
@@ -182,7 +178,7 @@ Describe 'Test Save-PSResource for PSResources' {
         $pkg.Name | Should -Contain "TestModule" 
         (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
 
-        # Delete all files and subdirectories in the current , but keep the directory $Tempdir
+        # Delete all files and subdirectories in the current , but keep the directory $SaveDir
         $pkgDir = Join-Path -Path . -ChildPath "TestModule"
         Remove-Item $pkgDir -Recurse -Force
     }

--- a/test/SavePSResource.Tests.ps1
+++ b/test/SavePSResource.Tests.ps1
@@ -27,67 +27,64 @@ Describe 'Test Save-PSResource for PSResources' {
 
     It "Save specific module resource by name" {
         Save-PSResource -Name "TestModule" -Repository $TestGalleryName -Path $SaveDir
-        $pkg = Get-ChildItem $SaveDir
-        $pkg.Name | Should -Be "TestModule" 
-        (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        $pkgDir | Should -Not -BeNullOrEmpty
+        (Get-ChildItem $pkgDir.FullName).Count | Should -Be 1
     }
 
     It "Save specific script resource by name" {
         Save-PSResource -Name "TestTestScript" -Repository $TestGalleryName -Path $SaveDir
-        $pkg = Get-ChildItem $SaveDir
-        $pkg.Name | Should -Be "TestTestScript.ps1" 
-        (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestTestScript.ps1"
+        $pkgDir | Should -Not -BeNullOrEmpty
+        (Get-ChildItem $pkgDir.FullName).Count | Should -Be 1
     }
 
     It "Save multiple resources by name" {
         $pkgNames = @("TestModule","TestModule99")
         Save-PSResource -Name $pkgNames -Repository $TestGalleryName -Path $SaveDir
-        $pkg = Get-ChildItem $SaveDir
-        $pkg.Name | Should -Be @("TestModule","TestModule99") 
-        (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
+        $pkgDirs = Get-ChildItem -Path $SaveDir | Where-Object { $_.Name -eq "TestModule" -or $_.Name -eq "TestModule99" }
+        $pkgDirs.Count | Should -Be 2
+        (Get-ChildItem $pkgDirs[0].FullName).Count | Should -Be 1
+        (Get-ChildItem $pkgDirs[1].FullName).Count | Should -Be 1
     }
 
     It "Should not save resource given nonexistant name" {
-        Save-PSResource -Name NonExistantModule -Repository $TestGalleryName -Path $SaveDir
-        $pkg = Get-ChildItem $SaveDir
-        $pkg.Name | Should -BeNullOrEmpty
+        Save-PSResource -Name NonExistentModule -Repository $TestGalleryName -Path $SaveDir
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "NonExistentModule"
+        $pkgDir.Name | Should -BeNullOrEmpty
     }
 
     # Do some version testing, but Find-PSResource should be doing thorough testing
     It "Should save resource given name and exact version" {
         Save-PSResource -Name "TestModule" -Version "1.2.0" -Repository $TestGalleryName -Path $SaveDir
-        $pkg = Get-ChildItem $SaveDir
-        $pkg.Name | Should -Be "TestModule" 
-        (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
-        $pkgVersion = Get-ChildItem $pkg
-        $pkgVersion.Name | Should -Be "1.2.0"
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        $pkgDir | Should -Not -BeNullOrEmpty
+        $pkgDirVersion = Get-ChildItem $pkgDir.FullName
+        $pkgDirVersion.Name | Should -Be "1.2.0"
     }
 
     It "Should save resource given name and exact version with bracket syntax" {
         Save-PSResource -Name "TestModule" -Version "[1.2.0]" -Repository $TestGalleryName -Path $SaveDir
-        $pkg = Get-ChildItem $SaveDir
-        $pkg.Name | Should -Be "TestModule" 
-        (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
-        $pkgVersion = Get-ChildItem $pkg
-        $pkgVersion.Name | Should -Be "1.2.0"
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        $pkgDir | Should -Not -BeNullOrEmpty
+        $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
+        $pkgDirVersion.Name | Should -Be "1.2.0"
     }
 
     It "Should save resource given name and exact range inclusive [1.0.0, 1.1.1]" {
         Save-PSResource -Name "TestModule" -Version "[1.0.0, 1.1.1]" -Repository $TestGalleryName -Path $SaveDir
-        $pkg = Get-ChildItem $SaveDir
-        $pkg.Name | Should -Be "TestModule" 
-        (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
-        $pkgVersion = Get-ChildItem $pkg
-        $pkgVersion.Name | Should -Be "1.1.1"
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        $pkgDir | Should -Not -BeNullOrEmpty
+        $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
+        $pkgDirVersion.Name | Should -Be "1.1.1"
     }
 
     It "Should save resource given name and exact range exclusive (1.0.0, 1.1.1)" {
         Save-PSResource -Name "TestModule" -Version "(1.0.0, 1.1.1)" -Repository $TestGalleryName -Path $SaveDir
-        $pkg = Get-ChildItem $SaveDir
-        $pkg.Name | Should -Be "TestModule" 
-        (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
-        $pkgVersion = Get-ChildItem $pkg
-        $pkgVersion.Name | Should -Be "1.1"
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        $pkgDir | Should -Not -BeNullOrEmpty
+        $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
+        $pkgDirVersion.Name | Should -Be "1.1"
     }
 
     It "Should not save resource with incorrectly formatted version such as <Description>" -TestCases @(
@@ -97,55 +94,54 @@ Describe 'Test Save-PSResource for PSResources' {
         param($Version, $Description)
 
         Save-PSResource -Name "TestModule" -Version $Version -Repository $TestGalleryName -Path $SaveDir
-        $res = Get-ChildItem $SaveDir
-        $res | Should -BeNullOrEmpty
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        $pkgDir | Should -BeNullOrEmpty
     }
 
     It "Save resource when given Name, Version '*', should install the latest version" {
         Save-PSResource -Name "TestModule" -Version "*" -Repository $TestGalleryName -Path $SaveDir
-        $pkg = Get-ChildItem $SaveDir
-        $pkg.Name | Should -Be "TestModule" 
-        (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
-        $pkgVersion = Get-ChildItem $pkg
-        $pkgVersion.Name | Should -Be "1.3.0"
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        $pkgDir | Should -Not -BeNullOrEmpty
+        $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
+        $pkgDirVersion.Name | Should -Be "1.3.0"
     }
 
     It "Save resource with latest (including prerelease) version given Prerelease parameter" {
         Save-PSResource -Name "TestModulePrerelease" -Prerelease -Repository $TestGalleryName -Path $SaveDir
-        $pkg = Get-ChildItem $SaveDir
-        $pkg.Name | Should -Be "TestModulePrerelease" 
-        (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
-        $pkgVersion = Get-ChildItem $pkg
-        $pkgVersion.Name | Should -Be "0.0.1"
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModulePrerelease"
+        $pkgDir | Should -Not -BeNullOrEmpty
+        $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
+        $pkgDirVersion.Name | Should -Be "0.0.1"
     }
 
     It "Save a module with a dependency" {
         Save-PSResource -Name "PSGetTestModule" -Prerelease -Repository $TestGalleryName -Path $SaveDir
-        $pkg = Get-ChildItem $SaveDir
-        $pkg.Name | Should -Be @("PSGetTestDependency1","PSGetTestModule") 
-        (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
+        $pkgDirs = Get-ChildItem -Path $SaveDir | Where-Object { $_.Name -eq "PSGetTestModule" -or $_.Name -eq "PSGetTestDependency1" }
+        $pkgDirs.Count | Should -Be 2
+        (Get-ChildItem $pkgDirs[0].FullName).Count | Should -Be 1
+        (Get-ChildItem $pkgDirs[1].FullName).Count | Should -Be 1
     }
 
     It "Save resource via InputObject by piping from Find-PSresource" {
         Find-PSResource -Name "TestModule" -Repository $TestGalleryName | Save-PSResource -Path $SaveDir
-        $pkg = Get-ChildItem $SaveDir
-        $pkg.Name | Should -Be "TestModule" 
-        (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
-        $pkgVersion = Get-ChildItem $pkg
-        $pkgVersion.Name | Should -Be "1.3.0"
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        $pkgDir | Should -Not -BeNullOrEmpty
+        $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
+        $pkgDirVersion.Name | Should -Be "1.3.0"
     }
 
     It "Save resource should not prompt 'trust repository' if repository is not trusted but -TrustRepository is used" {
-        Set-PSResourceRepository PoshTestGallery -Trusted:$false
-
-        Save-PSResource -Name "TestModule" -Repository $TestGalleryName -TrustRepository -Path $SaveDir
-        $pkg = Get-ChildItem $SaveDir
-        $pkg.Name | Should -Be "TestModule" 
-        (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
-        $pkgVersion = Get-ChildItem $pkg
-        $pkgVersion.Name | Should -Be "1.3.0"
-
-        Set-PSResourceRepository PoshTestGallery -Trusted
+        try {
+            Set-PSResourceRepository PoshTestGallery -Trusted:$false
+            Save-PSResource -Name "TestModule" -Repository $TestGalleryName -TrustRepository -Path $SaveDir
+            $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+            $pkgDir | Should -Not -BeNullOrEmpty
+            $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
+            $pkgDirVersion.Name | Should -Be "1.3.0"
+        }
+        finally {
+            Set-PSResourceRepository PoshTestGallery -Trusted
+        }
     }
 
     It "Save resource from local repository given Repository parameter" {
@@ -155,9 +151,9 @@ Describe 'Test Save-PSResource for PSResources' {
         Set-PSResourceRepository "psgettestlocal" -Trusted:$true
 
         Save-PSResource -Name $publishModuleName -Repository $repoName -Path $SaveDir
-        $pkg = Get-ChildItem $SaveDir
-        $pkg.Name | Should -Be $publishModuleName 
-        (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $publishModuleName
+        $pkgDir | Should -Not -BeNullOrEmpty
+        (Get-ChildItem -Path $pkgDir.FullName).Count | Should -Be 1
     }
 
     It "Save specific module resource by name when no repository is specified" {
@@ -166,22 +162,25 @@ Describe 'Test Save-PSResource for PSResources' {
         Set-PSResourceRepository "psgettestlocal2" -Trusted:$True
 
         Save-PSResource -Name "TestModule" -Path $SaveDir
-        $pkg = Get-ChildItem $SaveDir
-        $pkg.Name | Should -Be "TestModule" 
-        (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        $pkgDir | Should -Not -BeNullOrEmpty 
+        (Get-ChildItem -Path $pkgDir.FullName).Count | Should -Be 1
     }
 
+<#
+    # Tests should not write to module directory
     It "Save specific module resource by name if no -Path param is specifed" {
         Save-PSResource -Name "TestModule" -Repository $TestGalleryName
-        $pkg = Get-ChildItem .
-
-        $pkg.Name | Should -Contain "TestModule" 
-        (Get-ChildItem $pkg).Count | Should -BeGreaterThan 0
+        $pkgDir = Get-ChildItem -Path . | Where-Object Name -eq "TestModule"
+        $pkgDir | Should -Not -BeNullOrEmpty
+        (Get-ChildItem $pkgDir.FullName).Count | Should -Be 1
 
         # Delete all files and subdirectories in the current , but keep the directory $SaveDir
-        $pkgDir = Join-Path -Path . -ChildPath "TestModule"
-        Remove-Item $pkgDir -Recurse -Force
+        if (Test-Path -Path $pkgDir.FullName) {
+            Remove-Item -Path $pkgDir.FullName -Recurse -Force -ErrorAction SilentlyContinue
+        }
     }
+#>
 
 <#
     # This needs to be manually tested due to prompt


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes save psresource tests by using the Pester TestDrive, which provides a consistent temporary directory location.

## PR Context

Save psresource tests were failing in some CI test images because of invalid destination drive.
This PR does the following:

- Updates save psresource tests to use Pester TestDrive
- Adds missing argument completer for Repository parameter
- Minor clean up by adding source code region sections

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
