### PR TITLE
Value from pipeline cleanup

### DIFF
--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -41,7 +41,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// </summary>
         [Parameter(Position = 0, 
                    ValueFromPipeline = true,
-                   ValueFromPipelineByPropertyName = true,
                    ParameterSetName = ResourceNameParameterSet)]
         [ValidateNotNullOrEmpty]
         public string[] Name { get; set; }

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -30,7 +30,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// <summary>
         /// Specifies the desired name for the resource to look for.
         /// </summary>
-        [Parameter(Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(Position = 0, ValueFromPipeline = true)]
         public string[] Name { get; set; }
 
         /// <summary>

--- a/src/code/GetPSResourceRepository.cs
+++ b/src/code/GetPSResourceRepository.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// Specifies the name(s) of a registered repository to find.
         /// Supports wild card characters.
         /// </summary>
-        [Parameter(Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(Position = 0, ValueFromPipeline = true)]
         [ArgumentCompleter(typeof(RepositoryNameCompleter))]
         [ValidateNotNullOrEmpty]
         public string[] Name { get; set; } = Utils.EmptyStrArray;

--- a/src/code/GetPSResourceRepository.cs
+++ b/src/code/GetPSResourceRepository.cs
@@ -17,8 +17,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// </summary>
 
     [Cmdlet(VerbsCommon.Get,
-        "PSResourceRepository",
-        HelpUri = "<add>")]
+        "PSResourceRepository")]
     public sealed
     class GetPSResourceRepository : PSCmdlet
     {

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// Specifies the path to the resource that you want to publish. This parameter accepts the path to the folder that contains the resource.
         /// Specifies a path to one or more locations. Wildcards are permitted. The default location is the current directory (.).
         /// </summary>
-        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "PathParameterSet")]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "PathParameterSet")]
         [ValidateNotNullOrEmpty]
         public string Path
         {
@@ -80,7 +80,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// No characters are interpreted as wildcards. If the path includes escape characters, enclose them in single quotation marks.
         /// Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
         /// </summary>
-        [Parameter(Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "PathLiteralParameterSet")]
+        [Parameter(Mandatory = true, ParameterSetName = "PathLiteralParameterSet")]
         [ValidateNotNullOrEmpty]
         public string LiteralPath
         {
@@ -118,7 +118,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// <summary>
         /// Specifies a proxy server for the request, rather than a direct connection to the internet resource.
         /// </summary>
-        [Parameter(ValueFromPipelineByPropertyName = true)]
+        [Parameter()]
         [ValidateNotNullOrEmpty]
         public Uri Proxy {
             set
@@ -135,7 +135,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// <summary>
         /// Specifies a user account that has permission to use the proxy server that is specified by the Proxy parameter.
         /// </summary>
-        [Parameter(ValueFromPipelineByPropertyName = true)]
+        [Parameter()]
         [ValidateNotNullOrEmpty]
         public PSCredential ProxyCredential {
             set

--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -5,7 +5,6 @@ using Microsoft.PowerShell.PowerShellGet.UtilClasses;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Management.Automation;
 using Dbg = System.Diagnostics.Debug;
 

--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -20,8 +20,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     [Cmdlet(VerbsLifecycle.Register,
         "PSResourceRepository",
         DefaultParameterSetName = NameParameterSet,
-        SupportsShouldProcess = true,
-        HelpUri = "<add>")]
+        SupportsShouldProcess = true)]
     public sealed
     class RegisterPSResourceRepository : PSCmdlet
     {
@@ -63,7 +62,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// <summary>
         /// Specifies a hashtable of repositories and is used to register multiple repositories at once.
         /// </summary>
-        [Parameter(Mandatory = true, ParameterSetName = "RepositoriesParameterSet", ValueFromPipeline = true)]
+        [Parameter(Mandatory = true, ParameterSetName = RepositoriesParameterSet)]
         [ValidateNotNullOrEmpty]
         public Hashtable[] Repositories {get; set;}
 

--- a/src/code/SetPSResourceRepository.cs
+++ b/src/code/SetPSResourceRepository.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Dbg = System.Diagnostics.Debug;
-using System.Globalization;
 using System.Management.Automation;
 using Microsoft.PowerShell.PowerShellGet.UtilClasses;
 
@@ -17,8 +16,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     [Cmdlet(VerbsCommon.Set,
         "PSResourceRepository",
         DefaultParameterSetName = NameParameterSet,
-        SupportsShouldProcess = true,
-        HelpUri = "<add>")]
+        SupportsShouldProcess = true)]
     public sealed
     class SetPSResourceRepository : PSCmdlet
     {
@@ -35,8 +33,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// <summary>
         /// Specifies the name of the repository to be set.
         /// </sumamry>
-        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true,
-            ValueFromPipelineByPropertyName = true, ParameterSetName = NameParameterSet)]
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = NameParameterSet)]
         [ArgumentCompleter(typeof(RepositoryNameCompleter))]
         [ValidateNotNullOrEmpty]
         public string Name { get; set; }
@@ -51,7 +48,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// <summary>
         /// Specifies a hashtable of repositories and is used to register multiple repositories at once.
         /// </summary>
-        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = RepositoriesParameterSet)]
+        [Parameter(Mandatory = true, ParameterSetName = RepositoriesParameterSet)]
         [ValidateNotNullOrEmpty]
         public Hashtable[] Repositories { get; set; }
 

--- a/src/code/UnregisterPSResourceRepository.cs
+++ b/src/code/UnregisterPSResourceRepository.cs
@@ -14,8 +14,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
     [Cmdlet(VerbsLifecycle.Unregister,
         "PSResourceRepository",
-        SupportsShouldProcess = true,
-        HelpUri = "<add>")]
+        SupportsShouldProcess = true)]
     public sealed
     class UnregisterPSResourceRepository : PSCmdlet
     {
@@ -25,7 +24,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// Specifies the desired name for the repository to be registered.
         /// </summary>
         [Parameter(Mandatory= true, Position = 0,
-            ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
         [ArgumentCompleter(typeof(RepositoryNameCompleter))]
         [ValidateNotNullOrEmpty]

--- a/src/code/UnregisterPSResourceRepository.cs
+++ b/src/code/UnregisterPSResourceRepository.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// <summary>
         /// Specifies the desired name for the repository to be registered.
         /// </summary>
-        [Parameter(Mandatory= true, Position = 0, ValueFromPipelineByPropertyName = true)]
+        [Parameter(Mandatory= true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [ArgumentCompleter(typeof(RepositoryNameCompleter))]
         [ValidateNotNullOrEmpty]
         public string[] Name { get; set; } = Utils.EmptyStrArray;

--- a/src/code/UnregisterPSResourceRepository.cs
+++ b/src/code/UnregisterPSResourceRepository.cs
@@ -23,8 +23,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// <summary>
         /// Specifies the desired name for the repository to be registered.
         /// </summary>
-        [Parameter(Mandatory= true, Position = 0,
-            ValueFromPipelineByPropertyName = true)]
+        [Parameter(Mandatory= true, Position = 0, ValueFromPipelineByPropertyName = true)]
         [ArgumentCompleter(typeof(RepositoryNameCompleter))]
         [ValidateNotNullOrEmpty]
         public string[] Name { get; set; } = Utils.EmptyStrArray;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

For the following cmdlets, ensure they have following pipeline support for the listed parameter(s):
- Find-PSResource (Name param, ValueFromPipeline)
- Get-InstalledPSResource (Name param, ValueFromPipeline)
- Publish-PSResource (None)
- Get-PSResourceRepository (Name param, ValueFromPipeline)
- Set-PSResourceRepository (Name param, ValueFromPipeline)
- Register-PSResourceRepository (None)
- Unregister-PSResourceRepository (Name param, ValueFromPipelineByPropertyName)

## PR Context

For consistent pipeline input support for *-PSResource and *-PSResourceRepository cmdlets for next PSGet release.

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
