### PR TITLE
Fix linux path

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -123,14 +123,14 @@ stages:
       imageName: windows-latest
       powershellExecutable: powershell
 
-#  - template: test.yml
-#    parameters:
-#      jobName: TestPkgUbuntu16
-#      displayName: PowerShell Core on Ubuntu 16.04
-#      imageName: ubuntu-16.04
+  - template: test.yml
+    parameters:
+      jobName: TestPkgUbuntu16
+      displayName: PowerShell Core on Ubuntu
+      imageName: ubuntu-latest
 
 #  - template: test.yml
 #    parameters:
 #      jobName: TestPkgWinMacOS
 #      displayName: PowerShell Core on macOS
-#      imageName: macOS-10.14
+#      imageName: macOS-latest

--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -123,11 +123,11 @@ stages:
       imageName: windows-latest
       powershellExecutable: powershell
 
-  - template: test.yml
-    parameters:
-      jobName: TestPkgUbuntu16
-      displayName: PowerShell Core on Ubuntu
-      imageName: ubuntu-latest
+#  - template: test.yml
+#    parameters:
+#      jobName: TestPkgUbuntu16
+#      displayName: PowerShell Core on Ubuntu
+#      imageName: ubuntu-latest
 
 #  - template: test.yml
 #    parameters:

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -578,17 +578,29 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
         }
 
-        private void MoveFilesIntoInstallPath(PSResourceInfo p, bool isScript, bool isLocalRepo, string dirNameVersion, string tempInstallPath, string installPath, string newVersion, string moduleManifestVersion, string nupkgVersion, string versionWithoutPrereleaseTag, string scriptPath)
+        private void MoveFilesIntoInstallPath(
+            PSResourceInfo p, 
+            bool isScript, 
+            bool isLocalRepo, 
+            string dirNameVersion, 
+            string tempInstallPath, 
+            string installPath, 
+            string newVersion, 
+            string moduleManifestVersion, 
+            string nupkgVersion, 
+            string versionWithoutPrereleaseTag, 
+            string scriptPath)
         {
             // Creating the proper installation path depending on whether pkg is a module or script
             var newPathParent = isScript ? installPath : Path.Combine(installPath, p.Name);
             var finalModuleVersionDir = isScript ? installPath : Path.Combine(installPath, p.Name, moduleManifestVersion);  // versionWithoutPrereleaseTag
-            _cmdletPassedIn.WriteDebug(string.Format("Installation path is: '{0}'", finalModuleVersionDir));
 
             // If script, just move the files over, if module, move the version directory over
             var tempModuleVersionDir = (isScript || isLocalRepo) ? dirNameVersion
                 : Path.Combine(tempInstallPath, p.Name.ToLower(), newVersion);
-            _cmdletPassedIn.WriteVerbose(string.Format("Full installation path is: '{0}'", tempModuleVersionDir));
+
+            _cmdletPassedIn.WriteVerbose(string.Format("Installation source path is: '{0}'", tempModuleVersionDir));
+            _cmdletPassedIn.WriteVerbose(string.Format("Installation destination path is: '{0}'", finalModuleVersionDir));    
 
             if (isScript)
             {

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -125,7 +125,7 @@ Describe 'Test Install-PSResource for Module' {
     }
 
     # Windows only
-    It "Install resource under CurrentUser scope" {
+    It "Install resource under CurrentUser scope" -Skip:(!$IsWindows) {
         Install-PSResource -Name "TestModule" -Repository $TestGalleryName -Scope CurrentUser
         $pkg = Get-Module "TestModule" -ListAvailable
         $pkg.Name | Should -Be "TestModule" 
@@ -133,7 +133,7 @@ Describe 'Test Install-PSResource for Module' {
     }
 
     # Windows only
-    It "Install resource under AllUsers scope" {
+    It "Install resource under AllUsers scope" -Skip:(!$IsWindows) {
         Install-PSResource -Name "TestModule" -Repository $TestGalleryName -Scope AllUsers
         $pkg = Get-Module "TestModule" -ListAvailable
         $pkg.Name | Should -Be "TestModule" 
@@ -141,7 +141,7 @@ Describe 'Test Install-PSResource for Module' {
     }
 
     # Windows only
-    It "Install resource under no specified scope" {
+    It "Install resource under no specified scope" -Skip:(!$IsWindows) {
         Install-PSResource -Name "TestModule" -Repository $TestGalleryName
         $pkg = Get-Module "TestModule" -ListAvailable
         $pkg.Name | Should -Be "TestModule" 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Non-Windows installation paths did not have correct casing and so resources were not discoverable by PowerShell.

## PR Context

Also updated tests to not run Windows only tests on Linux/macOS images.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
