### PR TITLE
Fix bug with some modules installing as scripts

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -376,9 +376,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     var version4digitNoPrerelease = pkgIdentity.Version.Version.ToString();
                     string moduleManifestVersion = string.Empty;
                     var scriptPath = Path.Combine(tempDirNameVersion, (p.Name + ".ps1"));
-                    var isScript = File.Exists(scriptPath) ? true : false;
+                    var modulePath = Path.Combine(tempDirNameVersion, (p.Name + ".psd1"));
+                    // Check if the package is a module or a script
+                    var isModule = File.Exists(modulePath) ? true : false;
 
-                    if (!isScript)
+                    if (isModule)
                     {
                         var moduleManifest = Path.Combine(tempDirNameVersion, pkgIdentity.Id + ".psd1");
                         if (!File.Exists(moduleManifest))
@@ -420,16 +422,16 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         /// ./Modules
                         /// ./Scripts
                         /// _pathsToInstallPkg is sorted by desirability, Find will pick the pick the first Script or Modules path found in the list
-                        installPath = isScript ? _pathsToInstallPkg.Find(path => path.EndsWith("Scripts", StringComparison.InvariantCultureIgnoreCase))
-                                : _pathsToInstallPkg.Find(path => path.EndsWith("Modules", StringComparison.InvariantCultureIgnoreCase));
+                        installPath = isModule ? _pathsToInstallPkg.Find(path => path.EndsWith("Modules", StringComparison.InvariantCultureIgnoreCase))
+                                : _pathsToInstallPkg.Find(path => path.EndsWith("Scripts", StringComparison.InvariantCultureIgnoreCase));
                     }
 
                     if (_includeXML)
                     {
-                        CreateMetadataXMLFile(tempDirNameVersion, installPath, repoName, p, isScript);
+                        CreateMetadataXMLFile(tempDirNameVersion, installPath, repoName, p, isModule);
                     }
                     
-                    MoveFilesIntoInstallPath(p, isScript, isLocalRepo, tempDirNameVersion, tempInstallPath, installPath, newVersion, moduleManifestVersion, normalizedVersionNoPrereleaseLabel, version4digitNoPrerelease, scriptPath);
+                    MoveFilesIntoInstallPath(p, isModule, isLocalRepo, tempDirNameVersion, tempInstallPath, installPath, newVersion, moduleManifestVersion, normalizedVersionNoPrereleaseLabel, version4digitNoPrerelease, scriptPath);
                     
                     _cmdletPassedIn.WriteVerbose(String.Format("Successfully installed package '{0}' to location '{1}'", p.Name, installPath));
                     pkgsSuccessfullyInstalled.Add(p.Name);
@@ -535,12 +537,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             return success;
         }
 
-        private void CreateMetadataXMLFile(string dirNameVersion, string installPath, string repoName, PSResourceInfo pkg, bool isScript)
+        private void CreateMetadataXMLFile(string dirNameVersion, string installPath, string repoName, PSResourceInfo pkg, bool isModule)
         {
             // Script will have a metadata file similar to:  "TestScript_InstalledScriptInfo.xml"
             // Modules will have the metadata file: "PSGetModuleInfo.xml"
-            var metadataXMLPath = isScript ? Path.Combine(dirNameVersion, (pkg.Name + "_InstalledScriptInfo.xml"))
-                : Path.Combine(dirNameVersion, "PSGetModuleInfo.xml");
+            var metadataXMLPath = isModule ? Path.Combine(dirNameVersion, "PSGetModuleInfo.xml")
+                : Path.Combine(dirNameVersion, (pkg.Name + "_InstalledScriptInfo.xml"));
 
             pkg.InstalledDate = DateTime.Now;
             pkg.InstalledLocation = installPath;
@@ -627,7 +629,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         private void MoveFilesIntoInstallPath(
             PSResourceInfo p, 
-            bool isScript, 
+            bool isModule, 
             bool isLocalRepo, 
             string dirNameVersion, 
             string tempInstallPath, 
@@ -639,18 +641,42 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             string scriptPath)
         {
             // Creating the proper installation path depending on whether pkg is a module or script
-            var newPathParent = isScript ? installPath : Path.Combine(installPath, p.Name);
-            var finalModuleVersionDir = isScript ? installPath : Path.Combine(installPath, p.Name, moduleManifestVersion);  // versionWithoutPrereleaseTag
+            var newPathParent = isModule ? Path.Combine(installPath, p.Name) : installPath;
+            var finalModuleVersionDir = isModule ? Path.Combine(installPath, p.Name, moduleManifestVersion) : installPath;  // versionWithoutPrereleaseTag
 
             // If script, just move the files over, if module, move the version directory over
-            var tempModuleVersionDir = (isScript || isLocalRepo) ? dirNameVersion
+            var tempModuleVersionDir = (!isModule || isLocalRepo) ? dirNameVersion
                 : Path.Combine(tempInstallPath, p.Name.ToLower(), newVersion);
 
             _cmdletPassedIn.WriteVerbose(string.Format("Installation source path is: '{0}'", tempModuleVersionDir));
-            _cmdletPassedIn.WriteVerbose(string.Format("Installation destination path is: '{0}'", finalModuleVersionDir));    
+            _cmdletPassedIn.WriteVerbose(string.Format("Installation destination path is: '{0}'", finalModuleVersionDir));
 
-            if (isScript)
+            if (isModule)
             {
+                // If new path does not exist
+                if (!Directory.Exists(newPathParent))
+                {
+                    _cmdletPassedIn.WriteVerbose(string.Format("Attempting to move '{0}' to '{1}'", tempModuleVersionDir, finalModuleVersionDir));
+                    Directory.CreateDirectory(newPathParent);
+                    Utils.MoveDirectory(tempModuleVersionDir, finalModuleVersionDir);
+                }
+                else
+                {
+                    _cmdletPassedIn.WriteVerbose(string.Format("Temporary module version directory is: '{0}'", tempModuleVersionDir));
+
+                    // At this point if 
+                    if (Directory.Exists(finalModuleVersionDir))
+                    {
+                        // Delete the directory path before replacing it with the new module
+                        _cmdletPassedIn.WriteVerbose(string.Format("Attempting to delete '{0}'", finalModuleVersionDir));
+                        Directory.Delete(finalModuleVersionDir, true);
+                    }
+
+                    _cmdletPassedIn.WriteVerbose(string.Format("Attempting to move '{0}' to '{1}'", tempModuleVersionDir, finalModuleVersionDir));
+                    Utils.MoveDirectory(tempModuleVersionDir, finalModuleVersionDir);
+                }
+            }
+            else {
                 if (!_savePkg)
                 {
                     // Need to delete old xml files because there can only be 1 per script
@@ -676,31 +702,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                 _cmdletPassedIn.WriteVerbose(string.Format("Moving '{0}' to '{1}'", scriptPath, Path.Combine(finalModuleVersionDir, p.Name + ".ps1")));
                 Utils.MoveFiles(scriptPath, Path.Combine(finalModuleVersionDir, p.Name + ".ps1"));
-            }
-            else
-            {
-                // If new path does not exist
-                if (!Directory.Exists(newPathParent))
-                {
-                    _cmdletPassedIn.WriteVerbose(string.Format("Attempting to move '{0}' to '{1}'", tempModuleVersionDir, finalModuleVersionDir));
-                    Directory.CreateDirectory(newPathParent);
-                    Utils.MoveDirectory(tempModuleVersionDir, finalModuleVersionDir);
-                }
-                else
-                {
-                    _cmdletPassedIn.WriteVerbose(string.Format("Temporary module version directory is: '{0}'", tempModuleVersionDir));
-
-                    // At this point if 
-                    if (Directory.Exists(finalModuleVersionDir))
-                    {
-                        // Delete the directory path before replacing it with the new module
-                        _cmdletPassedIn.WriteVerbose(string.Format("Attempting to delete '{0}'", finalModuleVersionDir));
-                        Directory.Delete(finalModuleVersionDir, true);
-                    }
-
-                    _cmdletPassedIn.WriteVerbose(string.Format("Attempting to move '{0}' to '{1}'", tempModuleVersionDir, finalModuleVersionDir));
-                    Utils.MoveDirectory(tempModuleVersionDir, finalModuleVersionDir);
-                }
             }
         }
     }

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -378,7 +378,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     var scriptPath = Path.Combine(tempDirNameVersion, (p.Name + ".ps1"));
                     var modulePath = Path.Combine(tempDirNameVersion, (p.Name + ".psd1"));
                     // Check if the package is a module or a script
-                    var isModule = File.Exists(modulePath) ? true : false;
+                    var isModule = File.Exists(modulePath);
+
 
                     if (isModule)
                     {

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -245,7 +245,7 @@ Describe 'Test Install-PSResource for Module' {
     }
 
     It "Validate that Pester is installing under Modules path" {
-        Install-PSResource -Name "Pester" -Repository PSGallery
+        Install-PSResource -Name "Pester" -Repository $PSGalleryName
     
         $res = Get-Module "Pester" -ListAvailable
         $res.Path.Contains("Modules") | Should -Be $true

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -243,6 +243,13 @@ Describe 'Test Install-PSResource for Module' {
         $res = Get-Module "TestModule" -ListAvailable
         $res | Should -BeNullOrEmpty
     }
+
+    It "Validate that Pester is installing under Modules path" {
+        Install-PSResource -Name "Pester" -Repository PSGallery
+    
+        $res = Get-Module "Pester" -ListAvailable
+        $res.Path.Contains("Modules") | Should -Be $true
+    }
 }
 
 <# Temporarily commented until -Tag is implemented for this Describe block

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -244,7 +244,8 @@ Describe 'Test Install-PSResource for Module' {
         $res | Should -BeNullOrEmpty
     }
 
-    It "Validate that Pester is installing under Modules path" {
+    It "Validates that a module with module-name script files (like Pester) installs under Modules path" {
+
         Install-PSResource -Name "testModuleWithScript" -Repository $TestGalleryName
     
         $res = Get-Module "testModuleWithScript" -ListAvailable

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -245,9 +245,11 @@ Describe 'Test Install-PSResource for Module' {
     }
 
     It "Validate that Pester is installing under Modules path" {
+        write-Output $PSGalleryName
         Install-PSResource -Name "Pester" -Repository $PSGalleryName
     
         $res = Get-Module "Pester" -ListAvailable
+        Write-Output ($res)
         $res.Path.Contains("Modules") | Should -Be $true
     }
 }

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -245,11 +245,9 @@ Describe 'Test Install-PSResource for Module' {
     }
 
     It "Validate that Pester is installing under Modules path" {
-        write-Output $PSGalleryName
-        Install-PSResource -Name "Pester" -Repository $PSGalleryName
+        Install-PSResource -Name "testModuleWithScript" -Repository $TestGalleryName
     
-        $res = Get-Module "Pester" -ListAvailable
-        Write-Output ($res)
+        $res = Get-Module "testModuleWithScript" -ListAvailable
         $res.Path.Contains("Modules") | Should -Be $true
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Any module that contained both a .ps1 file and a .psd1 file was being read as a script instead of a module.  This was causing issues with Pester in particular installing in the incorrect location (under the /scripts path instead of /modules).  

I've changed the condition to determine whether a package is a module or a script to check for a .psd1 instead of checking for a .ps1.  This logic makes more sense because a module can contain a .ps1 but a script cannot contain a .psd1.
 
## PR Context

Resolves issue #383 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
