### PR TITLE
Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yaml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yaml
@@ -1,0 +1,73 @@
+name: Bug report 🐛
+description: Report errors or unexpected behavior 🤔
+labels: Needs-Triage
+body:
+- type: markdown
+  attributes:
+    value: >
+      For Windows PowerShell 5.1 issues, suggestions, or feature requests please use the
+      [Feedback Hub app](https://support.microsoft.com/windows/send-feedback-to-microsoft-with-the-feedback-hub-app-f59187f8-8739-22d6-ba93-f66612949332)
+
+      For PowerShellGet v2 issues, please use [PowerShellGetv2 repo](https://github.com/PowerShell/PowerShellGetv2).
+
+      This repository is **ONLY** for PowerShellGet v3 issues.
+- type: checkboxes
+  attributes:
+    label: Prerequisites
+    options:
+    - label: Write a descriptive title.
+      required: true
+    - label: Make sure you are able to repro it on the [latest released version](https://www.powershellgallery.com/packages/PowerShellGet)
+      required: true
+    - label: Search the existing issues.
+      required: true
+- type: textarea
+  attributes:
+    label: Steps to reproduce
+    description: >
+      List of steps, sample code, failing test or link to a project that reproduces the behavior.
+      Make sure you place a stack trace inside a code (```) block to avoid linking unrelated issues.
+    placeholder: >
+      I am experiencing a problem with X.
+      I think Y should be happening but Z is actually happening.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected behavior
+    render: console
+    placeholder: |
+      PS> 2 + 2
+      4
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Actual behavior
+    render: console
+    placeholder: |
+      PS> 2 + 2
+      5
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Error details
+    description: Paste verbatim output from `Get-Error` if PowerShell return an error.
+    render: console
+    placeholder: PS> Get-Error
+- type: textarea
+  attributes:
+    label: Environment data
+    description: Paste verbatim output from `Get-Module PowerShellGet; $PSVersionTable` below.
+    render: powershell
+    placeholder: PS> Get-Module PowerShellGet; $PSVersionTable
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Visuals
+    description: >
+      Please upload images or animations that can be used to reproduce issues in the area below.
+      Try the [Steps Recorder](https://support.microsoft.com/en-us/windows/record-steps-to-reproduce-a-problem-46582a9b-620f-2e36-00c9-04e25d784e47)
+      on Windows or [Screenshot](https://support.apple.com/en-us/HT208721) on macOS.

--- a/.github/ISSUE_TEMPLATE/Feature_Request.yaml
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.yaml
@@ -1,0 +1,20 @@
+name: Feature Request / Idea 🚀
+description: Suggest a new feature or improvement (this does not mean you have to implement it)
+labels: [feature_request, Needs-Triage]
+body:
+- type: textarea
+  attributes:
+    label: Summary of the new feature / enhancement
+    description: >
+      A clear and concise description of what the problem is that the
+      new feature would solve. Try formulating it in user story style
+      (if applicable).
+    placeholder: "'As a user I want X so that Y...' with X being the being the action and Y being the value of the action."
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Proposed technical implementation details (optional)
+    placeholder: >
+      A clear and concise description of what you want to happen.
+      Consider providing an example PowerShell experience with expected result.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation Issue
+    url: https://github.com/MicrosoftDocs/PowerShell-Docs
+    about: Please open issues on documentation for PowerShellGet here.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add issue templates for issues vs features. 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
