### PR TITLE
Install should implement ShouldProcess

### DIFF
--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -15,7 +15,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// It returns nothing.
     /// </summary>
 
-    [Cmdlet(VerbsLifecycle.Install, "PSResource", DefaultParameterSetName = "NameParameterSet", SupportsShouldProcess = true, HelpUri = "<add>")]
+    [Cmdlet(VerbsLifecycle.Install, "PSResource", DefaultParameterSetName = "NameParameterSet", SupportsShouldProcess = true)]
     public sealed
     class InstallPSResource : PSCmdlet
     {
@@ -124,6 +124,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void ProcessRecord()
         {
+            if (!ShouldProcess(string.Format("package to install: '{0}'", String.Join(", ", Name))))
+            {
+                WriteVerbose("ShouldProcess was set to false.");
+                return;
+            }
+
             var installHelper = new InstallHelper(updatePkg: false, savePkg: false, cmdletPassedIn: this);
 
             switch (ParameterSetName)

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -1,3 +1,4 @@
+using System.Collections.Specialized;
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using System;
@@ -126,7 +127,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             if (!ShouldProcess(string.Format("package to install: '{0}'", String.Join(", ", Name))))
             {
-                WriteVerbose("ShouldProcess was set to false.");
+                WriteVerbose(string.Format("Install operation cancelled by user for packages: {0}", String.Join(", ", Name)));
                 return;
             }
 

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -226,6 +226,13 @@ Describe 'Test Install-PSResource for Module' {
         $pkg | Should -Not -BeNullOrEmpty
         $pkg.Name | Should -Be $publishModuleName
     }
+
+    It "Install module using -WhatIf, should not install the module" {
+        Install-PSResource -Name "TestModule" -WhatIf
+    
+        $res = Get-Module "TestModule" -ListAvailable
+        $res | Should -BeNullOrEmpty
+    }
 }
 
 <# Temporarily commented until -Tag is implemented for this Describe block


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add implementation for ShouldProcess to InstallPSResource cmdlet. Resolves issue #279 #131 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
