### PR TITLE
update error message to mention repo & clean up some success/fail messages

### DIFF
--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -374,7 +374,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     return;
                 }
 
-                 PushNupkg(outputNupkgDir, repositoryUrl);
+                PushNupkg(outputNupkgDir, repository.Name, repositoryUrl);
             }
             finally {
                 WriteVerbose(string.Format("Deleting temporary directory '{0}'", outputDir));
@@ -831,13 +831,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
             else
             {
-                WriteVerbose("Successfully packed the resource into a .nupkg");
+                WriteVerbose("Not able to successfully pack the resource into a .nupkg");
             }
 
             return success;
         }
 
-        private void PushNupkg(string outputNupkgDir, string repoUrl)
+        private void PushNupkg(string outputNupkgDir, string repoName, string repoUrl)
         {
             // Push the nupkg to the appropriate repository 
             // Pkg version is parsed from .ps1 file or .psd1 file 
@@ -875,7 +875,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 //  look in PS repo for how httpRequestExceptions are handled
 
                 // Unfortunately there is no response message  are no status codes provided with the exception and no 
-                var ex = new ArgumentException(e.Message);
+                var ex = new ArgumentException(String.Format("Repository '{0}': {1}", repoName, e.Message));
                 if (e.Message.Contains("401"))
                 {
                     if (e.Message.Contains("API"))
@@ -924,7 +924,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
             else
             {
-                WriteVerbose(string.Format("Successfully published the resource to '{0}'", repoUrl));
+                WriteVerbose(string.Format("Not able to publish resource to '{0}'", repoUrl));
             }            
         }
     }


### PR DESCRIPTION
If publishing to a repository fails currently we write an error with the error code and a corresponding message. For further clarity that error message should also specify which repository the user was attempting to publish to when this error occurred. I add this to the error message, by passing in the repository name to `PublishPSResource.PushNupkg()`.

Some of the success/failure verbose messages I saw in publish were the same regardless of whether it was a failure or success, so I updated that as well.

screenshot of updated error message:
![image](https://user-images.githubusercontent.com/30238344/140193619-10418092-b5c9-421b-9ef4-4d936a87b19c.png)

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Resolves #345 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
