### PR TITLE
Preview tag support

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -268,7 +268,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 if (_version.Contains("-"))
                 {
                     _prerelease = true;
-                    Console.WriteLine("early on detected it's a prerelease version");
+                    // Console.WriteLine("ANAM early on detected it's a prerelease version");
                 }
             }
 

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -408,6 +408,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     // at this point foundPackagesMetadata contains latest version for each package, get list of distinct
                     // package names and get all versions for each name, this is due to the SearchAsync and GetMetadataAsync() API restrictions !
                     List<IPackageSearchMetadata> allPkgsAllVersions = new List<IPackageSearchMetadata>();
+                    foreach (string n in foundPackagesMetadata.Select(p => p.Identity.Id).Distinct(StringComparer.InvariantCultureIgnoreCase))
+                    {
+                        // get all versions for this package
+                        allPkgsAllVersions.AddRange(pkgMetadataResource.GetMetadataAsync(n, _prerelease, false, sourceContext, NullLogger.Instance, _cancellationToken).GetAwaiter().GetResult().ToList());
+                    }
 
                     foundPackagesMetadata = allPkgsAllVersions;
                     if (versionRange == VersionRange.All) // Version = "*"

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -392,6 +392,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     yield break;
                 }
 
+                if (versionRange.ToString().Contains("-"))
+                {
+                    Console.WriteLine("prerelease version bc - detected");
+                    _prerelease = true;
+                    Console.WriteLine("prerelease is: " + _prerelease);
+                }
+
                 Console.WriteLine("ANAM- version range: " + versionRange);
                 // at this point, version should be parsed successfully, into allVersions (null or "*") or versionRange (specific or range)
                 if (pkgName.Contains("*"))

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -392,6 +392,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     yield break;
                 }
 
+                Console.WriteLine("ANAM- version range: " + versionRange);
                 // at this point, version should be parsed successfully, into allVersions (null or "*") or versionRange (specific or range)
                 if (pkgName.Contains("*"))
                 {
@@ -427,10 +428,19 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     // for non wildcard names, NuGet GetMetadataAsync() API is which returns all versions for that package ordered descendingly
                     if (versionRange != VersionRange.All) // Version range
                     {
+                        foreach(var anamPkg in foundPackagesMetadata.ToList())
+                        {
+                            Console.WriteLine("package pre sort by version: " + anamPkg.Identity.Version.ToString());
+                        }
                         foundPackagesMetadata = foundPackagesMetadata.Where(
                             p => versionRange.Satisfies(
                                 p.Identity.Version, VersionComparer.VersionRelease)).OrderByDescending(
                                     p => p.Identity.Version).ToList();
+                        
+                        foreach(var anamPkg in foundPackagesMetadata.ToList())
+                        {
+                            Console.WriteLine("package post sort by version: " + anamPkg.Identity.Version.ToString());
+                        }
                     }
                 }
             }

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -268,7 +268,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 if (_version.Contains("-"))
                 {
                     _prerelease = true;
-                    // Console.WriteLine("ANAM early on detected it's a prerelease version");
                 }
             }
 
@@ -402,7 +401,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
             else
             {
-                Console.WriteLine("ANAM- version range: " + versionRange);
                 // at this point, version should be parsed successfully, into allVersions (null or "*") or versionRange (specific or range)
                 if (pkgName.Contains("*"))
                 {
@@ -410,12 +408,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     // at this point foundPackagesMetadata contains latest version for each package, get list of distinct
                     // package names and get all versions for each name, this is due to the SearchAsync and GetMetadataAsync() API restrictions !
                     List<IPackageSearchMetadata> allPkgsAllVersions = new List<IPackageSearchMetadata>();
-                    foreach (string n in foundPackagesMetadata.Select(p => p.Identity.Id).Distinct(StringComparer.InvariantCultureIgnoreCase))
-                    {
-                        // get all versions for this package
-                        Console.WriteLine("right before GetMEtadataAsync prerelease is: " + _prerelease);
-                        allPkgsAllVersions.AddRange(pkgMetadataResource.GetMetadataAsync(n, _prerelease, false, sourceContext, NullLogger.Instance, _cancellationToken).GetAwaiter().GetResult().ToList());
-                    }
 
                     foundPackagesMetadata = allPkgsAllVersions;
                     if (versionRange == VersionRange.All) // Version = "*"
@@ -439,19 +431,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     // for non wildcard names, NuGet GetMetadataAsync() API is which returns all versions for that package ordered descendingly
                     if (versionRange != VersionRange.All) // Version range
                     {
-                        foreach(var anamPkg in foundPackagesMetadata.ToList())
-                        {
-                            Console.WriteLine("package pre sort by version: " + anamPkg.Identity.Version.ToString());
-                        }
                         foundPackagesMetadata = foundPackagesMetadata.Where(
                             p => versionRange.Satisfies(
                                 p.Identity.Version, VersionComparer.VersionRelease)).OrderByDescending(
                                     p => p.Identity.Version).ToList();
-                        
-                        foreach(var anamPkg in foundPackagesMetadata.ToList())
-                        {
-                            Console.WriteLine("package post sort by version: " + anamPkg.Identity.Version.ToString());
-                        }
                     }
                 }
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Detect if valid version range contains "-" in it, if so set `_prerelease` field to be true (to support 1st case below).

Support the following:
Assuming there's a package Az.Sql with version 3.0.0-preview
- [x] `Find-PSResource -Name "Az.Sql" -Version "3.0.0-preview"`
<strike>- [ ] `Find-PSResource -Name "Az.Sql" -Version "3.0.0.0" -Prerelease` </strike>
<strike>- [ ] `Find-PSResource -Name "Az.Sql" -Version "[3.0.0.0,3.0.0.0] -Prerelease`</strike>

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
