### PR TITLE
Auto-create PSResourceRepository.xml file if the file does not already exist. 

### DIFF
--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -138,18 +138,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             // Create a respository story (the PSResourceRepository.xml file) if it does not already exist
             // This is to create a better experience for those who have just installed v3 and want to get up and running quickly
-            try
-            {
-                RepositorySettings.CheckRepositoryStore();
-            }
-            catch (PSInvalidOperationException e)
-            {
-                ThrowTerminatingError(new ErrorRecord(
-                    new PSInvalidOperationException(e.Message),
-                    "RepositoryStoreException",
-                    ErrorCategory.ReadError,
-                    this));
-            }
+            RepositorySettings.CheckRepositoryStore();
         }
 
         protected override void StopProcessing()

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -135,6 +135,21 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             _source = new CancellationTokenSource();
             _cancellationToken = _source.Token;
+
+            // Create a respository story (the PSResourceRepository.xml file) if it does not already exist
+            // This is to create a better experience for those who have just installed v3 and want to get up and running quickly
+            try
+            {
+                RepositorySettings.CheckRepositoryStore();
+            }
+            catch (PSInvalidOperationException e)
+            {
+                ThrowTerminatingError(new ErrorRecord(
+                    new PSInvalidOperationException(e.Message),
+                    "RepositoryStoreException",
+                    ErrorCategory.ReadError,
+                    this));
+            }
         }
 
         protected override void StopProcessing()

--- a/src/code/GetPSResourceRepository.cs
+++ b/src/code/GetPSResourceRepository.cs
@@ -39,19 +39,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void BeginProcessing()
         {
-            try
-            {
-                WriteVerbose("Calling API to check repository store exists in non-corrupted state");
-                RepositorySettings.CheckRepositoryStore();
-            }
-            catch (PSInvalidOperationException e)
-            {
-                ThrowTerminatingError(new ErrorRecord(
-                    new PSInvalidOperationException(e.Message),
-                    "RepositoryStoreException",
-                    ErrorCategory.ReadError,
-                    this));
-            }
+            RepositorySettings.CheckRepositoryStore();
         }
         protected override void ProcessRecord()
         {

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -105,18 +105,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             // Create a respository story (the PSResourceRepository.xml file) if it does not already exist
             // This is to create a better experience for those who have just installed v3 and want to get up and running quickly
-            try
-            {
-                RepositorySettings.CheckRepositoryStore();
-            }
-            catch (PSInvalidOperationException e)
-            {
-                ThrowTerminatingError(new ErrorRecord(
-                    new PSInvalidOperationException(e.Message),
-                    "RepositoryStoreException",
-                    ErrorCategory.ReadError,
-                    this));
-            }
+            RepositorySettings.CheckRepositoryStore();
 
             // validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
             // An exact version will be formatted into a version range.

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -103,6 +103,21 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void BeginProcessing()
         {
+            // Create a respository story (the PSResourceRepository.xml file) if it does not already exist
+            // This is to create a better experience for those who have just installed v3 and want to get up and running quickly
+            try
+            {
+                RepositorySettings.CheckRepositoryStore();
+            }
+            catch (PSInvalidOperationException e)
+            {
+                ThrowTerminatingError(new ErrorRecord(
+                    new PSInvalidOperationException(e.Message),
+                    "RepositoryStoreException",
+                    ErrorCategory.ReadError,
+                    this));
+            }
+
             // validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
             // An exact version will be formatted into a version range.
             if (ParameterSetName.Equals(NameParameterSet) && Version != null && !Utils.TryParseVersionOrVersionRange(Version, out _versionRange))

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -156,10 +156,27 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         private NuGetVersion _pkgVersion;
         private string _pkgName;
         private static char[] _PathSeparators = new [] { System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar };
-        
+
         #endregion
 
         #region Method overrides
+        protected override void BeginProcessing()
+        {
+            // Create a respository story (the PSResourceRepository.xml file) if it does not already exist
+            // This is to create a better experience for those who have just installed v3 and want to get up and running quickly
+            try
+            {
+                RepositorySettings.CheckRepositoryStore();
+            }
+            catch (PSInvalidOperationException e)
+            {
+                ThrowTerminatingError(new ErrorRecord(
+                    new PSInvalidOperationException(e.Message),
+                    "RepositoryStoreException",
+                    ErrorCategory.ReadError,
+                    this));
+            }
+        }
 
         protected override void ProcessRecord()
         {

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -164,18 +164,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             // Create a respository story (the PSResourceRepository.xml file) if it does not already exist
             // This is to create a better experience for those who have just installed v3 and want to get up and running quickly
-            try
-            {
-                RepositorySettings.CheckRepositoryStore();
-            }
-            catch (PSInvalidOperationException e)
-            {
-                ThrowTerminatingError(new ErrorRecord(
-                    new PSInvalidOperationException(e.Message),
-                    "RepositoryStoreException",
-                    ErrorCategory.ReadError,
-                    this));
-            }
+            RepositorySettings.CheckRepositoryStore();
         }
 
         protected override void ProcessRecord()

--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -118,19 +118,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     ErrorCategory.NotImplemented,
                     this));
             }
-
-            try
-            {
-                RepositorySettings.CheckRepositoryStore();
-            }
-            catch (PSInvalidOperationException e)
-            {
-                ThrowTerminatingError(new ErrorRecord(
-                    new PSInvalidOperationException(e.Message),
-                    "RepositoryStoreException",
-                    ErrorCategory.ReadError,
-                    this));
-            }
+            
+            RepositorySettings.CheckRepositoryStore();
         }
         protected override void ProcessRecord()
         {

--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -27,7 +27,10 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         private static readonly string RepositoryFileName = "PSResourceRepository.xml";
         private static readonly string RepositoryPath = Path.Combine(Environment.GetFolderPath(SpecialFolder.LocalApplicationData), "PowerShellGet");
         private static readonly string FullRepositoryPath = Path.Combine(RepositoryPath, RepositoryFileName);
-
+        private static readonly string PSGalleryRepoName = "PSGallery";
+        private static readonly string PSGalleryRepoURL = "https://www.powershellgallery.com/api/v2";
+        private const int defaultPriority = 50;
+        private const bool defaultTrusted = false;
 
         /// <summary>
         /// Check if repository store xml file exists, if not then create
@@ -52,6 +55,10 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 {
                     throw new PSInvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Repository store creation failed with error: {0}.", e.Message));
                 }
+
+                // Add PSGallery to the newly created store
+                Uri psGalleryUri = new Uri(PSGalleryRepoURL);
+                Add(PSGalleryRepoName, psGalleryUri, defaultPriority, defaultTrusted);
             }
 
             // Open file (which should exist now), if cannot/is corrupted then throw error

--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -24,13 +24,13 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         /// File name for a user's repository store file is 'PSResourceRepository.xml'
         /// The repository store file's location is currently only at '%LOCALAPPDATA%\PowerShellGet' for the user account.
         /// </summary>
-        private static readonly string RepositoryFileName = "PSResourceRepository.xml";
-        private static readonly string RepositoryPath = Path.Combine(Environment.GetFolderPath(SpecialFolder.LocalApplicationData), "PowerShellGet");
-        private static readonly string FullRepositoryPath = Path.Combine(RepositoryPath, RepositoryFileName);
-        private static readonly string PSGalleryRepoName = "PSGallery";
-        private static readonly string PSGalleryRepoURL = "https://www.powershellgallery.com/api/v2";
+        private const string PSGalleryRepoName = "PSGallery";
+        private const string PSGalleryRepoURL = "https://www.powershellgallery.com/api/v2";
         private const int defaultPriority = 50;
         private const bool defaultTrusted = false;
+        private const string RepositoryFileName = "PSResourceRepository.xml";
+        private static readonly string RepositoryPath = Path.Combine(Environment.GetFolderPath(SpecialFolder.LocalApplicationData), "PowerShellGet");
+        private static readonly string FullRepositoryPath = Path.Combine(RepositoryPath, RepositoryFileName);
 
         /// <summary>
         /// Check if repository store xml file exists, if not then create

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -127,18 +127,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             // Create a respository story (the PSResourceRepository.xml file) if it does not already exist
             // This is to create a better experience for those who have just installed v3 and want to get up and running quickly
-            try
-            {
-                RepositorySettings.CheckRepositoryStore();
-            }
-            catch (PSInvalidOperationException e)
-            {
-                ThrowTerminatingError(new ErrorRecord(
-                    new PSInvalidOperationException(e.Message),
-                    "RepositoryStoreException",
-                    ErrorCategory.ReadError,
-                    this));
-            }
+            RepositorySettings.CheckRepositoryStore();
 
             // validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
             // an exact version will be formatted into a version range.

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -125,6 +125,21 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void BeginProcessing()
         {
+            // Create a respository story (the PSResourceRepository.xml file) if it does not already exist
+            // This is to create a better experience for those who have just installed v3 and want to get up and running quickly
+            try
+            {
+                RepositorySettings.CheckRepositoryStore();
+            }
+            catch (PSInvalidOperationException e)
+            {
+                ThrowTerminatingError(new ErrorRecord(
+                    new PSInvalidOperationException(e.Message),
+                    "RepositoryStoreException",
+                    ErrorCategory.ReadError,
+                    this));
+            }
+
             // validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
             // an exact version will be formatted into a version range.
             if (ParameterSetName.Equals("NameParameterSet") && 

--- a/src/code/SetPSResourceRepository.cs
+++ b/src/code/SetPSResourceRepository.cs
@@ -95,19 +95,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         #region Methods
         protected override void BeginProcessing()
         {
-            try
-            {
-                WriteVerbose("Calling API to check repository store exists in non-corrupted state");
-                RepositorySettings.CheckRepositoryStore();
-            }
-            catch (PSInvalidOperationException e)
-            {
-                ThrowTerminatingError(new ErrorRecord(
-                    new PSInvalidOperationException(e.Message),
-                    "RepositoryStoreException",
-                    ErrorCategory.ReadError,
-                    this));
-            }
+            RepositorySettings.CheckRepositoryStore();
         }
 
         protected override void ProcessRecord()

--- a/src/code/UnregisterPSResourceRepository.cs
+++ b/src/code/UnregisterPSResourceRepository.cs
@@ -37,19 +37,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void BeginProcessing()
         {
-            try
-            {
-                WriteVerbose("Calling API to check repository store exists in non-corrupted state");
-                RepositorySettings.CheckRepositoryStore();
-            }
-            catch (PSInvalidOperationException e)
-            {
-                ThrowTerminatingError(new ErrorRecord(
-                    new PSInvalidOperationException(e.Message),
-                    "RepositoryStoreException",
-                    ErrorCategory.ReadError,
-                    this));
-            }
+            RepositorySettings.CheckRepositoryStore();
         }
         protected override void ProcessRecord()
         {

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -104,6 +104,21 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void BeginProcessing()
         {
+            // Create a respository story (the PSResourceRepository.xml file) if it does not already exist
+            // This is to create a better experience for those who have just installed v3 and want to get up and running quickly
+            try
+            {
+                RepositorySettings.CheckRepositoryStore();
+            }
+            catch (PSInvalidOperationException e)
+            {
+                ThrowTerminatingError(new ErrorRecord(
+                    new PSInvalidOperationException(e.Message),
+                    "RepositoryStoreException",
+                    ErrorCategory.ReadError,
+                    this));
+            }
+
             _pathsToInstallPkg = Utils.GetAllInstallationPaths(this, Scope);
         }
 

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -106,18 +106,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             // Create a respository story (the PSResourceRepository.xml file) if it does not already exist
             // This is to create a better experience for those who have just installed v3 and want to get up and running quickly
-            try
-            {
-                RepositorySettings.CheckRepositoryStore();
-            }
-            catch (PSInvalidOperationException e)
-            {
-                ThrowTerminatingError(new ErrorRecord(
-                    new PSInvalidOperationException(e.Message),
-                    "RepositoryStoreException",
-                    ErrorCategory.ReadError,
-                    this));
-            }
+            RepositorySettings.CheckRepositoryStore();
 
             _pathsToInstallPkg = Utils.GetAllInstallationPaths(this, Scope);
         }
@@ -181,6 +170,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         }
 
         #endregion
+
         #region Private Methods
 
         /// <Summary>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Automatically create the PSGet repository store (PSResourceRepository.xml file) if the file does not already exist. 
This functionality already existed in the *-PSResourceRepository cmdlets, but did not exist for the *-PSResource cmdlets.  All of the latter cmdlets that read from the PSResourceRepository.xml file (ie, Find, Install, Save, and Publish) now check to makes sure that the file already exists before processing.  If the file does not exist, it gets created.

Another change is that upon each new PSResourceRepository.xml file creation, the PowerShellGallery gets registered by default with the following settings:
```
Name:  PSGallery
URL:  https://powershellgallery.com/api/v2
Priority: 50
Trusted: false
```

## PR Context

Resolves #258 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
