### PR TITLE
Add -SkipDependencyCheck to cmdlets.

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -79,6 +79,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             string specifiedPath,
             bool asNupkg,
             bool includeXML,
+            bool skipDependencyCheck,
             List<string> pathsToInstallPkg)
         {
             _cmdletPassedIn.WriteVerbose(string.Format("Parameters passed in >>> Name: '{0}'; Version: '{1}'; Prerelease: '{2}'; Repository: '{3}'; " +
@@ -123,7 +124,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
 
             // Go through the repositories and see which is the first repository to have the pkg version available
-            ProcessRepositories(names, repository, _trustRepository, _credential);
+            ProcessRepositories(
+                packageNames: names,
+                repository: repository,
+                trustRepository: _trustRepository,
+                credential: _credential,
+                skipDependencyCheck: skipDependencyCheck);
         }
 
         #endregion
@@ -135,7 +141,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             string[] packageNames,
             string[] repository,
             bool trustRepository,
-            PSCredential credential)
+            PSCredential credential,
+            bool skipDependencyCheck)
         {
             var listOfRepositories = RepositorySettings.Read(repository, out string[] _);
             List<string> pckgNamesToInstall = packageNames.ToList();
@@ -185,7 +192,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     tag: null,
                     repository: new string[] { repoName },
                     credential: credential,
-                    includeDependencies: true);
+                    includeDependencies: !skipDependencyCheck);
 
                 if (!pkgsFromRepoToInstall.Any())
                 {

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -15,7 +15,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// The Install-PSResource cmdlet installs a resource.
     /// It returns nothing.
     /// </summary>
-
     [Cmdlet(VerbsLifecycle.Install, "PSResource", DefaultParameterSetName = "NameParameterSet", SupportsShouldProcess = true)]
     public sealed
     class InstallPSResource : PSCmdlet
@@ -105,6 +104,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = InputObjectParameterSet)]
         [ValidateNotNullOrEmpty]
         public PSResourceInfo InputObject { get; set; }
+
+        /// <summary>
+        /// Skips the check for resource dependencies, so that only found resources are installed,
+        /// and not any resources the found resource depends on.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter SkipDependencyCheck { get; set; }
 
         #endregion
 
@@ -250,6 +256,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 specifiedPath: null,
                 asNupkg: false,
                 includeXML: true,
+                skipDependencyCheck: SkipDependencyCheck,
                 pathsToInstallPkg: _pathsToInstallPkg);
         }
 

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -123,6 +123,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         [ValidateNotNullOrEmpty]
         public PSResourceInfo InputObject { get; set; }
 
+        /// <summary>
+        /// Skips the check for resource dependencies, so that only found resources are saved,
+        /// and not any resources the found resource depends on.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter SkipDependencyCheck { get; set; }
+
         #endregion
 
         #region Method overrides
@@ -243,7 +250,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 noClobber: false, 
                 specifiedPath: _path, 
                 asNupkg: false, 
-                includeXML: false, 
+                includeXML: false,
+                skipDependencyCheck: SkipDependencyCheck,
                 pathsToInstallPkg: new List<string> { _path } );
         }
         

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -97,6 +97,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         [Parameter]
         public SwitchParameter Force { get; set; }
 
+        /// <summary>
+        /// Skips the check for resource dependencies, so that only found resources are updated,
+        /// and not any resources the found resource depends on.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter SkipDependencyCheck { get; set; }
+
         #endregion
 
         #region Override Methods
@@ -166,6 +173,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 specifiedPath: null,
                 asNupkg: false,
                 includeXML: true,
+                skipDependencyCheck: SkipDependencyCheck,
                 pathsToInstallPkg: _pathsToInstallPkg);
         }
 
@@ -253,7 +261,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 tag: null,
                 repository: Repository,
                 credential: Credential,
-                includeDependencies: false))
+                includeDependencies: !SkipDependencyCheck))
             {
                 if (!repositoryPackages.ContainsKey(foundResource.Name))
                 {

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -103,14 +103,14 @@ Describe 'Test Install-PSResource for Module' {
     }
 
     It "Install resource when given Name, Version '*', should install the latest version" {
-        $pkg = Install-PSResource -Name "TestModule" -Version "*" -Repository $TestGalleryName
+        Install-PSResource -Name "TestModule" -Version "*" -Repository $TestGalleryName
         $pkg = Get-Module "TestModule" -ListAvailable
         $pkg.Name | Should -Be "TestModule"
         $pkg.Version | Should -Be "1.3.0"
     }
 
     It "Install resource with latest (including prerelease) version given Prerelease parameter" {
-        $pkg = Install-PSResource -Name "TestModulePrerelease" -Prerelease -Repository $TestGalleryName 
+        Install-PSResource -Name "TestModulePrerelease" -Prerelease -Repository $TestGalleryName 
         $pkg = Get-Module "TestModulePrerelease" -ListAvailable
         $pkg.Name | Should -Be "TestModulePrerelease"
         $pkg.Version | Should -Be "0.0.1"
@@ -118,7 +118,7 @@ Describe 'Test Install-PSResource for Module' {
     }
 
     It "Install a module with a dependency" {
-        $pkg = Install-PSResource -Name "PSGetTestModule" -Prerelease -Repository $TestGalleryName 
+        Install-PSResource -Name "PSGetTestModule" -Prerelease -Repository $TestGalleryName 
         $pkg = Get-Module "PSGetTestModule" -ListAvailable
         $pkg.Name | Should -Be "PSGetTestModule"
         $pkg.Version | Should -Be "2.0.2"
@@ -127,6 +127,17 @@ Describe 'Test Install-PSResource for Module' {
         $pkg = Get-Module "PSGetTestDependency1" -ListAvailable
         $pkg.Name | Should -Be "PSGetTestDependency1"
         $pkg.Version | Should -Be "1.0.0"
+    }
+
+    It "Install a module with a dependency and skip installing the dependency" {
+        Install-PSResource -Name "PSGetTestModule" -Prerelease -Repository $TestGalleryName -SkipDependencyCheck
+        $pkg = Get-Module "PSGetTestModule" -ListAvailable
+        $pkg.Name | Should -Be "PSGetTestModule"
+        $pkg.Version | Should -Be "2.0.2"
+        $pkg.PrivateData.PSData.Prerelease | Should -Be "-alpha1"
+
+        $pkg = Get-Module "PSGetTestDependency1" -ListAvailable
+        $pkg | Should -BeNullOrEmpty
     }
 
     It "Install resource via InputObject by piping from Find-PSresource" {

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -17,7 +17,7 @@ Describe 'Test Install-PSResource for Module' {
     AfterEach {
         Uninstall-PSResource "TestModule", "TestModule99", "myTestModule", "myTestModule2", "testModulePrerelease", 
             "testModuleWithlicense","PSGetTestModule", "PSGetTestDependency1", "TestFindModule","ClobberTestModule1",
-            "ClobberTestModule2" -Force -ErrorAction SilentlyContinue
+            "ClobberTestModule2" -SkipDependencyCheck -ErrorAction SilentlyContinue
     }
 
     AfterAll {
@@ -320,7 +320,7 @@ Describe 'Test Install-PSResource for interactive and root user scenarios' {
     }
 
     AfterEach {
-        Uninstall-PSResource "TestModule", "testModuleWithlicense" -Force -ErrorAction SilentlyContinue
+        Uninstall-PSResource "TestModule", "testModuleWithlicense" -SkipDependencyCheck -ErrorAction SilentlyContinue
     }
 
     AfterAll {

--- a/test/SavePSResource.Tests.ps1
+++ b/test/SavePSResource.Tests.ps1
@@ -129,6 +129,13 @@ Describe 'Test Save-PSResource for PSResources' {
         (Get-ChildItem $pkgDirs[1].FullName).Count | Should -Be 1
     }
 
+    It "Save a module with a dependency and skip saving the dependency" {
+        Save-PSResource -Name "PSGetTestModule" -Prerelease -Repository $TestGalleryName -Path $SaveDir -SkipDependencyCheck
+        $pkgDirs = Get-ChildItem -Path $SaveDir | Where-Object { $_.Name -eq "PSGetTestModule" -or $_.Name -eq "PSGetTestDependency1" }
+        $pkgDirs.Count | Should -Be 1
+        (Get-ChildItem $pkgDirs[0].FullName).Count | Should -Be 1
+    }
+
     It "Save resource via InputObject by piping from Find-PSresource" {
         Find-PSResource -Name "TestModule" -Repository $TestGalleryName | Save-PSResource -Path $SaveDir
         $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"

--- a/test/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResource.Tests.ps1
@@ -11,7 +11,7 @@ Describe 'Test Uninstall-PSResource for Modules' {
         $testModuleName = "test_module"
         $testScriptName = "test_script"
         Get-NewPSResourceRepositoryFile
-        $res = Uninstall-PSResource -name ContosoServer -Version "*"
+        Uninstall-PSResource -name ContosoServer -Version "*"
     }
     BeforeEach{
         $null = Install-PSResource ContosoServer -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
@@ -21,7 +21,7 @@ Describe 'Test Uninstall-PSResource for Modules' {
     }
 
     It "Uninstall a specific module by name" {
-        $res = Uninstall-PSResource -name ContosoServer 
+        Uninstall-PSResource -name ContosoServer 
         Get-Module ContosoServer -ListAvailable | Should -Be $null
     }
 
@@ -38,20 +38,20 @@ Describe 'Test Uninstall-PSResource for Modules' {
     It "Uninstall a list of modules by name" {
         $null = Install-PSResource BaseTestPackage -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
 
-        $res = Uninstall-PSResource -Name BaseTestPackage, ContosoServer 
+        Uninstall-PSResource -Name BaseTestPackage, ContosoServer 
         Get-Module ContosoServer, BaseTestPackage -ListAvailable | Should -be $null
     }
 
     It "Uninstall a specific script by name" {
         $null = Install-PSResource Test-RPC -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
 
-        $pkg = Uninstall-PSResource -name Test-RPC 
+        Uninstall-PSResource -name Test-RPC 
     }
 
     It "Uninstall a list of scripts by name" {
         $null = Install-PSResource adsql, airoute -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
 
-        $pkg = Uninstall-PSResource -Name adsql, airoute 
+        Uninstall-PSResource -Name adsql, airoute 
     }
 
     It "Uninstall a module when given name and specifying all versions" {
@@ -59,7 +59,7 @@ Describe 'Test Uninstall-PSResource for Modules' {
         $null = Install-PSResource ContosoServer -Repository $TestGalleryName -Version "1.5.0" -TrustRepository -WarningAction SilentlyContinue
         $null = Install-PSResource ContosoServer -Repository $TestGalleryName -Version "2.0.0" -TrustRepository -WarningAction SilentlyContinue
 
-        $res = Uninstall-PSResource -Name ContosoServer -version "*"
+        Uninstall-PSResource -Name ContosoServer -version "*"
         $pkgs = Get-Module ContosoServer -ListAvailable
         $pkgs.Version | Should -Not -Contain "1.0.0"
         $pkgs.Version | Should -Not -Contain "1.5.0"
@@ -72,7 +72,7 @@ Describe 'Test Uninstall-PSResource for Modules' {
         $null = Install-PSResource ContosoServer -Repository $TestGalleryName -Version "1.5.0" -TrustRepository -WarningAction SilentlyContinue
         $null = Install-PSResource ContosoServer -Repository $TestGalleryName -Version "2.0.0" -TrustRepository -WarningAction SilentlyContinue
 
-        $res = Uninstall-PSResource -Name ContosoServer
+        Uninstall-PSResource -Name ContosoServer
         $pkgs = Get-Module ContosoServer -ListAvailable
         $pkgs.Version | Should -Not -Contain "1.0.0"
         $pkgs.Version | Should -Not -Contain "1.5.0"
@@ -85,7 +85,7 @@ Describe 'Test Uninstall-PSResource for Modules' {
         $null = Install-PSResource ContosoServer -Repository $TestGalleryName -Version "1.5.0" -TrustRepository -WarningAction SilentlyContinue
         $null = Install-PSResource ContosoServer -Repository $TestGalleryName -Version "2.0.0" -TrustRepository -WarningAction SilentlyContinue
 
-        $res = Uninstall-PSResource -Name "ContosoServer" -Version "1.0.0"
+        Uninstall-PSResource -Name "ContosoServer" -Version "1.0.0"
         $pkgs = Get-Module ContosoServer -ListAvailable
         $pkgs.Version | Should -Not -Contain "1.0.0"
     }
@@ -106,7 +106,7 @@ Describe 'Test Uninstall-PSResource for Modules' {
         $null = Install-PSResource ContosoServer -Repository $TestGalleryName -Version "1.5.0" -TrustRepository -WarningAction SilentlyContinue
         $null = Install-PSResource ContosoServer -Repository $TestGalleryName -Version "2.0.0" -TrustRepository -WarningAction SilentlyContinue
 
-        $res = Uninstall-PSResource -Name ContosoServer -Version $Version
+        Uninstall-PSResource -Name ContosoServer -Version $Version
         $pkgs = Get-Module ContosoServer -ListAvailable
         $pkgs.Version | Should -Not -Contain $Version
     }
@@ -169,8 +169,7 @@ Describe 'Test Uninstall-PSResource for Modules' {
     }
 
     It "Uninstall module using -WhatIf, should not uninstall the module" {
-        $res = Uninstall-PSResource -Name "ContosoServer" -WhatIf
-
+        Uninstall-PSResource -Name "ContosoServer" -WhatIf
         $pkg = Get-Module ContosoServer -ListAvailable
         $pkg.Version | Should -Be "2.5"
     }
@@ -183,16 +182,16 @@ Describe 'Test Uninstall-PSResource for Modules' {
         $pkg = Get-Module "RequiredModule1" -ListAvailable
         $pkg | Should -Not -Be $null
 
-        $ev | Should -Be "Cannot uninstall 'RequiredModule1', the following package(s) take a dependency on this package: test_module. If you would still like to uninstall, rerun the command with -Force"
+        $ev.FullyQualifiedErrorId | Should -BeExactly 'UninstallPSResourcePackageIsaDependency,Microsoft.PowerShell.PowerShellGet.Cmdlets.UninstallPSResource'
     }
 
-    It "Uninstall module that is a dependency for another module using -Force" {
+    It "Uninstall module that is a dependency for another module using -SkipDependencyCheck" {
         $null = Install-PSResource "test_module" -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
 
-        $res = Uninstall-PSResource -Name "RequiredModule1" -Force
+        Uninstall-PSResource -Name "RequiredModule1" -SkipDependencyCheck
         
         $pkg = Get-Module "RequiredModule1" -ListAvailable
-        $pkg | Should -Be $null
+        $pkg | Should -BeNullOrEmpty
     }
 
     It "Uninstall PSResourceInfo object piped in" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR addresses issue #494, but also adds the new switch to the install/save/update cmdlets.

## PR Context

Replaces `Uninstall-PSResource` `-Force` with `-SkipDependencyCheck` parameter, since force only affects searching for dependency links.

Also adds `-SkipDependencyCheck` parameter to `Install-PSResource`, `Save-PSResource`, `Update-PSResource` cmdlets.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed]()
        - [x] Issue filed: #549
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
