### PR TITLE
Add clarifying comments to directory utility functions

### DIFF
--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -459,6 +459,9 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
         /// <Summary>
         /// Deletes a directory and its contents
+        /// This is a workaround for .NET Directory.Delete(), which can fail with WindowsPowerShell
+        /// on OneDrive with 'access denied' error.
+        /// Later versions of .NET, with PowerShellCore, do not have this bug.
         /// </Summary>
         public static void DeleteDirectory(string dirPath)
         {
@@ -477,7 +480,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
         /// <Summary>
         /// Moves files from source to destination locations.
-        /// Works over different file volumes.
+        /// This is a workaround for .NET File.Move(), which fails over different file volumes.
         /// </Summary>
         public static void MoveFiles(
             string sourceFilePath,
@@ -490,7 +493,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
         /// <Summary>
         /// Moves the directory, including contents, from source to destination locations.
-        /// Works over different file volumes.
+        /// This is a workaround for .NET Directory.Move(), which fails over different file volumes.
         /// </Summary>
         public static void MoveDirectory(
             string sourceDirPath,


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR adds clarifying comments to utility directory functions workarounds of .NET.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
