### PR TITLE
Find tests

### DIFF
--- a/test/FindPSResource.Tests.ps1
+++ b/test/FindPSResource.Tests.ps1
@@ -27,6 +27,12 @@ Describe 'Test Find-PSResource for Module' {
         $res | Should -BeNullOrEmpty
     }
 
+    It "should not find any resources given names with invalid wildcard characters" {
+        Find-PSResource -Name "Invalid?PkgName", "Invalid[PkgName" -ErrorVariable err -ErrorAction SilentlyContinue
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "ErrorFilteringNamesForUnsupportedWildcards,Microsoft.PowerShell.PowerShellGet.Cmdlets.FindPSResource" 
+    }
+
     It "find resources when Name contains * from V2 endpoint repository (PowerShellGallery))" {
         $foundScript = $False
         $res = Find-PSResource -Name "AzureS*" -Repository $PSGalleryName

--- a/test/FindPSResource.Tests.ps1
+++ b/test/FindPSResource.Tests.ps1
@@ -108,6 +108,30 @@ Describe 'Test Find-PSResource for Module' {
         $res.Count | Should -BeGreaterOrEqual 1
     }
 
+    It "find resources when given Name with wildcard, Version not null --> '*'" {
+        $res = Find-PSResource -Name "TestModuleWithDependency*" -Version "*" -Repository $TestGalleryName
+        $moduleA = $res | Where-Object {$_.Name -eq "TestModuleWithDependencyA"}
+        $moduleA.Count | Should -BeGreaterOrEqual 3
+        $moduleB = $res | Where-Object {$_.Name -eq "TestModuleWithDependencyB"}
+        $moduleB.Count | Should -BeGreaterOrEqual 2
+        $moduleC = $res | Where-Object {$_.Name -eq "TestModuleWithDependencyC"}
+        $moduleC.Count | Should -BeGreaterOrEqual 3
+        $moduleD = $res | Where-Object {$_.Name -eq "TestModuleWithDependencyD"}
+        $moduleD.Count | Should -BeGreaterOrEqual 2
+        $moduleE = $res | Where-Object {$_.Name -eq "TestModuleWithDependencyE"}
+        $moduleE.Count | Should -BeGreaterOrEqual 1        
+        $moduleF = $res | Where-Object {$_.Name -eq "TestModuleWithDependencyF"}
+        $moduleF.Count | Should -BeGreaterOrEqual 1
+    }
+
+    It "find resources when given Name with wildcard, Version range" {
+        $res = Find-PSResource -Name "TestModuleWithDependency*" -Version "[1.0.0.0, 2.0.0.0]" -Repository $TestGalleryName
+        foreach ($pkg in $res) {
+            $pkg.Name | Should -Match "TestModuleWithDependency*"
+            [System.Version]$pkg.Version -ge [System.Version]"1.0.0.0" -or [System.Version]$pkg.Version -le [System.Version]"2.0.0.0" | Should -Be $true
+        }
+    }
+
     It "find resource when given Name, Version param null" {
         $res = Find-PSResource -Name "Carbon" -Repository $PSGalleryName
         $res.Name | Should -Be "Carbon"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Added tests for invalid wildcard character name error handling and for package name containing wildcard with different version combinations.

## PR Context

These tests were added to provide test coverage in areas implemented but not yet tested.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
