### PR TITLE
Fix for Install-PSResource always reinstall issue

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-MIT License
+Copyright (c) Microsoft Corporation.
 
-Copyright (c) 2020 PowerShell Team
+MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/doBuild.ps1
+++ b/doBuild.ps1
@@ -36,6 +36,14 @@ function DoBuild
     Write-Verbose -Verbose -Message "Copying help files to '$BuildOutPath'"
     Copy-Item -Path "${HelpPath}/${Culture}" -Dest "$BuildOutPath" -Recurse -Force
 
+    # Copy license
+    Write-Verbose -Verbose -Message "Copying LICENSE file to '$BuildOutPath'"
+    Copy-Item -Path "./LICENSE" -Dest "$BuildOutPath"
+
+    # Copy notice
+    # Write-Verbose -Verbose -Message "Copying ThirdPartyNotices.txt to '$BuildOutPath'"
+    # Copy-Item -Path "./ThirdPartyNotices.txt" -Dest "$BuildOutPath"
+
     #
     # Copy DSC resources
     # TODO: This should not be part of PowerShellGet build/publish and should be moved to its own project
@@ -65,40 +73,21 @@ function DoBuild
             }
 
             # Place build results
-            if ($BuildFramework -eq "netstandard2.0") {
-                $assemblyNames = @(
-                    'PowerShellGet'
-                    'Microsoft.Extensions.Logging.Abstractions'
-                    'MoreLinq'
-                    'NuGet.Commands'
-                    'NuGet.Common'
-                    'NuGet.Configuration'
-                    'NuGet.Frameworks'
-                    'NuGet.Packaging'
-                    'NuGet.ProjectModel'
-                    'NuGet.Protocol'
-                    'NuGet.Repositories'
-                    'NuGet.Versioning'
-                    'Newtonsoft.Json'
-                )
-            } elseif ($BuildFramework -eq 'net472') {
-                $assemblyNames = @(
-                    'PowerShellGet'
-                    'Microsoft.Extensions.Logging.Abstractions'
-                    'MoreLinq'
-                    'NuGet.Commands'
-                    'NuGet.Common'
-                    'NuGet.Configuration'
-                    'NuGet.Frameworks'
-                    'NuGet.Packaging'
-                    'NuGet.ProjectModel'
-                    'NuGet.Protocol'
-                    'NuGet.Repositories'
-                    'NuGet.Versioning'
-                    'Newtonsoft.Json'
-                    'System.Security.Principal.Windows'
-                )
-            }
+            $assemblyNames = @(
+                'PowerShellGet'
+                'Microsoft.Extensions.Logging.Abstractions'
+                'MoreLinq'
+                'NuGet.Commands'
+                'NuGet.Common'
+                'NuGet.Configuration'
+                'NuGet.Frameworks'
+                'NuGet.Packaging'
+                'NuGet.ProjectModel'
+                'NuGet.Protocol'
+                'NuGet.Repositories'
+                'NuGet.Versioning'
+                'Newtonsoft.Json'
+            )
 
             $buildSuccess = $true
             foreach ($fileName in $assemblyNames)

--- a/src/PowerShellGet.psd1
+++ b/src/PowerShellGet.psd1
@@ -3,7 +3,7 @@
 
 @{
     RootModule        = './netstandard2.0/PowerShellGet.dll'
-    ModuleVersion     = '3.0.11'
+    ModuleVersion     = '3.0.12'
     GUID              = '1d73a601-4a6c-43c5-ba3f-619b18bbb404'
     Author            = 'Microsoft Corporation'
     CompanyName       = 'Microsoft Corporation'

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -1,23 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Data;
-using Dbg = System.Diagnostics.Debug;
-using System.Linq;
-using System.Management.Automation;
-using System.Net;
-using System.Net.Http;
-using System.Threading;
-using MoreLinq.Extensions;
 using Microsoft.PowerShell.PowerShellGet.UtilClasses;
-using static Microsoft.PowerShell.PowerShellGet.UtilClasses.PSResourceInfo;
+using MoreLinq.Extensions;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Management.Automation;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+
+using Dbg = System.Diagnostics.Debug;
 
 namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 {
@@ -26,6 +26,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// </summary>
     internal class FindHelper
     {
+        #region Members
+
         private CancellationToken _cancellationToken;
         private readonly PSCmdlet _cmdletPassedIn;
         private List<string> _pkgsLeftToFind;
@@ -50,11 +52,21 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         private const int SearchAsyncMaxReturned = 5990;
         private const int GalleryMax = 12000;
 
+        #endregion
+
+        #region Constructor
+
+        private FindHelper() { }
+
         public FindHelper(CancellationToken cancellationToken, PSCmdlet cmdletPassedIn)
         {
             _cancellationToken = cancellationToken;
             _cmdletPassedIn = cmdletPassedIn;
         }
+
+        #endregion
+
+        #region Public methods
 
         public IEnumerable<PSResourceInfo> FindByResourceName(
             string[] name,
@@ -175,7 +187,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
         }
 
-        public IEnumerable<PSResourceInfo> SearchFromRepository(
+        #endregion
+
+        #region Private methods
+
+        private IEnumerable<PSResourceInfo> SearchFromRepository(
             string repositoryName,
             Uri repositoryUrl)
         {
@@ -255,7 +271,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
         }
 
-        public IEnumerable<PSResourceInfo> SearchAcrossNamesInRepository(
+        private IEnumerable<PSResourceInfo> SearchAcrossNamesInRepository(
             string repositoryName,
             PackageSearchResource pkgSearchResource,
             PackageMetadataResource pkgMetadataResource,
@@ -637,5 +653,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 }
             }
         }
+        #endregion
     }
 }

--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+using Microsoft.PowerShell.PowerShellGet.UtilClasses;
+using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
-using Dbg = System.Diagnostics.Debug;
 using System.IO;
-using System.Linq;
 using System.Management.Automation;
-using System.Threading;
-using MoreLinq.Extensions;
-using Microsoft.PowerShell.PowerShellGet.UtilClasses;
+
+using Dbg = System.Diagnostics.Debug;
 using static Microsoft.PowerShell.PowerShellGet.UtilClasses.PSResourceInfo;
-using NuGet.Versioning;
 
 namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 {
@@ -38,7 +37,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         #region Public methods
 
-        public IEnumerable<PSResourceInfo> FilterPkgPaths(
+        public IEnumerable<PSResourceInfo> GetPackagesFromPath(
             string[] name,
             VersionRange versionRange,
             List<string> pathsToSearch)

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Management.Automation;
-using System.Threading;
 using Microsoft.PowerShell.PowerShellGet.UtilClasses;
 using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.Management.Automation;
 
 namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 {
@@ -130,7 +128,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
 
             GetHelper getHelper = new GetHelper(this);
-            foreach (PSResourceInfo pkg in getHelper.FilterPkgPaths(namesToSearch, _versionRange, _pathsToSearch))
+            foreach (PSResourceInfo pkg in getHelper.GetPackagesFromPath(namesToSearch, _versionRange, _pathsToSearch))
             {
                 WriteObject(pkg);
             }

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -1,5 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+using Microsoft.PowerShell.PowerShellGet.UtilClasses;
+using MoreLinq.Extensions;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Packaging.PackageExtraction;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -10,16 +21,6 @@ using System.Management.Automation;
 using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading;
-using MoreLinq.Extensions;
-using NuGet.Common;
-using NuGet.Configuration;
-using NuGet.Packaging;
-using NuGet.Packaging.Core;
-using NuGet.Packaging.PackageExtraction;
-using NuGet.Protocol;
-using NuGet.Protocol.Core.Types;
-using NuGet.Versioning;
-using Microsoft.PowerShell.PowerShellGet.UtilClasses;
 
 namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 {
@@ -28,33 +29,37 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// </summary>
     internal class InstallHelper : PSCmdlet
     {
+        #region Members
+
+        private const string MsgRepositoryNotTrusted = "Untrusted repository";
+        private const string MsgInstallUntrustedPackage = "You are installing the modules from an untrusted repository. If you trust this repository, change its Trusted value by running the Set-PSResourceRepository cmdlet. Are you sure you want to install the PSresource from '{0}' ?";
+
         private CancellationToken _cancellationToken;
-        private readonly bool _updatePkg;
         private readonly bool _savePkg;
         private readonly PSCmdlet _cmdletPassedIn;
-        List<string> _pathsToInstallPkg;
-        VersionRange _versionRange;
-        bool _prerelease;
-        bool _acceptLicense;
-        bool _quiet;
-        bool _reinstall;
-        bool _force;
-        bool _trustRepository;
-        bool _noClobber;
-        PSCredential _credential;
-        string _specifiedPath;
-        bool _asNupkg;
-        bool _includeXML;
+        private List<string> _pathsToInstallPkg;
+        private VersionRange _versionRange;
+        private bool _prerelease;
+        private bool _acceptLicense;
+        private bool _quiet;
+        private bool _reinstall;
+        private bool _force;
+        private bool _trustRepository;
+        private PSCredential _credential;
+        private string _specifiedPath;
+        private bool _asNupkg;
+        private bool _includeXML;
 
-        public InstallHelper(bool updatePkg, bool savePkg, PSCmdlet cmdletPassedIn)
+        #endregion
+
+        #region Public methods
+
+        public InstallHelper(bool savePkg, PSCmdlet cmdletPassedIn)
         {
-            // Define the cancellation token.
             CancellationTokenSource source = new CancellationTokenSource();
-            _cancellationToken = source.Token;
-            
-            this._updatePkg = updatePkg;
-            this._savePkg = savePkg;
-            this._cmdletPassedIn = cmdletPassedIn;
+            _cancellationToken = source.Token;   
+            _savePkg = savePkg;
+            _cmdletPassedIn = cmdletPassedIn;
         }
 
         public void InstallPackages(
@@ -67,7 +72,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             bool reinstall,
             bool force,
             bool trustRepository,
-            bool noClobber,
             PSCredential credential,
             string requiredResourceFile,
             string requiredResourceJson,
@@ -78,7 +82,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             List<string> pathsToInstallPkg)
         {
             _cmdletPassedIn.WriteVerbose(string.Format("Parameters passed in >>> Name: '{0}'; Version: '{1}'; Prerelease: '{2}'; Repository: '{3}'; " +
-                "AcceptLicense: '{4}'; Quiet: '{5}'; Reinstall: '{6}'; TrustRepository: '{7}'; NoClobber: '{8}';",
+                "AcceptLicense: '{4}'; Quiet: '{5}'; Reinstall: '{6}'; TrustRepository: '{7}';",
                 string.Join(",", names),
                 (versionRange != null ? versionRange.OriginalString : string.Empty),
                 prerelease.ToString(),
@@ -86,8 +90,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 acceptLicense.ToString(),
                 quiet.ToString(),
                 reinstall.ToString(),
-                trustRepository.ToString(),
-                noClobber.ToString()));
+                trustRepository.ToString()));
 
             _versionRange = versionRange;
             _prerelease = prerelease;
@@ -96,7 +99,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             _reinstall = reinstall;
             _force = force;
             _trustRepository = trustRepository;
-            _noClobber = noClobber;
             _credential = credential;
             _specifiedPath = specifiedPath;
             _asNupkg = asNupkg;
@@ -107,27 +109,30 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             ProcessRepositories(names, repository, _trustRepository, _credential);
         }
 
+        #endregion
+
+        #region Private methods
+
         // This method calls iterates through repositories (by priority order) to search for the pkgs to install
-        public void ProcessRepositories(string[] packageNames, string[] repository, bool trustRepository, PSCredential credential)
+        private void ProcessRepositories(string[] packageNames, string[] repository, bool trustRepository, PSCredential credential)
         {
             var listOfRepositories = RepositorySettings.Read(repository, out string[] _);
-            List<string> packagesToInstall = packageNames.ToList();
+            List<string> pckgNamesToInstall = packageNames.ToList();
             var yesToAll = false;
             var noToAll = false;
-            var repositoryIsNotTrusted = "Untrusted repository";
-            var queryInstallUntrustedPackage = "You are installing the modules from an untrusted repository. If you trust this repository, change its Trusted value by running the Set-PSResourceRepository cmdlet. Are you sure you want to install the PSresource from '{0}' ?";
 
+            var findHelper = new FindHelper(_cancellationToken, _cmdletPassedIn);
             foreach (var repo in listOfRepositories)
             {
                 // If no more packages to install, then return
-                if (!packagesToInstall.Any()) return;
+                if (!pckgNamesToInstall.Any()) return;
 
-                var sourceTrusted = false;
                 string repoName = repo.Name;
                 _cmdletPassedIn.WriteVerbose(string.Format("Attempting to search for packages in '{0}'", repoName));
 
                 // Source is only trusted if it's set at the repository level to be trusted, -TrustRepository flag is true, -Force flag is true
                 // OR the user issues trust interactively via console.
+                var sourceTrusted = true;
                 if (repo.Trusted == false && !trustRepository && !_force)
                 {
                     _cmdletPassedIn.WriteVerbose("Checking if untrusted repository should be used");
@@ -135,89 +140,74 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     if (!(yesToAll || noToAll))
                     {
                         // Prompt for installation of package from untrusted repository
-                        var message = string.Format(CultureInfo.InvariantCulture, queryInstallUntrustedPackage, repoName);
-                        sourceTrusted = _cmdletPassedIn.ShouldContinue(message, repositoryIsNotTrusted, true, ref yesToAll, ref noToAll);
+                        var message = string.Format(CultureInfo.InvariantCulture, MsgInstallUntrustedPackage, repoName);
+                        sourceTrusted = _cmdletPassedIn.ShouldContinue(message, MsgRepositoryNotTrusted, true, ref yesToAll, ref noToAll);
                     }
                 }
-                else
+
+                if (!sourceTrusted && !yesToAll)
                 {
-                    sourceTrusted = true;
+                    continue;
                 }
 
-                if (sourceTrusted || yesToAll)
+                _cmdletPassedIn.WriteVerbose("Untrusted repository accepted as trusted source.");
+
+                // If it can't find the pkg in one repository, it'll look for it in the next repo in the list
+                var isLocalRepo = repo.Url.AbsoluteUri.StartsWith(Uri.UriSchemeFile + Uri.SchemeDelimiter, StringComparison.OrdinalIgnoreCase);
+
+                // Finds parent packages and dependencies
+                IEnumerable<PSResourceInfo> pkgsFromRepoToInstall = findHelper.FindByResourceName(
+                    name: packageNames,
+                    type: ResourceType.None,
+                    version: _versionRange != null ? _versionRange.OriginalString : null,
+                    prerelease: _prerelease,
+                    tag: null,
+                    repository: new string[] { repoName },
+                    credential: credential,
+                    includeDependencies: true);
+
+                if (!pkgsFromRepoToInstall.Any())
                 {
-                    _cmdletPassedIn.WriteVerbose("Untrusted repository accepted as trusted source.");
+                    _cmdletPassedIn.WriteVerbose(string.Format("None of the specified resources were found in the '{0}' repository.", repoName));
+                    // Check in the next repository
+                    continue;
+                }
 
-                    // If it can't find the pkg in one repository, it'll look for it in the next repo in the list
-                    var isLocalRepo = repo.Url.AbsoluteUri.StartsWith(Uri.UriSchemeFile + Uri.SchemeDelimiter, StringComparison.OrdinalIgnoreCase);
+                // Select the first package from each name group, which is guaranteed to be the latest version.
+                // We should only have one version returned for each package name
+                // e.g.:
+                // PackageA (version 1.0)
+                // PackageB (version 2.0)
+                // PackageC (version 1.0)
+                pkgsFromRepoToInstall = pkgsFromRepoToInstall.GroupBy(
+                    m => new { m.Name }).Select(
+                        group => group.First()).ToList();
 
+                // Check to see if the pkgs (including dependencies) are already installed (ie the pkg is installed and the version satisfies the version range provided via param)
+                if (!_reinstall)
+                {
+                    // Removes all of the names that are already installed from the list of names to search for
+                    pkgsFromRepoToInstall = FilterByInstalledPkgs(pkgsFromRepoToInstall);
+                }
 
-                    var findHelper = new FindHelper(_cancellationToken, _cmdletPassedIn);
-                    // Finds parent packages and dependencies
-                    IEnumerable<PSResourceInfo> pkgsFromRepoToInstall = findHelper.FindByResourceName(
-                        name: packageNames,
-                        type: ResourceType.None,
-                        version: _versionRange != null ? _versionRange.OriginalString : null,
-                        prerelease: _prerelease,
-                        tag: null,
-                        repository: new string[] { repoName },
-                        credential: credential,
-                        includeDependencies: true);
+                if (!pkgsFromRepoToInstall.Any())
+                {
+                    continue;
+                }
 
-                    foreach (PSResourceInfo a in pkgsFromRepoToInstall)
-                    {
-                        var test = a;
-                        _cmdletPassedIn.WriteVerbose(a.Version.ToString());
-                    }
+                List<string> pkgsInstalled = InstallPackage(pkgsFromRepoToInstall, repoName, repo.Url.AbsoluteUri, credential, isLocalRepo);
 
-                    // Select the first package from each name group, which is guaranteed to be the latest version.
-                    // We should only have one version returned for each package name
-                    // e.g.:
-                    // PackageA (version 1.0)
-                    // PackageB (version 2.0)
-                    // PackageC (version 1.0)
-                    pkgsFromRepoToInstall = pkgsFromRepoToInstall.GroupBy(
-                        m => new { m.Name }).Select(
-                            group => group.First()).ToList();
-                    
-                    if (!pkgsFromRepoToInstall.Any())
-                    {
-                        _cmdletPassedIn.WriteVerbose(string.Format("None of the specified resources were found in the '{0}' repository.", repoName));
-                        // Check in the next repository
-                        continue;
-                    }
-
-                    // Check to see if the pkgs (including dependencies) are already installed (ie the pkg is installed and the version satisfies the version range provided via param)
-                    if (!_reinstall)
-                    {
-                        // Removes all of the names that are already installed from the list of names to search for
-                        pkgsFromRepoToInstall = FilterByInstalledPkgs(pkgsFromRepoToInstall);
-                    }
-
-                    if (!pkgsFromRepoToInstall.Any())
-                    {
-                        continue;
-                    }
-
-                    List<string> pkgsInstalled = InstallPackage(pkgsFromRepoToInstall, repoName, repo.Url.AbsoluteUri, credential, isLocalRepo);
-
-                    foreach (string name in pkgsInstalled)
-                    {
-                        packagesToInstall.Remove(name);
-                    }
+                foreach (string name in pkgsInstalled)
+                {
+                    pckgNamesToInstall.Remove(name);
                 }
             }
         }
 
         // Check if any of the pkg versions are already installed, if they are we'll remove them from the list of packages to install
-        public IEnumerable<PSResourceInfo> FilterByInstalledPkgs(IEnumerable<PSResourceInfo> packagesToInstall)
+        private IEnumerable<PSResourceInfo> FilterByInstalledPkgs(IEnumerable<PSResourceInfo> packages)
         {
-            List<string> pkgNames = new List<string>();
-            foreach (var pkg in packagesToInstall)
-            {
-                pkgNames.Add(pkg.Name);
-            }
-
+            // Create list of installation paths to search.
             List<string> _pathsToSearch = new List<string>();
             GetHelper getHelper = new GetHelper(_cmdletPassedIn);
             // _pathsToInstallPkg will only contain the paths specified within the -Scope param (if applicable)
@@ -232,21 +222,34 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 _pathsToSearch.AddRange(Utils.GetSubDirectories(path));
             }
 
-            IEnumerable<PSResourceInfo> pkgsAlreadyInstalled = getHelper.FilterPkgPaths(pkgNames.ToArray(), _versionRange, _pathsToSearch);
-
-            // If any pkg versions are already installed, write a message saying it is already installed and continue processing other pkg names
-            if (pkgsAlreadyInstalled.Any())
+            var filteredPackages = new Dictionary<string, PSResourceInfo>();
+            foreach (var pkg in packages)
             {
-                foreach (PSResourceInfo pkg in pkgsAlreadyInstalled)
-                {
-                    _cmdletPassedIn.WriteWarning(string.Format("Resource '{0}' with version '{1}' is already installed.  If you would like to reinstall, please run the cmdlet again with the -Reinstall parameter", pkg.Name, pkg.Version));
-
-                    // remove this pkg from the list of pkg names install
-                    packagesToInstall.ToList().Remove(pkg);
-                }
+                filteredPackages.Add(pkg.Name, pkg);
             }
 
-            return packagesToInstall;
+            // Get currently installed packages.
+            IEnumerable<PSResourceInfo> pkgsAlreadyInstalled = getHelper.GetPackagesFromPath(
+                name: filteredPackages.Keys.ToArray(),
+                versionRange: _versionRange,
+                pathsToSearch: _pathsToSearch);
+            if (!pkgsAlreadyInstalled.Any())
+            {
+                return packages;
+            }
+
+            // Remove from list package versions that are already installed.
+            foreach (PSResourceInfo pkg in pkgsAlreadyInstalled)
+            {
+                _cmdletPassedIn.WriteWarning(
+                    string.Format("Resource '{0}' with version '{1}' is already installed.  If you would like to reinstall, please run the cmdlet again with the -Reinstall parameter",
+                    pkg.Name,
+                    pkg.Version));
+
+                filteredPackages.Remove(pkg.Name);
+            }
+
+            return filteredPackages.Values.ToArray();
         }
 
         private List<string> InstallPackage(IEnumerable<PSResourceInfo> pkgsToInstall, string repoName, string repoUrl, PSCredential credential, bool isLocalRepo)
@@ -705,5 +708,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 Utils.MoveFiles(scriptPath, Path.Combine(finalModuleVersionDir, p.Name + ".ps1"));
             }
         }
+
+        #endregion
     }
 }

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -125,7 +125,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void ProcessRecord()
         {
-            var installHelper = new InstallHelper(updatePkg: false, savePkg: false, cmdletPassedIn: this);
+            var installHelper = new InstallHelper(savePkg: false, cmdletPassedIn: this);
             switch (ParameterSetName)
             {
                 case NameParameterSet:
@@ -235,7 +235,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 reinstall: Reinstall,
                 force: false,
                 trustRepository: TrustRepository,
-                noClobber: false,
                 credential: Credential,
                 requiredResourceFile: null, 
                 requiredResourceJson: null, 

--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -5,9 +5,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PowerShellGet</RootNamespace>
     <AssemblyName>PowerShellGet</AssemblyName>
-    <AssemblyVersion>3.0.11.0</AssemblyVersion>
-    <FileVersion>3.0.11</FileVersion>
-    <InformationalVersion>3.0.11</InformationalVersion>
+    <AssemblyVersion>3.0.12.0</AssemblyVersion>
+    <FileVersion>3.0.12</FileVersion>
+    <InformationalVersion>3.0.12</InformationalVersion>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -140,7 +140,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void ProcessRecord()
         {
-            var installHelper = new InstallHelper(updatePkg: false, savePkg: true, cmdletPassedIn: this);
+            var installHelper = new InstallHelper(savePkg: true, cmdletPassedIn: this);
             switch (ParameterSetName)
             {
                 case NameParameterSet:
@@ -234,8 +234,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 quiet: true, 
                 reinstall: true, 
                 force: false, 
-                trustRepository: TrustRepository, 
-                noClobber: false, 
+                trustRepository: TrustRepository,
                 credential: Credential, 
                 requiredResourceFile: null,
                 requiredResourceJson: null, 

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -1,16 +1,12 @@
-using System.Collections.Specialized;
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using Dbg = System.Diagnostics.Debug;
-using System.Linq;
-using System.Management.Automation;
-using System.Text;
-using System.Threading;
 using Microsoft.PowerShell.PowerShellGet.UtilClasses;
 using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
 
 namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 {
@@ -144,7 +140,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
 
             InstallHelper installHelper = new InstallHelper(
-                updatePkg: true,
                 savePkg: false,
                 cmdletPassedIn: this);
 
@@ -155,10 +150,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 repository: Repository,
                 acceptLicense: AcceptLicense,
                 quiet: Quiet,
-                reinstall: false,
+                reinstall: true,
                 force: Force,
                 trustRepository: TrustRepository,
-                noClobber: false,
                 credential: Credential,
                 requiredResourceFile: null,
                 requiredResourceJson: null,
@@ -211,7 +205,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 GetHelper getHelper = new GetHelper(
                     cmdletPassedIn: this);
 
-                namesToProcess = getHelper.FilterPkgPaths(
+                namesToProcess = getHelper.GetPackagesFromPath(
                     name: namesToProcess,
                     versionRange: versionRange,
                     pathsToSearch: Utils.GetAllResourcePaths(this)).Select(p => p.Name).ToArray();

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -196,6 +196,32 @@ Describe 'Test Install-PSResource for Module' {
         $pkg.Version | Should -Be "1.3.0"
     }
 
+    It "Restore resource after reinstall fails" {
+        Install-PSResource -Name "TestModule" -Repository $TestGalleryName
+        $pkg = Get-Module "TestModule" -ListAvailable
+        $pkg.Name | Should -Be "TestModule"
+        $pkg.Version | Should -Be "1.3.0"
+
+        $resourcePath = Split-Path -Path $pkg.Path -Parent
+        $resourceFiles = Get-ChildItem -Path $resourcePath -Recurse
+
+        # Lock resource file to prevent reinstall from succeeding.
+        $fs = [System.IO.File]::Open($resourceFiles[0].FullName, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
+        try
+        {
+            # Reinstall of resource should fail with one of its files locked.
+            Install-PSResource -Name "TestModule" -Repository $TestGalleryName -Reinstall -ErrorVariable ev -ErrorAction Silent
+            $ev.FullyQualifiedErrorId | Should -BeExactly 'InstallPackageFailed,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource'
+        }
+        finally
+        {
+            $fs.Close()
+        }
+
+        # Verify that resource module has been restored.
+        (Get-ChildItem -Path $resourcePath -Recurse).Count | Should -BeExactly $resourceFiles.Count
+    }
+
     It "Install resource that requires accept license with -AcceptLicense flag" {
         Install-PSResource -Name "testModuleWithlicense" -Repository $TestGalleryName -AcceptLicense
         $pkg = Get-InstalledPSResource "testModuleWithlicense"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR fixes the 'always reinstall and restore on fail issue' of Issue #498, and also updates the build version to the next release (beta12).  This PR also includes some general code clean up.

## PR Context

`Install-PSResource` was always reinstalling modules even though `-Reinstall` switch was not selected.  This is because the code was not correctly removing 'already installed' packages from the 'toinstall' list.

Also, if a reinstall fails because one of the files is locked (as can happen with loaded .NET binaries) then an error message is emitted and the original resource module files are restored.

Unused variables and parameter arguments were removed.
Some minor code refactoring and method renaming for better clarity.
Added some code regions where they were missing.
Alphabetized using statements per code style guidelines.
Upped module version to 3.0.12 beta.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
