### PR TITLE
Uri bug fix

### DIFF
--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -126,9 +126,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             switch (ParameterSetName)
             {
                 case NameParameterSet:
-                    if (!Utils.TryCreateValidUrl(urlString: URL,
+                    if (!Utils.TryCreateValidUrl(uriString: URL,
                         cmdletPassedIn: this,
-                        urlResult: out _url,
+                        uriResult: out _url,
                         errorRecord: out ErrorRecord errorRecord))
                     {
                         ThrowTerminatingError(errorRecord);
@@ -312,9 +312,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 return null;
             }
 
-            if (!Utils.TryCreateValidUrl(urlString: repo["Url"].ToString(),
+            if (!Utils.TryCreateValidUrl(uriString: repo["Url"].ToString(),
                 cmdletPassedIn: this,
-                urlResult: out Uri repoURL,
+                uriResult: out Uri repoURL,
                 errorRecord: out ErrorRecord errorRecord))
             {
                 WriteError(errorRecord);

--- a/src/code/SetPSResourceRepository.cs
+++ b/src/code/SetPSResourceRepository.cs
@@ -234,9 +234,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     return null;
                 }
 
-                if (!Utils.TryCreateValidUrl(urlString: repo["Url"].ToString(),
+                if (!Utils.TryCreateValidUrl(uriString: repo["Url"].ToString(),
                     cmdletPassedIn: this,
-                    urlResult: out repoURL,
+                    uriResult: out repoURL,
                     errorRecord: out ErrorRecord errorRecord))
                 {
                     WriteError(errorRecord);

--- a/test/RegisterPSResourceRepository.Tests.ps1
+++ b/test/RegisterPSResourceRepository.Tests.ps1
@@ -195,7 +195,7 @@ Describe "Test Register-PSResourceRepository" {
     $testCases2 = @{Type = "-Name is not specified";                 IncorrectHashTable = @{URL = $tmpDir1Path};                             ErrorId = "NullNameForRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
                   @{Type = "-Name is PSGallery";                     IncorrectHashTable = @{Name = "PSGallery"; URL = $tmpDir1Path};         ErrorId = "PSGalleryProvidedAsNameRepoPSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
                   @{Type = "-URL not specified";                     IncorrectHashTable = @{Name = "testRepository"};                        ErrorId = "NullURLForRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
-                  @{Type = "-URL is not valid scheme";               IncorrectHashTable = @{Name = "testRepository"; URL="www.google.com"};  ErrorId = "InvalidUrl,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"}
+                  @{Type = "-URL is not valid scheme";               IncorrectHashTable = @{Name = "testRepository"; URL="www.google.com"};  ErrorId = "InvalidUri,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"}
 
     It "not register incorrectly formatted Name type repo among correct ones when incorrect type is <Type>" -TestCases $testCases2 {
         param($Type, $IncorrectHashTable, $ErrorId)

--- a/test/RegisterPSResourceRepository.Tests.ps1
+++ b/test/RegisterPSResourceRepository.Tests.ps1
@@ -230,4 +230,12 @@ Describe "Test Register-PSResourceRepository" {
         $res.Trusted | Should -Be False
         $res.Priority | Should -Be 50
     }
+
+    It "should register local file share NuGet based repository" {
+        Register-PSResourceRepository -Name "localFileShareTestRepo" -URL "\\hcgg.rest.of.domain.name\test\ITxx\team\NuGet\"
+        $res = Get-PSResourceRepository -Name "localFileShareTestRepo"
+
+        $res.Name | Should -Be "localFileShareTestRepo"
+        $res.URL.LocalPath | Should -Contain "\\hcgg.rest.of.domain.name\test\ITxx\team\NuGet\"
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR addresses a bug that occurs when attempting to register certain types of repositories, for example, a local file share based NuGet repository. This PR allows for any repository URL that is of a valid URI scheme to be registered.

## PR Context
Resolves #496 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
