### PR TITLE
Tag type paramset

### DIFF
--- a/help/Find-PSResource.md
+++ b/help/Find-PSResource.md
@@ -159,7 +159,7 @@ Accept wildcard characters: False
 ```
 
 ### -Repository
-Specifies one or more repository names to search.
+Specifies one or more repository names to search, which can include wildcard.
 If not specified, search will include all currently registered repositories, in order of highest priority, until a repository is found that contains the package.
 
 ```yaml
@@ -171,7 +171,7 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Tag

--- a/src/PSGet.Format.ps1xml
+++ b/src/PSGet.Format.ps1xml
@@ -11,6 +11,7 @@
                 <TableColumnHeader><Label>Name</Label></TableColumnHeader>
                 <TableColumnHeader><Label>Version</Label></TableColumnHeader>
                 <TableColumnHeader><Label>Prerelease</Label></TableColumnHeader>
+                <TableColumnHeader><Label>Repository</Label></TableColumnHeader>
                 <TableColumnHeader><Label>Description</Label></TableColumnHeader>
             </TableHeaders>
                 <TableRowEntries>
@@ -19,6 +20,7 @@
                             <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
                             <TableColumnItem><PropertyName>Version</PropertyName></TableColumnItem>
                             <TableColumnItem><PropertyName>PrereleaseLabel</PropertyName></TableColumnItem>
+                            <TableColumnItem><PropertyName>Repository</PropertyName></TableColumnItem>
                             <TableColumnItem><PropertyName>Description</PropertyName></TableColumnItem>
                         </TableColumnItems>
                 </TableRowEntry>

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -369,18 +369,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 foundPackagesMetadata.AddRange(wildcardPkgs.Where(
                     p => nameWildcardPattern.IsMatch(p.Identity.Id)).ToList());
 
-                // if the Script Uri endpoint still needs to be searched, don't remove the wildcard name from _pkgsLeftToFind
-                // PSGallery + Type == null -> M, S
-                // PSGallery + Type == M    -> M
-                // PSGallery + Type == S    -> S (but PSGallery would be skipped early on, only PSGalleryScripts would be checked)
-                // PSGallery + Type == C    -> M
-                // PSGallery + Type == D    -> M
-
-                bool needToCheckPSGalleryScriptsRepo = String.Equals(repositoryName, _psGalleryRepoName, StringComparison.InvariantCultureIgnoreCase) && _type == ResourceType.None;
-                if (foundPackagesMetadata.Any() && !needToCheckPSGalleryScriptsRepo)
-                {
-                    _pkgsLeftToFind.Remove(pkgName);
-                }
+                // We don't remove the pkgName from _pkgsLeftToFind list because there may be matches for that name wildcard pattern
+                // in each repository, so search each specified repository.
             }
 
             if (foundPackagesMetadata.Count == 0)

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -198,7 +198,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 Name = new string[] {"*"};
             }
 
-            var namesToSearch = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool nameContainsWildcard);
+            Name = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool nameContainsWildcard);
             
             foreach (string error in errorMsgs)
             {
@@ -211,7 +211,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             // this catches the case where Name wasn't passed in as null or empty,
             // but after filtering out unsupported wildcard names there are no elements left in namesToSearch
-            if (namesToSearch.Length == 0)
+            if (Name.Length == 0)
             {
                 return;
             }            

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -184,52 +184,50 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             if (!MyInvocation.BoundParameters.ContainsKey(nameof(Name)))
             {
-                // TODO: Add support for Tag and Type parameters without Name parameter being specified.
-                if (MyInvocation.BoundParameters.ContainsKey(nameof(Type)) || MyInvocation.BoundParameters.ContainsKey(nameof(Tag)))
+                // only cases where Name is allowed to not be specified is if Type or Tag parameters are
+                if (!MyInvocation.BoundParameters.ContainsKey(nameof(Type)) && !MyInvocation.BoundParameters.ContainsKey(nameof(Tag)))
                 {
                     ThrowTerminatingError(
                         new ErrorRecord(
-                            new PSNotImplementedException("Search by Tag or Type parameter is not yet implemented."),
-                            "TagTypeSearchNotYetImplemented",
-                            ErrorCategory.NotImplemented,
+                            new PSInvalidOperationException("Name parameter must be provided."),
+                            "NameParameterNotProvided",
+                            ErrorCategory.InvalidOperation,
                             this));
                 }
 
-                ThrowTerminatingError(
-                    new ErrorRecord(
-                        new PSInvalidOperationException("Name parameter must be provided."),
-                        "NameParameterNotProvided",
-                        ErrorCategory.InvalidOperation,
+                Name = new string[] {"*"};
+            }
+            else
+            {
+                var namesToSearch = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool nameContainsWildcard);
+                
+                foreach (string error in errorMsgs)
+                {
+                    WriteError(new ErrorRecord(
+                        new PSInvalidOperationException(error),
+                        "ErrorFilteringNamesForUnsupportedWildcards",
+                        ErrorCategory.InvalidArgument,
                         this));
-            }
-            
-            var namesToSearch = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool nameContainsWildcard);
-            
-            foreach (string error in errorMsgs)
-            {
-                WriteError(new ErrorRecord(
-                    new PSInvalidOperationException(error),
-                    "ErrorFilteringNamesForUnsupportedWildcards",
-                    ErrorCategory.InvalidArgument,
-                    this));
-            }
+                }
 
-            // this catches the case where Name wasn't passed in as null or empty,
-            // but after filtering out unsupported wildcard names there are no elements left in namesToSearch
-            if (namesToSearch.Length == 0)
-            {
-                 return;
-            }
+                // this catches the case where Name wasn't passed in as null or empty,
+                // but after filtering out unsupported wildcard names there are no elements left in namesToSearch
+                if (namesToSearch.Length == 0)
+                {
+                    return;
+                }
 
-            if (String.Equals(namesToSearch[0], "*", StringComparison.InvariantCultureIgnoreCase))
-            {
-                // WriteVerbose("Package names were detected to be (or contain an element equal to): '*', so all packages will be updated");
-                WriteError(new ErrorRecord(
-                    new PSInvalidOperationException("-Name '*' is not supported for Find-PSResource so all Name entries will be discarded."),
-                    "NameEqualsWildcardIsNotSupported",
-                    ErrorCategory.InvalidArgument,
-                    this));
-                return;
+
+                // if (String.Equals(namesToSearch[0], "*", StringComparison.InvariantCultureIgnoreCase) && !MyInvocation.BoundParameters.ContainsKey(nameof(Type)) && !MyInvocation.BoundParameters.ContainsKey(nameof(Tag)))
+                if (String.Equals(namesToSearch[0], "*", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    WriteError(new ErrorRecord(
+                        new PSInvalidOperationException("-Name '*' is not supported for Find-PSResource so all Name entries will be discarded."),
+                        "NameEqualsWildcardIsNotSupported",
+                        ErrorCategory.InvalidArgument,
+                        this));
+                    return;
+                }
             }
 
             FindHelper findHelper = new FindHelper(_cancellationToken, this);

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -233,7 +233,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
 
             foreach (var uniquePackageVersion in foundPackages.GroupBy(
-                m => new {m.Name, m.Version}).Select(
+                m => new {m.Name, m.Version, m.Repository}).Select(
                     group => group.First()).ToList())
             {
                 WriteObject(uniquePackageVersion);

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -197,38 +197,24 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                 Name = new string[] {"*"};
             }
-            else
+
+            var namesToSearch = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool nameContainsWildcard);
+            
+            foreach (string error in errorMsgs)
             {
-                var namesToSearch = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool nameContainsWildcard);
-                
-                foreach (string error in errorMsgs)
-                {
-                    WriteError(new ErrorRecord(
-                        new PSInvalidOperationException(error),
-                        "ErrorFilteringNamesForUnsupportedWildcards",
-                        ErrorCategory.InvalidArgument,
-                        this));
-                }
-
-                // this catches the case where Name wasn't passed in as null or empty,
-                // but after filtering out unsupported wildcard names there are no elements left in namesToSearch
-                if (namesToSearch.Length == 0)
-                {
-                    return;
-                }
-
-
-                // if (String.Equals(namesToSearch[0], "*", StringComparison.InvariantCultureIgnoreCase) && !MyInvocation.BoundParameters.ContainsKey(nameof(Type)) && !MyInvocation.BoundParameters.ContainsKey(nameof(Tag)))
-                if (String.Equals(namesToSearch[0], "*", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    WriteError(new ErrorRecord(
-                        new PSInvalidOperationException("-Name '*' is not supported for Find-PSResource so all Name entries will be discarded."),
-                        "NameEqualsWildcardIsNotSupported",
-                        ErrorCategory.InvalidArgument,
-                        this));
-                    return;
-                }
+                WriteError(new ErrorRecord(
+                    new PSInvalidOperationException(error),
+                    "ErrorFilteringNamesForUnsupportedWildcards",
+                    ErrorCategory.InvalidArgument,
+                    this));
             }
+
+            // this catches the case where Name wasn't passed in as null or empty,
+            // but after filtering out unsupported wildcard names there are no elements left in namesToSearch
+            if (namesToSearch.Length == 0)
+            {
+                return;
+            }            
 
             FindHelper findHelper = new FindHelper(_cancellationToken, this);
             List<PSResourceInfo> foundPackages = new List<PSResourceInfo>();

--- a/test/FindPSResource.Tests.ps1
+++ b/test/FindPSResource.Tests.ps1
@@ -52,8 +52,8 @@ Describe 'Test Find-PSResource for Module' {
     It "should find all resources given Name that equals wildcard, '*'" {
         $foundScript = $False
         $foundPreview = $False
-        $res = Find-PSResource -Name "*" -Repository $PSGalleryName
-        $res.Count | Should -BeGreaterThan 1
+        $res = Find-PSResource -Name "*" -Repository $TestGalleryName
+        $res.Count | Should -BeGreaterOrEqual 2004
         #should find Module and Script resources
         foreach ($item in $res)
         {
@@ -75,8 +75,8 @@ Describe 'Test Find-PSResource for Module' {
     It "should find all resources (including prerelease) given Name that equals wildcard, '*' and Prerelease parameter" {
         $foundScript = $False
         $foundPreview = $False
-        $res = Find-PSResource -Name "*" -Prerelease -Repository $PSGalleryName
-        $res.Count | Should -BeGreaterThan 1
+        $res = Find-PSResource -Name "*" -Prerelease -Repository $TestGalleryName
+        $res.Count | Should -BeGreaterOrEqual 2781
         #should find Module and Script resources
         foreach ($item in $res)
         {

--- a/test/FindPSResource.Tests.ps1
+++ b/test/FindPSResource.Tests.ps1
@@ -9,6 +9,8 @@ Describe 'Test Find-PSResource for Module' {
         $TestGalleryName = Get-PoshTestGalleryName
         $PSGalleryName = Get-PSGalleryName
         $NuGetGalleryName = Get-NuGetGalleryName
+        $testModuleName = "testmodule"
+        $testScriptName = "test_script"
         Get-NewPSResourceRepositoryFile
         Register-LocalRepos
     }
@@ -50,16 +52,21 @@ Describe 'Test Find-PSResource for Module' {
     }
 
     It "should find all resources given Name that equals wildcard, '*'" {
-        $foundScript = $False
         $foundPreview = $False
+        $foundTestScript = $False
+        $foundTestModule = $False
         $res = Find-PSResource -Name "*" -Repository $TestGalleryName
-        $res.Count | Should -BeGreaterOrEqual 2004
         #should find Module and Script resources
         foreach ($item in $res)
         {
-            if ($item.Type -eq "Script")
+            if ($item.Name -eq $testModuleName)
             {
-                $foundScript = $True
+                $foundTestModule = $True
+            }
+
+            if ($item.Name -eq $testScriptName)
+            {
+                $foundTestScript = $True
             }
 
             if(-not [string]::IsNullOrEmpty($item.PrereleaseLabel))
@@ -68,21 +75,27 @@ Describe 'Test Find-PSResource for Module' {
             }
         }
 
-        $foundScript | Should -Be $True
         $foundPreview | Should -Be $False
+        $foundTestScript | Should -Be $True
+        $foundTestModule | Should -Be $True
     }
 
     It "should find all resources (including prerelease) given Name that equals wildcard, '*' and Prerelease parameter" {
-        $foundScript = $False
         $foundPreview = $False
+        $foundTestScript = $False
+        $foundTestModule = $False
         $res = Find-PSResource -Name "*" -Prerelease -Repository $TestGalleryName
-        $res.Count | Should -BeGreaterOrEqual 2781
         #should find Module and Script resources
         foreach ($item in $res)
         {
-            if ($item.Type -eq "Script")
+            if ($item.Name -eq $testModuleName)
             {
-                $foundScript = $True
+                $foundTestModule = $True
+            }
+
+            if ($item.Name -eq $testScriptName)
+            {
+                $foundTestScript = $True
             }
 
             if(-not [string]::IsNullOrEmpty($item.PrereleaseLabel))
@@ -91,8 +104,9 @@ Describe 'Test Find-PSResource for Module' {
             }
         }
 
-        $foundScript | Should -Be $True
         $foundPreview | Should -Be $True
+        $foundTestScript | Should -Be $True
+        $foundTestModule | Should -Be $True
     }
 
     It "find resource given Name from V3 endpoint repository (NuGetGallery)" {
@@ -255,12 +269,26 @@ Describe 'Test Find-PSResource for Module' {
     }
 
     It "find all resources with specified tag given Tag property" {
+        $foundTestModule = $False
+        $foundTestScript = $False
         $tagToFind = "Tag1"
         $res = Find-PSResource -Tag $tagToFind -Repository $TestGalleryName
-        $res.Count | Should -BeGreaterOrEqual 43
         foreach ($item in $res) {
             $item.Tags -contains $tagToFind | Should -Be $True
+
+            if ($item.Name -eq $testModuleName)
+            {
+                $foundTestModule = $True
+            }
+
+            if ($item.Name -eq $testScriptName)
+            {
+                $foundTestScript = $True
+            }
         }
+
+        $foundTestModule | Should -Be $True
+        $foundTestScript | Should -Be $True
     }
 
     It "find resource with IncludeDependencies parameter" {

--- a/test/FindPSResource.Tests.ps1
+++ b/test/FindPSResource.Tests.ps1
@@ -255,9 +255,9 @@ Describe 'Test Find-PSResource for Module' {
     }
 
     It "find all resources with specified tag given Tag property" {
-        $tagToFind = "Dell"
-        $res = Find-PSResource -Tag $tagToFind -Repository $PSGalleryName
-        $res.Count | Should -BeGreaterOrEqual 14
+        $tagToFind = "Tag1"
+        $res = Find-PSResource -Tag $tagToFind -Repository $TestGalleryName
+        $res.Count | Should -BeGreaterOrEqual 43
         foreach ($item in $res) {
             $item.Tags -contains $tagToFind | Should -Be $True
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- [x] Support `-Name "*"` for Find-PSResource. 
- [x] Support "*" cases for `-Repository` parameter.
- [x] Implement Tag parameter set (`Find-PSResource -Tag "Dell"`)
- [x] Implement Type parameter set (`Find-PSResource -Type Module`) 
- [x] Packages returned will be unique by Name,Version,Repository

## PR Context

Complete not yet implemented parameter sets for Find-PSResource. Towards resolving issue #466 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
