### PR TITLE
Implement Progress Bar for Install

### DIFF
--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -229,7 +229,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 IncludeDependencies))
             {
                 foundPackages.Add(package);
-                WriteVerbose("pkgName: " + package.Name);
             }
 
 

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -229,7 +229,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 IncludeDependencies))
             {
                 foundPackages.Add(package);
+                WriteVerbose("pkgName: " + package.Name);
             }
+
 
             foreach (var uniquePackageVersion in foundPackages.GroupBy(
                 m => new {m.Name, m.Version, m.Repository}).Select(

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -231,7 +231,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 foundPackages.Add(package);
             }
 
-
             foreach (var uniquePackageVersion in foundPackages.GroupBy(
                 m => new {m.Name, m.Version, m.Repository}).Select(
                     group => group.First()).ToList())

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -138,7 +138,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             PSCredential credential)
         {
             var listOfRepositories = RepositorySettings.Read(repository, out string[] _);
-            List<string> pckgNamesToInstall = packageNames.ToList();
+            List<string> pkgNamesToInstall = packageNames.ToList();
             var yesToAll = false;
             var noToAll = false;
 
@@ -146,7 +146,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             foreach (var repo in listOfRepositories)
             {
                 // If no more packages to install, then return
-                if (!pckgNamesToInstall.Any()) return;
+                if (!pkgNamesToInstall.Any()) return;
 
                 string repoName = repo.Name;
                 _cmdletPassedIn.WriteVerbose(string.Format("Attempting to search for packages in '{0}'", repoName));
@@ -178,7 +178,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                 // Finds parent packages and dependencies
                 IEnumerable<PSResourceInfo> pkgsFromRepoToInstall = findHelper.FindByResourceName(
-                    name: pckgNamesToInstall.ToArray(),
+                    name: pkgNamesToInstall.ToArray(),
                     type: ResourceType.None,
                     version: _versionRange != null ? _versionRange.OriginalString : null,
                     prerelease: _prerelease,
@@ -218,7 +218,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                 List<string> pkgsInstalled = InstallPackage(
                     pkgsFromRepoToInstall,
-                    pckgNamesToInstall,
+                    pkgNamesToInstall,
                     repoName,
                     repo.Url.AbsoluteUri,
                     credential,
@@ -226,7 +226,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                 foreach (string name in pkgsInstalled)
                 {
-                    pckgNamesToInstall.Remove(name);
+                    pkgNamesToInstall.Remove(name);
                 }
             }
         }

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -281,7 +281,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         private List<string> InstallPackage(
             IEnumerable<PSResourceInfo> pkgsToInstall, // those found to be required to be installed (includes Dependency packages as well)
-            List<string> pckgNamesPassedInToInstall, // those requested by the user to be installed
+            List<string> pkgNamesToInstall, // those requested by the user to be installed
             string repoName,
             string repoUrl,
             PSCredential credential,
@@ -319,7 +319,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     string activity = "";
                     string statusDescription = "";
 
-                    if (pckgNamesPassedInToInstall.ToList().Contains(pkg.Name, StringComparer.InvariantCultureIgnoreCase))
+                    if (pkgNamesToInstall.ToList().Contains(pkg.Name, StringComparer.InvariantCultureIgnoreCase))
                     {
                         // Installing parent package (one whose name was passed in to install)
                         activityId = 0;

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -337,7 +337,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     var progressRecord = new ProgressRecord(activityId, activity, statusDescription);
                     _cmdletPassedIn.WriteProgress(progressRecord);
                     
-        
                     // Create PackageIdentity in order to download
                     string createFullVersion = pkgInfo.Version.ToString();
                     if (pkgInfo.IsPrerelease)

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -219,7 +219,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 List<string> pkgsInstalled = InstallPackage(
                     pkgsFromRepoToInstall,
                     pkgNamesToInstall,
-                    repoName,
                     repo.Url.AbsoluteUri,
                     credential,
                     isLocalRepo);
@@ -282,7 +281,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         private List<string> InstallPackage(
             IEnumerable<PSResourceInfo> pkgsToInstall, // those found to be required to be installed (includes Dependency packages as well)
             List<string> pkgNamesToInstall, // those requested by the user to be installed
-            string repoName,
             string repoUrl,
             PSCredential credential,
             bool isLocalRepo)

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -294,10 +294,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             // needs to be installed we don't want a default value of 0 which throws a division error.
             // if parent package isn't already installed we'll set this value properly in the below if condition anyways
             int currentPkgNumOfDependentPkgs = 1;
-            int i = 1;
+            // counter for dependency packages
             int j = 1;
-            foreach (PSResourceInfo pkgInfo in pkgsToInstall)
+            for (int i = 0; i < pkgsToInstall.Count(); i++)
             {
+                PSResourceInfo pkgInfo = pkgsToInstall.ElementAt(i);
                 var tempInstallPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
                 try
                 {
@@ -321,8 +322,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         // Installing parent package (one whose name was passed in to install)
                         activityId = 0;
                         activity = string.Format("Installing {0}...", pkgInfo.Name);
-                        statusDescription = string.Format("{0}% Complete:", Math.Round(((double) i/totalPkgs) * 100), 2);
-                        i++;
+                        statusDescription = string.Format("{0}% Complete:", Math.Round(((double) (i+1)/totalPkgs) * 100), 2);
 
                         currentPkgNumOfDependentPkgs = pkgInfo.Dependencies.Count();
                         j = 1;
@@ -334,11 +334,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         activity = string.Format("Installing dependent package {0}...", pkgInfo.Name);
                         statusDescription = string.Format("{0}% Complete:", Math.Round(((double) j/currentPkgNumOfDependentPkgs) * 100), 2);   
                         j++;
-                        i++;
                     }
 
                     var progressRecord = new ProgressRecord(activityId, activity, statusDescription);
-                    _cmdletPassedIn.WriteVerbose(statusDescription);
                     _cmdletPassedIn.WriteProgress(progressRecord);
                     
                     // Create PackageIdentity in order to download

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -321,7 +321,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         // Installing parent package (one whose name was passed in to install)
                         activityId = 0;
                         activity = string.Format("Installing {0}...", pkgInfo.Name);
-                        statusDescription = string.Format("{0}% Complete:", ((i++/totalPkgs) * 100));
+                        statusDescription = string.Format("{0}% Complete:", Math.Round(((double) i/totalPkgs) * 100), 2);
+                        i++;
 
                         currentPkgNumOfDependentPkgs = pkgInfo.Dependencies.Count();
                         j = 1;
@@ -331,10 +332,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         // Installing dependent package
                         activityId = 1;
                         activity = string.Format("Installing dependent package {0}...", pkgInfo.Name);
-                        statusDescription = string.Format("{0}% Complete:", ((j++/currentPkgNumOfDependentPkgs) * 100));                        
+                        statusDescription = string.Format("{0}% Complete:", Math.Round(((double) j/currentPkgNumOfDependentPkgs) * 100), 2);   
+                        j++;
+                        i++;
                     }
 
                     var progressRecord = new ProgressRecord(activityId, activity, statusDescription);
+                    _cmdletPassedIn.WriteVerbose(statusDescription);
                     _cmdletPassedIn.WriteProgress(progressRecord);
                     
                     // Create PackageIdentity in order to download


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add Progress Bar for Install-Helper. This means that cmdlets which call into Install-Helper (i.e. Update/Save) will now also have a progress bar displayed while the install portion of the operation is occurring.

Not sure how to capture the progress bar in tests, but I tested interactively and checked the progress bar for the following scenarios,
where PSGetTestModule has a dependency package, PSGetTestDependency1.

Scenarios:
1) `Install-PSResource -Name "PSGetTestModule" -Repository PoshTestGallery`
2) `Install-PSResource -Name "PSGetTestModule","TestModule" -Repository PoshTestGallery`
3) scenario where the parent package is installed (and won't reinstall) but dependency package needs to be installed:
`Install-PSResource -Name "PSGetTestModule" -Repository PoshTestGallery`
`Uninstall-PSResource -Name "PSGetTestDependency1 -Force`
`Install-PSResource -Name "PSGetTestModule" -Repository PoshTestGallery`

Note: We already have tests for installing PSGetTestModule and checking for its dependency package.

## PR Context

Part of missing cmdlet implementation, resolves #518 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
