### PR TITLE
WIP: Fix pipeline support for Version property for *-PSResource cmdlets

### DIFF
--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -148,16 +148,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void ProcessRecord()
         {
-            WriteDebug("Find- Repository is: " + String.Join(", ", Repository));
-            if (Version == null)
-            {
-                WriteDebug("Find- Version is null");
-            }
-            else
-            {
-                WriteDebug("Find- Version is: " + Version);
-            }
-
             switch (ParameterSetName)
             {
                 case ResourceNameParameterSet:

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -148,6 +148,16 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void ProcessRecord()
         {
+            WriteDebug("Find- Repository is: " + String.Join(", ", Repository));
+            if (Version == null)
+            {
+                WriteDebug("Find- Version is null");
+            }
+            else
+            {
+                WriteDebug("Find- Version is: " + Version);
+            }
+
             switch (ParameterSetName)
             {
                 case ResourceNameParameterSet:

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -53,20 +53,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void BeginProcessing()
         {
-            // Validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
-            // an exact version will be formatted into a version range.
-            if (Version == null)
-            {
-                _versionRange = VersionRange.All;
-            }
-            else if (!Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
-            {
-                var exMessage = "Argument for -Version parameter is not in the proper format.";
-                var ex = new ArgumentException(exMessage);
-                var IncorrectVersionFormat = new ErrorRecord(ex, "IncorrectVersionFormat", ErrorCategory.InvalidArgument, null);
-                ThrowTerminatingError(IncorrectVersionFormat);
-            }
-
             // Determine paths to search.
             _pathsToSearch = new List<string>();
             if (Path != null)
@@ -111,6 +97,20 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         protected override void ProcessRecord()
         {
             WriteVerbose("Entering GetInstalledPSResource");
+
+            // Validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
+            // an exact version will be formatted into a version range.
+            if (Version == null)
+            {
+                _versionRange = VersionRange.All;
+            }
+            else if (!Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
+            {
+                var exMessage = "Argument for -Version parameter is not in the proper format.";
+                var ex = new ArgumentException(exMessage);
+                var IncorrectVersionFormat = new ErrorRecord(ex, "IncorrectVersionFormat", ErrorCategory.InvalidArgument, null);
+                ThrowTerminatingError(IncorrectVersionFormat);
+            }
 
             var namesToSearch = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool _);
             foreach (string error in errorMsgs)

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// <summary>
         /// Specifies the version of the resource to include to look for. 
         /// </summary>
-        [Parameter()]
+        [Parameter(ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty()]
         public string Version { get; set; }
 

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -98,8 +98,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             WriteVerbose("Entering GetInstalledPSResource");
 
-            // Validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
-            // an exact version will be formatted into a version range.
+            // If no Version specified, get latest version for the package.
+            // Otherwise, validate that the -Version param passed in can be parsed into a NuGet version range. 
+            // An exact version will be formatted into a version range.
             if (Version == null)
             {
                 _versionRange = VersionRange.All;

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -112,14 +112,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void ProcessRecord()
         {
-            // if no Version specified, install latest version for the package
+            // If no Version specified, install latest version for the package.
+            // Otherwise, validate that the -Version param passed in can be parsed into a NuGet version range. 
+            // An exact version will be formatted into a version range.
             if (Version == null)
             {
                 _versionRange = VersionRange.All;
             }
-            
-            // otherwise if a -Version param is passed in validate that it can be parsed into a NuGet version range. 
-            // An exact version will be formatted into a version range.
             else if (ParameterSetName.Equals(NameParameterSet) && !Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
             {
                 var exMessage = "Argument for -Version parameter is not in the proper format.";

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// <summary>
         /// Specifies the repositories from which to search for the resource to be installed.
         /// </summary>
-        [Parameter(ParameterSetName = NameParameterSet)]
+        [Parameter(ValueFromPipelineByPropertyName = true, ParameterSetName = NameParameterSet)]
         [ArgumentCompleter(typeof(RepositoryNameCompleter))]
         [ValidateNotNullOrEmpty]
         public string[] Repository { get; set; }
@@ -110,7 +110,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             // validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
             // An exact version will be formatted into a version range.
             if (ParameterSetName.Equals(NameParameterSet) && Version != null && !Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
-
             {
                 var exMessage = "Argument for -Version parameter is not in the proper format.";
                 var ex = new ArgumentException(exMessage);
@@ -118,17 +117,42 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 ThrowTerminatingError(IncorrectVersionFormat);
             }
 
-            // if no Version specified, install latest version for the package
-            if (Version == null)
-            {
-                _versionRange = VersionRange.All;
-            }
+            // // if no Version specified, install latest version for the package
+            // if (Version == null)
+            // {
+            //     WriteDebug("Install- version is null!");
+            //     _versionRange = VersionRange.All;
+            // }
 
+            // if (Repository != null)
+            // {
+            //     WriteDebug("Install- Repository is: " + String.Join(", ", Repository));
+            // }
+            // else
+            // {
+            //     WriteDebug("Install- Repository is: null" );
+            // }
             _pathsToInstallPkg = Utils.GetAllInstallationPaths(this, Scope);
         }
 
         protected override void ProcessRecord()
         {
+            // if no Version specified, install latest version for the package
+            if (Version == null)
+            {
+                _versionRange = VersionRange.All;
+            }
+            else
+            {
+                Utils.TryParseVersionOrVersionRange(Version, out _versionRange);
+            }
+
+            // WriteDebug("Install 2- Version is: " + Version);
+            // if (Repository != null)
+            // {
+            //     WriteDebug("Install 2- Repository is: " + String.Join(", ", Repository));
+            // }
+
             if (!ShouldProcess(string.Format("package to install: '{0}'", String.Join(", ", Name))))
             {
                 WriteVerbose(string.Format("Install operation cancelled by user for packages: {0}", String.Join(", ", Name)));

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// <summary>
         /// Specifies the repositories from which to search for the resource to be installed.
         /// </summary>
-        [Parameter(ValueFromPipelineByPropertyName = true, ParameterSetName = NameParameterSet)]
+        [Parameter(ParameterSetName = NameParameterSet)]
         [ArgumentCompleter(typeof(RepositoryNameCompleter))]
         [ValidateNotNullOrEmpty]
         public string[] Repository { get; set; }

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -107,31 +107,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             // This is to create a better experience for those who have just installed v3 and want to get up and running quickly
             RepositorySettings.CheckRepositoryStore();
 
-            // validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
-            // An exact version will be formatted into a version range.
-            if (ParameterSetName.Equals(NameParameterSet) && Version != null && !Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
-            {
-                var exMessage = "Argument for -Version parameter is not in the proper format.";
-                var ex = new ArgumentException(exMessage);
-                var IncorrectVersionFormat = new ErrorRecord(ex, "IncorrectVersionFormat", ErrorCategory.InvalidArgument, null);
-                ThrowTerminatingError(IncorrectVersionFormat);
-            }
-
-            // // if no Version specified, install latest version for the package
-            // if (Version == null)
-            // {
-            //     WriteDebug("Install- version is null!");
-            //     _versionRange = VersionRange.All;
-            // }
-
-            // if (Repository != null)
-            // {
-            //     WriteDebug("Install- Repository is: " + String.Join(", ", Repository));
-            // }
-            // else
-            // {
-            //     WriteDebug("Install- Repository is: null" );
-            // }
             _pathsToInstallPkg = Utils.GetAllInstallationPaths(this, Scope);
         }
 
@@ -142,16 +117,16 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 _versionRange = VersionRange.All;
             }
-            else
+            
+            // otherwise if a -Version param is passed in validate that it can be parsed into a NuGet version range. 
+            // An exact version will be formatted into a version range.
+            else if (ParameterSetName.Equals(NameParameterSet) && !Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
             {
-                Utils.TryParseVersionOrVersionRange(Version, out _versionRange);
+                var exMessage = "Argument for -Version parameter is not in the proper format.";
+                var ex = new ArgumentException(exMessage);
+                var IncorrectVersionFormat = new ErrorRecord(ex, "IncorrectVersionFormat", ErrorCategory.InvalidArgument, null);
+                ThrowTerminatingError(IncorrectVersionFormat);
             }
-
-            // WriteDebug("Install 2- Version is: " + Version);
-            // if (Repository != null)
-            // {
-            //     WriteDebug("Install 2- Repository is: " + String.Join(", ", Repository));
-            // }
 
             if (!ShouldProcess(string.Format("package to install: '{0}'", String.Join(", ", Name))))
             {

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -144,15 +144,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 return;
             }
 
-            // TODO: what should versionRange be by default;
-            // if no Version specified, install latest version for the package
+            // If no Version specified, save latest version for the package.
+            // Otherwise, validate that the -Version param passed in can be parsed into a NuGet version range. 
+            // An exact version will be formatted into a version range.
             if (Version == null)
             {
                 _versionRange = VersionRange.All;
             }
-        
-            // validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
-            // an exact version will be formatted into a version range.
             else if (ParameterSetName.Equals("NameParameterSet") && !Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
             {
                 var exMessage = "Argument for -Version parameter is not in the proper format.";

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -129,18 +129,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             // This is to create a better experience for those who have just installed v3 and want to get up and running quickly
             RepositorySettings.CheckRepositoryStore();
 
-            // validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
-            // an exact version will be formatted into a version range.
-            if (ParameterSetName.Equals("NameParameterSet") && 
-                Version != null && 
-                !Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
-            {
-                var exMessage = "Argument for -Version parameter is not in the proper format.";
-                var ex = new ArgumentException(exMessage);
-                var IncorrectVersionFormat = new ErrorRecord(ex, "IncorrectVersionFormat", ErrorCategory.InvalidArgument, null);
-                ThrowTerminatingError(IncorrectVersionFormat);
-            }
-
             // If the user does not specify a path to save to, use the user's current working directory
             if (string.IsNullOrWhiteSpace(_path))
             {
@@ -155,6 +143,20 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 WriteVerbose(string.Format("Save operation cancelled by user for resources: {0}", String.Join(", ", Name)));
                 return;
             }
+
+            // validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
+            // an exact version will be formatted into a version range.
+            if (ParameterSetName.Equals("NameParameterSet") && 
+                Version != null && 
+                !Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
+            {
+                var exMessage = "Argument for -Version parameter is not in the proper format.";
+                var ex = new ArgumentException(exMessage);
+                var IncorrectVersionFormat = new ErrorRecord(ex, "IncorrectVersionFormat", ErrorCategory.InvalidArgument, null);
+                ThrowTerminatingError(IncorrectVersionFormat);
+            }
+
+            // TODO: what should versionRange be by default;
 
             var installHelper = new InstallHelper(updatePkg: false, savePkg: true, cmdletPassedIn: this);
 

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -144,19 +144,22 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 return;
             }
 
+            // TODO: what should versionRange be by default;
+            // if no Version specified, install latest version for the package
+            if (Version == null)
+            {
+                _versionRange = VersionRange.All;
+            }
+        
             // validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
             // an exact version will be formatted into a version range.
-            if (ParameterSetName.Equals("NameParameterSet") && 
-                Version != null && 
-                !Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
+            else if (ParameterSetName.Equals("NameParameterSet") && !Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
             {
                 var exMessage = "Argument for -Version parameter is not in the proper format.";
                 var ex = new ArgumentException(exMessage);
                 var IncorrectVersionFormat = new ErrorRecord(ex, "IncorrectVersionFormat", ErrorCategory.InvalidArgument, null);
                 ThrowTerminatingError(IncorrectVersionFormat);
             }
-
-            // TODO: what should versionRange be by default;
 
             var installHelper = new InstallHelper(updatePkg: false, savePkg: true, cmdletPassedIn: this);
 

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -60,9 +60,19 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         #region Methods
         protected override void BeginProcessing()
         {
+            _pathsToSearch = Utils.GetAllResourcePaths(this);
+        }
+
+        protected override void ProcessRecord()
+        {
+            // if no Version specified, uninstall all versions for the package
+            if (Version == null)
+            {
+                _versionRange = VersionRange.All;
+            }
             // validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
             // an exact version will be formatted into a version range.
-            if (ParameterSetName.Equals("NameParameterSet") && Version != null && !Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
+            else if (ParameterSetName.Equals("NameParameterSet") && !Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
             {
                 var exMessage = "Argument for -Version parameter is not in the proper format.";
                 var ex = new ArgumentException(exMessage);
@@ -70,17 +80,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 ThrowTerminatingError(IncorrectVersionFormat);
             }
 
-            // if no Version specified, uninstall all versions for the package
-            if (Version == null)
-            {
-                _versionRange = VersionRange.All;
-            }
-
-            _pathsToSearch = Utils.GetAllResourcePaths(this);
-        }
-
-        protected override void ProcessRecord()
-        {
             switch (ParameterSetName)
             {
                 case NameParameterSet:

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -56,13 +56,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void ProcessRecord()
         {
-            // if no Version specified, uninstall all versions for the package
+            // If no Version specified, uninstall all versions for the package.
+            // Otherwise, validate that the -Version param passed in can be parsed into a NuGet version range. 
+            // An exact version will be formatted into a version range.
             if (Version == null)
             {
                 _versionRange = VersionRange.All;
             }
-            // validate that if a -Version param is passed in that it can be parsed into a NuGet version range. 
-            // an exact version will be formatted into a version range.
             else if (!Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
             {
                 var exMessage = "Argument for -Version parameter is not in the proper format.";

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -115,7 +115,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             VersionRange versionRange;
 
-            // handle case where Version == null
+            // If no Version specified, update to latest version for the package.
+            // Otherwise, validate that the -Version param passed in can be parsed into a NuGet version range. 
+            // An exact version will be formatted into a version range.
             if (Version == null) { 
                 versionRange = VersionRange.All;
             }

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// <summary>
         /// Specifies the version the resource is to be updated to.
         /// </summary>
-        [Parameter]
+        [Parameter(ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
         public string Version { get; set; }
 

--- a/test/GetInstalledPSResource.Tests.ps1
+++ b/test/GetInstalledPSResource.Tests.ps1
@@ -18,6 +18,7 @@ Describe 'Test Get-InstalledPSResource for Module' {
 
     AfterAll {
         Get-RevertPSResourceRepositoryFile
+        Uninstall-PSResource -Name "ContosoServer", "TestTestScript"
     }
 
     It "Get resources without any parameter values" {
@@ -105,5 +106,12 @@ $testCases =
     It "Get resources when given Name, and Version is '*'" {
         $pkgs = Get-InstalledPSResource -Name ContosoServer -Version "*"
         $pkgs.Count | Should -BeGreaterOrEqual 2
+    }
+
+    It "Get PSResourceInfo object piped in" {
+        $res = Find-PSResource -Name "ContosoServer" -Version "1.5.0.0" -Repository $TestGalleryName | Get-InstalledPSResource
+        $res.Name | Should -Be "ContosoServer"
+        $res.Version | Should -Be "1.5.0.0"
+        $res.Repository | Should -Be $TestGalleryName
     }
 }

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -258,7 +258,6 @@ Describe 'Test Install-PSResource for Module' {
         $res = Get-InstalledPSResource -Name $testModuleName
         $res.Name | Should -Be $testModuleName
         $res.Version | Should -Be "1.1.0.0"
-        $res.Repository | Should -Be $TestGalleryName
     }
 }
 

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -9,6 +9,7 @@ Describe 'Test Install-PSResource for Module' {
         $TestGalleryName = Get-PoshTestGalleryName
         $PSGalleryName = Get-PSGalleryName
         $NuGetGalleryName = Get-NuGetGalleryName
+        $testModuleName = "TestModule"
         Get-NewPSResourceRepositoryFile
         Register-LocalRepos
     }
@@ -242,6 +243,14 @@ Describe 'Test Install-PSResource for Module' {
     
         $res = Get-Module "TestModule" -ListAvailable
         $res | Should -BeNullOrEmpty
+    }
+
+    It "Install PSResourceInfo object piped in" {
+        Find-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName | Install-PSResource
+        $res = Get-InstalledPSResource -Name $testModuleName
+        $res.Name | Should -Be $testModuleName
+        $res.Version | Should -Be "1.1.0.0"
+        $res.Repository | Should -Be $TestGalleryName
     }
 }
 

--- a/test/SavePSResource.Tests.ps1
+++ b/test/SavePSResource.Tests.ps1
@@ -173,6 +173,13 @@ Describe 'Test Save-PSResource for PSResources' {
         (Get-ChildItem -Path $pkgDir.FullName).Count | Should -Be 1
     }
 
+    It "Save PSResourceInfo object piped in" {
+        Find-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName | Save-PSResource -Path $SaveDir
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        $pkgDir | Should -Not -BeNullOrEmpty 
+        (Get-ChildItem -Path $pkgDir.FullName).Count | Should -Be 1   
+    }
+
 <#
     # Tests should not write to module directory
     It "Save specific module resource by name if no -Path param is specifed" {

--- a/test/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResource.Tests.ps1
@@ -162,4 +162,11 @@ Describe 'Test Uninstall-PSResource for Modules' {
         $pkg = Get-Module "RequiredModule1" -ListAvailable
         $pkg | Should -Be $null
     }
+
+    It "Uninstall PSResourceInfo object piped in" {
+        Install-PSResource -Name "ContosoServer" -Version "1.5.0.0" -Repository $TestGalleryName
+        Get-InstalledPSResource -Name "ContosoServer" -Version "1.5.0.0" | Uninstall-PSResource
+        $res = Get-InstalledPSResource -Name "ContosoServer" -Version "1.5.0.0"
+        $res | Should -BeNullOrEmpty
+    }
 }

--- a/test/UpdatePSResource.Tests.ps1
+++ b/test/UpdatePSResource.Tests.ps1
@@ -347,8 +347,8 @@ Describe 'Test Update-PSResource' {
 
     It "Update to PSResourceInfo object piped in" {
         Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName
-        Find-PSResource -Name "TestModule" -Version "1.2.0.0" | Updated-PSResource
-        $res = Get-InstalledPSResource -Name "TestModule"
+        Find-PSResource -Name "TestModule" -Version "1.2.0.0" | Update-PSResource
+        $res = Get-InstalledPSResource -Name "TestModule" -Version "1.2.0.0"
         $res.Name | Should -Be "TestModule"
         $res.Version | Should -Be "1.2.0.0"
     }

--- a/test/UpdatePSResource.Tests.ps1
+++ b/test/UpdatePSResource.Tests.ps1
@@ -344,4 +344,12 @@ Describe 'Test Update-PSResource' {
 
         $isPkgUpdated | Should -Be $false
     }
+
+    It "Update to PSResourceInfo object piped in" {
+        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName
+        Find-PSResource -Name "TestModule" -Version "1.2.0.0" | Updated-PSResource
+        $res = Get-InstalledPSResource -Name "TestModule"
+        $res.Name | Should -Be "TestModule"
+        $res.Version | Should -Be "1.2.0.0"
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add pipeline support for the `-Version` parameter with `ValueFromPipelineByPropertyName = true`. Previously, the `-Version` parameter was being parsed and set to a default in `BeginProcessing()` however to support this for pipeline input, it should be parsed in ProcessRecord(). Uninstall-PSResource doesn't need an InputObject parameter set, as it can just read properties by name for the piped in PSResourceInfo object.
## PR Context

To fully support pipeline input, resolves issues #482 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
