### PR TITLE
Update help documentation for minimum inclusive version range

### DIFF
--- a/help/Find-PSResource.md
+++ b/help/Find-PSResource.md
@@ -207,16 +207,16 @@ Accept wildcard characters: False
 ```
 
 ### -Version
-Specifies the version of the resource to be found.
-Can be an exact version or a version range, using the NuGet versioning syntax.
+Specifies the version of the resource to be returned. The value can be an exact version or a version
+range using the NuGet versioning syntax.
 
-Expected NuGet Version/Version Range format is documented here: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges.
+For more information about NuGet version ranges, see [Package versioning](/nuget/concepts/package-versioning#version-ranges)
 
-All but the "minimum inclusive version" listed in the NuGet Version/Version Range documentation above are
-supported. The NuGet version documentation suggested minimum inclusive version will be considered as a required version instead in PowerShellGet.
-So inputting "1.0.0.0" as the version won't yield versions 1.0.0.0 and higher (minimum inclusive range)
-but instead will consider that as the required version and yield version 1.0.0.0 only (required version).
-To use the minimum inclusive range, provide "[1.0.0.0, ]" as the version range.
+PowerShellGet supports all but the _minimum inclusive version_ listed in the NuGet version range
+documentation. So inputting "1.0.0.0" as the version doesn't yield versions 1.0.0.0 and higher
+(minimum inclusive range). Instead, the values is considered as the required version and yields
+version 1.0.0.0 only (required version). To use the minimum inclusive range, provide `[1.0.0.0, ]` as
+the version range.
 
 ```yaml
 Type: System.String

--- a/help/Find-PSResource.md
+++ b/help/Find-PSResource.md
@@ -207,8 +207,16 @@ Accept wildcard characters: False
 ```
 
 ### -Version
-Specifies the version of the resource to be returned.
-Expected version/version range format is documented here: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges
+Specifies the version of the resource to be found.
+Can be an exact version or a version range, using the NuGet versioning syntax.
+
+Expected NuGet Version/Version Range format is documented here: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges.
+
+All but the "minimum inclusive version" listed in the NuGet Version/Version Range documentation above are
+supported. The NuGet version documentation suggested minimum inclusive version will be considered as a required version instead in PowerShellGet.
+So inputting "1.0.0.0" as the version won't yield versions 1.0.0.0 and higher (minimum inclusive range)
+but instead will consider that as the required version and yield version 1.0.0.0 only (required version).
+To use the minimum inclusive range, provide "[1.0.0.0, ]" as the version range.
 
 ```yaml
 Type: System.String

--- a/help/Get-InstalledPSResource.md
+++ b/help/Get-InstalledPSResource.md
@@ -89,16 +89,16 @@ Accept wildcard characters: False
 ```
 
 ### -Version
-Specifies the version of the resource to be returned.
-Can be an exact version or a version range, using the NuGet versioning syntax.
+Specifies the version of the resource to be returned. The value can be an exact version or a version
+range using the NuGet versioning syntax.
 
-Expected NuGet Version/Version Range format is documented here: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges.
+For more information about NuGet version ranges, see [Package versioning](/nuget/concepts/package-versioning#version-ranges)
 
-All but the "minimum inclusive version" listed in the NuGet Version/Version Range documentation above are
-supported. The NuGet version documentation suggested minimum inclusive version will be considered as a required version instead in PowerShellGet.
-So inputting "1.0.0.0" as the version won't yield versions 1.0.0.0 and higher (minimum inclusive range)
-but instead will consider that as the required version and yield version 1.0.0.0 only (required version).
-To use the minimum inclusive range, provide "[1.0.0.0, ]" as the version range.
+PowerShellGet supports all but the _minimum inclusive version_ listed in the NuGet version range
+documentation. So inputting "1.0.0.0" as the version doesn't yield versions 1.0.0.0 and higher
+(minimum inclusive range). Instead, the values is considered as the required version and yields 
+version 1.0.0.0 only (required version). To use the minimum inclusive range, provide `[1.0.0.0, ]` as 
+the version range.
 
 ```yaml
 Type: System.String

--- a/help/Get-InstalledPSResource.md
+++ b/help/Get-InstalledPSResource.md
@@ -89,9 +89,16 @@ Accept wildcard characters: False
 ```
 
 ### -Version
-Specifies the version of the resource to be returned. 
-Can be an exact version or a version range, using the NuGet versioning syntax. 
-Expected version/version range format is documented here: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges
+Specifies the version of the resource to be returned.
+Can be an exact version or a version range, using the NuGet versioning syntax.
+
+Expected NuGet Version/Version Range format is documented here: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges.
+
+All but the "minimum inclusive version" listed in the NuGet Version/Version Range documentation above are
+supported. The NuGet version documentation suggested minimum inclusive version will be considered as a required version instead in PowerShellGet.
+So inputting "1.0.0.0" as the version won't yield versions 1.0.0.0 and higher (minimum inclusive range)
+but instead will consider that as the required version and yield version 1.0.0.0 only (required version).
+To use the minimum inclusive range, provide "[1.0.0.0, ]" as the version range.
 
 ```yaml
 Type: System.String

--- a/help/Install-PSResource.md
+++ b/help/Install-PSResource.md
@@ -72,7 +72,7 @@ Accept wildcard characters: False
 ```
 
 ### -Version
-Specifies the version of the resource to be returned. The value can be an exact version or a version
+Specifies the version of the resource to be installed. The value can be an exact version or a version
 range using the NuGet versioning syntax.
 
 For more information about NuGet version ranges, see [Package versioning](/nuget/concepts/package-versioning#version-ranges)

--- a/help/Install-PSResource.md
+++ b/help/Install-PSResource.md
@@ -72,9 +72,16 @@ Accept wildcard characters: False
 ```
 
 ### -Version
-Specifies the version of the resource to be installed. 
-Can be an exact version or a version range, using the NuGet versioning syntax. 
-Expected version/version range format is documented here: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges
+Specifies the version of the resource to be installed.
+Can be an exact version or a version range, using the NuGet versioning syntax.
+
+Expected NuGet Version/Version Range format is documented here: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges.
+
+All but the "minimum inclusive version" listed in the NuGet Version/Version Range documentation above are
+supported. The NuGet version documentation suggested minimum inclusive version will be considered as a required version instead in PowerShellGet.
+So inputting "1.0.0.0" as the version won't yield versions 1.0.0.0 and higher (minimum inclusive range)
+but instead will consider that as the required version and yield version 1.0.0.0 only (required version).
+To use the minimum inclusive range, provide "[1.0.0.0, ]" as the version range.
 
 ```yaml
 Type: System.String

--- a/help/Install-PSResource.md
+++ b/help/Install-PSResource.md
@@ -72,16 +72,16 @@ Accept wildcard characters: False
 ```
 
 ### -Version
-Specifies the version of the resource to be installed.
-Can be an exact version or a version range, using the NuGet versioning syntax.
+Specifies the version of the resource to be returned. The value can be an exact version or a version
+range using the NuGet versioning syntax.
 
-Expected NuGet Version/Version Range format is documented here: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges.
+For more information about NuGet version ranges, see [Package versioning](/nuget/concepts/package-versioning#version-ranges)
 
-All but the "minimum inclusive version" listed in the NuGet Version/Version Range documentation above are
-supported. The NuGet version documentation suggested minimum inclusive version will be considered as a required version instead in PowerShellGet.
-So inputting "1.0.0.0" as the version won't yield versions 1.0.0.0 and higher (minimum inclusive range)
-but instead will consider that as the required version and yield version 1.0.0.0 only (required version).
-To use the minimum inclusive range, provide "[1.0.0.0, ]" as the version range.
+PowerShellGet supports all but the _minimum inclusive version_ listed in the NuGet version range
+documentation. So inputting "1.0.0.0" as the version doesn't yield versions 1.0.0.0 and higher
+(minimum inclusive range). Instead, the values is considered as the required version and yields
+version 1.0.0.0 only (required version). To use the minimum inclusive range, provide `[1.0.0.0, ]` as
+the version range.
 
 ```yaml
 Type: System.String

--- a/help/Save-PSResource.md
+++ b/help/Save-PSResource.md
@@ -66,16 +66,16 @@ Accept wildcard characters: False
 ```
 
 ### -Version
-Specifies the version of the resource to be saved.
-Can be an exact version or a version range, using the NuGet versioning syntax.
+Specifies the version of the resource to be returned. The value can be an exact version or a version
+range using the NuGet versioning syntax.
 
-Expected NuGet Version/Version Range format is documented here: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges.
+For more information about NuGet version ranges, see [Package versioning](/nuget/concepts/package-versioning#version-ranges)
 
-All but the "minimum inclusive version" listed in the NuGet Version/Version Range documentation above are
-supported. The NuGet version documentation suggested minimum inclusive version will be considered as a required version instead in PowerShellGet.
-So inputting "1.0.0.0" as the version won't yield versions 1.0.0.0 and higher (minimum inclusive range)
-but instead will consider that as the required version and yield version 1.0.0.0 only (required version).
-To use the minimum inclusive range, provide "[1.0.0.0, ]" as the version range.
+PowerShellGet supports all but the _minimum inclusive version_ listed in the NuGet version range
+documentation. So inputting "1.0.0.0" as the version doesn't yield versions 1.0.0.0 and higher
+(minimum inclusive range). Instead, the values is considered as the required version and yields 
+version 1.0.0.0 only (required version). To use the minimum inclusive range, provide `[1.0.0.0, ]` as 
+the version range.
 
 ```yaml
 Type: System.String

--- a/help/Save-PSResource.md
+++ b/help/Save-PSResource.md
@@ -66,7 +66,7 @@ Accept wildcard characters: False
 ```
 
 ### -Version
-Specifies the version of the resource to be returned. The value can be an exact version or a version
+Specifies the version of the resource to be saved. The value can be an exact version or a version
 range using the NuGet versioning syntax.
 
 For more information about NuGet version ranges, see [Package versioning](/nuget/concepts/package-versioning#version-ranges)

--- a/help/Save-PSResource.md
+++ b/help/Save-PSResource.md
@@ -66,9 +66,16 @@ Accept wildcard characters: False
 ```
 
 ### -Version
-Specifies the version of the resource to be saved. 
-Can be an exact version or a version range, using the NuGet versioning syntax. 
-Expected version/version range format is documented here: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges
+Specifies the version of the resource to be saved.
+Can be an exact version or a version range, using the NuGet versioning syntax.
+
+Expected NuGet Version/Version Range format is documented here: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges.
+
+All but the "minimum inclusive version" listed in the NuGet Version/Version Range documentation above are
+supported. The NuGet version documentation suggested minimum inclusive version will be considered as a required version instead in PowerShellGet.
+So inputting "1.0.0.0" as the version won't yield versions 1.0.0.0 and higher (minimum inclusive range)
+but instead will consider that as the required version and yield version 1.0.0.0 only (required version).
+To use the minimum inclusive range, provide "[1.0.0.0, ]" as the version range.
 
 ```yaml
 Type: System.String

--- a/help/Update-PSResource.md
+++ b/help/Update-PSResource.md
@@ -169,7 +169,7 @@ Accept wildcard characters: False
 ```
 
 ### -Version
-Specifies the version of the resource to be returned. The value can be an exact version or a version
+Specifies the version of the resource to be updated to. The value can be an exact version or a version
 range using the NuGet versioning syntax.
 
 For more information about NuGet version ranges, see [Package versioning](/nuget/concepts/package-versioning#version-ranges)

--- a/help/Update-PSResource.md
+++ b/help/Update-PSResource.md
@@ -169,15 +169,16 @@ Accept wildcard characters: False
 ```
 
 ### -Version
-Specifies the version of the resource to be updated to.
-Can be an exact version or a version range, using the NuGet versioning syntax.
+Specifies the version of the resource to be returned. The value can be an exact version or a version
+range using the NuGet versioning syntax.
 
-Expected NuGet Version/Version Range format is documented here: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges.
+For more information about NuGet version ranges, see [Package versioning](/nuget/concepts/package-versioning#version-ranges)
 
-All but the "minimum inclusive version" listed in the NuGet Version/Version Range documentation above are
-supported. The NuGet version documentation suggested minimum inclusive version will be considered as a required version instead in PowerShellGet.
-So inputting "1.0.0.0" as the version won't yield versions 1.0.0.0 and higher (minimum inclusive range)
-but instead will consider that as the required version and yield version 1.0.0.0 only (required version). To use the minimum inclusive range, provide "[1.0.0.0, ]" as the version range.
+PowerShellGet supports all but the _minimum inclusive version_ listed in the NuGet version range
+documentation. So inputting "1.0.0.0" as the version doesn't yield versions 1.0.0.0 and higher
+(minimum inclusive range). Instead, the values is considered as the required version and yields 
+version 1.0.0.0 only (required version). To use the minimum inclusive range, provide `[1.0.0.0, ]` as 
+the version range.
 
 ```yaml
 Type: System.String

--- a/help/Update-PSResource.md
+++ b/help/Update-PSResource.md
@@ -169,8 +169,15 @@ Accept wildcard characters: False
 ```
 
 ### -Version
-Specifies the version the resource is to be updated to.
-Expected version/version range format is documented here: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges
+Specifies the version of the resource to be updated to.
+Can be an exact version or a version range, using the NuGet versioning syntax.
+
+Expected NuGet Version/Version Range format is documented here: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges.
+
+All but the "minimum inclusive version" listed in the NuGet Version/Version Range documentation above are
+supported. The NuGet version documentation suggested minimum inclusive version will be considered as a required version instead in PowerShellGet.
+So inputting "1.0.0.0" as the version won't yield versions 1.0.0.0 and higher (minimum inclusive range)
+but instead will consider that as the required version and yield version 1.0.0.0 only (required version). To use the minimum inclusive range, provide "[1.0.0.0, ]" as the version range.
 
 ```yaml
 Type: System.String


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

NuGet version/version range documentation lists supported version inputs, however minimum inclusive version range for NuGet isn't supported for PowerShellGet. The suggested minimum inclusive version range will be considered as a required version. I modified the help docs to include this information and contain the alternative way of providing the minimum inclusive version.

## PR Context

Resolves #120  

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
