### PR TITLE
Up the NuGet libraries to the latest stable version

### DIFF
--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -17,12 +17,12 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-preview.7.20364.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0-preview.7.20364.11" />
     <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="NuGet.Commands" Version="5.7.0-rtm.6702" />
-    <PackageReference Include="NuGet.Common" Version="5.7.0-rtm.6702" />
-    <PackageReference Include="NuGet.Configuration" Version="5.7.0-rtm.6702" />
-    <PackageReference Include="NuGet.Packaging" Version="5.7.0-rtm.6702" />
-    <PackageReference Include="NuGet.ProjectModel" Version="5.7.0-rtm.6702" />
-    <PackageReference Include="NuGet.Protocol" Version="5.7.0-rtm.6702" />
+    <PackageReference Include="NuGet.Commands" Version="5.10.0" />
+    <PackageReference Include="NuGet.Common" Version="5.10.0" />
+    <PackageReference Include="NuGet.Configuration" Version="5.10.0" />
+    <PackageReference Include="NuGet.Packaging" Version="5.10.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="5.10.0" />
+    <PackageReference Include="NuGet.Protocol" Version="5.10.0" />
     <PackageReference Include="NuGet.Repositories" Version="4.3.0-beta1-2418" />
     <PackageReference Include="PowerShellStandard.Library" Version="7.0.0-preview.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.6.0-preview3.19128.7" />

--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="LinqKit.Core" Version="1.1.17" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-preview.7.20364.11" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="NuGet.Commands" Version="5.10.0" />
     <PackageReference Include="NuGet.Common" Version="5.10.0" />

--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="LinqKit.Core" Version="1.1.17" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-preview.7.20364.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0-preview.7.20364.11" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="NuGet.Commands" Version="5.10.0" />
     <PackageReference Include="NuGet.Common" Version="5.10.0" />

--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -14,8 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="LinqKit.Core" Version="1.1.17" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-preview.7.20364.11" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0-preview.7.20364.11" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="NuGet.Commands" Version="5.10.0" />
     <PackageReference Include="NuGet.Common" Version="5.10.0" />

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -840,20 +840,20 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             try
             {
                 PushRunner.Run(
-                        settings: Settings.LoadDefaultSettings(root: null, configFileName: null, machineWideSettings: null),
-                        sourceProvider: new PackageSourceProvider(settings),
-                        packagePath: fullNupkgFile,
-                        source: publishLocation,
-                        apiKey: APIKey,
-                        symbolSource: null,
-                        symbolApiKey: null,
-                        timeoutSeconds: 0,
-                        disableBuffering: false,
-                        noSymbols: false,
-                        noServiceEndpoint: false,  // enable server endpoint  
-                        skipDuplicate: false, // if true-- if a package and version already exists, skip it and continue with the next package in the push, if any.
-                        logger: log // nuget logger
-                        ).GetAwaiter().GetResult();
+                    settings: Settings.LoadDefaultSettings(root: null, configFileName: null, machineWideSettings: null),
+                    sourceProvider: new PackageSourceProvider(settings),
+                    packagePaths: new List<string> { fullNupkgFile },
+                    source: publishLocation,
+                    apiKey: APIKey,
+                    symbolSource: null,
+                    symbolApiKey: null,
+                    timeoutSeconds: 0,
+                    disableBuffering: false,
+                    noSymbols: false,
+                    noServiceEndpoint: false, // enable server endpoint
+                    skipDuplicate: false, // if true-- if a package and version already exists, skip it and continue with the next package in the push, if any.
+                    logger: log // nuget logger
+                    ).GetAwaiter().GetResult();
             }
             catch (HttpRequestException e)
             {

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -844,7 +844,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     sourceProvider: new PackageSourceProvider(settings),
                     packagePaths: new List<string> { fullNupkgFile },
                     source: publishLocation,
-                    apiKey: APIKey,
+                    apiKey: ApiKey,
                     symbolSource: null,
                     symbolApiKey: null,
                     timeoutSeconds: 0,


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Updating the library dependencies to the latest stable version.

## PR Context

Resolves #306 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
