### PR TITLE
Add -Name parameter to Publish-PSResource

### DIFF
--- a/help/Publish-PSResource.md
+++ b/help/Publish-PSResource.md
@@ -19,9 +19,9 @@ Publish-PSResource [-APIKey <String>] [-Repository <String>] [-Path] <String>
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### PathLiteralParameterSet
+### NameParameterSet
 ```
-Publish-PSResource [-APIKey <String>] [-Repository <String>] -LiteralPath <String>
+Publish-PSResource [-APIKey <String>] [-Repository <String>] -Name <String>
  [-Credential <PSCredential>] [-SkipDependenciesCheck]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
@@ -80,7 +80,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-When specified, includes prerelease versions in search.
+Specifies the path to the resource that you want to publish. This parameter accepts the path to the folder that contains the module or the full path of the script.
 
 ```yaml
 Type: System.String
@@ -94,12 +94,13 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
-### -LiteralPath
-Specifies a path to one or more locations. Unlike the Path parameter, the value of the LiteralPath parameter is used exactly as entered. No characters are interpreted as wildcards. If the path includes escape characters, enclose them in single quotation marks. Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+### -Name
+Specifies the name of the module that you want to publish. Searches for the specified module name in $Env:PSModulePath.
+This parameter can only be used to publish modules.
 
 ```yaml
 Type: System.String
-Parameter Sets: PathLiteralParameterSet
+Parameter Sets: NameParameterSet
 Aliases:
 
 Required: True

--- a/test/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResource.Tests.ps1
@@ -74,6 +74,20 @@ Describe "Test Publish-PSResource" {
         (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath 
     }
 
+    It "Publish a module with -Name and -Repository" {
+        $version = "1.0.0"
+        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
+        $modulePath = $env:PSModulePath.split(";")[0]
+        Copy-Item -Path $script:PublishModuleBase -Destination $modulePath -recurse
+
+        Publish-PSResource -Name $script:PublishModuleName -Repository $testRepository2
+
+        $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$script:PublishModuleName.$version.nupkg"
+        (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath 
+
+        Remove-Item -Path (Join-Path -Path $modulePath -ChildPath $script:PublishModuleName) -Recurse
+    }
+
 <# Temporarily comment this test out until Find Helper is complete and code within PublishPSResource is uncommented 
     It "Publish a module with dependencies" {
         # Create dependency module


### PR DESCRIPTION
# PR Summary
Complete the -Name parameter for Publish-PSResource. 

## PR Context
As per the [v2 documentation](https://docs.microsoft.com/en-us/powershell/module/powershellget/publish-module?view=powershell-7.1#description): 

> Specifies the name of the module that you want to publish. Publish-Module searches for the specified module name in $Env:PSModulePath.
> 
> When you specify a module by name, Publish-Module publishes the first module that would be found by running Get-Module -ListAvailable <Name>. If you specify a minimum version of a module to publish, Publish-Module publishes the first module with a version that is greater than or equal to the minimum version that you have specified.

Parameter set names were added to differentiate between the 'NameParameterSet' (using the -Name param) and the 'PathParameterSet' (using the -Path param). 


Resolves #469 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
