### PR TITLE
Implement -DestinationPath parameter for Publish-PSResource

### DIFF
--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -420,7 +420,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         File.Move(System.IO.Path.Combine(outputNupkgDir, nupkgName), System.IO.Path.Combine(_destinationPath, nupkgName));
                     }
                     catch (Exception e) {
-                        var message = string.Format("Error moving .nupkg into destination path: '{0}'.", e.Message);
+                        var message = string.Format("Error moving .nupkg into destination path '{0}' due to: '{1}'.", _destinationPath, e.Message);
+
                         var ex = new ArgumentException(message);
                         var ErrorMovingNupkg = new ErrorRecord(ex, "ErrorMovingNupkg", ErrorCategory.NotSpecified, null);
                         WriteError(ErrorMovingNupkg);

--- a/test/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResource.Tests.ps1
@@ -271,4 +271,20 @@ Describe "Test Publish-PSResource" {
 
         $Error[0].FullyQualifiedErrorId | Should -be "403Error,Microsoft.PowerShell.PowerShellGet.Cmdlets.PublishPSResource"
     }
+
+    It "Publish a module with -Path -Repository and -DestinationPath" {
+        $version = "1.0.0"
+        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
+
+        $tmpPath = Join-Path -Path $TestDrive -ChildPath "testtmppath"
+        New-Item $tmpPath -Itemtype directory -Force
+
+        Publish-PSResource -Path $script:PublishModuleBase -Repository $testRepository2 -DestinationPath $tmpPath
+
+        $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$script:PublishModuleName.$version.nupkg"
+        (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath 
+
+        $expectedPath = Join-Path -Path $tmpPath -ChildPath "$script:PublishModuleName.$version.nupkg"
+        (Get-ChildItem $tmpPath).FullName | Should -Be $expectedPath 
+    }
 }

--- a/test/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResource.Tests.ps1
@@ -281,7 +281,8 @@ Describe "Test Publish-PSResource" {
 
         Publish-PSResource -Path $script:PublishModuleBase -Repository $testRepository2 -DestinationPath $tmpPath
 
-        $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$script:PublishModuleName.$version.nupkg"
+        $expectedPath = Join-Path -Path $script:repositoryPath2 -ChildPath "$script:PublishModuleName.$version.nupkg"
+
         (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath 
 
         $expectedPath = Join-Path -Path $tmpPath -ChildPath "$script:PublishModuleName.$version.nupkg"

--- a/test/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResource.Tests.ps1
@@ -74,16 +74,6 @@ Describe "Test Publish-PSResource" {
         (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath 
     }
 
-    It "Publish a module with -LiteralPath" {
-        $version = "1.0.0"
-        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
-
-        Publish-PSResource -LiteralPath $script:PublishModuleBase
-
-        $expectedPath = Join-Path -Path $script:repositoryPath -ChildPath "$script:PublishModuleName.$version.nupkg"
-        (Get-ChildItem $script:repositoryPath).FullName | Should -Be $expectedPath 
-    }
-
 <# Temporarily comment this test out until Find Helper is complete and code within PublishPSResource is uncommented 
     It "Publish a module with dependencies" {
         # Create dependency module


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Implements the -DestinationPath parameter for Publish-PSResource.  This allows the user to save the generated .nupkg that gets pushed to a repository to to a specified path on the local file system as well.

## PR Context
Resolves #430 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
