### PR TITLE
Uninstall and Get-Installed prerelease support for Version parameter

### DIFF
--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -124,7 +124,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         }
                         _cmdletPassedIn.WriteVerbose(string.Format("Directory parsed as NuGet version: '{0}'", dirAsNugetVersion));
 
-                        _cmdletPassedIn.WriteVerbose("versionRange: " + versionRange + " and dirAsNuGetVersion: " + dirAsNugetVersion);
                         if (versionRange.Satisfies(dirAsNugetVersion))
                         {
                             // This will be one version or a version range.

--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     foreach (string versionPath in versionsDirs)
                     {
                         _cmdletPassedIn.WriteVerbose(string.Format("Searching through package version path: '{0}'", versionPath));
-                        if(!Utils.GetVersionFromPSGetModuleInfoFile(installedPkgPath: versionPath,
+                        if(!Utils.GetVersionForInstallPath(installedPkgPath: versionPath,
                             isModule: true,
                             cmdletPassedIn: _cmdletPassedIn,
                             out NuGetVersion dirAsNugetVersion))
@@ -149,7 +149,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         // check to make sure it's within the version range.
                         // script versions will be parsed from the script xml file
                         PSResourceInfo scriptInfo = OutputPackageObject(pkgPath, _scriptDictionary);
-                        if(!Utils.GetVersionFromPSGetModuleInfoFile(installedPkgPath: pkgPath,
+                        if(!Utils.GetVersionForInstallPath(installedPkgPath: pkgPath,
                             isModule: false,
                             cmdletPassedIn: _cmdletPassedIn,
                             out NuGetVersion dirAsNugetVersion))

--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -112,16 +112,15 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     foreach (string versionPath in versionsDirs)
                     {
                         _cmdletPassedIn.WriteVerbose(string.Format("Searching through package version path: '{0}'", versionPath));
-                        DirectoryInfo dirInfo = new DirectoryInfo(versionPath);
-
-                        // if the version is not valid, we'll just skip it and output a debug message
-                        if (!NuGetVersion.TryParse(dirInfo.Name, out NuGetVersion dirAsNugetVersion))
+                        if(!Utils.GetVersionFromPSGetModuleInfoFile(installedPkgPath: versionPath,
+                            isModule: true,
+                            cmdletPassedIn: _cmdletPassedIn,
+                            out NuGetVersion dirAsNugetVersion))
                         {
-                            _cmdletPassedIn.WriteVerbose(string.Format("Leaf directory in path '{0}' cannot be parsed into a version.", versionPath));
-
                             // skip to next iteration of the loop
                             continue;
                         }
+
                         _cmdletPassedIn.WriteVerbose(string.Format("Directory parsed as NuGet version: '{0}'", dirAsNugetVersion));
 
                         if (versionRange.Satisfies(dirAsNugetVersion))
@@ -150,17 +149,17 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         // check to make sure it's within the version range.
                         // script versions will be parsed from the script xml file
                         PSResourceInfo scriptInfo = OutputPackageObject(pkgPath, _scriptDictionary);
-                        if (scriptInfo == null)
+                        if(!Utils.GetVersionFromPSGetModuleInfoFile(installedPkgPath: pkgPath,
+                            isModule: false,
+                            cmdletPassedIn: _cmdletPassedIn,
+                            out NuGetVersion dirAsNugetVersion))
                         {
-                            // if script was not found skip to the next iteration of the loop
-                            continue;
+                            // skip to next iteration of the loop
+                            yield return pkgPath;
                         }
 
-                        if (!NuGetVersion.TryParse(scriptInfo.Version.ToString(), out NuGetVersion scriptVersion))
-                        {
-                            _cmdletPassedIn.WriteVerbose(string.Format("Version '{0}' could not be properly parsed from the script metadata file from the script installed at '{1}'", scriptInfo.Version.ToString(), scriptInfo.InstalledLocation));
-                        }
-                        else if (versionRange.Satisfies(scriptVersion))
+                        _cmdletPassedIn.WriteVerbose(string.Format("Directory parsed as NuGet version: '{0}'", dirAsNugetVersion));
+                        if (versionRange.Satisfies(dirAsNugetVersion))
                         {
                             _scriptDictionary.Add(pkgPath, scriptInfo);
                             yield return pkgPath;

--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -115,15 +115,15 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         if(!Utils.GetVersionForInstallPath(installedPkgPath: versionPath,
                             isModule: true,
                             cmdletPassedIn: _cmdletPassedIn,
-                            out NuGetVersion dirAsNugetVersion))
+                            out NuGetVersion pkgNugetVersion))
                         {
                             // skip to next iteration of the loop
                             continue;
                         }
 
-                        _cmdletPassedIn.WriteVerbose(string.Format("Directory parsed as NuGet version: '{0}'", dirAsNugetVersion));
+                        _cmdletPassedIn.WriteVerbose(string.Format("Package version parsed as NuGet version: '{0}'", pkgNugetVersion));
 
-                        if (versionRange.Satisfies(dirAsNugetVersion))
+                        if (versionRange.Satisfies(pkgNugetVersion))
                         {
                             // This will be one version or a version range.
                             // yield results then continue with this iteration of the loop
@@ -152,14 +152,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         if(!Utils.GetVersionForInstallPath(installedPkgPath: pkgPath,
                             isModule: false,
                             cmdletPassedIn: _cmdletPassedIn,
-                            out NuGetVersion dirAsNugetVersion))
+                            out NuGetVersion pkgNugetVersion))
                         {
                             // skip to next iteration of the loop
                             yield return pkgPath;
                         }
 
-                        _cmdletPassedIn.WriteVerbose(string.Format("Directory parsed as NuGet version: '{0}'", dirAsNugetVersion));
-                        if (versionRange.Satisfies(dirAsNugetVersion))
+                        _cmdletPassedIn.WriteVerbose(string.Format("Package version parsed as NuGet version: '{0}'", pkgNugetVersion));
+                        if (versionRange.Satisfies(pkgNugetVersion))
                         {
                             _scriptDictionary.Add(pkgPath, scriptInfo);
                             yield return pkgPath;

--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -124,6 +124,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         }
                         _cmdletPassedIn.WriteVerbose(string.Format("Directory parsed as NuGet version: '{0}'", dirAsNugetVersion));
 
+                        _cmdletPassedIn.WriteVerbose("versionRange: " + versionRange + " and dirAsNuGetVersion: " + dirAsNugetVersion);
                         if (versionRange.Satisfies(dirAsNugetVersion))
                         {
                             // This will be one version or a version range.

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -22,7 +22,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         private VersionRange _versionRange;
         private List<string> _pathsToSearch;
-        string[] _prereleaseLabels = new string[]{};
 
         #endregion
 
@@ -60,8 +59,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 _versionRange = VersionRange.All;
             }
-            else if (!Utils.TryParseVersionOrVersionRange(version: Utils.GetVersionWithoutPrerelease(Version, out _prereleaseLabels),
-                        versionRange: out _versionRange))
+            else if (!Utils.TryParseVersionOrVersionRange(Version, out _versionRange))
             {
                 var exMessage = "Argument for -Version parameter is not in the proper format.";
                 var ex = new ArgumentException(exMessage);
@@ -132,16 +130,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
 
             GetHelper getHelper = new GetHelper(this);
-            string[] versionRangeParts = _versionRange.ToString().Trim(new char []{'[', ']', '(', ')'}).Split(',');
-
             foreach (PSResourceInfo pkg in getHelper.FilterPkgPaths(namesToSearch, _versionRange, _pathsToSearch))
             {
-                if ((_versionRange != VersionRange.All) && (!String.IsNullOrEmpty(versionRangeParts[0]) && pkg.Version.ToString().StartsWith(versionRangeParts[0]) && !String.Equals(pkg.PrereleaseLabel, _prereleaseLabels[0], StringComparison.InvariantCultureIgnoreCase)) ||
-                        (!String.IsNullOrEmpty(versionRangeParts[1]) && pkg.Version.ToString().StartsWith(versionRangeParts[1]) && !String.Equals(pkg.PrereleaseLabel, _prereleaseLabels[1], StringComparison.InvariantCultureIgnoreCase)))
-                {
-                    continue;
-                }
-
                 WriteObject(pkg);
             }
         }

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -132,9 +132,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
 
             GetHelper getHelper = new GetHelper(this);
-            WriteVerbose("versionRange: " + _versionRange);
             string[] versionRangeParts = _versionRange.ToString().Trim(new char []{'[', ']', '(', ')'}).Split(',');
-            WriteVerbose("version range parts: " + String.Join(",", versionRangeParts));
 
             foreach (PSResourceInfo pkg in getHelper.FilterPkgPaths(namesToSearch, _versionRange, _pathsToSearch))
             {

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -132,12 +132,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
 
             GetHelper getHelper = new GetHelper(this);
+            WriteVerbose("versionRange: " + _versionRange);
             string[] versionRangeParts = _versionRange.ToString().Trim(new char []{'[', ']', '(', ')'}).Split(',');
+            WriteVerbose("version range parts: " + String.Join(",", versionRangeParts));
 
             foreach (PSResourceInfo pkg in getHelper.FilterPkgPaths(namesToSearch, _versionRange, _pathsToSearch))
             {
-                if ((_versionRange != VersionRange.All) && (pkg.Version.ToString().StartsWith(versionRangeParts[0]) && !String.Equals(pkg.PrereleaseLabel, _prereleaseLabels[0], StringComparison.InvariantCultureIgnoreCase)) ||
-                        (pkg.Version.ToString().StartsWith(versionRangeParts[1]) && !String.Equals(pkg.PrereleaseLabel, _prereleaseLabels[1], StringComparison.InvariantCultureIgnoreCase)))
+                if ((_versionRange != VersionRange.All) && (!String.IsNullOrEmpty(versionRangeParts[0]) && pkg.Version.ToString().StartsWith(versionRangeParts[0]) && !String.Equals(pkg.PrereleaseLabel, _prereleaseLabels[0], StringComparison.InvariantCultureIgnoreCase)) ||
+                        (!String.IsNullOrEmpty(versionRangeParts[1]) && pkg.Version.ToString().StartsWith(versionRangeParts[1]) && !String.Equals(pkg.PrereleaseLabel, _prereleaseLabels[1], StringComparison.InvariantCultureIgnoreCase)))
                 {
                     continue;
                 }

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -204,15 +204,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             errRecord = null;
             var successfullyUninstalledPkg = false;
 
-            // TODO: remove
-            // if Version provided by user contains prerelease label and installed package contains same prerelease label, then uninstall
-            // if (!String.IsNullOrEmpty(_prereleaseLabel) && !CheckIfPrerelease(isModule: true,
-            //     pkgPath: pkgPath,
-            //     pkgName: pkgName,
-            //     expectedPrereleaseLabel: _prereleaseLabel))
-            // {
-            //     return false;
-            // }
             if (!CheckIfPrerelease(isModule: true, pkgName: pkgName, pkgPath: pkgPath))
             {
                 return false;
@@ -268,15 +259,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             errRecord = null;
             var successfullyUninstalledPkg = false;
 
-            // TODO: remove
-            // if Version provided by user contains prerelease label and installed package contains same prerelease label, then uninstall
-            // if (!String.IsNullOrEmpty(_prereleaseLabel) && !CheckIfPrerelease(isModule: true,
-            //     pkgPath: pkgPath,
-            //     pkgName: pkgName,
-            //     expectedPrereleaseLabel: _prereleaseLabel))
-            // {
-            //     return false;
-            // }
             if (!CheckIfPrerelease(isModule: false, pkgName: pkgName, pkgPath: pkgPath))
             {
                 return false;
@@ -365,7 +347,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         
         private bool CheckIfPrerelease(bool isModule, string pkgPath, string pkgName)
         {
-
             string PSGetModuleInfoFilePath = isModule ? Path.Combine(pkgPath, "PSGetModuleInfo.xml") : Path.Combine(Path.GetDirectoryName(pkgPath), "InstalledScriptInfos", pkgName + "_InstalledScriptInfo.xml");
             WriteVerbose("pkgPath: " + PSGetModuleInfoFilePath);
             if (!PSResourceInfo.TryRead(PSGetModuleInfoFilePath, out PSResourceInfo psGetInfo, out string errorMsg))
@@ -380,28 +361,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 return false;
             }
+
             return true;
-            
-            // // get module manifest path, same for modules and scripts:
-            // // ./Modules/TestModule/0.0.1/TestModule.psd1
-            // // ./Scripts/TestScript/0.0.1/TestScript.psd1
-            // string moduleManifestPath = Path.Combine(pkgPath, pkgName + ".psd1");
-
-            // if (!Utils.TryParseModuleManifest(moduleManifestPath, this, out Hashtable parsedMetadataHashtable))
-            // {
-            //     WriteError(new ErrorRecord(
-            //         new PSInvalidOperationException("Module manifest could not be parsed for package: " + pkgName),
-            //         "ErrorParsingModuleManifest",
-            //         ErrorCategory.InvalidData,
-            //         this));
-            //     return false;
-            // }
-
-            // if (String.Equals(parsedPrereleaseLabel, expectedPrereleaseLabel, StringComparison.InvariantCultureIgnoreCase))
-            // {
-            //     return true;
-            // }
         }
+
         #endregion
     }
 }

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     break;
 
                 case InputObjectParameterSet:
-                    // PSResourceInfo object will always have:
+                    // PSResourceInfo object piped in will always have:
                     // specific version, not version range
                     // Version and PrereleaseLabel (if any) as separate properties, i.e "1.0.0-alpha" case wouldn't be piped in
                     _prereleaseLabels[0] = InputObject.PrereleaseLabel;

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -111,7 +111,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 case InputObjectParameterSet:
                     string inputObjectPrereleaseLabel = InputObject.PrereleaseLabel;
                     string inputObjectVersion = String.IsNullOrEmpty(inputObjectPrereleaseLabel) ? InputObject.Version.ToString() : Utils.GetNormalizedVersionString(versionString: InputObject.Version.ToString(), prerelease: inputObjectPrereleaseLabel);
-                    if (!Utils.TryParseVersionOrVersionRange(version: inputObjectVersion, versionRange: out _versionRange))
+                    if (!Utils.TryParseVersionOrVersionRange(
+                        version: inputObjectVersion,
+                        versionRange: out _versionRange))
                     {
                         var exMessage = String.Format("Version '{0}' for resource '{1}' cannot be parsed.", InputObject.Version.ToString(), InputObject.Name);
                         var ex = new ArgumentException(exMessage);

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -116,8 +116,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     // specific version, not version range
                     // Version and PrereleaseLabel (if any) as separate properties, i.e "1.0.0-alpha" case wouldn't be piped in
 
-                    // if (!Utils.TryParseVersionOrVersionRange(version: Utils.GetVersionWithoutPrerelease(InputObject.Version.ToString(), out _prereleaseLabels),
-                    //     versionRange: out _versionRange))
                     _prereleaseLabels[0] = InputObject.PrereleaseLabel;
                     if (!Utils.TryParseVersionOrVersionRange(version: InputObject.Version.ToString(),
                         versionRange: out _versionRange))

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using System;

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -115,7 +115,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     // PSResourceInfo object will always have:
                     // specific version, not version range
                     // Version and PrereleaseLabel (if any) as separate properties, i.e "1.0.0-alpha" case wouldn't be piped in
-
                     _prereleaseLabels[0] = InputObject.PrereleaseLabel;
                     if (!Utils.TryParseVersionOrVersionRange(version: InputObject.Version.ToString(),
                         versionRange: out _versionRange))

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -121,25 +121,23 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             List<String> prereleaseLabelList = new List<string>();
             if (versionString.StartsWith("[") || versionString.StartsWith("("))
             {
-                // TODO: do I need to check end cases?
                 // this is a version range, i.e: [3.0.0-preview, ] or (2.9.0, 3.0.0-preview)
                 // not supported, bc you can't install versions with same core version part side by side (3.0.0, 3.0.0-preview)
-                string[] versionRangeParts = versionString.Substring(1, versionString.Length - 2).Split(',');
-                // versionRangeParts should be like: ["3.0.0-preview", ""] or ("2.9.0", "3.0.0-preview")
+                string[] versionRangeParts = versionString.Trim(new char[]{'[', ']', '(', ')'}).Split(',');
                 List<string> versionOnlyParts = new List<string>();
-                foreach(string individualVersion in versionRangeParts)
+                foreach(string indivVersion in versionRangeParts)
                 {
-                    if (!String.IsNullOrEmpty(individualVersion))
+                    if (!String.IsNullOrEmpty(indivVersion))
                     {
-                        versionOnlyParts.Add(GetVersionWithoutPrereleaseHelper(individualVersion, out string prereleaseLabel));
+                        versionOnlyParts.Add(GetVersionWithoutPrereleaseHelper(indivVersion, out string prereleaseLabel));
                         prereleaseLabelList.Add(prereleaseLabel);
                     }
                     else
                     {
+                        versionOnlyParts.Add(String.Empty);
                         prereleaseLabelList.Add(String.Empty);
                     }
                 }
-
                 prereleaseLabels = prereleaseLabelList.ToArray();
                 return versionString.Substring(0, 1) + String.Join(",", versionOnlyParts) + versionString.Substring(versionString.Length-1);
             }

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -134,6 +134,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                     }
                     else
                     {
+                        // prereleaseLabelList always has 2 entries, they might just be empty strings
                         versionOnlyParts.Add(String.Empty);
                         prereleaseLabelList.Add(String.Empty);
                     }

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -146,6 +146,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             prereleaseLabels = new string[]{""};
             return GetVersionWithoutPrereleaseHelper(versionString, out prereleaseLabels[0]);
         }
+
         public static string GetVersionWithoutPrereleaseHelper(string versionString, out string prereleaseLabel)
         {
             if (versionString.Contains("-"))

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -126,7 +126,6 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 // not supported, bc you can't install versions with same core version part side by side (3.0.0, 3.0.0-preview)
                 string[] versionRangeParts = versionString.Substring(1, versionString.Length - 2).Split(',');
                 // versionRangeParts should be like: ["3.0.0-preview", ""] or ("2.9.0", "3.0.0-preview")
-                string endString = versionString.Substring(0, 1); // "[" or "("
                 List<string> versionOnlyParts = new List<string>();
                 foreach(string individualVersion in versionRangeParts)
                 {
@@ -134,8 +133,6 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                     {
                         versionOnlyParts.Add(GetVersionWithoutPrereleaseHelper(individualVersion, out string prereleaseLabel));
                         prereleaseLabelList.Add(prereleaseLabel);
-                        // endString += GetVersionWithoutPrereleaseHelper(individualVersion, out string prereleaseLabel);
-                        // prereleaseLabelList.Add(prereleaseLabel);
                     }
                     else
                     {
@@ -145,13 +142,6 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
                 prereleaseLabels = prereleaseLabelList.ToArray();
                 return versionString.Substring(0, 1) + String.Join(",", versionOnlyParts) + versionString.Substring(versionString.Length-1);
-
-                // Console.WriteLine
-                // endString.TrimEnd(',');
-                // endString += versionString.Substring(versionString.Length -1);
-                // prereleaseLabels = prereleaseLabelList.ToArray();
-                // Console.WriteLine(endString);
-                // return endString;
             }
 
             // just a specific version

--- a/test/GetInstalledPSResource.Tests.ps1
+++ b/test/GetInstalledPSResource.Tests.ps1
@@ -7,6 +7,8 @@ Describe 'Test Get-InstalledPSResource for Module' {
 
     BeforeAll{
         $TestGalleryName = Get-PoshTestGalleryName
+        $testModuleName = "test_module"
+        $testScriptName = "test_script"
         Get-NewPSResourceRepositoryFile
 
         Install-PSResource ContosoServer -Repository $TestGalleryName -TrustRepository
@@ -105,5 +107,25 @@ $testCases =
     It "Get resources when given Name, and Version is '*'" {
         $pkgs = Get-InstalledPSResource -Name ContosoServer -Version "*"
         $pkgs.Count | Should -BeGreaterOrEqual 2
+    }
+
+    It "Get prerelease version module when version with correct prerelease label is specified" {
+        Install-PSResource -Name $testModuleName -Version "5.2.5-alpha001"
+        $res = Get-InstalledPSResource -Name $testModuleName -Version "5.2.5"
+        $res | Should -BeNullOrEmpty
+        $res = Get-InstalledPSResource -Name $testModuleName -Version "5.2.5-alpha001"
+        $res.Name | Should -Be $testModuleName
+        $res.Version | Should -Be "5.2.5"
+        $res.PrereleaseLabel | Should -Be "alpha001"
+    }
+
+    It "Get prerelease version script when version with correct prerelease label is specified" {
+        Install-PSResource -Name $testScriptName -Version "3.0.0-alpha001"
+        $res = Get-InstalledPSResource -Name $testScriptName -Version "3.0.0"
+        $res | Should -BeNullOrEmpty
+        $res = Get-InstalledPSResource -Name $testScriptName -Version "3.0.0-alpha001"
+        $res.Name | Should -Be $testScriptName
+        $res.Version | Should -Be "3.0.0"
+        $res.PrereleaseLabel | Should -Be "alpha001"
     }
 }

--- a/test/GetInstalledPSResource.Tests.ps1
+++ b/test/GetInstalledPSResource.Tests.ps1
@@ -110,7 +110,7 @@ $testCases =
     }
 
     It "Get prerelease version module when version with correct prerelease label is specified" {
-        Install-PSResource -Name $testModuleName -Version "5.2.5-alpha001"
+        Install-PSResource -Name $testModuleName -Version "5.2.5-alpha001" -Repository $TestGalleryName
         $res = Get-InstalledPSResource -Name $testModuleName -Version "5.2.5"
         $res | Should -BeNullOrEmpty
         $res = Get-InstalledPSResource -Name $testModuleName -Version "5.2.5-alpha001"
@@ -120,7 +120,7 @@ $testCases =
     }
 
     It "Get prerelease version script when version with correct prerelease label is specified" {
-        Install-PSResource -Name $testScriptName -Version "3.0.0-alpha001"
+        Install-PSResource -Name $testScriptName -Version "3.0.0-alpha001" -Repository $TestGalleryName
         $res = Get-InstalledPSResource -Name $testScriptName -Version "3.0.0"
         $res | Should -BeNullOrEmpty
         $res = Get-InstalledPSResource -Name $testScriptName -Version "3.0.0-alpha001"

--- a/test/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResource.Tests.ps1
@@ -204,9 +204,6 @@ Describe 'Test Uninstall-PSResource for Modules' {
 
     It "Uninstall PSResourceInfo object piped in for prerelease version object" {
         Install-PSResource -Name $testModuleName -Version "4.5.2-alpha001" -Repository $TestGalleryName
-        # Powershell cannot create install locations indicating a prerelease version (with prerelease label indicated in install location).
-        # To test we can uninstall prerelease versions, we must use the numeric part of the prerelease version only and it must be unique
-        # of all versions installed for that module.
         Get-InstalledPSResource -Name $testModuleName -Version "4.5.2-alpha001" | Uninstall-PSResource
         $res = Get-InstalledPSResource -Name $testModuleName -Version "4.5.2-alpha001"
         $res | Should -BeNullOrEmpty

--- a/test/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResource.Tests.ps1
@@ -207,8 +207,8 @@ Describe 'Test Uninstall-PSResource for Modules' {
         # Powershell cannot create install locations indicating a prerelease version (with prerelease label indicated in install location).
         # To test we can uninstall prerelease versions, we must use the numeric part of the prerelease version only and it must be unique
         # of all versions installed for that module.
-        Get-InstalledPSResource -Name $testModuleName -Version "4.5.2" | Uninstall-PSResource
-        $res = Get-InstalledPSResource -Name $testModuleName -Version "4.5.2"
+        Get-InstalledPSResource -Name $testModuleName -Version "4.5.2-alpha001" | Uninstall-PSResource
+        $res = Get-InstalledPSResource -Name $testModuleName -Version "4.5.2-alpha001"
         $res | Should -BeNullOrEmpty
     }
 }

--- a/test/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResource.Tests.ps1
@@ -139,14 +139,14 @@ Describe 'Test Uninstall-PSResource for Modules' {
     }
 
     It "Uninstall prerelease version module when prerelease version specified" {
-        Install-PSResource -Name $testModuleName -Version "5.2.5-alpha001" -Repository $PSGalleryName
+        Install-PSResource -Name $testModuleName -Version "5.2.5-alpha001" -Repository $TestGalleryName
         Uninstall-PSResource -Name $testModuleName -Version "5.2.5-alpha001"
         $res = Get-InstalledPSResource $testModuleName -Version "5.2.5-alpha001"
         $res | Should -BeNullOrEmpty
     }
 
     It "Not uninstall non-prerelease version module when similar prerelease version is specified" {
-        Install-PSResource -Name $testModuleName -Version "5.0.0.0" -Repository $PSGalleryName
+        Install-PSResource -Name $testModuleName -Version "5.0.0.0" -Repository $TestGalleryName
         Uninstall-PSResource -Name $testModuleName -Version "5.0.0-preview"
         $res = Get-InstalledPSResource -Name $testModuleName -Version "5.0.0.0"
         $res.Name | Should -Be $testModuleName

--- a/test/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResource.Tests.ps1
@@ -137,6 +137,25 @@ Describe 'Test Uninstall-PSResource for Modules' {
         $pkg.Version | Should -Be "2.5"
     }
 
+    It "Uninstall version with prerelease" {
+        Install-PSResource -Name "Microsoft.PowerShell.SecretManagement" -Version "1.1.0-preview" -Repository $PSGalleryName
+        Uninstall-PSResource -Name "Microsoft.PowerShell.SecretManagement" -Version "1.1.0-preview"
+        $res = Get-InstalledPSResource "Microsoft.PowerShell.SecretManagement"
+        $prereleaseVersionFound = $false
+        foreach ($item in $res) {
+            if ([System.Version]$item.Version -eq "1.1.0" -and $item.PrereleaseLabel -eq "preview")
+            {
+                $prereleaseVersionFound = $true
+            }
+        }
+
+        $prereleaseVersionFound | Should -Be $true
+    }
+
+    It "Not Uninstall non-prerelease when similar prerelease version is specified" {
+
+    }
+
     It "Uninstall module using -WhatIf, should not uninstall the module" {
         $res = Uninstall-PSResource -Name "ContosoServer" -WhatIf
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add prerelease support for Uninstall-PSResource and Get-InstalledPSResource, so that a prerelease version module isn't obtained when the version part alone is provided, we look into the PSGetModuleInfo.xml file and verify that is the correct version with prerelease label specifically. 


## PR Context

Part of bug fixes for preview 12 release
resolves #365 , resolves #83, resolves #348
screenshot of #83 working:
![image](https://user-images.githubusercontent.com/30238344/140185452-0db22a8e-e4c2-41c2-bc56-1d693a8e6e5c.png)

screenshot of #348 working:
![image](https://user-images.githubusercontent.com/30238344/140186794-9e6df8dc-27f6-4540-8cc2-256f8201de01.png)


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
