### PR TITLE
Wildcard processing

### DIFF
--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             WriteDebug("Entering GetInstalledPSResource");
 
-            Name = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool _);
+            var namesToSearch = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool _);
             foreach (string error in errorMsgs)
             {
                 WriteError(new ErrorRecord(
@@ -124,13 +124,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             // this catches the case where Name wasn't passed in as null or empty,
             // but after filtering out unsupported wildcard names in BeginProcessing() there are no elements left in Name
-            if (Name.Length == 0)
+            if (namesToSearch.Length == 0)
             {
                  return;
             }
 
             GetHelper getHelper = new GetHelper(this);
-            foreach (PSResourceInfo pkg in getHelper.FilterPkgPaths(Name, _versionRange, _pathsToSearch))
+            foreach (PSResourceInfo pkg in getHelper.FilterPkgPaths(namesToSearch, _versionRange, _pathsToSearch))
             {
                 WriteObject(pkg);
             }

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -106,6 +106,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 // retrieve all possible paths
                 _pathsToSearch = Utils.GetAllResourcePaths(this);
             }
+        }
+
+        protected override void ProcessRecord()
+        {
+            WriteDebug("Entering GetInstalledPSResource");
 
             Name = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool _);
             foreach (string error in errorMsgs)
@@ -118,16 +123,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
 
             // this catches the case where Name wasn't passed in as null or empty,
-            // but after filtering out unsupported wildcard names there are no elements left in namesToSearch
+            // but after filtering out unsupported wildcard names in BeginProcessing() there are no elements left in Name
             if (Name.Length == 0)
             {
                  return;
             }
-        }
-
-        protected override void ProcessRecord()
-        {
-            WriteDebug("Entering GetInstalledPSResource");
 
             GetHelper getHelper = new GetHelper(this);
             foreach (PSResourceInfo pkg in getHelper.FilterPkgPaths(Name, _versionRange, _pathsToSearch))

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -107,23 +107,21 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 _pathsToSearch = Utils.GetAllResourcePaths(this);
             }
 
-            if (Name == null)
+            Name = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool _);
+            foreach (string error in errorMsgs)
             {
-                Name = new string[] { "*" };
+                WriteError(new ErrorRecord(
+                    new PSInvalidOperationException(error),
+                    "ErrorFilteringNamesForUnsupportedWildcards",
+                    ErrorCategory.InvalidArgument,
+                    this));
             }
-            // if '*' is passed in as an argument for -Name with other -Name arguments, 
-            // ignore all arguments except for '*' since it is the most inclusive
-            // eg:  -Name ["TestModule, Test*, *"]  will become -Name ["*"]
-            if (Name != null && Name.Length > 1)
+
+            // this catches the case where Name wasn't passed in as null or empty,
+            // but after filtering out unsupported wildcard names there are no elements left in namesToSearch
+            if (Name.Length == 0)
             {
-                foreach (var pkgName in Name)
-                {
-                    if (pkgName.Trim().Equals("*"))
-                    {
-                        Name = new string[] { "*" };
-                        break;
-                    }
-                }
+                 return;
             }
         }
 

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -136,7 +136,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             switch (ParameterSetName)
             {
                 case NameParameterSet:
-                    Name = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool nameContainsWildcard);
+                    var namesToInstall = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool nameContainsWildcard);
                     if (nameContainsWildcard)
                     {
                         WriteError(new ErrorRecord(
@@ -158,13 +158,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                     // this catches the case where Name wasn't passed in as null or empty,
                     // but after filtering out unsupported wildcard names in BeginProcessing() there are no elements left in namesToSearch
-                    if (Name.Length == 0)
+                    if (namesToInstall.Length == 0)
                     {
                         return;
                     }
 
                     installHelper.InstallPackages(
-                        names: Name,
+                        names: namesToInstall,
                         versionRange: _versionRange,
                         prerelease: Prerelease,
                         repository: Repository,

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -157,7 +157,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     }
 
                     // this catches the case where Name wasn't passed in as null or empty,
-                    // but after filtering out unsupported wildcard names in BeginProcessing() there are no elements left in namesToSearch
+                    // but after filtering out unsupported wildcard names there are no elements left in namesToInstall
                     if (namesToInstall.Length == 0)
                     {
                         return;

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -151,8 +151,35 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             switch (ParameterSetName)
             {
                 case NameParameterSet:
+                    var namesToSave = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool nameContainsWildcard);
+                    if (nameContainsWildcard)
+                    {
+                        WriteError(new ErrorRecord(
+                            new PSInvalidOperationException("Name with wildcards is not supported for Save-PSResource cmdlet"),
+                            "NameContainsWildcard",
+                            ErrorCategory.InvalidArgument,
+                            this));
+                        return;
+                    }
+                    
+                    foreach (string error in errorMsgs)
+                    {
+                        WriteError(new ErrorRecord(
+                            new PSInvalidOperationException(error),
+                            "ErrorFilteringNamesForUnsupportedWildcards",
+                            ErrorCategory.InvalidArgument,
+                            this));
+                    }
+
+                    // this catches the case where Name wasn't passed in as null or empty,
+                    // but after filtering out unsupported wildcard names there are no elements left in namesToSave
+                    if (namesToSave.Length == 0)
+                    {
+                        return;
+                    }
+
                     installHelper.InstallPackages(
-                        names: Name, 
+                        names: namesToSave, 
                         versionRange: _versionRange, 
                         prerelease: Prerelease, 
                         repository: Repository, 

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// <summary>
     /// Uninstall-PSResource uninstalls a package found in a module or script installation path.
     /// </summary>
-    [Cmdlet(VerbsLifecycle.Uninstall, "PSResource", DefaultParameterSetName = NameParameterSet, SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+    [Cmdlet(VerbsLifecycle.Uninstall, "PSResource", DefaultParameterSetName = NameParameterSet, SupportsShouldProcess = true)]
     public sealed class UninstallPSResource : PSCmdlet
     {
         #region Parameters
@@ -84,14 +84,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             switch (ParameterSetName)
             {
                 case NameParameterSet:
-                    Name = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool nameContainsWildcard);
-                    if (nameContainsWildcard)
-                    {
-                        if (!ShouldProcess(string.Format("Uninstall resource with wildcard, so all of the following will be uninstalled from machine: '{0}'.", String.Join(",", Name))))
-                        {
-                            return;
-                        }
-                    }
+                    Name = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool _);
                     
                     foreach (string error in errorMsgs)
                     {

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -111,42 +111,6 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             errorMsgs = errorMsgsList.ToArray();
             return namesWithSupportedWildcards.ToArray();
         }
-
-        public static string[] FilterOutWildcardNames(
-            string[] pkgNames,
-            out string[] errorMsgs)
-        {
-            List<string> errorFreeNames = new List<string>();
-            List<string> errorMsgList = new List<string>();
-
-            foreach (string n in pkgNames)
-            {
-                bool isNameErrorProne = false;
-                if (WildcardPattern.ContainsWildcardCharacters(n))
-                {
-                    if (String.Equals(n, "*", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        errorMsgList = new List<string>(); // clear prior error messages
-                        errorMsgList.Add("-Name '*' is not supported for Find-PSResource so all Name entries will be discarded.");
-                        errorFreeNames = new List<string>();
-                        break;
-                    }
-                    else if (n.Contains("?") || n.Contains("["))
-                    {
-                        errorMsgList.Add(String.Format("-Name with wildcards '?' and '[' are not supported for Find-PSResource so Name entry: {0} will be discarded.", n));
-                        isNameErrorProne = true;
-                    }
-                }
-
-                if (!isNameErrorProne)
-                {
-                    errorFreeNames.Add(n);
-                }
-            }
-
-            errorMsgs = errorMsgList.ToArray();
-            return errorFreeNames.ToArray();
-        }
     
         #endregion
 

--- a/test/FindPSResource.Tests.ps1
+++ b/test/FindPSResource.Tests.ps1
@@ -42,6 +42,12 @@ Describe 'Test Find-PSResource for Module' {
         $foundScript | Should -BeTrue
     }
 
+    It "should not find resources given Name that equals wildcard, '*'" {
+        Find-PSResource -Name "*" -ErrorVariable err -ErrorAction SilentlyContinue
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "NameEqualsWildcardIsNotSupported,Microsoft.PowerShell.PowerShellGet.Cmdlets.FindPSResource"
+    }
+
     It "find resource given Name from V3 endpoint repository (NuGetGallery)" {
         $res = Find-PSResource -Name "Serilog" -Repository $NuGetGalleryName
         $res.Count | Should -Be 1

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -22,6 +22,17 @@ Describe 'Test Install-PSResource for Module' {
         Get-RevertPSResourceRepositoryFile
     }
 
+    $testCases = @{Name="*";                          ErrorId="NameContainsWildcard"}
+                 @{Name=$null;                        ErrorId="NameContainsWildcard"},
+                 @{Name="TestModule*";                ErrorId="NameContainsWildcard"},
+                 @{Name="Test?Module", "Test[Module"; ErrorId="ErrorFilteringNamesForUnsupportedWildcards"}
+
+    It "Should not install resource with wildcard in name" -TestCases $testCases {
+        Install-PSResource -Name $Name -ErrorVariable err -ErrorAction SilentlyContinue
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "$ErrorId,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
+    }
+
     It "Install specific module resource by name" {
         Install-PSResource -Name "TestModule" -Repository $TestGalleryName  
         $pkg = Get-Module "TestModule" -ListAvailable
@@ -42,7 +53,6 @@ Describe 'Test Install-PSResource for Module' {
         $pkg = Get-Module $pkgNames -ListAvailable
         $pkg.Name | Should -Be $pkgNames
     }
-
 
     It "Should not install resource given nonexistant name" {
         Install-PSResource -Name NonExistantModule -Repository $TestGalleryName  

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -24,9 +24,10 @@ Describe 'Test Install-PSResource for Module' {
 
     $testCases = @{Name="*";                          ErrorId="NameContainsWildcard"},
                  @{Name="TestModule*";                ErrorId="NameContainsWildcard"},
-                 @{Name="Test?Module", "Test[Module"; ErrorId="ErrorFilteringNamesForUnsupportedWildcards"}
+                 @{Name="Test?Module","Test[Module";  ErrorId="ErrorFilteringNamesForUnsupportedWildcards"}
 
     It "Should not install resource with wildcard in name" -TestCases $testCases {
+        param($Name, $ErrorId)
         Install-PSResource -Name $Name -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "$ErrorId,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -22,8 +22,7 @@ Describe 'Test Install-PSResource for Module' {
         Get-RevertPSResourceRepositoryFile
     }
 
-    $testCases = @{Name="*";                          ErrorId="NameContainsWildcard"}
-                 @{Name=$null;                        ErrorId="NameContainsWildcard"},
+    $testCases = @{Name="*";                          ErrorId="NameContainsWildcard"},
                  @{Name="TestModule*";                ErrorId="NameContainsWildcard"},
                  @{Name="Test?Module", "Test[Module"; ErrorId="ErrorFilteringNamesForUnsupportedWildcards"}
 

--- a/test/SavePSResource.Tests.ps1
+++ b/test/SavePSResource.Tests.ps1
@@ -54,6 +54,12 @@ Describe 'Test Save-PSResource for PSResources' {
         $pkgDir.Name | Should -BeNullOrEmpty
     }
 
+    It "Not Save module with Name containing wildcard" {
+        Save-PSResource -Name "TestModule*" -Repository $TestGalleryName -Path $SaveDir -ErrorVariable err -ErrorAction SilentlyContinue
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "NameContainsWildcard,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
+    }
+
     # Do some version testing, but Find-PSResource should be doing thorough testing
     It "Should save resource given name and exact version" {
         Save-PSResource -Name "TestModule" -Version "1.2.0" -Repository $TestGalleryName -Path $SaveDir

--- a/test/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResource.Tests.ps1
@@ -23,6 +23,16 @@ Describe 'Test Uninstall-PSResource for Modules' {
         Get-Module ContosoServer -ListAvailable | Should -Be $null
     }
 
+    $testCases = @{Name="Test?Module";      ErrorId="ErrorFilteringNamesForUnsupportedWildcards"},
+                 @{Name="Test[Module";      ErrorId="ErrorFilteringNamesForUnsupportedWildcards"}
+
+    It "not uninstall module given Name with invalid wildcard characters" -TestCases $testCases {
+        param($Name, $ErrorId)
+        Uninstall-PSResource -Name $Name -ErrorVariable err -ErrorAction SilentlyContinue
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "$ErrorId,Microsoft.PowerShell.PowerShellGet.Cmdlets.UninstallPSResource"
+    }
+
     It "Uninstall a list of modules by name" {
         $null = Install-PSResource BaseTestPackage -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Each cmdlet which takes a Name parameter should handle wildcards based on how it supports it for that cmdlet. I removed the original Utils.FilterOutWildcardNames() helper method (which didn't handle `name '*'` for different cmdlet cases (it just treated it as unsupported). I used Utils.ProcessNameWildcards() instead, which handles `name "*"` case in each cmdlet. I updated Get-InstalledPSResource, Find-PSResource, Install-PSResource (which doesn't support wildcards but needed error handling against it) and their tests accordingly.

Cmdlets left to add support/error handling for wildcards to:
- Save-PSResource
- Uninstall-PSResource
- Register-PSResourceRepository and Set-PSResourceRepository (only checks for `*` right now)

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
