### PR TITLE
Support Azure Artifacts for PowerShell modules

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -1,4 +1,3 @@
-using System.Text;
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using System;
@@ -388,21 +387,20 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         var moduleManifest = Path.Combine(tempDirNameVersion, pkgIdentity.Id + ".psd1");
                         if (!File.Exists(moduleManifest))
                         {
-                            // NuGet resources may not contain a PowerShell resource, so the manifest file may not exist.
-                            // Note: Every PowerShell resource is wrapped into a NuGet resource and published, but
-                            // not every NuGet resource contains a PowerShell resource wrapped within
-                            var message = String.Format("Module manifest file: {0} does not exist. This is not a valid PowerShell resource.", moduleManifest);
+                            var message = String.Format("Module manifest file: {0} does not exist. This is not a valid PowerShell module.", moduleManifest);
                             var ex = new ArgumentException(message);
                             var psdataFileDoesNotExistError = new ErrorRecord(ex, "psdataFileNotExistError", ErrorCategory.ReadError, null);
                             _cmdletPassedIn.WriteError(psdataFileDoesNotExistError);
                             continue;
                         }
 
-                        var parsedMetadataHashtable = Utils.ParseModuleManifest(moduleManifest, _cmdletPassedIn);
-                        if (parsedMetadataHashtable.Count == 0)
+                        if (!Utils.TryParseModuleManifest(moduleManifest, _cmdletPassedIn, out Hashtable parsedMetadataHashtable))
                         {
-                            // we ran into errors parsing the module manifest file which was found. Utils.ParseModuleManifest() wrote the errors
-                            continue;
+                            if (parsedMetadataHashtable.Count == 0)
+                            {
+                                // Ran into errors parsing the module manifest file which was found in Utils.ParseModuleManifest() and written.
+                                continue;
+                            }
                         }
 
                         moduleManifestVersion = parsedMetadataHashtable["ModuleVersion"] as string;

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -397,11 +397,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                         if (!Utils.TryParseModuleManifest(moduleManifest, _cmdletPassedIn, out Hashtable parsedMetadataHashtable))
                         {
-                            if (parsedMetadataHashtable.Count == 0)
-                            {
-                                // Ran into errors parsing the module manifest file which was found in Utils.ParseModuleManifest() and written.
-                                continue;
-                            }
+                            // Ran into errors parsing the module manifest file which was found in Utils.ParseModuleManifest() and written.
+                            continue;
                         }
 
                         moduleManifestVersion = parsedMetadataHashtable["ModuleVersion"] as string;

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -386,7 +386,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     {
                         var moduleManifest = Path.Combine(tempDirNameVersion, pkgIdentity.Id + ".psd1");
 
-                        var parsedMetadataHashtable = Utils.ParseModuleManifest(moduleManifest, this);
+                        var parsedMetadataHashtable = Utils.ParseModuleManifest(moduleManifest, _cmdletPassedIn);
+                        if (parsedMetadataHashtable.Count == 0)
+                        {
+                            continue;
+                        }
+
                         moduleManifestVersion = parsedMetadataHashtable["ModuleVersion"] as string;
 
                         // Accept License verification
@@ -435,6 +440,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     if (Directory.Exists(tempInstallPath))
                     {
                         Directory.Delete(tempInstallPath, true);
+                    }
+                    if (!Directory.Exists(tempInstallPath))
+                    {
+                        _cmdletPassedIn.WriteVerbose(string.Format("Sucessfully deleted '{0}'", tempInstallPath));
                     }
                 }
             }

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -625,6 +625,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             return true;
         }
+
         private void MoveFilesIntoInstallPath(
             PSResourceInfo p, 
             bool isScript, 

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -391,7 +391,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                             // NuGet resources may not contain a PowerShell resource, so the manifest file may not exist.
                             // Note: Every PowerShell resource is wrapped into a NuGet resource and published, but
                             // not every NuGet resource contains a PowerShell resource wrapped within
-                            var message = String.Format("Module manifest file: {0} does not exist. This is not a valid PowerShell resource.", moduleManifest);
+                            var message = String.Format("Module manifest file: {0} does not exist. This is not a valid PowerShell module.", moduleManifest);
+
                             var ex = new ArgumentException(message);
                             var psdataFileDoesNotExistError = new ErrorRecord(ex, "psdataFileNotExistError", ErrorCategory.ReadError, null);
                             _cmdletPassedIn.WriteError(psdataFileDoesNotExistError);

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -396,7 +396,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             {
                 if (!File.Exists(moduleFileInfo))
                 {
-                    var message = String.Format("File {0} does not exist", moduleFileInfo);
+                    var message = String.Format("File {0} does not exist {0}. This is not a valid PowerShell package.", moduleFileInfo);
                     var ex = new ArgumentException(message);
                     var psdataFileDoesNotExistError = new ErrorRecord(ex, "psdataFileNotExistError", ErrorCategory.ReadError, null);
                     cmdletPassedIn.WriteError(psdataFileDoesNotExistError);

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -394,15 +394,6 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             // a module will still need the module manifest to be parsed.
             if (moduleFileInfo.EndsWith(".psd1", StringComparison.OrdinalIgnoreCase))
             {
-                if (!File.Exists(moduleFileInfo))
-                {
-                    var message = String.Format("File {0} does not exist {0}. This is not a valid PowerShell package.", moduleFileInfo);
-                    var ex = new ArgumentException(message);
-                    var psdataFileDoesNotExistError = new ErrorRecord(ex, "psdataFileNotExistError", ErrorCategory.ReadError, null);
-                    cmdletPassedIn.WriteError(psdataFileDoesNotExistError);
-                    return parsedMetadataHash;
-                }
-
                 // Parse the module manifest 
                 System.Management.Automation.Language.Token[] tokens;
                 ParseError[] errors;

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -387,9 +387,14 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
         #region Manifest methods
 
-        public static Hashtable ParseModuleManifest(string moduleFileInfo, PSCmdlet cmdletPassedIn)
+        public static bool TryParseModuleManifest(
+            string moduleFileInfo,
+            PSCmdlet cmdletPassedIn,
+            out Hashtable parsedMetadataHashtable)
         {
-            Hashtable parsedMetadataHash = new Hashtable();
+            parsedMetadataHashtable = new Hashtable();
+            bool successfullyParsed = false;
+
             // A script will already  have the metadata parsed into the parsedMetadatahash,
             // a module will still need the module manifest to be parsed.
             if (moduleFileInfo.EndsWith(".psd1", StringComparison.OrdinalIgnoreCase))
@@ -405,13 +410,15 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                     var ex = new ArgumentException(message);
                     var psdataParseError = new ErrorRecord(ex, "psdataParseError", ErrorCategory.ParserError, null);
                     cmdletPassedIn.WriteError(psdataParseError);
+                    return successfullyParsed;
                 }
                 else
                 {
                     var data = ast.Find(a => a is HashtableAst, false);
                     if (data != null)
                     {
-                        parsedMetadataHash = (Hashtable)data.SafeGetValue();
+                        parsedMetadataHashtable = (Hashtable)data.SafeGetValue();
+                        successfullyParsed = true;
                     }
                     else
                     {
@@ -423,7 +430,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 }
             }
 
-            return parsedMetadataHash;
+            return successfullyParsed;
         }
 
         #endregion

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -394,6 +394,15 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             // a module will still need the module manifest to be parsed.
             if (moduleFileInfo.EndsWith(".psd1", StringComparison.OrdinalIgnoreCase))
             {
+                if (!File.Exists(moduleFileInfo))
+                {
+                    var message = String.Format("File {0} does not exist", moduleFileInfo);
+                    var ex = new ArgumentException(message);
+                    var psdataFileDoesNotExistError = new ErrorRecord(ex, "psdataFileNotExistError", ErrorCategory.ReadError, null);
+                    cmdletPassedIn.WriteError(psdataFileDoesNotExistError);
+                    return parsedMetadataHash;
+                }
+
                 // Parse the module manifest 
                 System.Management.Automation.Language.Token[] tokens;
                 ParseError[] errors;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

If Azure Artifacts (or other repository) contains packages that are not PowerShell packages they will not contain a `.psd1` file. Add error handling for this case.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Resolves #48 

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
