### PR TITLE
Command dsc parametersets

### DIFF
--- a/help/Find-PSResource.md
+++ b/help/Find-PSResource.md
@@ -19,13 +19,13 @@ Searches for packages from a repository (local or remote), based on `-Name` and 
 
 ### CommandNameParameterSet
 ``` PowerShell
-[[-CommandName] <string[]>] [-ModuleName <string>] [-Version <string>] [-Prerelease] [-Tag <string[]>]
+[[-CommandName] <string[]>] [-ModuleName <string[]>] [-Version <string>] [-Prerelease] [-Tag <string[]>]
 [-Repository <string[]>] [-Credential <pscredential>] [-IncludeDependencies] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### DscResourceNameParameterSet
 ``` PowerShell
-[[-DscResourceName] <string[]>] [-ModuleName <string>] [-Version <string>] [-Prerelease] [-Tag <string[]>]
+[[-DscResourceName] <string[]>] [-ModuleName <string[]>] [-Version <string>] [-Prerelease] [-Tag <string[]>]
 [-Repository <string[]>] [-Credential <pscredential>] [-IncludeDependencies] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -76,6 +76,47 @@ PS C:\> Find-PSResource -Name "Microsoft.PowerShell.SecretManagement" -Version "
 ```
 
 This examples searches for the package with `-Name` "Microsoft.PowerShell.SecretManagement". It returns all versions which satisfy the specified `-Version` range by looking through the specified `-Repository` "PSGallery". At the time of writing this example those satisfying versions are: "0.9.1.0" and "1.0.0.0".
+
+### Example 4
+```powershell
+PS C:\> Find-PSResource -CommandName "Get-TargetResource" -Repository PSGallery
+        Name                                    Version    Prerelease   ModuleName                     Repository
+        ----                                    -------    ----------   ----------                     ----------
+        Get-TargetResource                      3.1.0.0                 xPowerShellExecutionPolicy     PSGallery
+        Get-TargetResource                      1.0.0.4                 WindowsDefender                PSGallery
+        Get-TargetResource                      1.2.0.0                 SystemLocaleDsc                PSGallery
+        Get-TargetResource                      1.0.0.0                 xInternetExplorerHomePage      PSGallery
+        Get-TargetResource                      4.0.1055.0              OctopusDSC                     PSGallery
+        Get-TargetResource                      1.2.0.0                 cRegFile                       PSGallery
+        Get-TargetResource                      1.1.0.0                 cWindowsErrorReporting         PSGallery
+        Get-TargetResource                      1.0.0.0                 cVNIC                          PSGallery
+        Get-TargetResource                      1.1.17.0                supVsts                        PSGallery
+
+```
+
+This examples searches for all module resources with `-CommandName` "Get-TargetResource" from the `-Repository` PSGallery. It returns all the module resources which include a command named "Get-TargetResource" and also lists the following information for each module resource: version, name (displayed under ModuleName) and repository. To access the rest of the properties of the parent module resource, you can access the `$_.ParentResource` of the PSIncludedResourceInfo object returned from the CommandName parameter set.
+
+### Example 5
+```powershell
+PS C:\> Find-PSResource -CommandName "Get-TargetResource" -ModuleName "SystemLocaleDsc" -Repository PSGallery
+        Name                                    Version    Prerelease   ModuleName                     Repository
+        ----                                    -------    ----------   ----------                     ----------
+        Get-TargetResource                      1.2.0.0                 SystemLocaleDsc                PSGallery
+```
+
+This examples searches for a module resource with a command named "Get-TargetResource" (via the `-CommandName` parameter), specifically from the module resource "SystemLocaleDsc" (via the `-ModuleName` parameter) from the `-Repository` PSGallery. The "SystemLocaleDsc" resource does indeed include a command named Get-TargetResource so this resource will be returned. The returned object lists the name of the command (displayed under Name) and the following information for the parent module resource: version, name (displayed under ModuleName) and repository. To access the rest of the properties of the parent module resource, you can access the `$_.ParentResource` of the PSIncludedResourceInfo object returned from the CommandName parameter set.
+
+### Example 6
+```powershell
+PS C:\> Find-PSResource -DscResourceName "SystemLocale" -Repository PSGallery
+        Name                                    Version    Prerelease   ModuleName                     Repository
+        ----                                    -------    ----------   ----------                     ----------
+        Get-TargetResource                      8.5.0.0                 ComputerManagementDsc          PSGallery
+        Get-TargetResource                      1.2.0.0                 SystemLocaleDsc                PSGallery
+
+```
+
+This examples searches for all module resources with `-DscResourceName` "SystemLocale" from the `-Repository` PSGallery. It returns all the module resources which include a DSC resource named "SystemLocale" and also lists the following information for each module resource: version, name (displayed under ModuleName) and repository. To access the rest of the properties of the parent module resource, you can access the `$_.ParentResource` of the PSIncludedResourceInfo object returned from the DSCResourceName parameter set.
 
 ## PARAMETERS
 

--- a/src/PSGet.Format.ps1xml
+++ b/src/PSGet.Format.ps1xml
@@ -25,7 +25,7 @@
                 </TableRowEntries>
             </TableControl>
         </View>
-        <View>
+        <!-- <View>
             <Name>PSIncludedResourceInfo</Name>
             <ViewSelectedBy>
                 <TypeName>Microsoft.PowerShell.PowerShellGet.UtilClasses.PSIncludedResourceInfo</TypeName>
@@ -42,7 +42,15 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
-                            <TableColumnItem><PropertyName>($this.ParentResource.Version)</PropertyName></TableColumnItem>
+                                <TableColumnItem>
+                                    <PropertyName>
+                                        <ScriptProperty>
+                                            <GetScriptBlock>
+                                                ($this.ParentResource)
+                                            </GetScriptBlock>
+                                        </ScriptProperty>
+                                    </PropertyName>
+                                </TableColumnItem>
                             <TableColumnItem><PropertyName>($this.ParentResource.PrereleaseLabel)</PropertyName></TableColumnItem>
                             <TableColumnItem><PropertyName>($this.ParentResource.Name)</PropertyName></TableColumnItem>
                             <TableColumnItem><PropertyName>($this.ParentResource.Repository)</PropertyName></TableColumnItem>
@@ -50,6 +58,6 @@
                 </TableRowEntry>
                 </TableRowEntries>
             </TableControl>
-        </View>
+        </View> -->
     </ViewDefinitions>
 </Configuration>

--- a/src/PSGet.Format.ps1xml
+++ b/src/PSGet.Format.ps1xml
@@ -42,10 +42,10 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
-                            <TableColumnItem><PropertyName>ParentResource.Version</PropertyName></TableColumnItem>
-                            <TableColumnItem><PropertyName>ParentResource.PrereleaseLabel</PropertyName></TableColumnItem>
-                            <TableColumnItem><PropertyName>ParentResource.Name</PropertyName></TableColumnItem>
-                            <TableColumnItem><PropertyName>ParentResource.Repository</PropertyName></TableColumnItem>
+                            <TableColumnItem><PropertyName>($this.ParentResource.Version)</PropertyName></TableColumnItem>
+                            <TableColumnItem><PropertyName>($this.ParentResource.PrereleaseLabel)</PropertyName></TableColumnItem>
+                            <TableColumnItem><PropertyName>($this.ParentResource.Name)</PropertyName></TableColumnItem>
+                            <TableColumnItem><PropertyName>($this.ParentResource.Repository)</PropertyName></TableColumnItem>
                         </TableColumnItems>
                 </TableRowEntry>
                 </TableRowEntries>

--- a/src/PSGet.Format.ps1xml
+++ b/src/PSGet.Format.ps1xml
@@ -25,39 +25,39 @@
                 </TableRowEntries>
             </TableControl>
         </View>
-        <!-- <View>
-            <Name>PSIncludedResourceInfo</Name>
+        <View>
+            <Name>PSIncludedResourceInfoTable</Name>
             <ViewSelectedBy>
-                <TypeName>Microsoft.PowerShell.PowerShellGet.UtilClasses.PSIncludedResourceInfo</TypeName>
-        </ViewSelectedBy>
+            <TypeName>Microsoft.PowerShell.PowerShellGet.UtilClasses.PSIncludedResourceInfo</TypeName>
+            </ViewSelectedBy>
             <TableControl>
             <TableHeaders>
-                <TableColumnHeader><Label>Name</Label></TableColumnHeader>
-                <TableColumnHeader><Label>Version</Label></TableColumnHeader>
-                <TableColumnHeader><Label>Prerelease</Label></TableColumnHeader>
-                <TableColumnHeader><Label>ModuleName</Label></TableColumnHeader>
-                <TableColumnHeader><Label>Repository</Label></TableColumnHeader>
+            <TableColumnHeader><Label>Name</Label></TableColumnHeader>
+            <TableColumnHeader>
+                <Label>Version</Label>
+            </TableColumnHeader>
+            <TableColumnHeader>
+                <Label>Prerelease</Label>
+            </TableColumnHeader>
+            <TableColumnHeader>
+                <Label>ModuleName</Label>
+            </TableColumnHeader>
+            <TableColumnHeader>
+                <Label>Repository</Label>
+            </TableColumnHeader>
             </TableHeaders>
-                <TableRowEntries>
-                    <TableRowEntry>
-                        <TableColumnItems>
-                            <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
-                                <TableColumnItem>
-                                    <PropertyName>
-                                        <ScriptProperty>
-                                            <GetScriptBlock>
-                                                ($this.ParentResource)
-                                            </GetScriptBlock>
-                                        </ScriptProperty>
-                                    </PropertyName>
-                                </TableColumnItem>
-                            <TableColumnItem><PropertyName>($this.ParentResource.PrereleaseLabel)</PropertyName></TableColumnItem>
-                            <TableColumnItem><PropertyName>($this.ParentResource.Name)</PropertyName></TableColumnItem>
-                            <TableColumnItem><PropertyName>($this.ParentResource.Repository)</PropertyName></TableColumnItem>
-                        </TableColumnItems>
-                </TableRowEntry>
-                </TableRowEntries>
+            <TableRowEntries>
+            <TableRowEntry>
+            <TableColumnItems>
+                <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
+            <TableColumnItem><ScriptBlock>$_.ParentResource.Version</ScriptBlock></TableColumnItem>
+            <TableColumnItem><ScriptBlock>$_.ParentResource.PrereleaseLabel</ScriptBlock></TableColumnItem>
+            <TableColumnItem><ScriptBlock>$_.ParentResource.Name</ScriptBlock></TableColumnItem>
+            <TableColumnItem><ScriptBlock>$_.ParentResource.Repository</ScriptBlock></TableColumnItem>
+            </TableColumnItems>
+            </TableRowEntry>
+            </TableRowEntries>
             </TableControl>
-        </View> -->
+        </View>
     </ViewDefinitions>
 </Configuration>

--- a/src/PSGet.Format.ps1xml
+++ b/src/PSGet.Format.ps1xml
@@ -25,5 +25,31 @@
                 </TableRowEntries>
             </TableControl>
         </View>
+        <View>
+            <Name>PSIncludedResourceInfo</Name>
+            <ViewSelectedBy>
+                <TypeName>Microsoft.PowerShell.PowerShellGet.UtilClasses.PSIncludedResourceInfo</TypeName>
+        </ViewSelectedBy>
+            <TableControl>
+            <TableHeaders>
+                <TableColumnHeader><Label>Name</Label></TableColumnHeader>
+                <TableColumnHeader><Label>Version</Label></TableColumnHeader>
+                <TableColumnHeader><Label>Prerelease</Label></TableColumnHeader>
+                <TableColumnHeader><Label>ModuleName</Label></TableColumnHeader>
+                <TableColumnHeader><Label>Repository</Label></TableColumnHeader>
+            </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
+                            <TableColumnItem><PropertyName>ParentResource.Version</PropertyName></TableColumnItem>
+                            <TableColumnItem><PropertyName>ParentResource.PrereleaseLabel</PropertyName></TableColumnItem>
+                            <TableColumnItem><PropertyName>ParentResource.Name</PropertyName></TableColumnItem>
+                            <TableColumnItem><PropertyName>ParentResource.Repository</PropertyName></TableColumnItem>
+                        </TableColumnItems>
+                </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
     </ViewDefinitions>
 </Configuration>

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -320,16 +320,16 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             // if a single package contains multiple commands we are interested in, return a unique entry for each:
             // Command1 , PackageA
             // Command2 , PackageA        
-            foreach (string resourceName in commandOrDSCNamesToSearch)
+            foreach (string nameToSearch in commandOrDSCNamesToSearch)
             {
                 foreach (var package in foundPackages)
                 {
                     // this check ensures DSC names provided as a Command name won't get returned mistakenly
                     // -CommandName "command1", "dsc1" <- (will not return or add DSC name)
-                    if ((isSearchingForCommands && package.Includes.Command.Contains(resourceName)) ||
-                        (!isSearchingForCommands && package.Includes.DscResource.Contains(resourceName)))
+                    if ((isSearchingForCommands && package.Includes.Command.Contains(nameToSearch)) ||
+                        (!isSearchingForCommands && package.Includes.DscResource.Contains(nameToSearch)))
                     {
-                        WriteObject(new PSIncludedResourceInfo(resourceName, package));
+                        WriteObject(new PSIncludedResourceInfo(nameToSearch, package));
                     }
                 }
             }

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -315,13 +315,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             
             List<PSIncludedResourceInfo> resourcesWithCorrectCommandOrDSC = new List<PSIncludedResourceInfo>();
 
-            // if package contained multiple commands we are interested in, we'd return:
+            // if a single package contains multiple commands we are interested in, return a unique entry for each:
             // Command1 , PackageA
             // Command2 , PackageA        
             foreach (string resourceName in commandOrDSCNamesToSearch)
             {
                 foreach (var uniquePkgsWithType in foundPackages)
                 {
+                    // this check ensures DSC names provided as a Command name won't get returned mistakenly
                     // -CommandName "command1", "dsc1" <- (will not return or add DSC name)
                     if (isSearchingForCommands && uniquePkgsWithType.Includes.Command.Contains(resourceName))
                     {

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         "PSResource",
         DefaultParameterSetName = ResourceNameParameterSet,
         SupportsShouldProcess = true)]
-    [OutputType(typeof(PSResourceInfo))]
+    [OutputType(typeof(PSResourceInfo), typeof(PSCommandResourceInfo))]
     public sealed class FindPSResource : PSCmdlet
     {
         #region Members

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -328,22 +328,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 {
                     // this check ensures DSC names provided as a Command name won't get returned mistakenly
                     // -CommandName "command1", "dsc1" <- (will not return or add DSC name)
-                    if (isSearchingForCommands && uniquePkgsWithType.Includes.Command.Contains(resourceName))
+                    if ((isSearchingForCommands && uniquePkgsWithType.Includes.Command.Contains(resourceName)) ||
+                        (!isSearchingForCommands && uniquePkgsWithType.Includes.DscResource.Contains(resourceName)))
                     {
-                        resourcesWithCorrectCommandOrDSC.Add(new PSIncludedResourceInfo(resourceName, uniquePkgsWithType));
-                        WriteVerbose("Command Added " + resourceName + " from " + uniquePkgsWithType.Name);
-                    }
-                    else if (!isSearchingForCommands && uniquePkgsWithType.Includes.DscResource.Contains(resourceName))
-                    {
-                        resourcesWithCorrectCommandOrDSC.Add(new PSIncludedResourceInfo(resourceName, uniquePkgsWithType));
-                        WriteVerbose("DSC Added " + resourceName + " from " + uniquePkgsWithType.Name);
+                        WriteObject(new PSIncludedResourceInfo(resourceName, uniquePkgsWithType));
                     }
                 }
-            }
-
-            foreach (PSIncludedResourceInfo resource in resourcesWithCorrectCommandOrDSC)
-            {
-                WriteObject(resource);
             }
         }
 

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -295,6 +295,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     this));
             }
 
+            if (moduleNamesToSearch.Length == 0)
+            {
+                moduleNamesToSearch = new string[] {"*"};
+            }
+
             FindHelper findHelper = new FindHelper(_cancellationToken, this);
             List<PSResourceInfo> foundPackages = new List<PSResourceInfo>();
 

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -329,7 +329,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     if ((isSearchingForCommands && package.Includes.Command.Contains(nameToSearch)) ||
                         (!isSearchingForCommands && package.Includes.DscResource.Contains(nameToSearch)))
                     {
-                        WriteObject(new PSIncludedResourceInfo(nameToSearch, package));
+                        WriteObject(new PSCommandResourceInfo(nameToSearch, package));
                     }
                 }
             }

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -316,8 +316,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 foundPackages.Add(package);
             }
-            
-            List<PSIncludedResourceInfo> resourcesWithCorrectCommandOrDSC = new List<PSIncludedResourceInfo>();
 
             // if a single package contains multiple commands we are interested in, return a unique entry for each:
             // Command1 , PackageA

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -322,14 +322,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             // Command2 , PackageA        
             foreach (string resourceName in commandOrDSCNamesToSearch)
             {
-                foreach (var uniquePkgsWithType in foundPackages)
+                foreach (var package in foundPackages)
                 {
                     // this check ensures DSC names provided as a Command name won't get returned mistakenly
                     // -CommandName "command1", "dsc1" <- (will not return or add DSC name)
-                    if ((isSearchingForCommands && uniquePkgsWithType.Includes.Command.Contains(resourceName)) ||
-                        (!isSearchingForCommands && uniquePkgsWithType.Includes.DscResource.Contains(resourceName)))
+                    if ((isSearchingForCommands && package.Includes.Command.Contains(resourceName)) ||
+                        (!isSearchingForCommands && package.Includes.DscResource.Contains(resourceName)))
                     {
-                        WriteObject(new PSIncludedResourceInfo(resourceName, uniquePkgsWithType));
+                        WriteObject(new PSIncludedResourceInfo(resourceName, package));
                     }
                 }
             }

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -155,11 +155,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     break;
 
                 case CommandNameParameterSet:
-                    ProcessCommandOrDscParameterSet();
+                    ProcessCommandOrDscParameterSet(isSearchingForCommands: true);
                     break;
 
                 case DscResourceNameParameterSet:
-                    ProcessCommandOrDscParameterSet();
+                    ProcessCommandOrDscParameterSet(isSearchingForCommands: false);
                     break;
 
                 default:
@@ -248,9 +248,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
         }
 
-        private void ProcessCommandOrDscParameterSet()
+        private void ProcessCommandOrDscParameterSet(bool isSearchingForCommands)
         {
-            bool isSearchingForCommands = (DscResourceName == null || DscResourceName.Length == 0);
             var commandOrDSCNamesToSearch = Utils.ProcessNameWildcards(
                 pkgNames: isSearchingForCommands ? CommandName : DscResourceName,
                 errorMsgs: out string[] errorMsgs,

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -199,10 +199,10 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
     #endregion
 
-    #region PSIncludedResourceInfo
-    public sealed class PSIncludedResourceInfo
+    #region PSCommandResourceInfo
+    public sealed class PSCommandResourceInfo
     {
-        // this object will represent a Command or DSCResource or Function
+        // this object will represent a Command or DSCResource
         // included by the PSResourceInfo property
 
         #region Properties
@@ -219,7 +219,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         /// </summary>
         /// <param name="name">Name of the command or DSC resource</param>
         /// <param name="parentResource">the parent module resource the command or dsc resource belongs to</param>
-        public PSIncludedResourceInfo(string name, PSResourceInfo parentResource)
+        public PSCommandResourceInfo(string name, PSResourceInfo parentResource)
         {
            Name = name;
            ParentResource = parentResource; 

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -212,6 +212,13 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         #endregion
 
         #region Constructor
+
+        /// <summary>
+        /// Constructor
+        ///
+        /// </summary>
+        /// <param name="name">Name of the command or DSC resource</param>
+        /// <param name="parentResource">the parent module resource the command or dsc resource belongs to</param>
         public PSIncludedResourceInfo(string name, PSResourceInfo parentResource)
         {
            Name = name;

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -199,6 +199,29 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
     #endregion
 
+    #region PSIncludedResourceInfo
+    public sealed class PSIncludedResourceInfo
+    {
+        // this object will represent a Command or DSCResource or Function
+        // included by the PSResourceInfo property
+
+        #region Properties
+        public string Name { get; }
+
+        public PSResourceInfo ParentResource { get; }
+        #endregion
+
+        #region Constructor
+        public PSIncludedResourceInfo(string name, PSResourceInfo parentResource)
+        {
+           Name = name;
+           ParentResource = parentResource; 
+        }
+        #endregion        
+    }
+
+    #endregion
+
     #region PSResourceInfo
 
     public sealed class PSResourceInfo

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -217,6 +217,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
            Name = name;
            ParentResource = parentResource; 
         }
+
         #endregion        
     }
 

--- a/test/FindPSResource.Tests.ps1
+++ b/test/FindPSResource.Tests.ps1
@@ -244,7 +244,6 @@ Describe 'Test Find-PSResource for Module' {
     }
 
     It "find resource given CommandName (CommandNameParameterSet)" {
-        $commandName = "Get-TargetResource"
         $res = Find-PSResource -CommandName $commandName -Repository $PSGalleryName
         foreach ($item in $res) {
             $item.Name | Should -Be $commandName
@@ -253,16 +252,13 @@ Describe 'Test Find-PSResource for Module' {
     }
 
     It "find resource given CommandName and ModuleName (CommandNameParameterSet)" {
-        $commandName = "Get-TargetResource"
-        $moduleName = "SystemLocaleDsc"
-        $res = Find-PSResource -CommandName $commandName -ModuleName $moduleName -Repository $PSGalleryName
+        $res = Find-PSResource -CommandName $commandName -ModuleName $parentModuleName -Repository $PSGalleryName
         $res.Name | Should -Be $commandName
-        $res.ParentResource.Name | Should -Be $moduleName
+        $res.ParentResource.Name | Should -Be $parentModuleName
         $res.ParentResource.Includes.Command | Should -Contain $commandName
     }
 
     It "find resource given DSCResourceName (DSCResourceNameParameterSet)" {
-        $dscResourceName = "SystemLocale"
         $res = Find-PSResource -DscResourceName $dscResourceName -Repository $PSGalleryName
         foreach ($item in $res) {
             $item.Name | Should -Be $dscResourceName
@@ -271,11 +267,9 @@ Describe 'Test Find-PSResource for Module' {
     }
 
     It "find resource given DscResourceName and ModuleName (DSCResourceNameParameterSet)" {
-        $dscResourceName = "SystemLocale"
-        $moduleName = "SystemLocaleDsc"
-        $res = Find-PSResource -DscResourceName $dscResourceName -ModuleName $moduleName -Repository $PSGalleryName
+        $res = Find-PSResource -DscResourceName $dscResourceName -ModuleName $parentModuleName -Repository $PSGalleryName
         $res.Name | Should -Be $dscResourceName
-        $res.ParentResource.Name | Should -Be $moduleName
+        $res.ParentResource.Name | Should -Be $parentModuleName
         $res.ParentResource.Includes.DscResource | Should -Contain $dscResourceName
     }
 }

--- a/test/FindPSResource.Tests.ps1
+++ b/test/FindPSResource.Tests.ps1
@@ -9,6 +9,9 @@ Describe 'Test Find-PSResource for Module' {
         $TestGalleryName = Get-PoshTestGalleryName
         $PSGalleryName = Get-PSGalleryName
         $NuGetGalleryName = Get-NuGetGalleryName
+        $commandName = "Get-TargetResource"
+        $dscResourceName = "SystemLocale"
+        $parentModuleName = "SystemLocaleDsc"
         Get-NewPSResourceRepositoryFile
         Register-LocalRepos
     }

--- a/test/FindPSResource.Tests.ps1
+++ b/test/FindPSResource.Tests.ps1
@@ -239,4 +239,40 @@ Describe 'Test Find-PSResource for Module' {
         $resNonDefault = Find-PSResource -Name $moduleName -Repository $repoLowerPriorityRanking
         $resNonDefault.Repository | Should -Be $repoLowerPriorityRanking
     }
+
+    It "find resource given CommandName (CommandNameParameterSet)" {
+        $commandName = "Get-TargetResource"
+        $res = Find-PSResource -CommandName $commandName -Repository $PSGalleryName
+        foreach ($item in $res) {
+            $item.Name | Should -Be $commandName
+            $item.ParentResource.Includes.Command | Should -Contain $commandName
+        }
+    }
+
+    It "find resource given CommandName and ModuleName (CommandNameParameterSet)" {
+        $commandName = "Get-TargetResource"
+        $moduleName = "SystemLocaleDsc"
+        $res = Find-PSResource -CommandName $commandName -ModuleName $moduleName -Repository $PSGalleryName
+        $res.Name | Should -Be $commandName
+        $res.ParentResource.Name | Should -Be $moduleName
+        $res.ParentResource.Includes.Command | Should -Contain $commandName
+    }
+
+    It "find resource given DSCResourceName (DSCResourceNameParameterSet)" {
+        $dscResourceName = "SystemLocale"
+        $res = Find-PSResource -DscResourceName $dscResourceName -Repository $PSGalleryName
+        foreach ($item in $res) {
+            $item.Name | Should -Be $dscResourceName
+            $item.ParentResource.Includes.DscResource | Should -Contain $dscResourceName
+        }
+    }
+
+    It "find resource given DscResourceName and ModuleName (DSCResourceNameParameterSet)" {
+        $dscResourceName = "SystemLocale"
+        $moduleName = "SystemLocaleDsc"
+        $res = Find-PSResource -DscResourceName $dscResourceName -ModuleName $moduleName -Repository $PSGalleryName
+        $res.Name | Should -Be $dscResourceName
+        $res.ParentResource.Name | Should -Be $moduleName
+        $res.ParentResource.Includes.DscResource | Should -Contain $dscResourceName
+    }
 }


### PR DESCRIPTION
# PR Summary

Implemented missing CommandName and DSCResourceName parameter sets for Find-PSResource.

To do so, I added a class `PSIncludedResourceInfo` in the PSResourceInfo.cs file. The `PSIncludedResourceInfo` object will have a `Name` property (for the name of the Command or DSCResource) and a `ParentResource` property which is the reference to the `PSResourceInfo` parent resource it belongs to. 

I also updated the PSResourceInfo.TryConvert() method to populate the Includes property with the appropriate commands and dscresource, parsed from the tags.

I also added tests for the CommandName and DSCResourceName parameter sets.

Some assumptions of these parameter sets are:
- [x] if no `-ModuleName` is specified, search for the Command name (or DSCResource name) from all modules
- [x] can only search for `-CommandName` OR `DSCResourceName` at a time. Can't do both at the same time.
- [x] if a user wishes to search for multiple Command names (or DSCResource names) and it belongs to different packages, we return entries for each package. So entries returned are unique by CommandName,ModuleName not just CommandName.

## PR Context

This PR is to implement missing functionality for preview 12. Resolves issue #466 

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
