### PR TITLE
Added Functional Test results XML file to .gitignore & small code logic/assignment simplication changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ src/code/obj
 srcOld/code/bin
 srcOld/code/obj
 out
+test/result.pester.xml

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -267,7 +267,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 if (String.IsNullOrWhiteSpace(pkgName))
                 {
                     _cmdletPassedIn.WriteVerbose(String.Format("Package name: {0} provided was null or whitespace, so name was skipped in search.",
-                        pkgName == null ? "null string" : pkgName));
+                        pkgName ?? "null string"));
                     continue;
                 }
 

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -157,7 +157,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     IEnumerable<PSResourceInfo> pkgsFromRepoToInstall = findHelper.FindByResourceName(
                         name: packageNames,
                         type: ResourceType.None,
-                        version: _versionRange != null ? _versionRange.OriginalString : null,
+                        version: _versionRange?.OriginalString,
                         prerelease: _prerelease,
                         tag: null,
                         repository: new string[] { repoName },
@@ -264,7 +264,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                                                                            // TODO: check the attributes and if it's read only then set it 
                                                                            // attribute may be inherited from the parent
                                                                            // TODO:  are there Linux accommodations we need to consider here?
-                    dir.Attributes = dir.Attributes & ~FileAttributes.ReadOnly;
+                    dir.Attributes &= ~FileAttributes.ReadOnly;
 
                     _cmdletPassedIn.WriteVerbose(string.Format("Begin installing package: '{0}'", p.Name));
 
@@ -380,7 +380,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     var version4digitNoPrerelease = pkgIdentity.Version.Version.ToString();
                     string moduleManifestVersion = string.Empty;
                     var scriptPath = Path.Combine(tempDirNameVersion, (p.Name + ".ps1"));
-                    var isScript = File.Exists(scriptPath) ? true : false;
+                    var isScript = File.Exists(scriptPath);
 
                     if (!isScript)
                     {

--- a/src/code/NuGetLogger.cs
+++ b/src/code/NuGetLogger.cs
@@ -89,8 +89,7 @@ public class NuGetLogger : ILogger
 
     public void Clear()
     {
-        string msg;
-        while (Messages.TryDequeue(out msg))
+        while (Messages.TryDequeue(out string msg))
         {
             // do nothing
         }

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -155,7 +155,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         private NuGetVersion _pkgVersion;
         private string _pkgName;
-        private static char[] _PathSeparators = new [] { System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar };
+        private static readonly char[] _PathSeparators = new [] { System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar };
 
         #endregion
 
@@ -196,7 +196,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 // ParseScriptMetadata will write non-terminating error if it's unsucessful in parsing
                 parsedMetadataHash = ParseScriptMetadata(moduleFileInfo);
 
-                var message = string.Empty;
+                string message;
                 // Check that the value is valid input
                 // If it does not contain 'Version' or the Version empty or whitespace, write error
                 if (!parsedMetadataHash.ContainsKey("Version") || String.IsNullOrWhiteSpace(parsedMetadataHash["Version"].ToString()))
@@ -442,9 +442,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             if (moduleFileInfo.Extension.Equals(".psd1", StringComparison.OrdinalIgnoreCase))
             {
                 // Parse the module manifest 
-                System.Management.Automation.Language.Token[] tokens;
-                ParseError[] errors;
-                var ast = Parser.ParseFile(moduleFileInfo.FullName, out tokens, out errors);
+                var ast = Parser.ParseFile(moduleFileInfo.FullName, out System.Management.Automation.Language.Token[] tokens, out ParseError[] errors);
 
                 if (errors.Length > 0)
                 {
@@ -488,10 +486,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             XmlElement packageElement = doc.CreateElement("package", nameSpaceUri);
             XmlElement metadataElement = doc.CreateElement("metadata", nameSpaceUri);
 
-            Dictionary<string, string> metadataElementsDictionary = new Dictionary<string, string>();
-       
-            // id is mandatory
-            metadataElementsDictionary.Add("id", _pkgName);
+            Dictionary<string, string> metadataElementsDictionary = new Dictionary<string, string>
+            {
+
+                // id is mandatory
+                { "id", _pkgName }
+            };
 
             string version = String.Empty;
             if (parsedMetadataHash.ContainsKey("moduleversion"))
@@ -732,11 +732,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             // We're retrieving all the comments within a script and grabbing all the key/value pairs
             // because there's no standard way to create metadata for a script.
             Hashtable parsedMetadataHash = new Hashtable(StringComparer.InvariantCultureIgnoreCase);
-            
+
             // parse comments out           
-            System.Management.Automation.Language.Token[] tokens;
-            ParseError[] errors;
-            Parser.ParseFile(moduleFileInfo.FullName, out tokens, out errors);
+            Parser.ParseFile(moduleFileInfo.FullName, out System.Management.Automation.Language.Token[] tokens, out ParseError[] errors);
 
             if (errors.Length > 0)
             {

--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -258,7 +258,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         WriteVerbose("(RepositoriesParameterSet): on repo: PSGallery. Registers PSGallery repository");
                         reposAddedFromHashTable.Add(PSGalleryParameterSetHelper(
                             repo.ContainsKey("Priority") ? (int)repo["Priority"] : defaultPriority,
-                            repo.ContainsKey("Trusted") ? (bool)repo["Trusted"] : defaultTrusted));
+                            repo.ContainsKey("Trusted") && (bool)repo["Trusted"]));
                     }
                     catch (Exception e)
                     {
@@ -329,7 +329,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 return NameParameterSetHelper(repo["Name"].ToString(),
                     repoURL,
                     repo.ContainsKey("Priority") ? Convert.ToInt32(repo["Priority"].ToString()) : defaultPriority,
-                    repo.ContainsKey("Trusted") ? Convert.ToBoolean(repo["Trusted"].ToString()) : defaultTrusted);
+                    repo.ContainsKey("Trusted") && Convert.ToBoolean(repo["Trusted"].ToString()));
             }
             catch (Exception e)
             {

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -153,6 +153,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             GetHelper getHelper = new GetHelper(this);
             List<string>  dirsToDelete = getHelper.FilterPkgPathsByName(Name, _pathsToSearch);
 
+
             // Checking if module or script
             // a module path will look like:
             // ./Modules/TestModule/0.0.1
@@ -161,12 +162,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             // ./Scripts/TestScript.ps1
             // note that the xml file is located in ./Scripts/InstalledScriptInfos, eg: ./Scripts/InstalledScriptInfos/TestScript_InstalledScriptInfo.xml
 
-            string pkgName = string.Empty;
-
             foreach (string pkgPath in getHelper.FilterPkgPathsByVersion(_versionRange, dirsToDelete))
             {
-                pkgName = Utils.GetInstalledPackageName(pkgPath);
+                
 
+                string pkgName = Utils.GetInstalledPackageName(pkgPath);
                 if (!ShouldProcess(string.Format("Uninstall resource '{0}' from the machine.", pkgName)))
                 {
                     WriteVerbose("ShouldProcess is set to false.");

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -400,9 +400,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             if (moduleFileInfo.EndsWith(".psd1", StringComparison.OrdinalIgnoreCase))
             {
                 // Parse the module manifest 
-                System.Management.Automation.Language.Token[] tokens;
-                ParseError[] errors;
-                var ast = Parser.ParseFile(moduleFileInfo, out tokens, out errors);
+                var ast = Parser.ParseFile(moduleFileInfo, out Token[] tokens, out ParseError[] errors);
 
                 if (errors.Length > 0)
                 {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. --> 
Adds the test result xml file generated after running functional tests to the .gitignore file to ensure it is not accidentally added to source control. Simplifies some logic, variable assignment, etc. No logical differences should exist and everything should be equivalent to the previous code (including two failing functional tests).

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Code simplification..

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [X] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
