### PR TITLE
add ShouldSupport implementation for Save-PSResource

### DIFF
--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -146,9 +146,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void ProcessRecord()
         {
-            if (!ShouldProcess(string.Format("package to save: '{0}'", String.Join(", ", Name))))
+            if (!ShouldProcess(string.Format("resources to save: '{0}'", String.Join(", ", Name))))
             {
-                WriteVerbose(string.Format("Save operation cancelled by user for packages: {0}", String.Join(", ", Name)));
+                WriteVerbose(string.Format("Save operation cancelled by user for resources: {0}", String.Join(", ", Name)));
                 return;
             }
 

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -146,7 +146,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void ProcessRecord()
         {
-            if (!ShouldProcess(string.Format("resources to save: '{0}'", String.Join(", ", Name))))
+            if (!ShouldProcess(string.Format("Resources to save: '{0}'", String.Join(", ", Name))))
             {
                 WriteVerbose(string.Format("Save operation cancelled by user for resources: {0}", String.Join(", ", Name)));
                 return;

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -146,6 +146,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void ProcessRecord()
         {
+            if (!ShouldProcess(string.Format("package to save: '{0}'", String.Join(", ", Name))))
+            {
+                WriteVerbose(string.Format("Save operation cancelled by user for packages: {0}", String.Join(", ", Name)));
+                return;
+            }
+
             var installHelper = new InstallHelper(updatePkg: false, savePkg: true, cmdletPassedIn: this);
 
             switch (ParameterSetName)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Save-PSResource should implement ShouldProcess check

## PR Context

Addresses issue: #279 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
