### PR TITLE
Update NuGet libraries to stable version

### DIFF
--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -16,12 +16,12 @@
     <PackageReference Include="LinqKit.Core" Version="1.1.17" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-preview.7.20364.11" />
     <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="NuGet.Commands" Version="5.10.0" />
-    <PackageReference Include="NuGet.Common" Version="5.7.0-rtm.6702" />
-    <PackageReference Include="NuGet.Configuration" Version="5.7.0-rtm.6702" />
-    <PackageReference Include="NuGet.Packaging" Version="5.7.0-rtm.6702" />
-    <PackageReference Include="NuGet.ProjectModel" Version="5.7.0-rtm.6702" />
-    <PackageReference Include="NuGet.Protocol" Version="5.7.0-rtm.6702" />
+    <PackageReference Include="NuGet.Commands" Version="5.7.0" />
+    <PackageReference Include="NuGet.Common" Version="5.7.0" />
+    <PackageReference Include="NuGet.Configuration" Version="5.7.0" />
+    <PackageReference Include="NuGet.Packaging" Version="5.7.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="5.7.0" />
+    <PackageReference Include="NuGet.Protocol" Version="5.7.0" />
     <PackageReference Include="NuGet.Repositories" Version="4.3.0-beta1-2418" />
     <PackageReference Include="PowerShellStandard.Library" Version="7.0.0-preview.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.6.0-preview3.19128.7" />

--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -16,12 +16,12 @@
     <PackageReference Include="LinqKit.Core" Version="1.1.17" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-preview.7.20364.11" />
     <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="NuGet.Commands" Version="5.7.0" />
-    <PackageReference Include="NuGet.Common" Version="5.7.0" />
-    <PackageReference Include="NuGet.Configuration" Version="5.7.0" />
-    <PackageReference Include="NuGet.Packaging" Version="5.7.0" />
-    <PackageReference Include="NuGet.ProjectModel" Version="5.7.0" />
-    <PackageReference Include="NuGet.Protocol" Version="5.7.0" />
+    <PackageReference Include="NuGet.Commands" Version="5.8.0" />
+    <PackageReference Include="NuGet.Common" Version="5.8.0" />
+    <PackageReference Include="NuGet.Configuration" Version="5.8.0" />
+    <PackageReference Include="NuGet.Packaging" Version="5.8.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="5.8.0" />
+    <PackageReference Include="NuGet.Protocol" Version="5.8.0" />
     <PackageReference Include="NuGet.Repositories" Version="4.3.0-beta1-2418" />
     <PackageReference Include="PowerShellStandard.Library" Version="7.0.0-preview.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.6.0-preview3.19128.7" />

--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -17,12 +17,12 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-preview.7.20364.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0-preview.7.20364.11" />
     <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="NuGet.Commands" Version="5.7.0-rtm.6702" />
-    <PackageReference Include="NuGet.Common" Version="5.7.0-rtm.6702" />
-    <PackageReference Include="NuGet.Configuration" Version="5.7.0-rtm.6702" />
-    <PackageReference Include="NuGet.Packaging" Version="5.7.0-rtm.6702" />
-    <PackageReference Include="NuGet.ProjectModel" Version="5.7.0-rtm.6702" />
-    <PackageReference Include="NuGet.Protocol" Version="5.7.0-rtm.6702" />
+    <PackageReference Include="NuGet.Commands" Version="5.10.0" />
+    <PackageReference Include="NuGet.Common" Version="5.10.0" />
+    <PackageReference Include="NuGet.Configuration" Version="5.10.0" />
+    <PackageReference Include="NuGet.Packaging" Version="5.10.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="5.10.0" />
+    <PackageReference Include="NuGet.Protocol" Version="5.10.0" />
     <PackageReference Include="NuGet.Repositories" Version="4.3.0-beta1-2418" />
     <PackageReference Include="PowerShellStandard.Library" Version="7.0.0-preview.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.6.0-preview3.19128.7" />

--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -14,8 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="LinqKit.Core" Version="1.1.17" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-preview.7.20364.11" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0-preview.7.20364.11" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="NuGet.Commands" Version="5.7.0-rtm.6702" />
     <PackageReference Include="NuGet.Common" Version="5.7.0-rtm.6702" />

--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="LinqKit.Core" Version="1.1.17" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-preview.7.20364.11" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="NuGet.Commands" Version="5.7.0-rtm.6702" />
     <PackageReference Include="NuGet.Common" Version="5.7.0-rtm.6702" />

--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -14,8 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="LinqKit.Core" Version="1.1.17" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-preview.7.20364.11" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0-preview.7.20364.11" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="NuGet.Commands" Version="5.10.0" />
     <PackageReference Include="NuGet.Common" Version="5.10.0" />

--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -14,6 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="LinqKit.Core" Version="1.1.17" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-preview.7.20364.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0-preview.7.20364.11" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="NuGet.Commands" Version="5.10.0" />
     <PackageReference Include="NuGet.Common" Version="5.10.0" />

--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="LinqKit.Core" Version="1.1.17" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-preview.7.20364.11" />
     <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="NuGet.Commands" Version="5.7.0-rtm.6702" />
+    <PackageReference Include="NuGet.Commands" Version="5.10.0" />
     <PackageReference Include="NuGet.Common" Version="5.7.0-rtm.6702" />
     <PackageReference Include="NuGet.Configuration" Version="5.7.0-rtm.6702" />
     <PackageReference Include="NuGet.Packaging" Version="5.7.0-rtm.6702" />

--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -17,12 +17,12 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-preview.7.20364.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0-preview.7.20364.11" />
     <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="NuGet.Commands" Version="5.10.0" />
-    <PackageReference Include="NuGet.Common" Version="5.10.0" />
-    <PackageReference Include="NuGet.Configuration" Version="5.10.0" />
-    <PackageReference Include="NuGet.Packaging" Version="5.10.0" />
-    <PackageReference Include="NuGet.ProjectModel" Version="5.10.0" />
-    <PackageReference Include="NuGet.Protocol" Version="5.10.0" />
+    <PackageReference Include="NuGet.Commands" Version="5.7.0-rtm.6702" />
+    <PackageReference Include="NuGet.Common" Version="5.7.0-rtm.6702" />
+    <PackageReference Include="NuGet.Configuration" Version="5.7.0-rtm.6702" />
+    <PackageReference Include="NuGet.Packaging" Version="5.7.0-rtm.6702" />
+    <PackageReference Include="NuGet.ProjectModel" Version="5.7.0-rtm.6702" />
+    <PackageReference Include="NuGet.Protocol" Version="5.7.0-rtm.6702" />
     <PackageReference Include="NuGet.Repositories" Version="4.3.0-beta1-2418" />
     <PackageReference Include="PowerShellStandard.Library" Version="7.0.0-preview.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.6.0-preview3.19128.7" />

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -842,7 +842,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 PushRunner.Run(
                         settings: Settings.LoadDefaultSettings(root: null, configFileName: null, machineWideSettings: null),
                         sourceProvider: new PackageSourceProvider(settings),
-                        packagePath: fullNupkgFile,
+                        packagePaths: new List<string> {fullNupkgFile},
                         source: publishLocation,
                         apiKey: ApiKey,
                         symbolSource: null,

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -842,7 +842,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 PushRunner.Run(
                         settings: Settings.LoadDefaultSettings(root: null, configFileName: null, machineWideSettings: null),
                         sourceProvider: new PackageSourceProvider(settings),
-                        packagePaths: new List<string> {fullNupkgFile},
+                        packagePath: fullNupkgFile,
                         source: publishLocation,
                         apiKey: ApiKey,
                         symbolSource: null,


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Updating the library dependencies to stable version 5.8.0.  CI tests fail when updated to version 5.10.0, so for now the update is simply to 5.8.0.  

I've also removed the package reference to Microsoft.Extensions.Logging.Abstractions as it's not needed.

## PR Context

Resolves #306 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
