### PR TITLE
Replace Directory.Delete with Utils.DeleteDirectory

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -695,12 +695,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             if (Directory.Exists(relsDirToDelete))
             {
                 _cmdletPassedIn.WriteVerbose(string.Format("Deleting '{0}'", relsDirToDelete));
-                Directory.Delete(relsDirToDelete, true);
+                Utils.DeleteDirectory(relsDirToDelete);
             }
             if (Directory.Exists(packageDirToDelete))
             {
                 _cmdletPassedIn.WriteVerbose(string.Format("Deleting '{0}'", packageDirToDelete));
-                Directory.Delete(packageDirToDelete, true);
+                Utils.DeleteDirectory(packageDirToDelete);
             }
         }
 

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -413,7 +413,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
             finally {
                 WriteVerbose(string.Format("Deleting temporary directory '{0}'", outputDir));
-                Directory.Delete(outputDir, recursive:true);
+                Utils.DeleteDirectory(outputDir);
             }
         }
 

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -227,7 +227,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 {
                     if (Utils.GetSubDirectories(dir.Parent.FullName).Length == 0)
                     {
-                        Directory.Delete(dir.Parent.FullName, true);
+                        Utils.DeleteDirectory(dir.Parent.FullName);
                     }
                 }
                 catch (Exception e) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR replaces the use of `Directory.Delete` with our utility function `Utils.DeleteDirectory`.  This utility will include any special processing like ensuring directory files accessibility allow deletion.

## PR Context

We should be consistent using the same directory delete utility (unless there is a good reason not to).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
