### PR TITLE
Rename params: *url to *uri

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -40,7 +40,7 @@ param (
     [string] $BuildFramework = "netstandard2.0"
 )
 
-if ( ! ( Get-Module -ErrorAction SilentlyContinue PSPackageProject) ) {
+if ( -not (Get-Module -ErrorAction SilentlyContinue PSPackageProject) -and -not (Import-Module -PassThru -ErrorAction SilentlyContinue PSPackageProject -MinimumVersion 0.1.18) ) {
     Install-Module -Name PSPackageProject -MinimumVersion 0.1.18 -Force
 }
 

--- a/help/Get-PSResourceRepository.md
+++ b/help/Get-PSResourceRepository.md
@@ -24,7 +24,7 @@ The Get-PSResourceRepository cmdlet searches for the PowerShell resource reposit
 ### Example 1
 ```
 PS C:\> Get-PSResourceRepository -Name "PSGallery"
-        Name         Url                                        Trusted   Priority
+        Name         Uri                                        Trusted   Priority
         ----         ---                                        -------   --------
         PSGallery    https://www.powershellgallery.com/api/v2     False         50
 ```
@@ -34,7 +34,7 @@ This example runs the command with the 'Name' parameter being set to "PSGallery"
 ### Example 2
 ```
 PS C:\> Get-PSResourceRepository -Name "*Gallery"
-        Name             Url                                          Trusted   Priority
+        Name             Uri                                          Trusted   Priority
         ----             ---                                          -------   --------
         PoshTestGallery  https://www.poshtestgallery.com/api/v2          True         40
         PSGallery        https://www.powershellgallery.com/api/v2       False         50
@@ -46,7 +46,7 @@ This example runs the command with the 'Name' parameter being set to "*Gallery" 
 ### Example 3
 ```
 PS C:\> Get-PSResourceRepository -Name "PSGallery","PoshTestGallery"
-        Name             Url                                          Trusted   Priority
+        Name             Uri                                          Trusted   Priority
         ----             ---                                          -------   --------
         PoshTestGallery  https://www.poshtestgallery.com/api/v2          True         40
         PSGallery        https://www.powershellgallery.com/api/v2       False         50
@@ -58,7 +58,7 @@ This example runs the command with the 'Name' parameter being set to an array of
 ### Example 4
 ```
 PS C:\> Get-PSResourceRepository -Name "*"
-        Name             Url                                          Trusted   Priority
+        Name             Uri                                          Trusted   Priority
         ----             ---                                          -------   --------
         PoshTestGallery  https://www.poshtestgallery.com/api/v2          True         40
         PSGallery        https://www.powershellgallery.com/api/v2       False         50

--- a/help/Register-PSResourceRepository.md
+++ b/help/Register-PSResourceRepository.md
@@ -14,7 +14,7 @@ Registers a repository for PowerShell resources.
 
 ### NameParameterSet (Default)
 ```
-Register-PSResourceRepository [-Name] <String> [-URL] <String> [-Trusted] [-Priority <Int32>] [-PassThru]
+Register-PSResourceRepository [-Name] <String> [-Uri] <String> [-Trusted] [-Priority <Int32>] [-PassThru]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -36,32 +36,32 @@ The Register-PSResourceRepository cmdlet registers a repository for PowerShell r
 These examples assume that the repository we attempt to register is not already registered on the user's machine.
 ### Example 1
 ```
-PS C:\> Register-PSResourceRepository -Name "PoshTestGallery" -URL "https://www.powershellgallery.com/api/v2"
+PS C:\> Register-PSResourceRepository -Name "PoshTestGallery" -Uri "https://www.powershellgallery.com/api/v2"
 PS C:\> Get-PSResourceRepository -Name "PoshTestGallery"
-        Name             Url                                          Trusted   Priority
+        Name             Uri                                          Trusted   Priority
         ----             ---                                          -------   --------
         PoshTestGallery  https://www.poshtestgallery.com/api/v2         False         50
 ```
 
-This example registers the repository with the `-Name` of "PoshTestGallery" along with the associated `URL` value for it.
+This example registers the repository with the `-Name` of "PoshTestGallery" along with the associated `Uri` value for it.
 
 ### Example 2
 ```
 PS C:\> Register-PSResourceRepository -PSGallery
 PS C:\> Get-PSResourceRepository -Name "PSGallery"
-        Name             Url                                          Trusted   Priority
+        Name             Uri                                          Trusted   Priority
         ----             ---                                          -------   --------
         PSGallery        https://www.powershellgallery.com/api/v2       False         50
 ```
 
-This example registers the "PSGallery" repository, with the 'PSGallery' parameter. Unlike the previous example, we cannot use the `-Name` or `-URL` parameters to register the "PSGallery" repository as it is considered Powershell's default repository store and has its own value for URL.
+This example registers the "PSGallery" repository, with the 'PSGallery' parameter. Unlike the previous example, we cannot use the `-Name` or `-Uri` parameters to register the "PSGallery" repository as it is considered Powershell's default repository store and has its own value for Uri.
 
 ### Example 3
 ```
-PS C:\> $arrayOfHashtables = @{Name = "psgettestlocal"; URL = "c:/code/testdir"},@{PSGallery = $True}
+PS C:\> $arrayOfHashtables = @{Name = "psgettestlocal"; Uri = "c:/code/testdir"}, @{PSGallery = $True}
 PS C:\> Register-PSResourceRepository -Repositories $arrayOfHashtables
 PS C:\> Get-PSResourceRepository
-        Name             Url                                          Trusted   Priority
+        Name             Uri                                          Trusted   Priority
         ----             ---                                          -------   --------
         PSGallery        https://www.powershellgallery.com/api/v2       False         50
         psgettestlocal   file:///c:/code/testdir                        False         50
@@ -149,9 +149,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -URL
+### -Uri
 Specifies the location of the repository to be registered.
-URL can be of the following Uri schemas: HTTPS, HTTP, FTP, file share based.
+URI can be of the following URI schemas: HTTPS, HTTP, FTP, file share based.
 
 ```yaml
 Type: String
@@ -225,8 +225,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 Repositories are unique by 'Name'. Attempting to register a repository with same 'Name' as an already registered repository will not successfully register.
 
-Registering the PSGallery repository must be done via the PSGalleryParameterSet (i.e by using the 'PSGallery' parameter instead of 'Name' and 'URL' parameters).
+Registering the PSGallery repository must be done via the PSGalleryParameterSet (i.e by using the 'PSGallery' parameter instead of 'Name' and 'Uri' parameters).
 
-URL string input must be of one of the following Uri schemes: HTTP, HTTPS, FTP, File
+URI string input must be of one of the following URI schemes: HTTP, HTTPS, FTP, File
 
 ## RELATED LINKS

--- a/help/Register-PSResourceRepository.md
+++ b/help/Register-PSResourceRepository.md
@@ -151,7 +151,7 @@ Accept wildcard characters: False
 
 ### -Uri
 Specifies the location of the repository to be registered.
-URI can be of the following URI schemas: HTTPS, HTTP, FTP, file share based.
+Uri can be of the following Uri schemas: HTTPS, HTTP, FTP, file share based.
 
 ```yaml
 Type: String
@@ -227,6 +227,6 @@ Repositories are unique by 'Name'. Attempting to register a repository with same
 
 Registering the PSGallery repository must be done via the PSGalleryParameterSet (i.e by using the 'PSGallery' parameter instead of 'Name' and 'Uri' parameters).
 
-URI string input must be of one of the following URI schemes: HTTP, HTTPS, FTP, File
+Uri string input must be of one of the following Uri schemes: HTTP, HTTPS, FTP, File
 
 ## RELATED LINKS

--- a/help/Set-PSResourceRepository.md
+++ b/help/Set-PSResourceRepository.md
@@ -14,7 +14,7 @@ Sets information for a registered repository.
 
 ### NameParameterSet (Default)
 ```
-Set-PSResourceRepository [-Name] <String> [-URL <String>] [-Trusted] [-Priority <Int32>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-PSResourceRepository [-Name] <String> [-Uri <String>] [-Trusted] [-Priority <Int32>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### RepositoriesParameterSet
@@ -30,43 +30,43 @@ These examples are run independently of each other and assume the repositories u
 ### Example 1
 ```powershell
 PS C:\> Get-PSResourceRepository -Name "PoshTestGallery"
-        Name             Url                                          Trusted   Priority
+        Name             Uri                                          Trusted   Priority
         ----             ---                                          -------   --------
         PoshTestGallery  https://www.poshtestgallery.com/api/v2         False         50
-PS C:\> Set-PSResourceRepository -Name "PoshTestGallery" -URL "c:/code/testdir" -PassThru
-        Name             Url                                          Trusted   Priority
+PS C:\> Set-PSResourceRepository -Name "PoshTestGallery" -Uri "c:/code/testdir" -PassThru
+        Name             Uri                                          Trusted   Priority
         ----             ---                                          -------   --------
         PoshTestGallery  file:///c:/code/testdir                        False         50
 ```
 
-This example first checks if the PoshTestGallery repository has been registered. We wish to set the `-URL` value of this repository by running the Set-PSResourceRepository cmdlet with the `-URL` parameter and a valid Uri scheme url. We run the Get-PSResourceRepository cmdlet again to ensure that the `-URL` of the repository was changed. We also use the `-PassThru` parameter to see the changed repository.
+This example first checks if the PoshTestGallery repository has been registered. We wish to set the `-Uri` value of this repository by running the Set-PSResourceRepository cmdlet with the `-Uri` parameter and a valid URI scheme URI. We run the Get-PSResourceRepository cmdlet again to ensure that the `-Uri` of the repository was changed. We also use the `-PassThru` parameter to see the changed repository.
 
 ### Example 2
 ```powershell
 PS C:\> Get-PSResourceRepository -Name "PSGallery"
-        Name             Url                                          Trusted   Priority
+        Name             Uri                                          Trusted   Priority
         ----             ---                                          -------   --------
         PSGallery        https://www.powershellgallery.com/api/v2       False         50
 PS C:\> Set-PSResourceRepository -Name "PSGallery" -Priority 25 -Trusted -PassThru
-        Name             Url                                          Trusted   Priority
+        Name             Uri                                          Trusted   Priority
         ----             ---                                          -------   --------
         PSGallery        https://www.powershellgallery.com/api/v2        True         25
 ```
 
-This example first checks if the PSGallery repository has been registered. We wish to set the `-Priority` and `-Trusted` values of this repository by running the Set-PSResourceRepository cmdlet with the `-Priority` parameter set to a value between 0 and 50 and by using the `-Trusted` parameter switch. We run the Get-PSResourceRepository cmdlet again to ensure that the `-Priority` and `-Trusted` values of the repository were changed. An important note here is that just for the default PSGallery repository, the `-URL` value can't be changed/set. We also use the `-PassThru` parameter to see the changed repository.
+This example first checks if the PSGallery repository has been registered. We wish to set the `-Priority` and `-Trusted` values of this repository by running the Set-PSResourceRepository cmdlet with the `-Priority` parameter set to a value between 0 and 50 and by using the `-Trusted` parameter switch. We run the Get-PSResourceRepository cmdlet again to ensure that the `-Priority` and `-Trusted` values of the repository were changed. An important note here is that just for the default PSGallery repository, the `-Uri` value can't be changed/set. We also use the `-PassThru` parameter to see the changed repository.
 
 ### Example 3
 ```powershell
 PS C:\> Get-PSResourceRepository -Name "*"
-        Name             Url                                          Trusted   Priority
+        Name             Uri                                          Trusted   Priority
         ----             ---                                          -------   --------
         PSGallery        https://www.powershellgallery.com/api/v2       False         50
         PoshTestGallery  https://www.poshtestgallery.com/api/v2         False         50
 
-PS C:\> $arrayOfHashtables = @{Name = "PSGallery"; Trusted = $True},@{Name = "PoshTestGallery"; URL = "c:/code/testdir"}
+PS C:\> $arrayOfHashtables = @{Name = "PSGallery"; Trusted = $True}, @{Name = "PoshTestGallery"; Uri = "c:/code/testdir"}
 
 PS C:\> Set-PSResourceRepository -Repositories $arrayOfHashtables -PassThru
-        Name             Url                                          Trusted   Priority
+        Name             Uri                                          Trusted   Priority
         ----             ---                                          -------   --------
         PSGallery        https://www.powershellgallery.com/api/v2        True         50
         PoshTestGallery  file:///c:/code/testdir                        False         50
@@ -121,7 +121,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -URL
+### -Uri
 Specifies the location of the repository to be set.
 
 ```yaml

--- a/help/Set-PSResourceRepository.md
+++ b/help/Set-PSResourceRepository.md
@@ -39,7 +39,7 @@ PS C:\> Set-PSResourceRepository -Name "PoshTestGallery" -Uri "c:/code/testdir" 
         PoshTestGallery  file:///c:/code/testdir                        False         50
 ```
 
-This example first checks if the PoshTestGallery repository has been registered. We wish to set the `-Uri` value of this repository by running the Set-PSResourceRepository cmdlet with the `-Uri` parameter and a valid URI scheme URI. We run the Get-PSResourceRepository cmdlet again to ensure that the `-Uri` of the repository was changed. We also use the `-PassThru` parameter to see the changed repository.
+This example first checks if the PoshTestGallery repository has been registered. We wish to set the `-Uri` value of this repository by running the Set-PSResourceRepository cmdlet with the `-Uri` parameter and a valid Uri scheme Uri. We run the Get-PSResourceRepository cmdlet again to ensure that the `-Uri` of the repository was changed. We also use the `-PassThru` parameter to see the changed repository.
 
 ### Example 2
 ```powershell

--- a/help/Unregister-PSResourceRepository.md
+++ b/help/Unregister-PSResourceRepository.md
@@ -36,7 +36,7 @@ In this example, we assume the repository "PoshTestGallery" has been previously 
 ### Example 2
 ```
 PS C:\> Get-PSResourceRepository
-        Name             Url                                          Trusted   Priority
+        Name             Uri                                          Trusted   Priority
         ----             ---                                          -------   --------
         PoshTestGallery  https://www.poshtestgallery.com/api/v2          True         40
         PSGallery        https://www.powershellgallery.com/api/v2       False         50
@@ -44,7 +44,7 @@ PS C:\> Get-PSResourceRepository
 
 PS C:\> Unregister-PSResourceRepository -Name "PoshTestGallery","psgettestlocal"
 PS C:\> Get-PSResourceRepository
-        Name             Url                                          Trusted   Priority
+        Name             Uri                                          Trusted   Priority
         ----             ---                                          -------   --------
         PSGallery        https://www.powershellgallery.com/api/v2       False         50
 
@@ -75,7 +75,7 @@ Passes the resource installed to the console.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named

--- a/src/PSGet.Format.ps1xml
+++ b/src/PSGet.Format.ps1xml
@@ -69,7 +69,7 @@
             <TableControl>
                 <TableHeaders>
                     <TableColumnHeader><Label>Name</Label></TableColumnHeader>
-                    <TableColumnHeader><Label>Url</Label></TableColumnHeader>
+                    <TableColumnHeader><Label>Uri</Label></TableColumnHeader>
                     <TableColumnHeader><Label>Trusted</Label></TableColumnHeader>
                     <TableColumnHeader><Label>Priority</Label></TableColumnHeader>
                 </TableHeaders>
@@ -77,7 +77,7 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
-                            <TableColumnItem><PropertyName>Url</PropertyName></TableColumnItem>
+                            <TableColumnItem><PropertyName>Uri</PropertyName></TableColumnItem>
                             <TableColumnItem><PropertyName>Trusted</PropertyName></TableColumnItem>
                             <TableColumnItem><PropertyName>Priority</PropertyName></TableColumnItem>
                         </TableColumnItems>

--- a/src/PowerShellGet.psd1
+++ b/src/PowerShellGet.psd1
@@ -46,5 +46,5 @@ See change log (CHANGELOG.md) at https://github.com/PowerShell/PowerShellGet
         }
     }
 
-    HelpInfoURI       = 'http://go.microsoft.com/fwlink/?linkid=855963'
+    HelpInfoUri       = 'http://go.microsoft.com/fwlink/?linkid=855963'
 }

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -59,7 +59,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         public InstallHelper(PSCmdlet cmdletPassedIn)
         {
             CancellationTokenSource source = new CancellationTokenSource();
-            _cancellationToken = source.Token;   
+            _cancellationToken = source.Token;
             _cmdletPassedIn = cmdletPassedIn;
         }
 
@@ -183,7 +183,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 _cmdletPassedIn.WriteVerbose("Untrusted repository accepted as trusted source.");
 
                 // If it can't find the pkg in one repository, it'll look for it in the next repo in the list
-                var isLocalRepo = repo.Url.AbsoluteUri.StartsWith(Uri.UriSchemeFile + Uri.SchemeDelimiter, StringComparison.OrdinalIgnoreCase);
+                var isLocalRepo = repo.Uri.AbsoluteUri.StartsWith(Uri.UriSchemeFile + Uri.SchemeDelimiter, StringComparison.OrdinalIgnoreCase);
 
                 // Finds parent packages and dependencies
                 IEnumerable<PSResourceInfo> pkgsFromRepoToInstall = findHelper.FindByResourceName(
@@ -227,7 +227,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 List<PSResourceInfo> pkgsInstalled = InstallPackage(
                     pkgsFromRepoToInstall,
                     repoName,
-                    repo.Url.AbsoluteUri,
+                    repo.Uri.AbsoluteUri,
                     repo.CredentialInfo,
                     credential,
                     isLocalRepo);
@@ -306,7 +306,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         private List<PSResourceInfo> InstallPackage(
             IEnumerable<PSResourceInfo> pkgsToInstall, // those found to be required to be installed (includes Dependency packages as well)
             string repoName,
-            string repoUrl,
+            string repoUri,
             PSCredentialInfo repoCredentialInfo,
             PSCredential credential,
             bool isLocalRepo)
@@ -326,7 +326,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     var dir = Directory.CreateDirectory(tempInstallPath);  // should check it gets created properly
                                                                            // To delete file attributes from the existing ones get the current file attributes first and use AND (&) operator
                                                                            // with a mask (bitwise complement of desired attributes combination).
-                                                                           // TODO: check the attributes and if it's read only then set it 
+                                                                           // TODO: check the attributes and if it's read only then set it
                                                                            // attribute may be inherited from the parent
                                                                            // TODO:  are there Linux accommodations we need to consider here?
                     dir.Attributes &= ~FileAttributes.ReadOnly;
@@ -368,8 +368,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     if (isLocalRepo)
                     {
                         /* Download from a local repository -- this is slightly different process than from a server */
-                        var localResource = new FindLocalPackagesResourceV2(repoUrl);
-                        var resource = new LocalDownloadResource(repoUrl, localResource);
+                        var localResource = new FindLocalPackagesResourceV2(repoUri);
+                        var resource = new LocalDownloadResource(repoUri, localResource);
 
                         // Actually downloading the .nupkg from a local repo
                         var result = resource.GetDownloadResourceResultAsync(
@@ -378,7 +378,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                              globalPackagesFolder: tempInstallPath,
                              logger: NullLogger.Instance,
                              token: _cancellationToken).GetAwaiter().GetResult();
-                        
+
                         // Create the package extraction context
                         PackageExtractionContext packageExtractionContext = new PackageExtractionContext(
                                 packageSaveMode: PackageSaveMode.Nupkg,
@@ -401,13 +401,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     {
                         /* Download from a non-local repository */
                         // Set up NuGet API resource for download
-                        PackageSource source = new PackageSource(repoUrl);
+                        PackageSource source = new PackageSource(repoUri);
 
                         // Explicitly passed in Credential takes precedence over repository CredentialInfo
                         if (credential != null)
                         {
                             string password = new NetworkCredential(string.Empty, credential.Password).Password;
-                            source.Credentials = PackageSourceCredential.FromUserInput(repoUrl, credential.UserName, password, true, null);
+                            source.Credentials = PackageSourceCredential.FromUserInput(repoUri, credential.UserName, password, true, null);
                         }
                         else if (repoCredentialInfo != null)
                         {
@@ -417,7 +417,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                                 _cmdletPassedIn);
 
                             string password = new NetworkCredential(string.Empty, repoCredential.Password).Password;
-                            source.Credentials = PackageSourceCredential.FromUserInput(repoUrl, repoCredential.UserName, password, true, null);
+                            source.Credentials = PackageSourceCredential.FromUserInput(repoUri, repoCredential.UserName, password, true, null);
                         }
                         var provider = FactoryExtensionsV3.GetCoreV3(NuGet.Protocol.Core.Types.Repository.Provider);
                         SourceRepository repository = new SourceRepository(source, provider);
@@ -447,7 +447,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                     _cmdletPassedIn.WriteVerbose(string.Format("Successfully able to download package from source to: '{0}'", tempInstallPath));
 
-                    // pkgIdentity.Version.Version gets the version without metadata or release labels.      
+                    // pkgIdentity.Version.Version gets the version without metadata or release labels.
                     string newVersion = pkgIdentity.Version.ToNormalizedString();
                     string normalizedVersionNoPrerelease = newVersion;
                     if (pkgIdentity.Version.IsPrerelease)
@@ -455,7 +455,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         // eg: 2.0.2
                         normalizedVersionNoPrerelease = pkgIdentity.Version.ToNormalizedString().Substring(0, pkgIdentity.Version.ToNormalizedString().IndexOf('-'));
                     }
-                    
+
                     string tempDirNameVersion = isLocalRepo ? tempInstallPath : Path.Combine(tempInstallPath, pkgIdentity.Id.ToLower(), newVersion);
                     var version4digitNoPrerelease = pkgIdentity.Version.Version.ToString();
                     string moduleManifestVersion = string.Empty;
@@ -485,7 +485,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     }
                     else
                     {
-                        // PSModules: 
+                        // PSModules:
                         /// ./Modules
                         /// ./Scripts
                         /// _pathsToInstallPkg is sorted by desirability, Find will pick the pick the first Script or Modules path found in the list
@@ -535,9 +535,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     {
                         CreateMetadataXMLFile(tempDirNameVersion, installPath, pkg, isModule);
                     }
-                    
+
                     MoveFilesIntoInstallPath(
-                        pkg, 
+                        pkg,
                         isModule,
                         isLocalRepo,
                         tempDirNameVersion,
@@ -546,7 +546,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         newVersion,
                         moduleManifestVersion,
                         scriptPath);
-                    
+
                     _cmdletPassedIn.WriteVerbose(String.Format("Successfully installed package '{0}' to location '{1}'", pkg.Name, installPath));
                     pkgsSuccessfullyInstalled.Add(pkg);
                 }
@@ -566,7 +566,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 {
                     // Delete the temp directory and all its contents
                     _cmdletPassedIn.WriteVerbose(string.Format("Attempting to delete '{0}'", tempInstallPath));
-                    
+
                     if (Directory.Exists(tempInstallPath))
                     {
                         if (!TryDeleteDirectory(tempInstallPath, out ErrorRecord errorMsg))
@@ -671,7 +671,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             List<string> listOfCmdlets = new List<string>();
             foreach (var cmdletName in parsedMetadataHashtable["CmdletsToExport"] as object[])
             {
-                listOfCmdlets.Add(cmdletName as string); 
+                listOfCmdlets.Add(cmdletName as string);
 
             }
 
@@ -692,8 +692,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 }
 
                 if (duplicateCmdlets.Any() || duplicateCmds.Any())
-                { 
-                    
+                {
+
                     duplicateCmdlets.AddRange(duplicateCmds);
 
                     var errMessage = string.Format(
@@ -807,14 +807,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         }
 
         private void MoveFilesIntoInstallPath(
-            PSResourceInfo pkgInfo, 
-            bool isModule, 
-            bool isLocalRepo, 
-            string dirNameVersion, 
-            string tempInstallPath, 
-            string installPath, 
-            string newVersion, 
-            string moduleManifestVersion, 
+            PSResourceInfo pkgInfo,
+            bool isModule,
+            bool isLocalRepo,
+            string dirNameVersion,
+            string tempInstallPath,
+            string installPath,
+            string newVersion,
+            string moduleManifestVersion,
             string scriptPath)
         {
             // Creating the proper installation path depending on whether pkg is a module or script

--- a/src/code/PSRepositoryInfo.cs
+++ b/src/code/PSRepositoryInfo.cs
@@ -13,10 +13,10 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
     {
         #region Constructor
 
-        public PSRepositoryInfo(string name, Uri url, int priority, bool trusted, PSCredentialInfo credentialInfo)
+        public PSRepositoryInfo(string name, Uri uri, int priority, bool trusted, PSCredentialInfo credentialInfo)
         {
             Name = name;
-            Url = url;
+            Uri = uri;
             Priority = priority;
             Trusted = trusted;
             CredentialInfo = credentialInfo;
@@ -32,9 +32,9 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         public string Name { get; }
 
         /// <summary>
-        /// the Url for the repository
+        /// the URI for the repository
         /// </summary>
-        public Uri Url { get; }
+        public Uri Uri { get; }
 
         /// <summary>
         /// whether the repository is trusted

--- a/src/code/PSRepositoryInfo.cs
+++ b/src/code/PSRepositoryInfo.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         public string Name { get; }
 
         /// <summary>
-        /// the URI for the repository
+        /// the Uri for the repository
         /// </summary>
         public Uri Uri { get; }
 

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -218,10 +218,10 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         public PSCommandResourceInfo(string name, PSResourceInfo parentResource)
         {
            Name = name;
-           ParentResource = parentResource; 
+           ParentResource = parentResource;
         }
 
-        #endregion        
+        #endregion
     }
 
     #endregion
@@ -512,7 +512,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             }
 
             try
-            {                
+            {
                 var typeInfo = ParseMetadataType(metadataToParse, repositoryName, type, out ArrayList commandNames, out ArrayList dscResourceNames);
                 var resourceHashtable = new Hashtable();
                 resourceHashtable.Add(nameof(PSResourceInfo.Includes.Command), new PSObject(commandNames));

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -121,7 +121,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         [Parameter]
         [ValidateNotNullOrEmpty]
         public SwitchParameter SkipDependenciesCheck { get; set; }
-        
+
         /// <summary>
         /// Specifies a proxy server for the request, rather than a direct connection to the internet resource.
         /// </summary>
@@ -227,7 +227,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     return;
                 }
 
-                // remove '.ps1' extension from file name 
+                // remove '.ps1' extension from file name
                 _pkgName = pkgFileOrDir.Name.Remove(pkgFileOrDir.Name.Length - 4);
             }
             else
@@ -235,7 +235,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 _pkgName = pkgFileOrDir.Name;
                 resourceFilePath = System.IO.Path.Combine(_path, _pkgName + ".psd1");
 
-                // Validate that there's a module manifest 
+                // Validate that there's a module manifest
                 if (!File.Exists(resourceFilePath))
                 {
                     var message = String.Format("No file with a .psd1 extension was found in {0}.  Please specify a path to a valid modulemanifest.", resourceFilePath);
@@ -246,7 +246,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     return;
                 }
 
-                // validate that the module manifest has correct data 
+                // validate that the module manifest has correct data
                 if (!IsValidModuleManifest(resourceFilePath))
                 {
                     return;
@@ -268,7 +268,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     WriteError(ErrorCreatingTempDir);
 
                     return;
-                }  
+                }
             }
 
             try
@@ -315,15 +315,15 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     return;
                 }
 
-                string repositoryUrl = repository.Url.AbsoluteUri;
+                string repositoryUri = repository.Uri.AbsoluteUri;
 
                 // Check if dependencies already exist within the repo if:
-                // 1) the resource to publish has dependencies and 
+                // 1) the resource to publish has dependencies and
                 // 2) the -SkipDependenciesCheck flag is not passed in
                 if (dependencies != null && !SkipDependenciesCheck)
                 {
                     // If error gets thrown, exit process record
-                    if (!CheckDependenciesExist(dependencies, repositoryUrl))
+                    if (!CheckDependenciesExist(dependencies, repositoryUri))
                     {
                         return;
                     }
@@ -401,7 +401,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 }
 
                 // This call does not throw any exceptions, but it will write unsuccessful responses to the console
-                PushNupkg(outputNupkgDir, repository.Name, repositoryUrl);
+                PushNupkg(outputNupkgDir, repository.Name, repositoryUri);
 
             }
             finally
@@ -423,7 +423,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 // use PowerShell cmdlet Test-ModuleManifest
                 // TODO: Test-ModuleManifest will throw an error if RequiredModules specifies a module that does not exist
-                // locally on the machine. Consider adding a -Syntax param to Test-ModuleManifest so that it only checks that 
+                // locally on the machine. Consider adding a -Syntax param to Test-ModuleManifest so that it only checks that
                 // the syntax is correct. In build/release pipelines for example, the modules listed under RequiredModules may
                 // not be locally available, but we still want to allow the user to publish.
                 var results = pwsh.AddCommand("Test-ModuleManifest").AddParameter("Path", moduleManifestPath).Invoke();
@@ -433,7 +433,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     var message = string.Empty;
                     if (string.IsNullOrWhiteSpace((results[0].BaseObject as PSModuleInfo).Author))
                     {
-                        message = "No author was provided in the module manifest. The module manifest must specify a version, author and description.";                  
+                        message = "No author was provided in the module manifest. The module manifest must specify a version, author and description.";
                     }
                     else if (string.IsNullOrWhiteSpace((results[0].BaseObject as PSModuleInfo).Description))
                     {
@@ -493,7 +493,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             XmlElement metadataElement = doc.CreateElement("metadata", nameSpaceUri);
 
             Dictionary<string, string> metadataElementsDictionary = new Dictionary<string, string>();
-       
+
             // id is mandatory
             metadataElementsDictionary.Add("id", _pkgName);
 
@@ -506,11 +506,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 version = parsedMetadataHash["version"].ToString();
             }
-            else 
+            else
             {
                 // no version is specified for the nuspec
                 var message = "There is no package version specified. Please specify a version before publishing.";
-                var ex = new ArgumentException(message);  
+                var ex = new ArgumentException(message);
                 var NoVersionFound = new ErrorRecord(ex, "NoVersionFound", ErrorCategory.InvalidArgument, null);
                 WriteError(NoVersionFound);
 
@@ -527,7 +527,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     {
                         if (psData.ContainsKey("Prerelease") && psData["Prerelease"] is string preReleaseVersion)
                         {
-                            version = string.Format(@"{0}-{1}", version, preReleaseVersion);    
+                            version = string.Format(@"{0}-{1}", version, preReleaseVersion);
                         }
                         if (psData.ContainsKey("Tags") && psData["Tags"] is Array manifestTags)
                         {
@@ -546,7 +546,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 metadataElementsDictionary.Add("version", _pkgVersion.ToNormalizedString());
             }
-            
+
             if (parsedMetadataHash.ContainsKey("author"))
             {
                 metadataElementsDictionary.Add("authors", parsedMetadataHash["author"].ToString().Trim());
@@ -560,8 +560,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             // defaults to false
             var requireLicenseAcceptance = parsedMetadataHash.ContainsKey("requirelicenseacceptance") ? parsedMetadataHash["requirelicenseacceptance"].ToString().ToLower().Trim()
                 : "false";
-            metadataElementsDictionary.Add("requireLicenseAcceptance", requireLicenseAcceptance); 
-           
+            metadataElementsDictionary.Add("requireLicenseAcceptance", requireLicenseAcceptance);
+
             if (parsedMetadataHash.ContainsKey("description"))
             {
                 metadataElementsDictionary.Add("description", parsedMetadataHash["description"].ToString().Trim());
@@ -587,19 +587,19 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
             metadataElementsDictionary.Add("tags", tags);
 
-            if (parsedMetadataHash.ContainsKey("licenseurl"))
+            if (parsedMetadataHash.ContainsKey("licenseuri"))
             {
-                metadataElementsDictionary.Add("licenseUrl", parsedMetadataHash["licenseurl"].ToString().Trim());
+                metadataElementsDictionary.Add("licenseUri", parsedMetadataHash["licenseuri"].ToString().Trim());
             }
 
-            if (parsedMetadataHash.ContainsKey("projecturl"))
+            if (parsedMetadataHash.ContainsKey("projecturi"))
             {
-                metadataElementsDictionary.Add("projectUrl", parsedMetadataHash["projecturl"].ToString().Trim());
+                metadataElementsDictionary.Add("projectUri", parsedMetadataHash["projecturi"].ToString().Trim());
             }
 
-            if (parsedMetadataHash.ContainsKey("iconurl"))
+            if (parsedMetadataHash.ContainsKey("iconuri"))
             {
-                metadataElementsDictionary.Add("iconUrl", parsedMetadataHash["iconurl"].ToString().Trim());
+                metadataElementsDictionary.Add("iconUri", parsedMetadataHash["iconuri"].ToString().Trim());
             }
 
             // Example nuspec:
@@ -613,9 +613,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 <owners>Microsoft,PowerShell</owners>
                 <requireLicenseAcceptance>false</requireLicenseAcceptance>
                 <license type="expression">MIT</license>
-                <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+                <licenseUri>https://licenses.nuget.org/MIT</licenseUri>
                 <icon>Powershell_black_64.png</icon>
-                <projectUrl>https://github.com/PowerShell/PowerShell</projectUrl>
+                <projectUri>https://github.com/PowerShell/PowerShell</projectUri>
                 <description>Example description here</description>
                 <copyright>Copyright (c) Microsoft Corporation. All rights reserved.</copyright>
                 <language>en-US</language>
@@ -629,7 +629,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
               </ metadata >
             </ package >
             */
-            
+
             foreach (var key in metadataElementsDictionary.Keys)
             {
                 if (metadataElementsDictionary.TryGetValue(key, out string elementInnerText))
@@ -663,7 +663,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 }
                 metadataElement.AppendChild(dependenciesElement);
             }
-            
+
             packageElement.AppendChild(metadataElement);
             doc.AppendChild(packageElement);
 
@@ -693,8 +693,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             var dependenciesHash = new Hashtable();
             if (LanguagePrimitives.TryConvertTo<Hashtable[]>(requiredModules, out Hashtable[] moduleList))
             {
-                // instead of returning an array of hashtables, 
-                // loop through the array and add each element of 
+                // instead of returning an array of hashtables,
+                // loop through the array and add each element of
                 foreach (Hashtable hash in moduleList)
                 {
                     dependenciesHash.Add(hash["ModuleName"], hash["ModuleVersion"]);
@@ -720,7 +720,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 .AUTHOR Jane Doe
                 .COMPANYNAME Microsoft
                 .COPYRIGHT
-                .TAGS Windows MacOS 
+                .TAGS Windows MacOS
                 #>
 
                 <#
@@ -736,8 +736,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             // We're retrieving all the comments within a script and grabbing all the key/value pairs
             // because there's no standard way to create metadata for a script.
             Hashtable parsedMetadataHash = new Hashtable(StringComparer.InvariantCultureIgnoreCase);
-            
-            // parse comments out           
+
+            // parse comments out
             Parser.ParseFile(
                 filePath,
                 out System.Management.Automation.Language.Token[] tokens,
@@ -758,12 +758,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 {
                     if (token.Kind == TokenKind.Comment)
                     {
-                        // expecting only one or two comments 
+                        // expecting only one or two comments
                         var commentText = token.Text;
                         parsedComments.AddRange(commentText.Split(new string[] { "\n\n" }, StringSplitOptions.RemoveEmptyEntries) );
                     }
                 }
-                
+
                 foreach (var line in parsedComments)
                 {
                     if (line.StartsWith("."))
@@ -777,14 +777,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     }
                 }
             }
-            
+
             return parsedMetadataHash;
         }
-        
-        private bool CheckDependenciesExist(Hashtable dependencies, string repositoryUrl)
+
+        private bool CheckDependenciesExist(Hashtable dependencies, string repositoryUri)
         {
-            // Check to see that all dependencies are in the repository 
-            // Searches for each dependency in the repository the pkg is being pushed to, 
+            // Check to see that all dependencies are in the repository
+            // Searches for each dependency in the repository the pkg is being pushed to,
             // If the dependency is not there, error
             foreach (var dependency in dependencies.Keys)
             {
@@ -792,7 +792,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 var depName = new[] { (string)dependency };
                 var depVersion = (string)dependencies[dependency];
                 var type = new[] { "module", "script" };
-                var repository = new[] { repositoryUrl };
+                var repository = new[] { repositoryUri };
 
                 // Search for and return the dependency if it's in the repository.
                 // TODO: When find is complete, uncomment beginFindHelper method below  (resourceNameParameterHelper)
@@ -801,7 +801,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 List<PSObject> dependencyFound = null;
                 if (dependencyFound == null || !dependencyFound.Any())
                 {
-                    var message = String.Format("Dependency '{0}' was not found in repository '{1}'.  Make sure the dependency is published to the repository before publishing this module.", dependency, repositoryUrl);
+                    var message = String.Format("Dependency '{0}' was not found in repository '{1}'.  Make sure the dependency is published to the repository before publishing this module.", dependency, repositoryUri);
                     var ex = new ArgumentException(message);  // System.ArgumentException vs PSArgumentException
                     var dependencyNotFound = new ErrorRecord(ex, "DependencyNotFound", ErrorCategory.ObjectNotFound, null);
 
@@ -842,17 +842,17 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             return success;
         }
 
-        private void PushNupkg(string outputNupkgDir, string repoName, string repoUrl)
+        private void PushNupkg(string outputNupkgDir, string repoName, string repoUri)
         {
-            // Push the nupkg to the appropriate repository 
-            // Pkg version is parsed from .ps1 file or .psd1 file 
+            // Push the nupkg to the appropriate repository
+            // Pkg version is parsed from .ps1 file or .psd1 file
             var fullNupkgFile = System.IO.Path.Combine(outputNupkgDir, _pkgName + "." + _pkgVersion.ToNormalizedString() + ".nupkg");
 
             // The PSGallery uses the v2 protocol still and publishes to a slightly different endpoint:
-            // "https://www.powershellgallery.com/api/v2/package" 
-            // Until the PSGallery is moved onto the NuGet v3 server protocol, we'll modify the repository url 
+            // "https://www.powershellgallery.com/api/v2/package"
+            // Until the PSGallery is moved onto the NuGet v3 server protocol, we'll modify the repository uri
             // to accommodate for the approprate publish location.
-            string publishLocation = repoUrl.EndsWith("/v2", StringComparison.OrdinalIgnoreCase) ? repoUrl + "/package" : repoUrl;
+            string publishLocation = repoUri.EndsWith("/v2", StringComparison.OrdinalIgnoreCase) ? repoUri + "/package" : repoUri;
 
             var settings = NuGet.Configuration.Settings.LoadDefaultSettings(null, null, null);
             ILogger log = new NuGetLogger();
@@ -870,7 +870,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         timeoutSeconds: 0,
                         disableBuffering: false,
                         noSymbols: false,
-                        noServiceEndpoint: false,  // enable server endpoint  
+                        noServiceEndpoint: false,  // enable server endpoint
                         skipDuplicate: false, // if true-- if a package and version already exists, skip it and continue with the next package in the push, if any.
                         logger: log // nuget logger
                         ).GetAwaiter().GetResult();
@@ -879,7 +879,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 //  look in PS repo for how httpRequestExceptions are handled
 
-                // Unfortunately there is no response message  are no status codes provided with the exception and no 
+                // Unfortunately there is no response message  are no status codes provided with the exception and no
                 var ex = new ArgumentException(String.Format("Repository '{0}': {1}", repoName, e.Message));
                 if (e.Message.Contains("401"))
                 {
@@ -925,12 +925,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             if (success)
             {
-                WriteVerbose(string.Format("Successfully published the resource to '{0}'", repoUrl));
+                WriteVerbose(string.Format("Successfully published the resource to '{0}'", repoUri));
             }
             else
             {
-                WriteVerbose(string.Format("Not able to publish resource to '{0}'", repoUrl));
-            }            
+                WriteVerbose(string.Format("Not able to publish resource to '{0}'", repoUri));
+            }
         }
     }
 

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -587,19 +587,19 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
             metadataElementsDictionary.Add("tags", tags);
 
-            if (parsedMetadataHash.ContainsKey("licenseuri"))
+            if (parsedMetadataHash.ContainsKey("licenseurl"))
             {
-                metadataElementsDictionary.Add("licenseUri", parsedMetadataHash["licenseuri"].ToString().Trim());
+                metadataElementsDictionary.Add("licenseUrl", parsedMetadataHash["licenseurl"].ToString().Trim());
             }
 
-            if (parsedMetadataHash.ContainsKey("projecturi"))
+            if (parsedMetadataHash.ContainsKey("projecturl"))
             {
-                metadataElementsDictionary.Add("projectUri", parsedMetadataHash["projecturi"].ToString().Trim());
+                metadataElementsDictionary.Add("projectUrl", parsedMetadataHash["projecturl"].ToString().Trim());
             }
 
-            if (parsedMetadataHash.ContainsKey("iconuri"))
+            if (parsedMetadataHash.ContainsKey("iconurl"))
             {
-                metadataElementsDictionary.Add("iconUri", parsedMetadataHash["iconuri"].ToString().Trim());
+                metadataElementsDictionary.Add("iconUrl", parsedMetadataHash["iconurl"].ToString().Trim());
             }
 
             // Example nuspec:
@@ -613,9 +613,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 <owners>Microsoft,PowerShell</owners>
                 <requireLicenseAcceptance>false</requireLicenseAcceptance>
                 <license type="expression">MIT</license>
-                <licenseUri>https://licenses.nuget.org/MIT</licenseUri>
+                <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
                 <icon>Powershell_black_64.png</icon>
-                <projectUri>https://github.com/PowerShell/PowerShell</projectUri>
+                <projectUrl>https://github.com/PowerShell/PowerShell</projectUrl>
                 <description>Example description here</description>
                 <copyright>Copyright (c) Microsoft Corporation. All rights reserved.</copyright>
                 <language>en-US</language>

--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -27,13 +27,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         #region Members
 
         private readonly string PSGalleryRepoName = "PSGallery";
-        private readonly string PSGalleryRepoURL = "https://www.powershellgallery.com/api/v2";
+        private readonly string PSGalleryRepoUri = "https://www.powershellgallery.com/api/v2";
         private const int defaultPriority = 50;
         private const bool defaultTrusted = false;
         private const string NameParameterSet = "NameParameterSet";
         private const string PSGalleryParameterSet = "PSGalleryParameterSet";
         private const string RepositoriesParameterSet = "RepositoriesParameterSet";
-        private Uri _url;
+        private Uri _uri;
 
         #endregion
 
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// </summary>
         [Parameter(Mandatory = true, Position = 1, ParameterSetName = NameParameterSet)]
         [ValidateNotNullOrEmpty]
-        public string URL { get; set; }
+        public string Uri { get; set; }
 
         /// <summary>
         /// When specified, registers PSGallery repository.
@@ -123,7 +123,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     ErrorCategory.NotImplemented,
                     this));
             }
-            
+
             RepositorySettings.CheckRepositoryStore();
         }
         protected override void ProcessRecord()
@@ -133,9 +133,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             switch (ParameterSetName)
             {
                 case NameParameterSet:
-                    if (!Utils.TryCreateValidUrl(uriString: URL,
+                    if (!Utils.TryCreateValidUri(uriString: Uri,
                         cmdletPassedIn: this,
-                        uriResult: out _url,
+                        uriResult: out _uri,
                         errorRecord: out ErrorRecord errorRecord))
                     {
                         ThrowTerminatingError(errorRecord);
@@ -143,7 +143,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                     try
                     {
-                        items.Add(NameParameterSetHelper(Name, _url, Priority, Trusted, CredentialInfo));
+                        items.Add(NameParameterSetHelper(Name, _uri, Priority, Trusted, CredentialInfo));
                     }
                     catch (Exception e)
                     {
@@ -200,7 +200,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
         }
 
-        private PSRepositoryInfo AddToRepositoryStoreHelper(string repoName, Uri repoUrl, int repoPriority, bool repoTrusted, PSCredentialInfo repoCredentialInfo)
+        private PSRepositoryInfo AddToRepositoryStoreHelper(string repoName, Uri repoUri, int repoPriority, bool repoTrusted, PSCredentialInfo repoCredentialInfo)
         {
             // remove trailing and leading whitespaces, and if Name is just whitespace Name should become null now and be caught by following condition
             repoName = repoName.Trim(' ');
@@ -209,9 +209,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 throw new ArgumentException("Name cannot be null/empty, contain asterisk or be just whitespace");
             }
 
-            if (repoUrl == null || !(repoUrl.Scheme == Uri.UriSchemeHttp || repoUrl.Scheme == Uri.UriSchemeHttps || repoUrl.Scheme == Uri.UriSchemeFtp || repoUrl.Scheme == Uri.UriSchemeFile))
+            if (repoUri == null || !(repoUri.Scheme == System.Uri.UriSchemeHttp || repoUri.Scheme == System.Uri.UriSchemeHttps || repoUri.Scheme == System.Uri.UriSchemeFtp || repoUri.Scheme == System.Uri.UriSchemeFile))
             {
-                throw new ArgumentException("Invalid url, must be one of the following Uri schemes: HTTPS, HTTP, FTP, File Based");
+                throw new ArgumentException("Invalid URI, must be one of the following URI schemes: HTTPS, HTTP, FTP, File Based");
             }
 
             if (repoCredentialInfo != null)
@@ -246,10 +246,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 return null;
             }
 
-            return RepositorySettings.Add(repoName, repoUrl, repoPriority, repoTrusted, repoCredentialInfo);
+            return RepositorySettings.Add(repoName, repoUri, repoPriority, repoTrusted, repoCredentialInfo);
         }
 
-        private PSRepositoryInfo NameParameterSetHelper(string repoName, Uri repoUrl, int repoPriority, bool repoTrusted, PSCredentialInfo repoCredentialInfo)
+        private PSRepositoryInfo NameParameterSetHelper(string repoName, Uri repoUri, int repoPriority, bool repoTrusted, PSCredentialInfo repoCredentialInfo)
         {
             if (repoName.Equals("PSGallery", StringComparison.OrdinalIgnoreCase))
             {
@@ -257,12 +257,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 throw new ArgumentException("Cannot register PSGallery with -Name parameter. Try: Register-PSResourceRepository -PSGallery");
             }
 
-            return AddToRepositoryStoreHelper(repoName, repoUrl, repoPriority, repoTrusted, repoCredentialInfo);
+            return AddToRepositoryStoreHelper(repoName, repoUri, repoPriority, repoTrusted, repoCredentialInfo);
         }
 
         private PSRepositoryInfo PSGalleryParameterSetHelper(int repoPriority, bool repoTrusted)
         {
-            Uri psGalleryUri = new Uri(PSGalleryRepoURL);
+            Uri psGalleryUri = new Uri(PSGalleryRepoUri);
             WriteVerbose("(PSGallerySet) internal name and uri values for Add() API are hardcoded and validated, priority and trusted values, if passed in, also validated");
             return AddToRepositoryStoreHelper(PSGalleryRepoName, psGalleryUri, repoPriority, repoTrusted, repoCredentialInfo: null);
         }
@@ -274,11 +274,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 if (repo.ContainsKey(PSGalleryRepoName))
                 {
-                    if (repo.ContainsKey("Name") || repo.ContainsKey("Url") || repo.ContainsKey("CredentialInfo"))
+                    if (repo.ContainsKey("Name") || repo.ContainsKey("Uri") || repo.ContainsKey("CredentialInfo"))
                     {
                         WriteError(new ErrorRecord(
-                                new PSInvalidOperationException("Repository hashtable cannot contain PSGallery key with -Name, -URL and/or -CredentialInfo key value pairs"),
-                                "NotProvideNameUrlCredentialInfoForPSGalleryRepositoriesParameterSetRegistration",
+                                new PSInvalidOperationException("Repository hashtable cannot contain PSGallery key with -Name, -Uri and/or -CredentialInfo key value pairs"),
+                                "NotProvideNameUriCredentialInfoForPSGalleryRepositoriesParameterSetRegistration",
                                 ErrorCategory.InvalidArgument,
                                 this));
                         continue;
@@ -335,19 +335,19 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 return null;
             }
 
-            if (!repo.ContainsKey("Url") || String.IsNullOrEmpty(repo["Url"].ToString()))
+            if (!repo.ContainsKey("Uri") || String.IsNullOrEmpty(repo["Uri"].ToString()))
             {
                 WriteError(new ErrorRecord(
-                        new PSInvalidOperationException("Repository url cannot be null"),
-                        "NullURLForRepositoriesParameterSetRegistration",
+                        new PSInvalidOperationException("Repository URI cannot be null"),
+                        "NullUriForRepositoriesParameterSetRegistration",
                         ErrorCategory.InvalidArgument,
                         this));
                 return null;
             }
 
-            if (!Utils.TryCreateValidUrl(uriString: repo["Url"].ToString(),
+            if (!Utils.TryCreateValidUri(uriString: repo["Uri"].ToString(),
                 cmdletPassedIn: this,
-                uriResult: out Uri repoURL,
+                uriResult: out Uri repoUri,
                 errorRecord: out ErrorRecord errorRecord))
             {
                 WriteError(errorRecord);
@@ -369,7 +369,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 WriteVerbose(String.Format("(RepositoriesParameterSet): on repo: {0}. Registers Name based repository", repo["Name"]));
                 return NameParameterSetHelper(repo["Name"].ToString(),
-                    repoURL,
+                    repoUri,
                     repo.ContainsKey("Priority") ? Convert.ToInt32(repo["Priority"].ToString()) : defaultPriority,
                     repo.ContainsKey("Trusted") ? Convert.ToBoolean(repo["Trusted"].ToString()) : defaultTrusted,
                     repoCredentialInfo);

--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -211,7 +211,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             if (repoUri == null || !(repoUri.Scheme == System.Uri.UriSchemeHttp || repoUri.Scheme == System.Uri.UriSchemeHttps || repoUri.Scheme == System.Uri.UriSchemeFtp || repoUri.Scheme == System.Uri.UriSchemeFile))
             {
-                throw new ArgumentException("Invalid URI, must be one of the following URI schemes: HTTPS, HTTP, FTP, File Based");
+                throw new ArgumentException("Invalid Uri, must be one of the following Uri schemes: HTTPS, HTTP, FTP, File Based");
             }
 
             if (repoCredentialInfo != null)
@@ -338,7 +338,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             if (!repo.ContainsKey("Uri") || String.IsNullOrEmpty(repo["Uri"].ToString()))
             {
                 WriteError(new ErrorRecord(
-                        new PSInvalidOperationException("Repository URI cannot be null"),
+                        new PSInvalidOperationException("Repository Uri cannot be null"),
                         "NullUriForRepositoriesParameterSetRegistration",
                         ErrorCategory.InvalidArgument,
                         this));

--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -123,7 +123,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         }
 
         /// <summary>
-        /// Updates a repository name, URI, priority, installation policy, or credential information
+        /// Updates a repository name, Uri, priority, installation policy, or credential information
         /// Returns:  void
         /// </summary>
         public static PSRepositoryInfo Update(string repoName, Uri repoUri, int repoPriority, bool? repoTrusted, PSCredentialInfo repoCredentialInfo)
@@ -143,8 +143,8 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 // Get root of XDocument (XElement)
                 var root = doc.Root;
 
-                // A null URI value passed in signifies the URI was not attempted to be set.
-                // So only set URI attribute if non-null value passed in for repoUri
+                // A null Uri value passed in signifies the Uri was not attempted to be set.
+                // So only set Uri attribute if non-null value passed in for repoUri
                 if (repoUri != null)
                 {
                     node.Attribute("Uri").Value = repoUri.AbsoluteUri;
@@ -190,7 +190,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 // Create Uri from node Uri attribute to create PSRepositoryInfo item to return.
                 if (!Uri.TryCreate(node.Attribute("Uri").Value, UriKind.Absolute, out Uri thisUri))
                 {
-                    throw new PSInvalidOperationException(String.Format("Unable to read incorrectly formatted URI for repo {0}", repoName));
+                    throw new PSInvalidOperationException(String.Format("Unable to read incorrectly formatted Uri for repo {0}", repoName));
                 }
 
                 // Create CredentialInfo based on new values or whether it was empty to begin with
@@ -298,7 +298,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 {
                     if (!Uri.TryCreate(repo.Attribute("Uri").Value, UriKind.Absolute, out Uri thisUri))
                     {
-                        tempErrorList.Add(String.Format("Unable to read incorrectly formatted URI for repo {0}", repo.Attribute("Name").Value));
+                        tempErrorList.Add(String.Format("Unable to read incorrectly formatted Uri for repo {0}", repo.Attribute("Name").Value));
                         continue;
                     }
 
@@ -356,7 +356,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                         if (!Uri.TryCreate(node.Attribute("Uri").Value, UriKind.Absolute, out Uri thisUri))
                         {
                             //debug statement
-                            tempErrorList.Add(String.Format("Unable to read incorrectly formatted URI for repo {0}", node.Attribute("Name").Value));
+                            tempErrorList.Add(String.Format("Unable to read incorrectly formatted Uri for repo {0}", node.Attribute("Name").Value));
                             continue;
                         }
 

--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         // File name for a user's repository store file is 'PSResourceRepository.xml'
         // The repository store file's location is currently only at '%LOCALAPPDATA%\PowerShellGet' for the user account.
         private const string PSGalleryRepoName = "PSGallery";
-        private const string PSGalleryRepoURL = "https://www.powershellgallery.com/api/v2";
+        private const string PSGalleryRepoUri = "https://www.powershellgallery.com/api/v2";
         private const int defaultPriority = 50;
         private const bool defaultTrusted = false;
         private const string RepositoryFileName = "PSResourceRepository.xml";
@@ -59,7 +59,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 }
 
                 // Add PSGallery to the newly created store
-                Uri psGalleryUri = new Uri(PSGalleryRepoURL);
+                Uri psGalleryUri = new Uri(PSGalleryRepoUri);
                 Add(PSGalleryRepoName, psGalleryUri, defaultPriority, defaultTrusted, repoCredentialInfo: null);
             }
 
@@ -79,7 +79,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         /// Returns: PSRepositoryInfo containing information about the repository just added to the repository store
         /// </summary>
         /// <param name="sectionName"></param>
-        public static PSRepositoryInfo Add(string repoName, Uri repoURL, int repoPriority, bool repoTrusted, PSCredentialInfo repoCredentialInfo)
+        public static PSRepositoryInfo Add(string repoName, Uri repoUri, int repoPriority, bool repoTrusted, PSCredentialInfo repoCredentialInfo)
         {
             try
             {
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 XElement newElement = new XElement(
                     "Repository",
                     new XAttribute("Name", repoName),
-                    new XAttribute("Url", repoURL),
+                    new XAttribute("Uri", repoUri),
                     new XAttribute("Priority", repoPriority),
                     new XAttribute("Trusted", repoTrusted)
                     );
@@ -119,14 +119,14 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 throw new PSInvalidOperationException(String.Format("Adding to repository store failed: {0}", e.Message));
             }
 
-            return new PSRepositoryInfo(repoName, repoURL, repoPriority, repoTrusted, repoCredentialInfo);
+            return new PSRepositoryInfo(repoName, repoUri, repoPriority, repoTrusted, repoCredentialInfo);
         }
 
         /// <summary>
-        /// Updates a repository name, URL, priority, installation policy, or credential information
+        /// Updates a repository name, URI, priority, installation policy, or credential information
         /// Returns:  void
         /// </summary>
-        public static PSRepositoryInfo Update(string repoName, Uri repoURL, int repoPriority, bool? repoTrusted, PSCredentialInfo repoCredentialInfo)
+        public static PSRepositoryInfo Update(string repoName, Uri repoUri, int repoPriority, bool? repoTrusted, PSCredentialInfo repoCredentialInfo)
         {
             PSRepositoryInfo updatedRepo;
             try
@@ -143,11 +143,11 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 // Get root of XDocument (XElement)
                 var root = doc.Root;
 
-                // A null URL value passed in signifies the URL was not attempted to be set.
-                // So only set Url attribute if non-null value passed in for repoUrl
-                if (repoURL != null)
+                // A null URI value passed in signifies the URI was not attempted to be set.
+                // So only set URI attribute if non-null value passed in for repoUri
+                if (repoUri != null)
                 {
-                    node.Attribute("Url").Value = repoURL.AbsoluteUri;
+                    node.Attribute("Uri").Value = repoUri.AbsoluteUri;
                 }
 
                 // A negative Priority value passed in signifies the Priority value was not attempted to be set.
@@ -187,10 +187,10 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                     }
                 }
 
-                // Create Uri from node Url attribute to create PSRepositoryInfo item to return.
-                if (!Uri.TryCreate(node.Attribute("Url").Value, UriKind.Absolute, out Uri thisUrl))
+                // Create Uri from node Uri attribute to create PSRepositoryInfo item to return.
+                if (!Uri.TryCreate(node.Attribute("Uri").Value, UriKind.Absolute, out Uri thisUri))
                 {
-                    throw new PSInvalidOperationException(String.Format("Unable to read incorrectly formatted URL for repo {0}", repoName));
+                    throw new PSInvalidOperationException(String.Format("Unable to read incorrectly formatted URI for repo {0}", repoName));
                 }
 
                 // Create CredentialInfo based on new values or whether it was empty to begin with
@@ -204,7 +204,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 }
 
                 updatedRepo = new PSRepositoryInfo(repoName,
-                    thisUrl,
+                    thisUri,
                     Int32.Parse(node.Attribute("Priority").Value),
                     Boolean.Parse(node.Attribute("Trusted").Value),
                     thisCredentialInfo);
@@ -259,7 +259,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 }
                 removedRepos.Add(
                     new PSRepositoryInfo(repo,
-                        new Uri(node.Attribute("Url").Value),
+                        new Uri(node.Attribute("Uri").Value),
                         Int32.Parse(node.Attribute("Priority").Value),
                         Boolean.Parse(node.Attribute("Trusted").Value),
                         repoCredentialInfo));
@@ -270,7 +270,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             // Close the file
             root.Save(FullRepositoryPath);
             errorList = tempErrorList.ToArray();
-            
+
             return removedRepos;
         }
 
@@ -296,9 +296,9 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 // iterate through the doc
                 foreach (XElement repo in doc.Descendants("Repository"))
                 {
-                    if (!Uri.TryCreate(repo.Attribute("Url").Value, UriKind.Absolute, out Uri thisUrl))
+                    if (!Uri.TryCreate(repo.Attribute("Uri").Value, UriKind.Absolute, out Uri thisUri))
                     {
-                        tempErrorList.Add(String.Format("Unable to read incorrectly formatted URL for repo {0}", repo.Attribute("Name").Value));
+                        tempErrorList.Add(String.Format("Unable to read incorrectly formatted URI for repo {0}", repo.Attribute("Name").Value));
                         continue;
                     }
 
@@ -335,7 +335,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                     }
 
                     PSRepositoryInfo currentRepoItem = new PSRepositoryInfo(repo.Attribute("Name").Value,
-                        thisUrl,
+                        thisUri,
                         Int32.Parse(repo.Attribute("Priority").Value),
                         Boolean.Parse(repo.Attribute("Trusted").Value),
                         thisCredentialInfo);
@@ -353,10 +353,10 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                     foreach (var node in doc.Descendants("Repository").Where(e => nameWildCardPattern.IsMatch(e.Attribute("Name").Value)))
                     {
                         repoMatch = true;
-                        if (!Uri.TryCreate(node.Attribute("Url").Value, UriKind.Absolute, out Uri thisUrl))
+                        if (!Uri.TryCreate(node.Attribute("Uri").Value, UriKind.Absolute, out Uri thisUri))
                         {
                             //debug statement
-                            tempErrorList.Add(String.Format("Unable to read incorrectly formatted URL for repo {0}", node.Attribute("Name").Value));
+                            tempErrorList.Add(String.Format("Unable to read incorrectly formatted URI for repo {0}", node.Attribute("Name").Value));
                             continue;
                         }
 
@@ -393,7 +393,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                         }
 
                         PSRepositoryInfo currentRepoItem = new PSRepositoryInfo(node.Attribute("Name").Value,
-                            thisUrl,
+                            thisUri,
                             Int32.Parse(node.Attribute("Priority").Value),
                             Boolean.Parse(node.Attribute("Trusted").Value),
                             thisCredentialInfo);

--- a/src/code/SetPSResourceRepository.cs
+++ b/src/code/SetPSResourceRepository.cs
@@ -166,7 +166,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             if (repoUri != null && !(repoUri.Scheme == System.Uri.UriSchemeHttp || repoUri.Scheme == System.Uri.UriSchemeHttps || repoUri.Scheme == System.Uri.UriSchemeFtp || repoUri.Scheme == System.Uri.UriSchemeFile))
             {
-                throw new ArgumentException("Invalid URI, must be one of the following URI schemes: HTTPS, HTTP, FTP, File Based");
+                throw new ArgumentException("Invalid Uri, must be one of the following Uri schemes: HTTPS, HTTP, FTP, File Based");
             }
 
             // check repoName can't contain * or just be whitespace
@@ -177,10 +177,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 throw new ArgumentException("Name cannot be null/empty, contain asterisk or be just whitespace");
             }
 
-            // check PSGallery URI is not trying to be set
+            // check PSGallery Uri is not trying to be set
             if (repoName.Equals("PSGallery", StringComparison.OrdinalIgnoreCase) && repoUri != null)
             {
-                throw new ArgumentException("The PSGallery repository has a pre-defined URI. Setting the -Uri parameter for this repository is not allowed, instead try running 'Register-PSResourceRepository -PSGallery'.");
+                throw new ArgumentException("The PSGallery repository has a pre-defined Uri. Setting the -Uri parameter for this repository is not allowed, instead try running 'Register-PSResourceRepository -PSGallery'.");
             }
 
             // check PSGallery CredentialInfo is not trying to be set
@@ -267,7 +267,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 if (String.IsNullOrEmpty(repo["Uri"].ToString()))
                 {
                     WriteError(new ErrorRecord(
-                            new PSInvalidOperationException("Repository URI cannot be null if provided"),
+                            new PSInvalidOperationException("Repository Uri cannot be null if provided"),
                             "NullUriForRepositoriesParameterSetUpdate",
                             ErrorCategory.InvalidArgument,
                             this));

--- a/src/code/SetPSResourceRepository.cs
+++ b/src/code/SetPSResourceRepository.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         private const string NameParameterSet = "NameParameterSet";
         private const string RepositoriesParameterSet = "RepositoriesParameterSet";
         private const int DefaultPriority = -1;
-        private Uri _url;
+        private Uri _uri;
 
         #endregion
 
@@ -44,7 +44,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// </sumamry>
         [Parameter(ParameterSetName = NameParameterSet)]
         [ValidateNotNullOrEmpty]
-        public string URL { get; set; }
+        public string Uri { get; set; }
 
         /// <summary>
         /// Specifies a hashtable of repositories and is used to register multiple repositories at once.
@@ -105,10 +105,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void ProcessRecord()
         {
-            if (MyInvocation.BoundParameters.ContainsKey(nameof(URL)))
+            if (MyInvocation.BoundParameters.ContainsKey(nameof(Uri)))
             {
-                bool isUrlValid = Utils.TryCreateValidUrl(URL, this, out _url, out ErrorRecord errorRecord);
-                if (!isUrlValid)
+                bool isUriValid = Utils.TryCreateValidUri(Uri, this, out _uri, out ErrorRecord errorRecord);
+                if (!isUriValid)
                 {
                     ThrowTerminatingError(errorRecord);
                 }
@@ -121,7 +121,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 case NameParameterSet:
                     try
                     {
-                        items.Add(UpdateRepositoryStoreHelper(Name, _url, Priority, Trusted, CredentialInfo));
+                        items.Add(UpdateRepositoryStoreHelper(Name, _uri, Priority, Trusted, CredentialInfo));
                     }
                     catch (Exception e)
                     {
@@ -162,11 +162,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
         }
 
-        private PSRepositoryInfo UpdateRepositoryStoreHelper(string repoName, Uri repoUrl, int repoPriority, bool repoTrusted, PSCredentialInfo repoCredentialInfo)
+        private PSRepositoryInfo UpdateRepositoryStoreHelper(string repoName, Uri repoUri, int repoPriority, bool repoTrusted, PSCredentialInfo repoCredentialInfo)
         {
-            if (repoUrl != null && !(repoUrl.Scheme == Uri.UriSchemeHttp || repoUrl.Scheme == Uri.UriSchemeHttps || repoUrl.Scheme == Uri.UriSchemeFtp || repoUrl.Scheme == Uri.UriSchemeFile))
+            if (repoUri != null && !(repoUri.Scheme == System.Uri.UriSchemeHttp || repoUri.Scheme == System.Uri.UriSchemeHttps || repoUri.Scheme == System.Uri.UriSchemeFtp || repoUri.Scheme == System.Uri.UriSchemeFile))
             {
-                throw new ArgumentException("Invalid url, must be one of the following Uri schemes: HTTPS, HTTP, FTP, File Based");
+                throw new ArgumentException("Invalid URI, must be one of the following URI schemes: HTTPS, HTTP, FTP, File Based");
             }
 
             // check repoName can't contain * or just be whitespace
@@ -177,16 +177,16 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 throw new ArgumentException("Name cannot be null/empty, contain asterisk or be just whitespace");
             }
 
-            // check PSGallery URL is not trying to be set
-            if (repoName.Equals("PSGallery", StringComparison.OrdinalIgnoreCase) && repoUrl != null)
+            // check PSGallery URI is not trying to be set
+            if (repoName.Equals("PSGallery", StringComparison.OrdinalIgnoreCase) && repoUri != null)
             {
-                throw new ArgumentException("The PSGallery repository has a pre-defined URL.  Setting the -URL parameter for this repository is not allowed, instead try running 'Register-PSResourceRepository -PSGallery'.");
+                throw new ArgumentException("The PSGallery repository has a pre-defined URI. Setting the -Uri parameter for this repository is not allowed, instead try running 'Register-PSResourceRepository -PSGallery'.");
             }
 
             // check PSGallery CredentialInfo is not trying to be set
             if (repoName.Equals("PSGallery", StringComparison.OrdinalIgnoreCase) && repoCredentialInfo != null)
             {
-                throw new ArgumentException("The PSGallery repository does not require authentication.  Setting the -CredentialInfo parameter for this repository is not allowed, instead try running 'Register-PSResourceRepository -PSGallery'.");
+                throw new ArgumentException("The PSGallery repository does not require authentication. Setting the -CredentialInfo parameter for this repository is not allowed, instead try running 'Register-PSResourceRepository -PSGallery'.");
             }
 
             // determine trusted value to pass in (true/false if set, null otherwise, hence the nullable bool variable)
@@ -218,11 +218,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 }
             }
 
-            // determine if either 1 of 4 values are attempting to be set: URL, Priority, Trusted, CredentialInfo.
+            // determine if either 1 of 4 values are attempting to be set: Uri, Priority, Trusted, CredentialInfo.
             // if none are (i.e only Name parameter was provided, write error)
-            if (repoUrl == null && repoPriority == DefaultPriority && _trustedNullable == null && repoCredentialInfo == null)
+            if (repoUri == null && repoPriority == DefaultPriority && _trustedNullable == null && repoCredentialInfo == null)
             {
-                throw new ArgumentException("Either URL, Priority, Trusted or CredentialInfo parameters must be requested to be set");
+                throw new ArgumentException("Either Uri, Priority, Trusted or CredentialInfo parameters must be requested to be set");
             }
 
             WriteVerbose("All required values to set repository provided, calling internal Update() API now");
@@ -230,7 +230,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 return null;
             }
-            return RepositorySettings.Update(repoName, repoUrl, repoPriority, _trustedNullable, repoCredentialInfo);
+            return RepositorySettings.Update(repoName, repoUri, repoPriority, _trustedNullable, repoCredentialInfo);
         }
 
         private List<PSRepositoryInfo> RepositoriesParameterSetHelper()
@@ -261,22 +261,22 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             WriteVerbose(String.Format("Parsing through repository: {0}", repo["Name"]));
 
-            Uri repoURL = null;
-            if (repo.ContainsKey("Url"))
+            Uri repoUri = null;
+            if (repo.ContainsKey("Uri"))
             {
-                if (String.IsNullOrEmpty(repo["Url"].ToString()))
+                if (String.IsNullOrEmpty(repo["Uri"].ToString()))
                 {
                     WriteError(new ErrorRecord(
-                            new PSInvalidOperationException("Repository url cannot be null if provided"),
-                            "NullURLForRepositoriesParameterSetUpdate",
+                            new PSInvalidOperationException("Repository URI cannot be null if provided"),
+                            "NullUriForRepositoriesParameterSetUpdate",
                             ErrorCategory.InvalidArgument,
                             this));
                     return null;
                 }
 
-                if (!Utils.TryCreateValidUrl(uriString: repo["Url"].ToString(),
+                if (!Utils.TryCreateValidUri(uriString: repo["Uri"].ToString(),
                     cmdletPassedIn: this,
-                    uriResult: out repoURL,
+                    uriResult: out repoUri,
                     errorRecord: out ErrorRecord errorRecord))
                 {
                     WriteError(errorRecord);
@@ -306,7 +306,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             try
             {
                 return UpdateRepositoryStoreHelper(repo["Name"].ToString(),
-                    repoURL,
+                    repoUri,
                     repo.ContainsKey("Priority") ? Convert.ToInt32(repo["Priority"].ToString()) : DefaultPriority,
                     repoTrusted,
                     repoCredentialInfo);

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -156,9 +156,9 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             errorMsgs = errorMsgsList.ToArray();
             return namesWithSupportedWildcards.ToArray();
         }
-    
+
         #endregion
-        
+
         #region Version methods
 
         public static string GetNormalizedVersionString(
@@ -269,9 +269,9 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
         #endregion
 
-        #region Url methods
+        #region Uri methods
 
-        public static bool TryCreateValidUrl(
+        public static bool TryCreateValidUri(
             string uriString,
             PSCmdlet cmdletPassedIn,
             out Uri uriResult,
@@ -286,7 +286,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             Exception ex;
             try
             {
-                // This is needed for a relative path urlstring. Does not throw error for an absolute path.
+                // This is needed for a relative path uri string. Does not throw error for an absolute path.
                 var filePath = cmdletPassedIn.SessionState.Path.GetResolvedPSPathFromPSPath(uriString)[0].Path;
                 if (Uri.TryCreate(filePath, UriKind.Absolute, out uriResult))
                 {
@@ -596,7 +596,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 // ex: ./PowerShell/Scripts/TestScript.ps1
                 return Path.GetFileNameWithoutExtension(pkgPath);
             }
-            
+
             // expecting the full version module path
             // ex:  ./PowerShell/Modules/TestModule/1.0.0
             return new DirectoryInfo(pkgPath).Parent.Name;
@@ -625,7 +625,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 resourcePaths.Add(Path.Combine(myDocumentsPath, "Modules"));
                 resourcePaths.Add(Path.Combine(myDocumentsPath, "Scripts"));
             }
-            
+
             if (scope is null || scope.Value is ScopeType.AllUsers)
             {
                 resourcePaths.Add(Path.Combine(programFilesPath, "Modules"));
@@ -740,7 +740,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             // a module will still need the module manifest to be parsed.
             if (moduleFileInfo.EndsWith(".psd1", StringComparison.OrdinalIgnoreCase))
             {
-                // Parse the module manifest 
+                // Parse the module manifest
                 var ast = Parser.ParseFile(
                     moduleFileInfo,
                     out Token[] tokens,
@@ -1059,8 +1059,8 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 ps.Runspace = _runspace;
 
                 var cmd = new Command(
-                    command: script, 
-                    isScript: true, 
+                    command: script,
+                    isScript: true,
                     useLocalScope: true);
                 cmd.MergeMyResults(
                     myResult: PipelineResultTypes.Error | PipelineResultTypes.Warning | PipelineResultTypes.Verbose | PipelineResultTypes.Debug | PipelineResultTypes.Information,
@@ -1070,7 +1070,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 {
                     ps.Commands.AddArgument(arg);
                 }
-                
+
                 try
                 {
                     // Invoke the script.
@@ -1102,7 +1102,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                             case InformationRecord info:
                                 cmdlet.WriteInformation(info);
                                 break;
-                                
+
                             case T result:
                                 returnCollection.Add(result);
                                 break;

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -286,7 +286,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             Exception ex;
             try
             {
-                // This is needed for a relative path uri string. Does not throw error for an absolute path.
+                // This is needed for a relative path Uri string. Does not throw error for an absolute path.
                 var filePath = cmdletPassedIn.SessionState.Path.GetResolvedPSPathFromPSPath(uriString)[0].Path;
                 if (Uri.TryCreate(filePath, UriKind.Absolute, out uriResult))
                 {

--- a/test/GetPSResourceRepository.Tests.ps1
+++ b/test/GetPSResourceRepository.Tests.ps1
@@ -25,16 +25,16 @@ Describe "Test Get-PSResourceRepository" {
     }
 
     It "get single already registered repo" {
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
         $res = Get-PSResourceRepository -Name $TestRepoName1
         $res | Should -Not -BeNullOrEmpty
         $res.Name | Should -Be $TestRepoName1
     }
 
     It "get all repositories matching single wildcard name" {
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
-        Register-PSResourceRepository -Name $TestRepoName2 -URL $tmpDir2Path
-        Register-PSResourceRepository -Name $TestRepoName3 -URL $tmpDir3Path
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName2 -Uri $tmpDir2Path
+        Register-PSResourceRepository -Name $TestRepoName3 -Uri $tmpDir3Path
         $res = Get-PSResourceRepository -Name "testReposit*"
         foreach ($entry in $res) {
             $entry.Name | Should -Match "testReposit"
@@ -42,9 +42,9 @@ Describe "Test Get-PSResourceRepository" {
     }
 
     It "get all repositories matching multiple wildcard names" {
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
-        Register-PSResourceRepository -Name $TestRepoName2 -URL $tmpDir2Path
-        Register-PSResourceRepository -Name "MyGallery" -URL $tmpDir3Path
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName2 -Uri $tmpDir2Path
+        Register-PSResourceRepository -Name "MyGallery" -Uri $tmpDir3Path
 
         $res = Get-PSResourceRepository -Name "testReposit*","*Gallery"
         foreach ($entry in $res) {
@@ -53,8 +53,8 @@ Describe "Test Get-PSResourceRepository" {
     }
 
     It "get all repositories matching multiple valid names provided" {
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
-        Register-PSResourceRepository -Name "MyGallery" -URL $tmpDir2Path
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        Register-PSResourceRepository -Name "MyGallery" -Uri $tmpDir2Path
 
         $res = Get-PSResourceRepository -Name $TestRepoName1,"MyGallery"
         foreach ($entry in $res) {
@@ -73,8 +73,8 @@ Describe "Test Get-PSResourceRepository" {
     It "given invalid and valid Names, get valid ones and write error for non valid ones" {
         $nonRegisteredRepoName = "nonRegisteredRepository"
 
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
-        Register-PSResourceRepository -Name $TestRepoName2 -URL $tmpDir2Path
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName2 -Uri $tmpDir2Path
 
         $res = Get-PSResourceRepository -Name $TestRepoName1,$nonRegisteredRepoName,$TestRepoName2 -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0

--- a/test/PSGetTestUtils.psm1
+++ b/test/PSGetTestUtils.psm1
@@ -234,21 +234,21 @@ function Get-NewPSResourceRepositoryFileWithCredentialInfo {
 }
 
 function Register-LocalRepos {
-    $repoURLAddress = Join-Path -Path $TestDrive -ChildPath "testdir"
-    $null = New-Item $repoURLAddress -ItemType Directory -Force
+    $repoUriAddress = Join-Path -Path $TestDrive -ChildPath "testdir"
+    $null = New-Item $repoUriAddress -ItemType Directory -Force
     $localRepoParams = @{
         Name = "psgettestlocal"
-        URL = $repoURLAddress
+        Uri = $repoUriAddress
         Priority = 40
         Trusted = $false
     }
     Register-PSResourceRepository @localRepoParams
 
-    $repoURLAddress2 = Join-Path -Path $TestDrive -ChildPath "testdir2"
-    $null = New-Item $repoURLAddress2 -ItemType Directory -Force
+    $repoUriAddress2 = Join-Path -Path $TestDrive -ChildPath "testdir2"
+    $null = New-Item $repoUriAddress2 -ItemType Directory -Force
     $localRepoParams2 = @{
         Name = "psgettestlocal2"
-        URL = $repoURLAddress2
+        Uri = $repoUriAddress2
         Priority = 50
         Trusted = $false
     }
@@ -384,22 +384,22 @@ function Get-ModuleResourcePublishedToLocalRepoTestDrive
 }
 
 function Register-LocalRepos {
-    $repoURLAddress = Join-Path -Path $TestDrive -ChildPath "testdir"
-    $null = New-Item $repoURLAddress -ItemType Directory -Force
+    $repoUriAddress = Join-Path -Path $TestDrive -ChildPath "testdir"
+    $null = New-Item $repoUriAddress -ItemType Directory -Force
     $localRepoParams = @{
         Name = "psgettestlocal"
-        URL = $repoURLAddress
+        Uri = $repoUriAddress
         Priority = 40
         Trusted = $false
     }
 
     Register-PSResourceRepository @localRepoParams
 
-    $repoURLAddress2 = Join-Path -Path $TestDrive -ChildPath "testdir2"
-    $null = New-Item $repoURLAddress2 -ItemType Directory -Force
+    $repoUriAddress2 = Join-Path -Path $TestDrive -ChildPath "testdir2"
+    $null = New-Item $repoUriAddress2 -ItemType Directory -Force
     $localRepoParams2 = @{
         Name = "psgettestlocal2"
-        URL = $repoURLAddress2
+        Uri = $repoUriAddress2
         Priority = 50
         Trusted = $false
     }

--- a/test/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResource.Tests.ps1
@@ -7,20 +7,20 @@ Describe "Test Publish-PSResource" {
     BeforeAll {
         Get-NewPSResourceRepositoryFile
 
-        # Register temporary repositories 
+        # Register temporary repositories
         $tmpRepoPath = Join-Path -Path $TestDrive -ChildPath "tmpRepoPath"
         New-Item $tmpRepoPath -Itemtype directory -Force
         $testRepository = "testRepository"
-        Register-PSResourceRepository -Name $testRepository -URL $tmpRepoPath -Priority 1 -ErrorAction SilentlyContinue
-        $script:repositoryPath = [IO.Path]::GetFullPath((get-psresourcerepository "testRepository").Url.AbsolutePath)
+        Register-PSResourceRepository -Name $testRepository -Uri $tmpRepoPath -Priority 1 -ErrorAction SilentlyContinue
+        $script:repositoryPath = [IO.Path]::GetFullPath((get-psresourcerepository "testRepository").Uri.AbsolutePath)
 
         $tmpRepoPath2 = Join-Path -Path $TestDrive -ChildPath "tmpRepoPath2"
         New-Item $tmpRepoPath2 -Itemtype directory -Force
         $testRepository2 = "testRepository2"
-        Register-PSResourceRepository -Name $testRepository2 -URL $tmpRepoPath2 -ErrorAction SilentlyContinue
-        $script:repositoryPath2 = [IO.Path]::GetFullPath((get-psresourcerepository "testRepository2").Url.AbsolutePath)
+        Register-PSResourceRepository -Name $testRepository2 -Uri $tmpRepoPath2 -ErrorAction SilentlyContinue
+        $script:repositoryPath2 = [IO.Path]::GetFullPath((get-psresourcerepository "testRepository2").Uri.AbsolutePath)
 
-        # Create module 
+        # Create module
         $script:tmpModulesPath = Join-Path -Path $TestDrive -ChildPath "tmpModulesPath"
         $script:PublishModuleName = "PSGetTestModule"
         $script:PublishModuleBase = Join-Path $script:tmpModulesPath -ChildPath $script:PublishModuleName
@@ -61,7 +61,7 @@ Describe "Test Publish-PSResource" {
         Publish-PSResource -Path $script:PublishModuleBase
 
         $expectedPath = Join-Path -Path $script:repositoryPath  -ChildPath "$script:PublishModuleName.$version.nupkg"
-        (Get-ChildItem $script:repositoryPath).FullName | Should -Be $expectedPath 
+        (Get-ChildItem $script:repositoryPath).FullName | Should -Be $expectedPath
     }
 
     It "Publish a module with -Path and -Repository" {
@@ -71,10 +71,10 @@ Describe "Test Publish-PSResource" {
         Publish-PSResource -Path $script:PublishModuleBase -Repository $testRepository2
 
         $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$script:PublishModuleName.$version.nupkg"
-        (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath 
+        (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath
     }
 
-<# Temporarily comment this test out until Find Helper is complete and code within PublishPSResource is uncommented 
+<# Temporarily comment this test out until Find Helper is complete and code within PublishPSResource is uncommented
     It "Publish a module with dependencies" {
         # Create dependency module
         $dependencyVersion = "2.0.0"
@@ -89,7 +89,7 @@ Describe "Test Publish-PSResource" {
         Publish-PSResource -LiteralPath $script:PublishModuleBase
 
         $expectedPath = Join-Path -Path $script:repositoryPath -ChildPath "$script:PublishModuleName.$version.nupkg"
-        Get-ChildItem $script:repositoryPath | select-object -Last 1 | Should -Be $expectedPath 
+        Get-ChildItem $script:repositoryPath | select-object -Last 1 | Should -Be $expectedPath
     }
 #>
 
@@ -122,7 +122,7 @@ Describe "Test Publish-PSResource" {
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"  -NestedModules "$script:PublishModuleName.psm1"
 
         # Create nuspec
-        $nuspec = 
+        $nuspec =
 @'
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
@@ -140,13 +140,13 @@ Describe "Test Publish-PSResource" {
 </package>
 '@
 
-        $nuspecPath = Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.nuspec" 
+        $nuspecPath = Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.nuspec"
         New-Item $nuspecPath -ItemType File -Value $nuspec
 
         Publish-PSResource -Path $script:PublishModuleBase -Nuspec $nuspecPath
 
         $expectedPath = Join-Path -Path $script:repositoryPath  -ChildPath "$script:PublishModuleName.$version.nupkg"
-        Get-ChildItem $script:repositoryPath | Should -Be $expectedPath 
+        Get-ChildItem $script:repositoryPath | Should -Be $expectedPath
     }
 
     It "Publish a module with -ReleaseNotes" {
@@ -157,7 +157,7 @@ Describe "Test Publish-PSResource" {
         Publish-PSResource -Path $script:PublishModuleBase -ReleaseNotes $releaseNotes
 
         $expectedNupkgPath = Join-Path -Path $script:repositoryPath  -ChildPath "$script:PublishModuleName.$version.nupkg"
-        Get-ChildItem $script:repositoryPath | Should -Be $expectedNupkgPath 
+        Get-ChildItem $script:repositoryPath | Should -Be $expectedNupkgPath
 
         $expectedExpandedPath = Join-Path -Path $script:repositoryPath -ChildPath "ExpandedPackage"
         New-Item -Path $expectedExpandedPath -ItemType directory
@@ -168,15 +168,15 @@ Describe "Test Publish-PSResource" {
         $expectedNuspecContents.Contains($releaseNotes) | Should Be $true
     }
 
-    It "Publish a module with -LicenseUrl" {
+    It "Publish a module with -LicenseUri" {
         $version = "1.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"  -NestedModules "$script:PublishModuleName.psm1"
 
-        $licenseUrl = "https://www.fakelicenseurl.com"
-        Publish-PSResource -Path $script:PublishModuleBase -LicenseUrl $licenseUrl
+        $licenseUri = "https://www.fakelicenseuri.com"
+        Publish-PSResource -Path $script:PublishModuleBase -LicenseUri $licenseUri
 
         $expectedNupkgPath = Join-Path -Path $script:repositoryPath  -ChildPath "$script:PublishModuleName.$version.nupkg"
-        Get-ChildItem $script:repositoryPath | Should -Be $expectedNupkgPath 
+        Get-ChildItem $script:repositoryPath | Should -Be $expectedNupkgPath
 
         $expectedExpandedPath = Join-Path -Path $script:repositoryPath -ChildPath "ExpandedPackage"
         New-Item -Path $expectedExpandedPath -ItemType directory
@@ -184,18 +184,18 @@ Describe "Test Publish-PSResource" {
 
         $expectedNuspec = Join-path -Path $expectedExpandedPath -ChildPath "$script:PublishModuleName.nuspec"
         $expectedNuspecContents =  Get-Content -Path $expectedNuspec -Raw
-        $expectedNuspecContents.Contains($licenseUrl) | Should Be $true
+        $expectedNuspecContents.Contains($licenseUri) | Should Be $true
     }
 
-    It "Publish a module with -IconUrl" {
+    It "Publish a module with -IconUri" {
         $version = "1.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"  -NestedModules "$script:PublishModuleName.psm1"
 
-        $iconUrl = "https://www.fakeiconurl.com"
-        Publish-PSResource -Path $script:PublishModuleBase -IconUrl $iconUrl
+        $iconUri = "https://www.fakeiconuri.com"
+        Publish-PSResource -Path $script:PublishModuleBase -IconUri $iconUri
 
         $expectedNupkgPath = Join-Path -Path $script:repositoryPath  -ChildPath "$script:PublishModuleName.$version.nupkg"
-        Get-ChildItem $script:repositoryPath | Should -Be $expectedNupkgPath 
+        Get-ChildItem $script:repositoryPath | Should -Be $expectedNupkgPath
 
         $expectedExpandedPath = Join-Path -Path $script:repositoryPath -ChildPath "ExpandedPackage"
         New-Item -Path $expectedExpandedPath -ItemType directory
@@ -203,19 +203,19 @@ Describe "Test Publish-PSResource" {
 
         $expectedNuspec = Join-path -Path $expectedExpandedPath -ChildPath "$script:PublishModuleName.nuspec"
         $expectedNuspecContents =  Get-Content -Path $expectedNuspec -Raw
-        $expectedNuspecContents.Contains($iconUrl) | Should Be $true
+        $expectedNuspecContents.Contains($iconUri) | Should Be $true
     }
 
-    
-    It "Publish a module with -ProjectUrl" {
+
+    It "Publish a module with -ProjectUri" {
         $version = "1.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"  -NestedModules "$script:PublishModuleName.psm1"
 
-        $projectUrl = "https://www.fakeprojecturl.com"
-        Publish-PSResource -Path $script:PublishModuleBase -ProjectUrl $projectUrl
+        $projectUri = "https://www.fakeprojectUri.com"
+        Publish-PSResource -Path $script:PublishModuleBase -ProjectUri $projectUri
 
         $expectedNupkgPath = Join-Path -Path $script:repositoryPath  -ChildPath "$script:PublishModuleName.$version.nupkg"
-        Get-ChildItem $script:repositoryPath | Should -Be $expectedNupkgPath 
+        Get-ChildItem $script:repositoryPath | Should -Be $expectedNupkgPath
 
         $expectedExpandedPath = Join-Path -Path $script:repositoryPath -ChildPath "ExpandedPackage"
         New-Item -Path $expectedExpandedPath -ItemType directory
@@ -223,7 +223,7 @@ Describe "Test Publish-PSResource" {
 
         $expectedNuspec = Join-path -Path $expectedExpandedPath -ChildPath "$script:PublishModuleName.nuspec"
         $expectedNuspecContents =  Get-Content -Path $expectedNuspec -Raw
-        $expectedNuspecContents.Contains($projectUrl) | Should Be $true
+        $expectedNuspecContents.Contains($projectUri) | Should Be $true
     }
 
     It "Publish a module with -Tags" {
@@ -233,7 +233,7 @@ Describe "Test Publish-PSResource" {
         Publish-PSResource -Path $script:PublishModuleBase -Tags $tags
 
         $expectedNupkgPath = Join-Path -Path $script:repositoryPath  -ChildPath "$script:PublishModuleName.$version.nupkg"
-        Get-ChildItem $script:repositoryPath | Should -Be $expectedNupkgPath 
+        Get-ChildItem $script:repositoryPath | Should -Be $expectedNupkgPath
 
         $expectedExpandedPath = Join-Path -Path $script:repositoryPath -ChildPath "ExpandedPackage"
         New-Item -Path $expectedExpandedPath -ItemType directory
@@ -270,10 +270,10 @@ Describe "Test Publish-PSResource" {
 
         $expectedPath = Join-Path -Path $script:repositoryPath2 -ChildPath "$script:PublishModuleName.$version.nupkg"
 
-        (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath 
+        (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath
 
         $expectedPath = Join-Path -Path $script:destinationPath -ChildPath "$script:PublishModuleName.$version.nupkg"
-        (Get-ChildItem $script:destinationPath).FullName | Should -Be $expectedPath 
+        (Get-ChildItem $script:destinationPath).FullName | Should -Be $expectedPath
     }
 
     It "Publish a module and clean up properly when file in module is readonly" {
@@ -288,6 +288,6 @@ Describe "Test Publish-PSResource" {
         Publish-PSResource -Path $script:PublishModuleBase -Repository $testRepository2
 
         $expectedPath = Join-Path -Path $script:repositoryPath2 -ChildPath "$script:PublishModuleName.$version.nupkg"
-        (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath 
+        (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath
     }
 }

--- a/test/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResource.Tests.ps1
@@ -168,12 +168,12 @@ Describe "Test Publish-PSResource" {
         $expectedNuspecContents.Contains($releaseNotes) | Should Be $true
     }
 
-    It "Publish a module with -LicenseUri" {
+    It "Publish a module with -LicenseUrl" {
         $version = "1.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"  -NestedModules "$script:PublishModuleName.psm1"
 
-        $licenseUri = "https://www.fakelicenseuri.com"
-        Publish-PSResource -Path $script:PublishModuleBase -LicenseUri $licenseUri
+        $licenseUrl = "https://www.fakelicenseurl.com"
+        Publish-PSResource -Path $script:PublishModuleBase -LicenseUrl $licenseUrl
 
         $expectedNupkgPath = Join-Path -Path $script:repositoryPath  -ChildPath "$script:PublishModuleName.$version.nupkg"
         Get-ChildItem $script:repositoryPath | Should -Be $expectedNupkgPath
@@ -184,15 +184,15 @@ Describe "Test Publish-PSResource" {
 
         $expectedNuspec = Join-path -Path $expectedExpandedPath -ChildPath "$script:PublishModuleName.nuspec"
         $expectedNuspecContents =  Get-Content -Path $expectedNuspec -Raw
-        $expectedNuspecContents.Contains($licenseUri) | Should Be $true
+        $expectedNuspecContents.Contains($licenseUrl) | Should Be $true
     }
 
-    It "Publish a module with -IconUri" {
+    It "Publish a module with -IconUrl" {
         $version = "1.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"  -NestedModules "$script:PublishModuleName.psm1"
 
-        $iconUri = "https://www.fakeiconuri.com"
-        Publish-PSResource -Path $script:PublishModuleBase -IconUri $iconUri
+        $iconUrl = "https://www.fakeiconurl.com"
+        Publish-PSResource -Path $script:PublishModuleBase -IconUrl $iconUrl
 
         $expectedNupkgPath = Join-Path -Path $script:repositoryPath  -ChildPath "$script:PublishModuleName.$version.nupkg"
         Get-ChildItem $script:repositoryPath | Should -Be $expectedNupkgPath
@@ -203,16 +203,16 @@ Describe "Test Publish-PSResource" {
 
         $expectedNuspec = Join-path -Path $expectedExpandedPath -ChildPath "$script:PublishModuleName.nuspec"
         $expectedNuspecContents =  Get-Content -Path $expectedNuspec -Raw
-        $expectedNuspecContents.Contains($iconUri) | Should Be $true
+        $expectedNuspecContents.Contains($iconUrl) | Should Be $true
     }
 
 
-    It "Publish a module with -ProjectUri" {
+    It "Publish a module with -ProjectUrl" {
         $version = "1.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"  -NestedModules "$script:PublishModuleName.psm1"
 
-        $projectUri = "https://www.fakeprojectUri.com"
-        Publish-PSResource -Path $script:PublishModuleBase -ProjectUri $projectUri
+        $projectUrl = "https://www.fakeprojectUrl.com"
+        Publish-PSResource -Path $script:PublishModuleBase -ProjectUrl $projectUrl
 
         $expectedNupkgPath = Join-Path -Path $script:repositoryPath  -ChildPath "$script:PublishModuleName.$version.nupkg"
         Get-ChildItem $script:repositoryPath | Should -Be $expectedNupkgPath
@@ -223,7 +223,7 @@ Describe "Test Publish-PSResource" {
 
         $expectedNuspec = Join-path -Path $expectedExpandedPath -ChildPath "$script:PublishModuleName.nuspec"
         $expectedNuspecContents =  Get-Content -Path $expectedNuspec -Raw
-        $expectedNuspecContents.Contains($projectUri) | Should Be $true
+        $expectedNuspecContents.Contains($projectUrl) | Should Be $true
     }
 
     It "Publish a module with -Tags" {

--- a/test/RegisterPSResourceRepository.Tests.ps1
+++ b/test/RegisterPSResourceRepository.Tests.ps1
@@ -6,7 +6,7 @@ Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
 Describe "Test Register-PSResourceRepository" {
     BeforeEach {
         $PSGalleryName = Get-PSGalleryName
-        $PSGalleryURL = Get-PSGalleryLocation
+        $PSGalleryUri = Get-PSGalleryLocation
         $TestRepoName1 = "testRepository"
         $TestRepoName2 = "testRepository2"
         $TestRepoName3 = "testRepository3"
@@ -37,34 +37,34 @@ Describe "Test Register-PSResourceRepository" {
         Get-RemoveTestDirs($tmpDirPaths)
     }
 
-    It "register repository given Name, URL (bare minimum for NameParmaterSet)" {
-        $res = Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path -PassThru
+    It "register repository given Name, Uri (bare minimum for NameParmaterSet)" {
+        $res = Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -PassThru
         $res.Name | Should -Be $TestRepoName1
-        $res.URL.LocalPath | Should -Contain $tmpDir1Path
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
         $res.Trusted | Should -Be False
         $res.Priority | Should -Be 50
     }
 
-    It "register repository with Name, URL, Trusted (NameParameterSet)" {
-        $res = Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path -Trusted -PassThru
+    It "register repository with Name, Uri, Trusted (NameParameterSet)" {
+        $res = Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -Trusted -PassThru
         $res.Name | Should -Be $TestRepoName1
-        $res.URL.LocalPath | Should -Contain $tmpDir1Path
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
         $res.Trusted | Should -Be True
         $res.Priority | Should -Be 50
     }
 
-    It "register repository given Name, URL, Trusted, Priority (NameParameterSet)" {
-        $res = Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path -Trusted -Priority 20 -PassThru
+    It "register repository given Name, Uri, Trusted, Priority (NameParameterSet)" {
+        $res = Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -Trusted -Priority 20 -PassThru
         $res.Name | Should -Be $TestRepoName1
-        $res.URL.LocalPath | Should -Contain $tmpDir1Path
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
         $res.Trusted | Should -Be True
         $res.Priority | Should -Be 20
     }
 
-    It "register repository given Name, URL, Trusted, Priority, CredentialInfo (NameParameterSet)" {
-        $res = Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path -Trusted -Priority 20 -CredentialInfo $credentialInfo1 -PassThru
+    It "register repository given Name, Uri, Trusted, Priority, CredentialInfo (NameParameterSet)" {
+        $res = Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -Trusted -Priority 20 -CredentialInfo $credentialInfo1 -PassThru
         $res.Name | Should -Be $TestRepoName1
-        $res.URL.LocalPath | Should -Contain $tmpDir1Path
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
         $res.Trusted | Should -Be True
         $res.Priority | Should -Be 20
         $res.CredentialInfo.VaultName | Should -Be "testvault"
@@ -75,7 +75,7 @@ Describe "Test Register-PSResourceRepository" {
         Unregister-PSResourceRepository -Name $PSGalleryName
         $res = Register-PSResourceRepository -PSGallery -PassThru
         $res.Name | Should -Be $PSGalleryName
-        $res.URL | Should -Be $PSGalleryURL
+        $res.Uri | Should -Be $PSGalleryUri
         $res.Trusted | Should -Be False
         $res.Priority | Should -Be 50
     }
@@ -84,7 +84,7 @@ Describe "Test Register-PSResourceRepository" {
         Unregister-PSResourceRepository -Name $PSGalleryName
         $res = Register-PSResourceRepository -PSGallery -Trusted -PassThru
         $res.Name | Should -Be $PSGalleryName
-        $res.URL | Should -Be $PSGalleryURL
+        $res.Uri | Should -Be $PSGalleryUri
         $res.Trusted | Should -Be True
         $res.Priority | Should -Be 50
     }
@@ -93,36 +93,36 @@ Describe "Test Register-PSResourceRepository" {
         Unregister-PSResourceRepository -Name $PSGalleryName
         $res = Register-PSResourceRepository -PSGallery -Trusted -Priority 20 -PassThru
         $res.Name | Should -Be $PSGalleryName
-        $res.URL | Should -Be $PSGalleryURL
+        $res.Uri | Should -Be $PSGalleryUri
         $res.Trusted | Should -Be True
         $res.Priority | Should -Be 20
     }
 
     It "register repositories with Repositories parameter, all name parameter style repositories (RepositoriesParameterSet)" {
-        $hashtable1 = @{Name = $TestRepoName1; URL = $tmpDir1Path}
-        $hashtable2 = @{Name = $TestRepoName2; URL = $tmpDir2Path; Trusted = $True}
-        $hashtable3 = @{Name = $TestRepoName3; URL = $tmpDir3Path; Trusted = $True; Priority = 20}
-        $hashtable4 = @{Name = $TestRepoName4; URL = $tmpDir4Path; Trusted = $True; Priority = 30; CredentialInfo = (New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "testsecret"))}
+        $hashtable1 = @{Name = $TestRepoName1; Uri = $tmpDir1Path}
+        $hashtable2 = @{Name = $TestRepoName2; Uri = $tmpDir2Path; Trusted = $True}
+        $hashtable3 = @{Name = $TestRepoName3; Uri = $tmpDir3Path; Trusted = $True; Priority = 20}
+        $hashtable4 = @{Name = $TestRepoName4; Uri = $tmpDir4Path; Trusted = $True; Priority = 30; CredentialInfo = (New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "testsecret"))}
         $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3, $hashtable4
 
         Register-PSResourceRepository -Repositories $arrayOfHashtables
         $res = Get-PSResourceRepository -Name $TestRepoName1
-        $res.URL.LocalPath | Should -Contain $tmpDir1Path
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
         $res.Trusted | Should -Be False
         $res.Priority | Should -Be 50
 
         $res2 = Get-PSResourceRepository -Name $TestRepoName2
-        $res2.URL.LocalPath | Should -Contain $tmpDir2Path
+        $res2.Uri.LocalPath | Should -Contain $tmpDir2Path
         $res2.Trusted | Should -Be True
         $res2.Priority | Should -Be 50
 
         $res3 = Get-PSResourceRepository -Name $TestRepoName3
-        $res3.URL.LocalPath | Should -Contain $tmpDir3Path
+        $res3.Uri.LocalPath | Should -Contain $tmpDir3Path
         $res3.Trusted | Should -Be True
         $res3.Priority | Should -Be 20
 
         $res4 = Get-PSResourceRepository -Name $TestRepoName4
-        $res4.URL.LocalPath | Should -Contain $tmpDir4Path
+        $res4.Uri.LocalPath | Should -Contain $tmpDir4Path
         $res4.Trusted | Should -Be True
         $res4.Priority | Should -Be 30
         $res4.CredentialInfo.VaultName | Should -Be "testvault"
@@ -135,7 +135,7 @@ Describe "Test Register-PSResourceRepository" {
         $hashtable1 = @{PSGallery = $True}
         Register-PSResourceRepository -Repositories $hashtable1
         $res = Get-PSResourceRepository -Name $PSGalleryName
-        $res.URL | Should -Be $PSGalleryURL
+        $res.Uri | Should -Be $PSGalleryUri
         $res.Trusted | Should -Be False
         $res.Priority | Should -Be 50
     }
@@ -143,36 +143,36 @@ Describe "Test Register-PSResourceRepository" {
     It "register repositories with Repositories parameter, name and psgallery parameter styles (RepositoriesParameterSet)" {
         Unregister-PSResourceRepository -Name $PSGalleryName
         $hashtable1 = @{PSGallery = $True}
-        $hashtable2 = @{Name = $TestRepoName1; URL = $tmpDir1Path}
-        $hashtable3 = @{Name = $TestRepoName2; URL = $tmpDir2Path; Trusted = $True}
-        $hashtable4 = @{Name = $TestRepoName3; URL = $tmpDir3Path; Trusted = $True; Priority = 20}
-        $hashtable5 = @{Name = $TestRepoName4; URL = $tmpDir4Path; Trusted = $True; Priority = 30; CredentialInfo = (New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "testsecret"))}
+        $hashtable2 = @{Name = $TestRepoName1; Uri = $tmpDir1Path}
+        $hashtable3 = @{Name = $TestRepoName2; Uri = $tmpDir2Path; Trusted = $True}
+        $hashtable4 = @{Name = $TestRepoName3; Uri = $tmpDir3Path; Trusted = $True; Priority = 20}
+        $hashtable5 = @{Name = $TestRepoName4; Uri = $tmpDir4Path; Trusted = $True; Priority = 30; CredentialInfo = (New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "testsecret"))}
         $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3, $hashtable4, $hashtable5
 
         Register-PSResourceRepository -Repositories $arrayOfHashtables
 
         $res1 = Get-PSResourceRepository -Name $PSGalleryName
-        $res1.URL | Should -Be $PSGalleryURL
+        $res1.Uri | Should -Be $PSGalleryUri
         $res1.Trusted | Should -Be False
         $res1.Priority | Should -Be 50
 
         $res2 = Get-PSResourceRepository -Name $TestRepoName1
-        $res2.URL.LocalPath | Should -Contain $tmpDir1Path
+        $res2.Uri.LocalPath | Should -Contain $tmpDir1Path
         $res2.Trusted | Should -Be False
         $res2.Priority | Should -Be 50
 
         $res3 = Get-PSResourceRepository -Name $TestRepoName2
-        $res3.URL.LocalPath | Should -Contain $tmpDir2Path
+        $res3.Uri.LocalPath | Should -Contain $tmpDir2Path
         $res3.Trusted | Should -Be True
         $res3.Priority | Should -Be 50
 
         $res4 = Get-PSResourceRepository -Name $TestRepoName3
-        $res4.URL.LocalPath | Should -Contain $tmpDir3Path
+        $res4.Uri.LocalPath | Should -Contain $tmpDir3Path
         $res4.Trusted | Should -Be True
         $res4.Priority | Should -Be 20
 
         $res5 = Get-PSResourceRepository -Name $TestRepoName4
-        $res5.URL.LocalPath | Should -Contain $tmpDir4Path
+        $res5.Uri.LocalPath | Should -Contain $tmpDir4Path
         $res5.Trusted | Should -Be True
         $res5.Priority | Should -Be 30
         $res5.CredentialInfo.VaultName | Should -Be "testvault"
@@ -180,49 +180,49 @@ Describe "Test Register-PSResourceRepository" {
         $res5.CredentialInfo.Credential | Should -BeNullOrEmpty
     }
 
-    It "not register repository when Name is provided but URL is not" {
-        {Register-PSResourceRepository -Name $TestRepoName1 -URL "" -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+    It "not register repository when Name is provided but Uri is not" {
+        {Register-PSResourceRepository -Name $TestRepoName1 -Uri "" -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
     }
 
-    It "not register repository when Name is empty but URL is provided" {
-        {Register-PSResourceRepository -Name "" -URL $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+    It "not register repository when Name is empty but URI is provided" {
+        {Register-PSResourceRepository -Name "" -Uri $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
     }
 
-    It "not register repository when Name is null but URL is provided" {
-        {Register-PSResourceRepository -Name $null -URL $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+    It "not register repository when Name is null but Uri is provided" {
+        {Register-PSResourceRepository -Name $null -Uri $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
     }
 
-    It "not register repository when Name is just whitespace but URL is provided" {
-        {Register-PSResourceRepository -Name " " -URL $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+    It "not register repository when Name is just whitespace but URI is provided" {
+        {Register-PSResourceRepository -Name " " -Uri $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
     }
 
     It "not register PSGallery with NameParameterSet" {
-        {Register-PSResourceRepository -Name $PSGalleryName -URL $PSGalleryURL -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+        {Register-PSResourceRepository -Name $PSGalleryName -Uri $PSGalleryUri -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
     }
 
     # this error message comes from the parameter cmdlet tags (earliest point of detection)
-    It "not register PSGallery when PSGallery parameter provided with Name, URL or CredentialInfo" {
+    It "not register PSGallery when PSGallery parameter provided with Name, Uri or CredentialInfo" {
         {Register-PSResourceRepository -PSGallery -Name $PSGalleryName -ErrorAction Stop} | Should -Throw -ErrorId "AmbiguousParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
-        {Register-PSResourceRepository -PSGallery -URL $PSGalleryURL -ErrorAction Stop} | Should -Throw -ErrorId "AmbiguousParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+        {Register-PSResourceRepository -PSGallery -Uri $PSGalleryUri -ErrorAction Stop} | Should -Throw -ErrorId "AmbiguousParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
         {Register-PSResourceRepository -PSGallery -CredentialInfo $credentialInfo1 -ErrorAction Stop} | Should -Throw -ErrorId "AmbiguousParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
     }
 
     $testCases = @{Type = "Name key specified with PSGallery key"; IncorrectHashTable = @{PSGallery = $True; Name=$PSGalleryName}},
-                 @{Type = "URL key specified with PSGallery key";  IncorrectHashTable = @{PSGallery = $True; URL=$PSGalleryURL}},
+                 @{Type = "Uri key specified with PSGallery key";  IncorrectHashTable = @{PSGallery = $True; Uri=$PSGalleryUri}},
                  @{Type = "CredentialInfo key specified with PSGallery key";  IncorrectHashTable = @{PSGallery = $True; CredentialInfo = $credentialInfo1}}
 
     It "not register incorrectly formatted PSGallery type repo among correct ones when incorrect type is <Type>" -TestCases $testCases {
         param($Type, $IncorrectHashTable)
 
-        $correctHashtable1 = @{Name = $TestRepoName1; URL = $tmpDir1Path}
-        $correctHashtable2 = @{Name = $TestRepoName2; URL = $tmpDir2Path; Trusted = $True}
-        $correctHashtable3 = @{Name = $TestRepoName3; URL = $tmpDir3Path; Trusted = $True; Priority = 20}
+        $correctHashtable1 = @{Name = $TestRepoName1; Uri = $tmpDir1Path}
+        $correctHashtable2 = @{Name = $TestRepoName2; Uri = $tmpDir2Path; Trusted = $True}
+        $correctHashtable3 = @{Name = $TestRepoName3; Uri = $tmpDir3Path; Trusted = $True; Priority = 20}
         $arrayOfHashtables = $correctHashtable1, $correctHashtable2, $IncorrectHashTable, $correctHashtable3
 
         Unregister-PSResourceRepository -Name $PSGalleryName
         Register-PSResourceRepository -Repositories $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "NotProvideNameUrlCredentialInfoForPSGalleryRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "NotProvideNameUriCredentialInfoForPSGalleryRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
 
         $res = Get-PSResourceRepository -Name $TestRepoName1
         $res.Name | Should -Be $TestRepoName1
@@ -234,16 +234,16 @@ Describe "Test Register-PSResourceRepository" {
         $res3.Name | Should -Be $TestRepoName3
     }
 
-    $testCases2 = @{Type = "-Name is not specified";                     IncorrectHashTable = @{URL = $tmpDir1Path};                           ErrorId = "NullNameForRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
-                  @{Type = "-Name is PSGallery";                         IncorrectHashTable = @{Name = $PSGalleryName; URL = $tmpDir1Path};    ErrorId = "PSGalleryProvidedAsNameRepoPSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
-                  @{Type = "-URL not specified";                         IncorrectHashTable = @{Name = $TestRepoName1};                        ErrorId = "NullURLForRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
-                  @{Type = "-URL is not valid scheme";                   IncorrectHashTable = @{Name = $TestRepoName1; URL="www.google.com"};  ErrorId = "InvalidUri,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"}
+    $testCases2 = @{Type = "-Name is not specified";                     IncorrectHashTable = @{Uri = $tmpDir1Path};                           ErrorId = "NullNameForRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
+                  @{Type = "-Name is PSGallery";                         IncorrectHashTable = @{Name = $PSGalleryName; Uri = $tmpDir1Path};    ErrorId = "PSGalleryProvidedAsNameRepoPSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
+                  @{Type = "-Uri not specified";                         IncorrectHashTable = @{Name = $TestRepoName1};                        ErrorId = "NullUriForRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
+                  @{Type = "-Uri is not valid scheme";                   IncorrectHashTable = @{Name = $TestRepoName1; Uri="www.google.com"};  ErrorId = "InvalidUri,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"}
 
     It "not register incorrectly formatted Name type repo among correct ones when incorrect type is <Type>" -TestCases $testCases2 {
         param($Type, $IncorrectHashTable, $ErrorId)
 
-        $correctHashtable1 = @{Name = $TestRepoName2; URL = $tmpDir2Path; Trusted = $True}
-        $correctHashtable2 = @{Name = $TestRepoName3; URL = $tmpDir3Path; Trusted = $True; Priority = 20}
+        $correctHashtable1 = @{Name = $TestRepoName2; Uri = $tmpDir2Path; Trusted = $True}
+        $correctHashtable2 = @{Name = $TestRepoName3; Uri = $tmpDir3Path; Trusted = $True; Priority = 20}
         $correctHashtable3 = @{PSGallery = $True; Priority = 30};
 
         $arrayOfHashtables = $correctHashtable1, $correctHashtable2, $IncorrectHashTable, $correctHashtable3
@@ -263,26 +263,26 @@ Describe "Test Register-PSResourceRepository" {
         $res3.Priority | Should -Be 30
     }
 
-    It "should register repository with relative location provided as URL" {
-        Register-PSResourceRepository -Name $TestRepoName1 -URL "./"
+    It "should register repository with relative location provided as URI" {
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri "./"
         $res = Get-PSResourceRepository -Name $TestRepoName1
 
         $res.Name | Should -Be $TestRepoName1
-        $res.URL.LocalPath | Should -Contain $relativeCurrentPath
+        $Res.Uri.LocalPath | Should -Contain $relativeCurrentPath
         $res.Trusted | Should -Be False
         $res.Priority | Should -Be 50
     }
 
     It "should register local file share NuGet based repository" {
-        Register-PSResourceRepository -Name "localFileShareTestRepo" -URL "\\hcgg.rest.of.domain.name\test\ITxx\team\NuGet\"
+        Register-PSResourceRepository -Name "localFileShareTestRepo" -Uri "\\hcgg.rest.of.domain.name\test\ITxx\team\NuGet\"
         $res = Get-PSResourceRepository -Name "localFileShareTestRepo"
 
         $res.Name | Should -Be "localFileShareTestRepo"
-        $res.URL.LocalPath | Should -Contain "\\hcgg.rest.of.domain.name\test\ITxx\team\NuGet\"
+        $res.Uri.LocalPath | Should -Contain "\\hcgg.rest.of.domain.name\test\ITxx\team\NuGet\"
     }
 
     It "prints a warning if CredentialInfo is passed in without SecretManagement module setup" {
-        $output = Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path -Trusted -Priority 20 -CredentialInfo $credentialInfo1 3>&1
+        $output = Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -Trusted -Priority 20 -CredentialInfo $credentialInfo1 3>&1
         $output | Should -Match "Microsoft.PowerShell.SecretManagement module cannot be found"
 
         $res = Get-PSResourceRepository -Name $TestRepoName1
@@ -290,7 +290,7 @@ Describe "Test Register-PSResourceRepository" {
     }
 
     It "throws error if CredentialInfo is passed in with Credential property without SecretManagement module setup" {
-        { Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path -Trusted -Priority 20 -CredentialInfo $credentialInfo2 } | Should -Throw -ErrorId "RepositoryCredentialSecretManagementUnavailableModule"
+        { Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -Trusted -Priority 20 -CredentialInfo $credentialInfo2 } | Should -Throw -ErrorId "RepositoryCredentialSecretManagementUnavailableModule"
 
         $res = Get-PSResourceRepository -Name $TestRepoName1 -ErrorAction Ignore
         $res | Should -BeNullOrEmpty

--- a/test/RegisterPSResourceRepository.Tests.ps1
+++ b/test/RegisterPSResourceRepository.Tests.ps1
@@ -184,7 +184,7 @@ Describe "Test Register-PSResourceRepository" {
         {Register-PSResourceRepository -Name $TestRepoName1 -Uri "" -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
     }
 
-    It "not register repository when Name is empty but URI is provided" {
+    It "not register repository when Name is empty but Uri is provided" {
         {Register-PSResourceRepository -Name "" -Uri $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
     }
 
@@ -192,7 +192,7 @@ Describe "Test Register-PSResourceRepository" {
         {Register-PSResourceRepository -Name $null -Uri $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
     }
 
-    It "not register repository when Name is just whitespace but URI is provided" {
+    It "not register repository when Name is just whitespace but Uri is provided" {
         {Register-PSResourceRepository -Name " " -Uri $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
     }
 
@@ -263,7 +263,7 @@ Describe "Test Register-PSResourceRepository" {
         $res3.Priority | Should -Be 30
     }
 
-    It "should register repository with relative location provided as URI" {
+    It "should register repository with relative location provided as Uri" {
         Register-PSResourceRepository -Name $TestRepoName1 -Uri "./"
         $res = Get-PSResourceRepository -Name $TestRepoName1
 

--- a/test/SetPSResourceRepository.Tests.ps1
+++ b/test/SetPSResourceRepository.Tests.ps1
@@ -170,7 +170,7 @@ Describe "Test Set-PSResourceRepository" {
         $res4.CredentialInfo | Should -BeNullOrEmpty
     }
 
-    It "not set and throw error for trying to set PSGallery URI (NameParameterSet)" {
+    It "not set and throw error for trying to set PSGallery Uri (NameParameterSet)" {
         Unregister-PSResourceRepository -Name $PSGalleryName
         Register-PSResourceRepository -PSGallery
         {Set-PSResourceRepository -Name $PSGalleryName -Uri $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
@@ -182,7 +182,7 @@ Describe "Test Set-PSResourceRepository" {
         {Set-PSResourceRepository -Name $PSGalleryName -CredentialInfo $credentialInfo1 -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
     }
 
-    It "not set repository and throw error for trying to set PSGallery URI (RepositoriesParameterSet)" {
+    It "not set repository and throw error for trying to set PSGallery Uri (RepositoriesParameterSet)" {
         Unregister-PSResourceRepository -Name $PSGalleryName
         Register-PSResourceRepository -PSGallery
 
@@ -202,7 +202,7 @@ Describe "Test Set-PSResourceRepository" {
         $res.Trusted | Should -Be False
     }
 
-    It "should set repository with relative URI provided" {
+    It "should set repository with relative Uri provided" {
         Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
         Set-PSResourceRepository -Name $TestRepoName1 -Uri $relativeCurrentPath
         $res = Get-PSResourceRepository -Name $TestRepoName1

--- a/test/SetPSResourceRepository.Tests.ps1
+++ b/test/SetPSResourceRepository.Tests.ps1
@@ -6,7 +6,7 @@ Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
 Describe "Test Set-PSResourceRepository" {
     BeforeEach {
         $PSGalleryName = Get-PSGalleryName
-        $PSGalleryURL = Get-PSGalleryLocation
+        $PSGalleryUri = Get-PSGalleryLocation
         $TestRepoName1 = "testRepository"
         $TestRepoName2 = "testRepository2"
         $TestRepoName3 = "testRepository3"
@@ -36,45 +36,45 @@ Describe "Test Set-PSResourceRepository" {
         Get-RemoveTestDirs($tmpDirPaths)
     }
 
-    It "set repository given Name and URL parameters" {
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
-        Set-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir2Path
+    It "set repository given Name and Uri parameters" {
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        Set-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir2Path
         $res = Get-PSResourceRepository -Name $TestRepoName1
         $res.Name | Should -Be $TestRepoName1
-        $res.URL.LocalPath | Should -Contain $tmpDir2Path
+        $Res.Uri.LocalPath | Should -Contain $tmpDir2Path
         $res.Priority | Should -Be 50
         $res.Trusted | Should -Be False
         $res.CredentialInfo | Should -BeNullOrEmpty
     }
 
     It "set repository given Name and Priority parameters" {
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
         Set-PSResourceRepository -Name $TestRepoName1 -Priority 25
         $res = Get-PSResourceRepository -Name $TestRepoName1
         $res.Name | Should -Be $TestRepoName1
-        $res.URL.LocalPath | Should -Contain $tmpDir1Path
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
         $res.Priority | Should -Be 25
         $res.Trusted | Should -Be False
         $res.CredentialInfo | Should -BeNullOrEmpty
     }
 
     It "set repository given Name and Trusted parameters" {
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
         Set-PSResourceRepository -Name $TestRepoName1 -Trusted
         $res = Get-PSResourceRepository -Name $TestRepoName1
         $res.Name | Should -Be $TestRepoName1
-        $res.URL.LocalPath | Should -Contain $tmpDir1Path
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
         $res.Priority | Should -Be 50
         $res.Trusted | Should -Be True
         $res.CredentialInfo | Should -BeNullOrEmpty
     }
 
     It "set repository given Name and CredentialInfo parameters" {
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
         Set-PSResourceRepository -Name $TestRepoName1 -CredentialInfo $credentialInfo1
         $res = Get-PSResourceRepository -Name $TestRepoName1
         $res.Name | Should -Be $TestRepoName1
-        $res.URL.LocalPath | Should -Contain $tmpDir1Path
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
         $res.Priority | Should -Be 50
         $res.Trusted | Should -Be False
         $res.CredentialInfo.VaultName | Should -Be "testvault"
@@ -83,7 +83,7 @@ Describe "Test Set-PSResourceRepository" {
     }
 
     It "not set repository and write error given just Name parameter" {
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
         {Set-PSResourceRepository -Name $TestRepoName1 -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
     }
 
@@ -94,7 +94,7 @@ Describe "Test Set-PSResourceRepository" {
     It "not set repository and throw error given Name <Type> (NameParameterSet)" -TestCases $testCases {
         param($Type, $Name)
 
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
         {Set-PSResourceRepository -Name $Name -Priority 25 -ErrorAction Stop} | Should -Throw -ErrorId "$ErrorId,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
     }
 
@@ -104,10 +104,10 @@ Describe "Test Set-PSResourceRepository" {
     It "not set repository and write error given Name <Type> (RepositoriesParameterSet)" -TestCases $testCases2 {
         param($Type, $Name, $ErrorId)
 
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
-        Register-PSResourceRepository -Name $TestRepoName2 -URL $tmpDir2Path
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName2 -Uri $tmpDir2Path
 
-        $hashtable1 = @{Name = $TestRepoName1; URL = $tmpDir3Path}
+        $hashtable1 = @{Name = $TestRepoName1; Uri = $tmpDir3Path}
         $hashtable2 = @{Name = $TestRepoName2; Priority = 25}
         $incorrectHashTable = @{Name = $Name; Trusted = $True}
         $arrayOfHashtables = $hashtable1, $incorrectHashTable, $hashtable2
@@ -117,7 +117,7 @@ Describe "Test Set-PSResourceRepository" {
         $err[0].FullyQualifiedErrorId | Should -BeExactly "$ErrorId,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
 
         $res = Get-PSResourceRepository -Name $TestRepoName1
-        $res.URL.LocalPath | Should -Contain $tmpDir3Path
+        $Res.Uri.LocalPath | Should -Contain $tmpDir3Path
         $res.Trusted | Should -Be False
 
         $res2 = Get-PSResourceRepository -Name $TestRepoName2
@@ -127,12 +127,12 @@ Describe "Test Set-PSResourceRepository" {
 
     It "set repositories with Repositories parameter" {
         Unregister-PSResourceRepository -Name $PSGalleryName
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
-        Register-PSResourceRepository -Name $TestRepoName2 -URL $tmpDir2Path
-        Register-PSResourceRepository -Name $TestRepoName3 -URL $tmpDir3Path
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName2 -Uri $tmpDir2Path
+        Register-PSResourceRepository -Name $TestRepoName3 -Uri $tmpDir3Path
         Register-PSResourceRepository -PSGallery
 
-        $hashtable1 = @{Name = $TestRepoName1; URL = $tmpDir2Path};
+        $hashtable1 = @{Name = $TestRepoName1; Uri = $tmpDir2Path};
         $hashtable2 = @{Name = $TestRepoName2; Priority = 25};
         $hashtable3 = @{Name = $TestRepoName3; CredentialInfo = [PSCustomObject] @{ VaultName = "testvault"; SecretName = "testsecret" }};
         $hashtable4 = @{Name = $PSGalleryName; Trusted = $True};
@@ -141,21 +141,21 @@ Describe "Test Set-PSResourceRepository" {
         Set-PSResourceRepository -Repositories $arrayOfHashtables
         $res = Get-PSResourceRepository -Name $TestRepoName1
         $res.Name | Should -Be $TestRepoName1
-        $res.URL.LocalPath | Should -Contain $tmpDir2Path
+        $Res.Uri.LocalPath | Should -Contain $tmpDir2Path
         $res.Priority | Should -Be 50
         $res.Trusted | Should -Be False
         $res.CredentialInfo | Should -BeNullOrEmpty
 
         $res2 = Get-PSResourceRepository -Name $TestRepoName2
         $res2.Name | Should -Be $TestRepoName2
-        $res2.URL.LocalPath | Should -Contain $tmpDir2Path
+        $res2.Uri.LocalPath | Should -Contain $tmpDir2Path
         $res2.Priority | Should -Be 25
         $res2.Trusted | Should -Be False
         $res2.CredentialInfo | Should -BeNullOrEmpty
 
         $res3 = Get-PSResourceRepository -Name $TestRepoName3
         $res3.Name | Should -Be $TestRepoName3
-        $res3.URL.LocalPath | Should -Contain $tmpDir3Path
+        $res3.Uri.LocalPath | Should -Contain $tmpDir3Path
         $res3.Priority | Should -Be 50
         $res3.Trusted | Should -Be False
         $res3.CredentialInfo.VaultName | Should -Be "testvault"
@@ -164,16 +164,16 @@ Describe "Test Set-PSResourceRepository" {
 
         $res4 = Get-PSResourceRepository -Name $PSGalleryName
         $res4.Name | Should -Be $PSGalleryName
-        $res4.URL | Should -Contain $PSGalleryURL
+        $res4.Uri | Should -Contain $PSGalleryUri
         $res4.Priority | Should -Be 50
         $res4.Trusted | Should -Be True
         $res4.CredentialInfo | Should -BeNullOrEmpty
     }
 
-    It "not set and throw error for trying to set PSGallery URL (NameParameterSet)" {
+    It "not set and throw error for trying to set PSGallery URI (NameParameterSet)" {
         Unregister-PSResourceRepository -Name $PSGalleryName
         Register-PSResourceRepository -PSGallery
-        {Set-PSResourceRepository -Name $PSGalleryName -URL $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
+        {Set-PSResourceRepository -Name $PSGalleryName -Uri $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
     }
 
     It "not set and throw error for trying to set PSGallery CredentialInfo (NameParameterSet)" {
@@ -182,13 +182,13 @@ Describe "Test Set-PSResourceRepository" {
         {Set-PSResourceRepository -Name $PSGalleryName -CredentialInfo $credentialInfo1 -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
     }
 
-    It "not set repository and throw error for trying to set PSGallery URL (RepositoriesParameterSet)" {
+    It "not set repository and throw error for trying to set PSGallery URI (RepositoriesParameterSet)" {
         Unregister-PSResourceRepository -Name $PSGalleryName
         Register-PSResourceRepository -PSGallery
 
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
 
-        $hashtable1 = @{Name = $PSGalleryName; URL = $tmpDir1Path}
+        $hashtable1 = @{Name = $PSGalleryName; Uri = $tmpDir1Path}
         $hashtable2 = @{Name = $TestRepoName1; Priority = 25}
         $arrayOfHashtables = $hashtable1, $hashtable2
 
@@ -197,17 +197,17 @@ Describe "Test Set-PSResourceRepository" {
         $err[0].FullyQualifiedErrorId | Should -BeExactly "ErrorSettingIndividualRepoFromRepositories,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
 
         $res = Get-PSResourceRepository -Name $TestRepoName1
-        $res.URL.LocalPath | Should -Contain $tmpDir1Path
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
         $res.Priority | Should -Be 25
         $res.Trusted | Should -Be False
     }
 
-    It "should set repository with relative URL provided" {
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
-        Set-PSResourceRepository -Name $TestRepoName1 -URL $relativeCurrentPath
+    It "should set repository with relative URI provided" {
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        Set-PSResourceRepository -Name $TestRepoName1 -Uri $relativeCurrentPath
         $res = Get-PSResourceRepository -Name $TestRepoName1
         $res.Name | Should -Be $TestRepoName1
-        $res.URL.LocalPath | Should -Contain $relativeCurrentPath
+        $Res.Uri.LocalPath | Should -Contain $relativeCurrentPath
         $res.Trusted | Should -Be False
         $res.Priority | Should -Be 50
     }
@@ -216,7 +216,7 @@ Describe "Test Set-PSResourceRepository" {
         Unregister-PSResourceRepository -Name $PSGalleryName
         Register-PSResourceRepository -PSGallery
 
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
 
         $hashtable1 = @{Name = $PSGalleryName; CredentialInfo = $credentialInfo1}
         $hashtable2 = @{Name = $TestRepoName1; Priority = 25}
@@ -227,32 +227,32 @@ Describe "Test Set-PSResourceRepository" {
         $err[0].FullyQualifiedErrorId | Should -BeExactly "ErrorSettingIndividualRepoFromRepositories,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
 
         $res = Get-PSResourceRepository -Name $TestRepoName1
-        $res.URL.LocalPath | Should -Contain $tmpDir1Path
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
         $res.Priority | Should -Be 25
         $res.Trusted | Should -Be False
         $res.CredentialInfo | Should -BeNullOrEmpty
     }
 
     It "should set repository with local file share NuGet based Uri" {
-        Register-PSResourceRepository -Name "localFileShareTestRepo" -URL $tmpDir1Path
-        Set-PSResourceRepository -Name "localFileShareTestRepo" -URL "\\hcgg.rest.of.domain.name\test\ITxx\team\NuGet\"
+        Register-PSResourceRepository -Name "localFileShareTestRepo" -Uri $tmpDir1Path
+        Set-PSResourceRepository -Name "localFileShareTestRepo" -Uri "\\hcgg.rest.of.domain.name\test\ITxx\team\NuGet\"
         $res = Get-PSResourceRepository -Name "localFileShareTestRepo"
         $res.Name | Should -Be "localFileShareTestRepo"
-        $res.URL.LocalPath | Should -Contain "\\hcgg.rest.of.domain.name\test\ITxx\team\NuGet\"
+        $Res.Uri.LocalPath | Should -Contain "\\hcgg.rest.of.domain.name\test\ITxx\team\NuGet\"
     }
 
     It "set repository and see updated repository with -PassThru" {
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
-        $res = Set-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir2Path -PassThru
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        $res = Set-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir2Path -PassThru
         $res.Name | Should -Be $TestRepoName1
-        $res.URL.LocalPath | Should -Contain $tmpDir2Path
+        $Res.Uri.LocalPath | Should -Contain $tmpDir2Path
         $res.Priority | Should -Be 50
         $res.Trusted | Should -Be False
     }
 
     It "prints a warning if CredentialInfo is passed in without SecretManagement module setup" {
-        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
-        $output = Set-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path -CredentialInfo $credentialInfo1 3>&1
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        $output = Set-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -CredentialInfo $credentialInfo1 3>&1
         $output | Should -Match "Microsoft.PowerShell.SecretManagement module cannot be found"
 
         $res = Get-PSResourceRepository -Name $TestRepoName1
@@ -261,8 +261,8 @@ Describe "Test Set-PSResourceRepository" {
 
     It "throws error if CredentialInfo is passed in with Credential property without SecretManagement module setup" {
         {
-            Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
-            Set-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path -CredentialInfo $credentialInfo2
+            Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+            Set-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -CredentialInfo $credentialInfo2
         } | Should -Throw -ErrorId "RepositoryCredentialSecretManagementUnavailableModule"
 
         $res = Get-PSResourceRepository -Name $TestRepoName1 -ErrorAction Ignore

--- a/test/UnregisterPSResourceRepository.Tests.ps1
+++ b/test/UnregisterPSResourceRepository.Tests.ps1
@@ -6,7 +6,7 @@ Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
 Describe "Test Unregister-PSResourceRepository" {
     BeforeEach {
         $TestGalleryName = Get-PoshTestGalleryName
-        $TestGalleryUrl = Get-PoshTestGalleryLocation
+        $TestGalleryUri = Get-PoshTestGalleryLocation
         Get-NewPSResourceRepositoryFile
         $tmpDir1Path = Join-Path -Path $TestDrive -ChildPath "tmpDir1"
         $tmpDir2Path = Join-Path -Path $TestDrive -ChildPath "tmpDir2"
@@ -24,7 +24,7 @@ Describe "Test Unregister-PSResourceRepository" {
     }
 
     It "unregister single repository previously registered" {
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
+        Register-PSResourceRepository -Name "testRepository" -Uri $tmpDir1Path
         Unregister-PSResourceRepository -Name "testRepository"
 
         $res = Get-PSResourceRepository -Name "testRepository" -ErrorVariable err -ErrorAction SilentlyContinue
@@ -32,8 +32,8 @@ Describe "Test Unregister-PSResourceRepository" {
     }
 
     It "unregister multiple repositories previously registered" {
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
-        Register-PSResourceRepository -Name "testRepository2" -URL $tmpDir2Path
+        Register-PSResourceRepository -Name "testRepository" -Uri $tmpDir1Path
+        Register-PSResourceRepository -Name "testRepository2" -Uri $tmpDir2Path
         Unregister-PSResourceRepository -Name "testRepository","testRepository2"
 
         $res = Get-PSResourceRepository -Name "testRepository","testRepository2" -ErrorVariable err -ErrorAction SilentlyContinue
@@ -47,8 +47,8 @@ Describe "Test Unregister-PSResourceRepository" {
     }
 
     It "not register when -Name contains wildcard" {
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
-        Register-PSResourceRepository -Name "testRepository2" -URL $tmpDir2Path
+        Register-PSResourceRepository -Name "testRepository" -Uri $tmpDir1Path
+        Register-PSResourceRepository -Name "testRepository2" -Uri $tmpDir2Path
         Unregister-PSResourceRepository -Name "testRepository*" -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "nameContainsWildCardError,Microsoft.PowerShell.PowerShellGet.Cmdlets.UnregisterPSResourceRepository"
@@ -56,7 +56,7 @@ Describe "Test Unregister-PSResourceRepository" {
 
     It "when multiple repo Names provided, if one name isn't valid unregister the rest and write error message" {
         $nonRegisteredRepoName = "nonRegisteredRepository"
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
+        Register-PSResourceRepository -Name "testRepository" -Uri $tmpDir1Path
         Unregister-PSResourceRepository -Name $nonRegisteredRepoName,"testRepository" -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "ErrorUnregisteringSpecifiedRepo,Microsoft.PowerShell.PowerShellGet.Cmdlets.UnregisterPSResourceRepository"
@@ -73,7 +73,7 @@ Describe "Test Unregister-PSResourceRepository" {
     It "unregister repository using -PassThru" {
         $res = Unregister-PSResourceRepository -Name $TestGalleryName -PassThru
         $res.Name | Should -Be $TestGalleryName
-        $res.Url | Should -Be $TestGalleryURL
+        $Res.Uri | Should -Be $TestGalleryUri
         $res = Get-PSResourceRepository -Name $TestGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0

--- a/test/testRepositories.xml
+++ b/test/testRepositories.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <Repository Name="PoshTestGallery" Url="https://www.poshtestgallery.com/api/v2"   Priority="10" Trusted="true"  />
-  <Repository Name="PSGallery"       Url="https://www.powershellgallery.com/api/v2" Priority="50" Trusted="false" />
-  <Repository Name="NuGetGallery"    Url="https://api.nuget.org/v3/index.json"      Priority="50" Trusted="true"  />
+  <Repository Name="PoshTestGallery" Uri="https://www.poshtestgallery.com/api/v2"   Priority="10" Trusted="true"  />
+  <Repository Name="PSGallery"       Uri="https://www.powershellgallery.com/api/v2" Priority="50" Trusted="false" />
+  <Repository Name="NuGetGallery"    Uri="https://api.nuget.org/v3/index.json"      Priority="50" Trusted="true"  />
 </configuration>

--- a/test/testRepositoriesWithCredentialInfo.xml
+++ b/test/testRepositoriesWithCredentialInfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <Repository Name="localtestrepo1"  Url="file:///c:/code/testdir1" Priority="10" Trusted="false" />
-  <Repository Name="localtestrepo2"  Url="file:///c:/code/testdir2" Priority="20" Trusted="false" VaultName="testvault" SecretName="testsecret" />
-  <Repository Name="localtestrepo3"  Url="file:///c:/code/testdir3" Priority="30" Trusted="false" VaultName="testvault" />
-  <Repository Name="localtestrepo4"  Url="file:///c:/code/testdir4" Priority="40" Trusted="false" VaultName="testvault" SecretName="" />
+  <Repository Name="localtestrepo1"  Uri="file:///c:/code/testdir1" Priority="10" Trusted="false" />
+  <Repository Name="localtestrepo2"  Uri="file:///c:/code/testdir2" Priority="20" Trusted="false" VaultName="testvault" SecretName="testsecret" />
+  <Repository Name="localtestrepo3"  Uri="file:///c:/code/testdir3" Priority="30" Trusted="false" VaultName="testvault" />
+  <Repository Name="localtestrepo4"  Uri="file:///c:/code/testdir4" Priority="40" Trusted="false" VaultName="testvault" SecretName="" />
 </configuration>


### PR DESCRIPTION
# PR Summary

- Changed `-URL` params to `-Uri` (including, e.g., `-LicenseUrl` => `-LicenseUri`)
    - Updated (almost) all identifiers in source code `url` => `uri`, for consistency
    - Updated docs
    - A few strings and comments left at `URL`, where they make sense in the context
- Added `test/result*` to `.gitignore`
- Amended `build.ps1` to try importing `PSPackageProject` before installing again

## PR Context

Ref https://github.com/PowerShell/PowerShellGet/issues/460

Broadly speaking, all installed-by-default modules use `uri` in parameter names instead of `url`. To provide consistency, I think PowerShellGet should also follow this convention.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
