### PR TITLE
Get helper sort

### DIFF
--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System.Collections;
+using System.ComponentModel;
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using System;
@@ -95,6 +96,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     _cmdletPassedIn.WriteDebug(string.Format("Searching through package path: '{0}'", pkgPath));
 
                     string[] versionsDirs = Utils.GetSubDirectories(pkgPath);
+
                     if (versionsDirs.Length == 0)
                     {
                         _cmdletPassedIn.WriteVerbose(
@@ -102,9 +104,15 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         continue;
                     }
 
-                    // versionRange should not be null if the cmdlet is Get-InstalledPSResource
+                    // sort and reverse to get package versions in descending order to maintain consistency with V2
+                    Array.Sort(versionsDirs);
+                    Array.Reverse(versionsDirs);
+
+                    // versionRange should not be null if the cmdlet is Get-InstalledPSResource or Uninstall-PSResource
                     if (versionRange == null)
                     {
+                        // Get-InstalledPSResource and Uninstall-PSResource, which call into this helper, should
+                        // not be calling this with null.
                         _cmdletPassedIn.WriteVerbose("version range in GetHelper is: " + versionRange);
                         // if no version is specified, just delete the latest version
                         if (versionsDirs.Length > 0)

--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.ComponentModel;
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
@@ -113,7 +111,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     {
                         // Get-InstalledPSResource and Uninstall-PSResource, which call into this helper, should
                         // not be calling this with null.
-                        _cmdletPassedIn.WriteVerbose("version range in GetHelper is: " + versionRange);
                         // if no version is specified, just delete the latest version
                         if (versionsDirs.Length > 0)
                         {

--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -97,20 +97,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     string[] versionsDirs = Utils.GetSubDirectories(pkgPath);
                     if (versionsDirs.Length == 0)
                     {
-<<<<<<< HEAD
-                        versionsDirs = Directory.GetDirectories(pkgPath);
-                        // versionsDirs are sorted in descending order, as was done in V2 cmdlets
-                        Array.Sort(versionsDirs);
-                        Array.Reverse(versionsDirs);
-                    }
-                    catch (Exception e){
-                        _cmdletPassedIn.WriteVerbose(string.Format("Error retreiving directories from path '{0}': '{1}'", pkgPath, e.Message));
-
-                        // skip to next iteration of the loop
-=======
                         _cmdletPassedIn.WriteVerbose(
                             $"No version subdirectories found for path: {pkgPath}");
->>>>>>> 9e882f0d179af94c4e1609e3b15e09632e08e1e5
                         continue;
                     }
 

--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
+using Dbg = System.Diagnostics.Debug;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
@@ -80,6 +81,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         // Filter by user provided version
         public IEnumerable<String> FilterPkgPathsByVersion(VersionRange versionRange, List<string> dirsToSearch)
         {
+            Dbg.Assert(versionRange != null, "Version Range cannot be null");
+            
             // if no version is specified, just get the latest version
             foreach (string pkgPath in dirsToSearch)
             {
@@ -105,19 +108,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     // sort and reverse to get package versions in descending order to maintain consistency with V2
                     Array.Sort(versionsDirs);
                     Array.Reverse(versionsDirs);
-
-                    // versionRange should not be null if the cmdlet is Get-InstalledPSResource or Uninstall-PSResource
-                    if (versionRange == null)
-                    {
-                        // Get-InstalledPSResource and Uninstall-PSResource, which call into this helper, should
-                        // not be calling this with null.
-                        // if no version is specified, just delete the latest version
-                        if (versionsDirs.Length > 0)
-                        {
-                            yield return versionsDirs[versionsDirs.Length - 1];
-                        }
-                        continue;
-                    }
 
                     foreach (string versionPath in versionsDirs)
                     {

--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿using System.ComponentModel;
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
@@ -97,6 +98,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     try
                     {
                         versionsDirs = Directory.GetDirectories(pkgPath);
+                        // versionsDirs are sorted in descending order, as was done in V2 cmdlets
+                        Array.Sort(versionsDirs);
+                        Array.Reverse(versionsDirs);
                     }
                     catch (Exception e){
                         _cmdletPassedIn.WriteVerbose(string.Format("Error retreiving directories from path '{0}': '{1}'", pkgPath, e.Message));
@@ -108,9 +112,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     // versionRange should not be null if the cmdlet is Get-InstalledPSResource
                     if (versionRange == null)
                     {
+                        _cmdletPassedIn.WriteVerbose("version range in GetHelper is: " + versionRange);
                         // if no version is specified, just delete the latest version
-                        Array.Sort(versionsDirs);
-
                         if (versionsDirs.Length > 0)
                         {
                             yield return versionsDirs[versionsDirs.Length - 1];

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -134,7 +134,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             GetHelper getHelper = new GetHelper(this);
             foreach (PSResourceInfo pkg in getHelper.FilterPkgPaths(Name, _versionRange, _pathsToSearch))
             {
-                WriteVerbose("version range for Get: " + _versionRange.ToString());
                 WriteObject(pkg);
             }
         }

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -34,14 +34,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         public string[] Name { get; set; }
 
         /// <summary>
-        /// Specifies the version of the resource to include to look for. 
+        /// Specifies the version of the resource to include to look for.
         /// </summary>
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         public string Version { get; set; }
 
         /// <summary>
-        /// Specifies the path to look in. 
+        /// Specifies the path to look in.
         /// </summary>
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -53,7 +53,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void BeginProcessing()
         {
-            // Validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
+            // Validate that if a -Version param is passed in that it can be parsed into a NuGet version range.
             // an exact version will be formatted into a version range.
             if (Version == null)
             {
@@ -109,7 +109,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 Name = new string[] { "*" };
             }
-            // if '*' is passed in as an argument for -Name with other -Name arguments, 
+            // if '*' is passed in as an argument for -Name with other -Name arguments,
             // ignore all arguments except for '*' since it is the most inclusive
             // eg:  -Name ["TestModule, Test*, *"]  will become -Name ["*"]
             if (Name != null && Name.Length > 1)
@@ -132,6 +132,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             GetHelper getHelper = new GetHelper(this);
             foreach (PSResourceInfo pkg in getHelper.FilterPkgPaths(Name, _versionRange, _pathsToSearch))
             {
+                WriteVerbose("version range for Get: " + _versionRange.ToString());
                 WriteObject(pkg);
             }
         }

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         public string[] Name { get; set; }
 
         /// <summary>
-        /// Specifies the version of the resource to include to look for.
+        /// Specifies the version of the resource to include to look for. 
         /// </summary>
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -53,7 +53,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void BeginProcessing()
         {
-            // Validate that if a -Version param is passed in that it can be parsed into a NuGet version range.
+            // Validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
             // an exact version will be formatted into a version range.
             if (Version == null)
             {
@@ -111,7 +111,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 Name = new string[] { "*" };
             }
-            // if '*' is passed in as an argument for -Name with other -Name arguments,
+            // if '*' is passed in as an argument for -Name with other -Name arguments, 
             // ignore all arguments except for '*' since it is the most inclusive
             // eg:  -Name ["TestModule, Test*, *"]  will become -Name ["*"]
             if (Name != null && Name.Length > 1)

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -41,7 +41,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         public string Version { get; set; }
 
         /// <summary>
-        /// Specifies the path to look in.
+        /// Specifies the path to look in. 
         /// </summary>
         [Parameter()]
         [ValidateNotNullOrEmpty()]

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -109,6 +109,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 ThrowTerminatingError(IncorrectVersionFormat);
             }
 
+            // if no Version specified, install latest version for the package
+            if (Version == null)
+            {
+                _versionRange = VersionRange.All;
+            }
+
             _pathsToInstallPkg = Utils.GetAllInstallationPaths(this, Scope);
         }
 

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -59,7 +59,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         #region Methods
         protected override void BeginProcessing()
         {
-            // validate that if a -Version param is passed in that it can be parsed into a NuGet version range.
+            // validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
             // an exact version will be formatted into a version range.
             if (ParameterSetName.Equals("NameParameterSet") && Version != null && !Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
             {
@@ -137,7 +137,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             // Checking if module or script
             // a module path will look like:
             // ./Modules/TestModule/0.0.1
-            // note that the xml file is located in this path, eg: ./Modules/TestModule/0.0.1/PSModuleInfo.xml
+            // note that the xml file is located in this path, eg: ./Modules/TestModule/0.0.1/PSModuleInfo.xml 
             // a script path will look like:
             // ./Scripts/TestScript.ps1
             // note that the xml file is located in ./Scripts/InstalledScriptInfos, eg: ./Scripts/InstalledScriptInfos/TestScript_InstalledScriptInfo.xml
@@ -188,7 +188,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             var successfullyUninstalledPkg = false;
 
-            // if -Force is not specified and the pkg is a dependency for another package,
+            // if -Force is not specified and the pkg is a dependency for another package, 
             // an error will be written and we return false
             if (!Force && CheckIfDependency(pkgName))
             {
@@ -278,7 +278,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             // this is a primitive implementation
             // TODO:  implement a dependencies database for querying dependency info
-            // cannot uninstall a module if another module is dependent on it
+            // cannot uninstall a module if another module is dependent on it 
             using (System.Management.Automation.PowerShell pwsh = System.Management.Automation.PowerShell.Create())
             {
                 // Check all modules for dependencies

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -144,7 +144,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             string pkgName = string.Empty;
 
-            WriteVerbose("version range for Uninstall: " + _versionRange);
             foreach (string pkgPath in getHelper.FilterPkgPathsByVersion(_versionRange, dirsToDelete))
             {
 

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -146,7 +146,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             foreach (string pkgPath in getHelper.FilterPkgPathsByVersion(_versionRange, dirsToDelete))
             {
-
                 pkgName = Utils.GetInstalledPackageName(pkgPath);
 
                 if (!ShouldProcess(string.Format("Uninstall resource '{0}' from the machine.", pkgName)))


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- [x] Get-InstalledPSResource should return packages with multiple versions in descending order by Version (as V2 did).
- [x] Uninstall-PSResource should uninstall all versions of a package if no `-Version` is specified
- [x] Get-Helper should not take a `versionRange` of null.

## PR Context

Issues found during PSGet V3 bug bash, resolving to ensure compatibility with V2 (except the Uninstall issue mentioned above, but that one seemed like an issue in V2).

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
