### PR TITLE
Create private cancellation token in InstallHelper

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -46,11 +46,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         bool _asNupkg;
         bool _includeXML;
 
-        public InstallHelper(bool updatePkg, bool savePkg, CancellationToken cancellationToken, PSCmdlet cmdletPassedIn)
+        public InstallHelper(bool updatePkg, bool savePkg, PSCmdlet cmdletPassedIn)
         {
+            // Define the cancellation token.
+            CancellationTokenSource source = new CancellationTokenSource();
+            _cancellationToken = source.Token;
+            
             this._updatePkg = updatePkg;
             this._savePkg = savePkg;
-            this._cancellationToken = cancellationToken;
             this._cmdletPassedIn = cmdletPassedIn;
         }
 

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -125,11 +125,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void ProcessRecord()
         {
-            // Define the cancellation token.
-            CancellationTokenSource source = new CancellationTokenSource();
-            CancellationToken cancellationToken = source.Token;
-
-            var installHelper = new InstallHelper(updatePkg: false, savePkg: false, cancellationToken: cancellationToken, cmdletPassedIn: this);
+            var installHelper = new InstallHelper(updatePkg: false, savePkg: false, cmdletPassedIn: this);
 
             switch (ParameterSetName)
             {

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -59,7 +59,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// <summary>
         /// Specifies the scope of installation.
         /// </summary>
-        [ValidateSet("CurrentUser", "AllUsers")]
         [Parameter(ParameterSetName = NameParameterSet)]
         public ScopeType Scope { get; set; }
 

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -146,11 +146,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void ProcessRecord()
         {
-            // Define the cancellation token.
-            CancellationTokenSource source = new CancellationTokenSource();
-            CancellationToken cancellationToken = source.Token;
-
-            var installHelper = new InstallHelper(updatePkg: false, savePkg: true, cancellationToken: cancellationToken, cmdletPassedIn: this);
+            var installHelper = new InstallHelper(updatePkg: false, savePkg: true, cmdletPassedIn: this);
 
             switch (ParameterSetName)
             {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Removed cancellation token from the InstallHelper constructor parameter.  The token is now created within the constructor itself. The token is needed for multiple calls (to FindHelper and to two different NuGet API calls-- GetDownloadResourceResultAsync and PackageReader.CopyFiles). 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
The cancellation token was unnecessarily being passed in to InstallHelper from InstallPSResource, SavePSResource and UpdatePSResource.  This PR just allows for consolidation and slightly more simplicity.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
