### PR TITLE
Change all instances of 'Get-InstalledPSResource' to 'Get-PSResource'

### DIFF
--- a/Docs/GetPSResource.md
+++ b/Docs/GetPSResource.md
@@ -1,6 +1,6 @@
-# Get-InstalledPSResource
+# Get-PSResource
 
-The `Get-InstalledPSResource` cmdlet combines the `Get-InstalledModule, Get-InstalledScript` cmdlets from V2.
+The `Get-PSResource` cmdlet combines the `Get-InstalledModule, Get-InstalledScript` cmdlets from V2.
 It performs a search within module or script installation paths based on the `-Name` parameter argument.
 It returns `PSRepositoryItemInfo` objects which describe each resource item found.
 Other parameters allow the returned results to be filtered by version, prerelease version, and path.

--- a/help/Get-PSResource.md
+++ b/help/Get-PSResource.md
@@ -5,7 +5,7 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-InstalledPSResource
+# Get-PSResource
 
 ## SYNOPSIS
 Returns resources (modules and scripts) installed on the machine via PowerShellGet.
@@ -13,45 +13,45 @@ Returns resources (modules and scripts) installed on the machine via PowerShellG
 ## SYNTAX
 
 ```
-Get-InstalledPSResource [[-Name] <String[]>] [-Version <String>] [-Path <String>] [<CommonParameters>]
+Get-PSResource [[-Name] <String[]>] [-Version <String>] [-Path <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Get-InstalledPSResource cmdlet combines the Get-InstalledModule, Get-InstalledScript cmdlets from V2. It performs a search within module or script installation paths based on the -Name parameter argument. It returns PSResourceInfo objects which describes each resource item found. Other parameters allow the returned results to be filtered by version and path.
+The Get-PSResource cmdlet combines the Get-InstalledModule, Get-InstalledScript cmdlets from V2. It performs a search within module or script installation paths based on the -Name parameter argument. It returns PSResourceInfo objects which describes each resource item found. Other parameters allow the returned results to be filtered by version and path.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> Get-InstalledPSResource Az
+PS C:\> Get-PSResource Az
 ```
 
 This will return versions of the Az module installed via PowerShellGet.
 
 ### Example 2
 ```powershell
-PS C:\> Get-InstalledPSResource Az -version "1.0.0"
+PS C:\> Get-PSResource Az -version "1.0.0"
 ```
 
 This will return version 1.0.0 of the Az module.
 
 ### Example 3
 ```powershell
-PS C:\> Get-InstalledPSResource Az -version "(1.0.0, 3.0.0)"
+PS C:\> Get-PSResource Az -version "(1.0.0, 3.0.0)"
 ```
 
 This will return all versions of the Az module within the specified range.
 
 ### Example 4
 ```powershell
-PS C:\> Get-InstalledPSResource Az -Path .
+PS C:\> Get-PSResource Az -Path .
 ```
 
 This will return all versions of the Az module that have been installed in the current directory.
 
 ### Example 5
 ```powershell
-PS C:\> Get-InstalledPSResource
+PS C:\> Get-PSResource
 ```
 
 This will return all versions and scripts installed on the machine.

--- a/help/Update-PSResource.md
+++ b/help/Update-PSResource.md
@@ -27,14 +27,14 @@ It does not return an object. Other parameters allow the package to be updated t
 
 ### Example 1
 ```powershell
-PS C:\> Get-InstalledPSResource -Name "TestModule"
+PS C:\> Update-PSResource -Name "TestModule"
         Name                                    Version                         Prerelease   Description
         ----                                    -------                         ----------   -----------
         TestModule                              1.2.0                                        test
 
 PS C:\> Update-PSResource -Name "TestModule"
 
-PS C:\> Get-InstalledPSResource -Name "TestModule"
+PS C:\> Update-PSResource -Name "TestModule"
         Name                                    Version                         Prerelease   Description
         ----                                    -------                         ----------   -----------
         TestModule                              1.3.0                                        test

--- a/help/en-US/PowerShellGet.dll-Help.xml
+++ b/help/en-US/PowerShellGet.dll-Help.xml
@@ -353,7 +353,7 @@
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
-      <command:name>Get-InstalledPSResource</command:name>
+      <command:name>Get-PSResource</command:name>
       <command:verb>Get</command:verb>
       <command:noun>PSResource</command:noun>
       <maml:description>

--- a/src/PowerShellGet.psd1
+++ b/src/PowerShellGet.psd1
@@ -15,7 +15,7 @@
     FormatsToProcess  = 'PSGet.Format.ps1xml'
     CmdletsToExport = @(
         'Find-PSResource',
-        'Get-InstalledPSResource',
+        'Get-PSResource',
         'Get-PSResourceRepository',
         'Install-PSResource',
         'Register-PSResourceRepository',
@@ -63,7 +63,7 @@ All tests have been reviewed and rewritten as needed.
 - Install-PSResource no longer creates version folder with the prerelease tag
 - Update-PSResource can now update all resources, and no longer requires name param
 - Save-PSResource properly handles saving scripts
-- Get-InstalledPSResource uses default PowerShell paths
+- Get-PSResource uses default PowerShell paths
 '@
         }
     }

--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -14,7 +14,7 @@ using static Microsoft.PowerShell.PowerShellGet.UtilClasses.PSResourceInfo;
 namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 {
     /// <summary>
-    /// Get helper class provides the core functionality for Get-InstalledPSResource.
+    /// Get helper class provides the core functionality for Get-PSResource.
     /// </summary>
     internal class GetHelper
     {

--- a/src/code/GetPSResource.cs
+++ b/src/code/GetPSResource.cs
@@ -13,8 +13,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// It retrieves a resource that was installed with Install-PSResource
     /// Returns a single resource or multiple resource.
     /// </summary>
-    [Cmdlet(VerbsCommon.Get, "InstalledPSResource")]
-    public sealed class GetInstalledPSResource : PSCmdlet
+    [Cmdlet(VerbsCommon.Get, "PSResource")]
+    public sealed class GetPSResource : PSCmdlet
     {
         #region Members
 
@@ -108,7 +108,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void ProcessRecord()
         {
-            WriteVerbose("Entering GetInstalledPSResource");
+            WriteVerbose("Entering GetPSResource");
 
             var namesToSearch = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool _);
             foreach (string error in errorMsgs)

--- a/test/GetInstalledPSResource.Tests.ps1
+++ b/test/GetInstalledPSResource.Tests.ps1
@@ -3,7 +3,7 @@
 
 Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
 
-Describe 'Test Get-InstalledPSResource for Module' {
+Describe 'Test Get-PSResource for Module' {
 
     BeforeAll{
         $TestGalleryName = Get-PoshTestGalleryName
@@ -23,17 +23,17 @@ Describe 'Test Get-InstalledPSResource for Module' {
     }
 
     It "Get resources without any parameter values" {
-        $pkgs = Get-InstalledPSResource
+        $pkgs = Get-PSResource
         $pkgs.Count | Should -BeGreaterThan 1
     }
 
     It "Get specific module resource by name" {
-        $pkg = Get-InstalledPSResource -Name ContosoServer
+        $pkg = Get-PSResource -Name ContosoServer
         $pkg.Name | Should -Contain "ContosoServer"
     }
 
     It "Get specific script resource by name" {
-        $pkg = Get-InstalledPSResource -Name TestTestScript
+        $pkg = Get-PSResource -Name TestTestScript
         $pkg.Name | Should -Be "TestTestScript"
     }
 
@@ -44,7 +44,7 @@ Describe 'Test Get-InstalledPSResource for Module' {
         @{Name="Cont*erver";   ExpectedName="ContosoServer"; Reason="validate name, with wildcard in middle of name: Cont*erver"}
     ) {
         param($Version, $ExpectedVersion)
-        $pkgs = Get-InstalledPSResource -Name $Name
+        $pkgs = Get-PSResource -Name $Name
         $pkgs.Name | Should -Contain "ContosoServer"
     }
 
@@ -61,7 +61,7 @@ $testCases =
 
     It "Get resource when given Name to <Reason> <Version>" -TestCases $testCases {
         param($Version, $ExpectedVersion)
-        $pkgs = Get-InstalledPSResource -Name "ContosoServer" -Version $Version
+        $pkgs = Get-PSResource -Name "ContosoServer" -Version $Version
         $pkgs.Name | Should -Contain "ContosoServer"
         $pkgs.Version | Should -Be $ExpectedVersion
     }
@@ -105,15 +105,15 @@ $testCases =
     }
 
     It "Get resources when given Name, and Version is '*'" {
-        $pkgs = Get-InstalledPSResource -Name ContosoServer -Version "*"
+        $pkgs = Get-PSResource -Name ContosoServer -Version "*"
         $pkgs.Count | Should -BeGreaterOrEqual 2
     }
 
     It "Get prerelease version module when version with correct prerelease label is specified" {
         Install-PSResource -Name $testModuleName -Version "5.2.5-alpha001" -Repository $TestGalleryName
-        $res = Get-InstalledPSResource -Name $testModuleName -Version "5.2.5"
+        $res = Get-PSResource -Name $testModuleName -Version "5.2.5"
         $res | Should -BeNullOrEmpty
-        $res = Get-InstalledPSResource -Name $testModuleName -Version "5.2.5-alpha001"
+        $res = Get-PSResource -Name $testModuleName -Version "5.2.5-alpha001"
         $res.Name | Should -Be $testModuleName
         $res.Version | Should -Be "5.2.5"
         $res.PrereleaseLabel | Should -Be "alpha001"
@@ -121,9 +121,9 @@ $testCases =
 
     It "Get prerelease version script when version with correct prerelease label is specified" {
         Install-PSResource -Name $testScriptName -Version "3.0.0-alpha001" -Repository $TestGalleryName
-        $res = Get-InstalledPSResource -Name $testScriptName -Version "3.0.0"
+        $res = Get-PSResource -Name $testScriptName -Version "3.0.0"
         $res | Should -BeNullOrEmpty
-        $res = Get-InstalledPSResource -Name $testScriptName -Version "3.0.0-alpha001"
+        $res = Get-PSResource -Name $testScriptName -Version "3.0.0-alpha001"
         $res.Name | Should -Be $testScriptName
         $res.Version | Should -Be "3.0.0"
         $res.PrereleaseLabel | Should -Be "alpha001"

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -44,7 +44,7 @@ Describe 'Test Install-PSResource for Module' {
 
     It "Install specific script resource by name" {
         Install-PSResource -Name "TestTestScript" -Repository $TestGalleryName  
-        $pkg = Get-InstalledPSResource "TestTestScript"
+        $pkg = Get-PSResource "TestTestScript"
         $pkg.Name | Should -Be "TestTestScript" 
         $pkg.Version | Should -Be "1.3.1.0"
     }
@@ -225,7 +225,7 @@ Describe 'Test Install-PSResource for Module' {
 
     It "Install resource that requires accept license with -AcceptLicense flag" {
         Install-PSResource -Name "testModuleWithlicense" -Repository $TestGalleryName -AcceptLicense
-        $pkg = Get-InstalledPSResource "testModuleWithlicense"
+        $pkg = Get-PSResource "testModuleWithlicense"
         $pkg.Name | Should -Be "testModuleWithlicense" 
         $pkg.Version | Should -Be "0.0.3.0"
     }
@@ -243,12 +243,12 @@ Describe 'Test Install-PSResource for Module' {
 
     It "Install resource with cmdlet names from a module already installed (should clobber)" {
         Install-PSResource -Name "myTestModule" -Repository $TestGalleryName  
-        $pkg = Get-InstalledPSResource "myTestModule"
+        $pkg = Get-PSResource "myTestModule"
         $pkg.Name | Should -Be "myTestModule" 
         $pkg.Version | Should -Be "0.0.3.0"
 
         Install-PSResource -Name "myTestModule2" -Repository $TestGalleryName  
-        $pkg = Get-InstalledPSResource "myTestModule2"
+        $pkg = Get-PSResource "myTestModule2"
         $pkg.Name | Should -Be "myTestModule2" 
         $pkg.Version | Should -Be "0.0.1.0"
     }
@@ -291,7 +291,7 @@ Describe 'Test Install-PSResource for Module' {
     }
         It "Install PSResourceInfo object piped in" {
         Find-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName | Install-PSResource
-        $res = Get-InstalledPSResource -Name $testModuleName
+        $res = Get-PSResource -Name $testModuleName
         $res.Name | Should -Be $testModuleName
         $res.Version | Should -Be "1.1.0.0"
     }
@@ -328,7 +328,7 @@ Describe 'Test Install-PSResource for interactive and root user scenarios' {
     # This needs to be manually tested due to prompt
     It "Install resource that requires accept license without -AcceptLicense flag" {
         Install-PSResource -Name "testModuleWithlicense" -Repository $TestGalleryName
-        $pkg = Get-InstalledPSResource "testModuleWithlicense"
+        $pkg = Get-PSResource "testModuleWithlicense"
         $pkg.Name | Should -Be "testModuleWithlicense" 
         $pkg.Version | Should -Be "0.0.1.0"
     }

--- a/test/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResource.Tests.ps1
@@ -141,14 +141,14 @@ Describe 'Test Uninstall-PSResource for Modules' {
     It "Uninstall prerelease version module when prerelease version specified" {
         Install-PSResource -Name $testModuleName -Version "5.2.5-alpha001" -Repository $TestGalleryName
         Uninstall-PSResource -Name $testModuleName -Version "5.2.5-alpha001"
-        $res = Get-InstalledPSResource $testModuleName -Version "5.2.5-alpha001"
+        $res = Get-PSResource $testModuleName -Version "5.2.5-alpha001"
         $res | Should -BeNullOrEmpty
     }
 
     It "Not uninstall non-prerelease version module when similar prerelease version is specified" {
         Install-PSResource -Name $testModuleName -Version "5.0.0.0" -Repository $TestGalleryName
         Uninstall-PSResource -Name $testModuleName -Version "5.0.0-preview"
-        $res = Get-InstalledPSResource -Name $testModuleName -Version "5.0.0.0"
+        $res = Get-PSResource -Name $testModuleName -Version "5.0.0.0"
         $res.Name | Should -Be $testModuleName
         $res.Version | Should -Be "5.0.0.0"
     }
@@ -156,14 +156,14 @@ Describe 'Test Uninstall-PSResource for Modules' {
     It "Uninstall prerelease version script when prerelease version specified" {
         Install-PSResource -Name $testScriptName -Version "3.0.0-alpha001" -Repository $TestGalleryName
         Uninstall-PSResource -Name $testScriptName -Version "3.0.0-alpha001"
-        $res = Get-InstalledPSResource -Name $testScriptName
+        $res = Get-PSResource -Name $testScriptName
         $res | Should -BeNullOrEmpty
     }
 
     It "Not uninstall non-prerelease version module when prerelease version specified" {
         Install-PSResource -Name $testScriptName -Version "2.5.0.0" -Repository $TestGalleryName
         Uninstall-PSResource -Name $testScriptName -Version "2.5.0-alpha001"
-        $res = Get-InstalledPSResource -Name $testScriptName -Version "2.5.0.0"
+        $res = Get-PSResource -Name $testScriptName -Version "2.5.0.0"
         $res.Name | Should -Be $testScriptName
         $res.Version | Should -Be "2.5.0.0"
     }
@@ -197,15 +197,15 @@ Describe 'Test Uninstall-PSResource for Modules' {
 
     It "Uninstall PSResourceInfo object piped in" {
         Install-PSResource -Name "ContosoServer" -Version "1.5.0.0" -Repository $TestGalleryName
-        Get-InstalledPSResource -Name "ContosoServer" -Version "1.5.0.0" | Uninstall-PSResource
-        $res = Get-InstalledPSResource -Name "ContosoServer" -Version "1.5.0.0"
+        Get-PSResource -Name "ContosoServer" -Version "1.5.0.0" | Uninstall-PSResource
+        $res = Get-PSResource -Name "ContosoServer" -Version "1.5.0.0"
         $res | Should -BeNullOrEmpty
     }
 
     It "Uninstall PSResourceInfo object piped in for prerelease version object" {
         Install-PSResource -Name $testModuleName -Version "4.5.2-alpha001" -Repository $TestGalleryName
-        Get-InstalledPSResource -Name $testModuleName -Version "4.5.2-alpha001" | Uninstall-PSResource
-        $res = Get-InstalledPSResource -Name $testModuleName -Version "4.5.2-alpha001"
+        Get-PSResource -Name $testModuleName -Version "4.5.2-alpha001" | Uninstall-PSResource
+        $res = Get-PSResource -Name $testModuleName -Version "4.5.2-alpha001"
         $res | Should -BeNullOrEmpty
     }
 }

--- a/test/UpdatePSResource.Tests.ps1
+++ b/test/UpdatePSResource.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'Test Update-PSResource' {
         Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName
 
         Update-PSResource -Name "TestModule" -Repository $TestGalleryName
-        $res = Get-InstalledPSResource -Name "TestModule"
+        $res = Get-PSResource -Name "TestModule"
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)
@@ -44,7 +44,7 @@ Describe 'Test Update-PSResource' {
         Install-PSResource -Name "TestModule99" -Version "0.0.4.0" -Repository $TestGalleryName
 
         Update-PSResource -Name "TestModule*" -Repository $TestGalleryName
-        $res = Get-InstalledPSResource -Name "TestModule*"
+        $res = Get-PSResource -Name "TestModule*"
 
         $inputHashtable = @{TestModule = "1.1.0.0"; TestModule99 = "0.0.4.0"}
         $isTestModuleUpdated = $false
@@ -72,7 +72,7 @@ Describe 'Test Update-PSResource' {
         Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName
 
         Update-PSResource -Name "TestModule" -Version "1.2.0.0" -Repository $TestGalleryName
-        $res = Get-InstalledPSResource -Name "TestModule"
+        $res = Get-PSResource -Name "TestModule"
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -102,7 +102,7 @@ Describe 'Test Update-PSResource' {
         Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName
         Update-PSResource -Name "TestModule" -Version $Version -Repository $TestGalleryName
 
-        $res = Get-InstalledPSResource -Name "TestModule"
+        $res = Get-PSResource -Name "TestModule"
 
         foreach ($item in $res) {
             $item.Name | Should -Be "TestModule"
@@ -120,7 +120,7 @@ Describe 'Test Update-PSResource' {
         Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName
         Update-PSResource -Name "TestModule" -Version $Version -Repository $TestGalleryName
 
-        $res = Get-InstalledPSResource -Name "TestModule"
+        $res = Get-PSResource -Name "TestModule"
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -138,7 +138,7 @@ Describe 'Test Update-PSResource' {
 
         Install-PSResource -Name "PSGetTestModule" -Version "1.0.2.0" -Repository $TestGalleryName
         Update-PSResource -Name "PSGetTestModule" -Prerelease -Repository $TestGalleryName
-        $res = Get-InstalledPSResource -Name "PSGetTestModule"
+        $res = Get-PSResource -Name "PSGetTestModule"
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)
@@ -161,7 +161,7 @@ Describe 'Test Update-PSResource' {
 
         Update-PSResource -Name "TestModule" -Version "1.2.0.0" -Repository $TestGalleryName -Scope CurrentUser
 
-        $res = Get-InstalledPSResource -Name "TestModule"
+        $res = Get-PSResource -Name "TestModule"
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)
@@ -183,7 +183,7 @@ Describe 'Test Update-PSResource' {
 
         Update-PSResource -Name "TestModule" -Version "1.2.0.0" -Repository $TestGalleryName -Scope AllUsers
 
-        $res = Get-InstalledPSResource -Name "TestModule"
+        $res = Get-PSResource -Name "TestModule"
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -202,7 +202,7 @@ Describe 'Test Update-PSResource' {
         Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName
         Update-PSResource -Name "TestModule" -Version "1.2.0.0" -Repository $TestGalleryName
 
-        $res = Get-InstalledPSResource -Name "TestModule"
+        $res = Get-PSResource -Name "TestModule"
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)
@@ -226,7 +226,7 @@ Describe 'Test Update-PSResource' {
 
         Update-PSResource -Name "TestModule" -Repository $TestGalleryName -Scope CurrentUser
 
-        $res = Get-InstalledPSResource -Name "TestModule"
+        $res = Get-PSResource -Name "TestModule"
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)
@@ -250,7 +250,7 @@ Describe 'Test Update-PSResource' {
 
         Update-PSResource -Name "TestModule" -Repository $TestGalleryName -Scope AllUsers
 
-        $res = Get-InstalledPSResource -Name "TestModule"
+        $res = Get-PSResource -Name "TestModule"
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)
@@ -274,7 +274,7 @@ Describe 'Test Update-PSResource' {
 
         Update-PSResource -Name "TestModule" -Repository $TestGalleryName
 
-        $res = Get-InstalledPSResource -Name "TestModule"
+        $res = Get-PSResource -Name "TestModule"
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)
@@ -292,7 +292,7 @@ Describe 'Test Update-PSResource' {
     It "update resource that requires accept license with -AcceptLicense flag" {
         Install-PSResource -Name "TestModuleWithLicense" -Version "0.0.1.0" -Repository $TestGalleryName -AcceptLicense
         Update-PSResource -Name "TestModuleWithLicense" -Repository $TestGalleryName -AcceptLicense
-        $res = Get-InstalledPSResource "TestModuleWithLicense"
+        $res = Get-PSResource "TestModuleWithLicense"
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)
@@ -312,7 +312,7 @@ Describe 'Test Update-PSResource' {
         Set-PSResourceRepository PoshTestGallery -Trusted:$false
 
         Update-PSResource -Name "TestModule" -Version "1.2.0.0" -Repository $TestGalleryName -TrustRepository
-        $res = Get-InstalledPSResource -Name "TestModule"
+        $res = Get-PSResource -Name "TestModule"
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)
@@ -331,7 +331,7 @@ Describe 'Test Update-PSResource' {
         Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName
         Update-PSResource -Name "TestModule" -WhatIf
 
-        $res = Get-InstalledPSResource -Name "TestModule"
+        $res = Get-PSResource -Name "TestModule"
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)


### PR DESCRIPTION
# PR Summary
Reverting cmdlet name 'Get-InstalledPSResource' to 'Get-PSResource'.

## PR Context
Resolves #457 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
