### PR TITLE
Add -PassThru support for Unregister-PSResourceRepository

### DIFF
--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -185,8 +185,9 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         /// Returns: void
         /// </summary>
         /// <param name="sectionName"></param>
-        public static void Remove(string[] repoNames, out string[] errorList)
+        public static List<PSRepositoryInfo> Remove(string[] repoNames, out string[] errorList)
         {
+            List<PSRepositoryInfo> removedRepos = new List<PSRepositoryInfo>();
             List<string> tempErrorList = new List<string>();
             XDocument doc;
             try
@@ -211,6 +212,11 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                     continue;
                 }
 
+                removedRepos.Add(
+                    new PSRepositoryInfo(repo,
+                        new Uri(node.Attribute("Url").Value),
+                        Int32.Parse(node.Attribute("Priority").Value),
+                        Boolean.Parse(node.Attribute("Trusted").Value)));
                 // Remove item from file
                 node.Remove();
             }
@@ -218,6 +224,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             // Close the file
             root.Save(FullRepositoryPath);
             errorList = tempErrorList.ToArray();
+            return removedRepos;
         }
 
         public static List<PSRepositoryInfo> Read(string[] repoNames, out string[] errorList)

--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -224,6 +224,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             // Close the file
             root.Save(FullRepositoryPath);
             errorList = tempErrorList.ToArray();
+            
             return removedRepos;
         }
 

--- a/src/code/UnregisterPSResourceRepository.cs
+++ b/src/code/UnregisterPSResourceRepository.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.PowerShell.PowerShellGet.UtilClasses;
 using System;
+using System.Collections.Generic;
 using System.Management.Automation;
 
 namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
@@ -28,6 +29,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         [ValidateNotNullOrEmpty]
         public string[] Name { get; set; } = Utils.EmptyStrArray;
 
+        /// <summary>
+        /// When specified, displays the repositories that were just unregistered
+        /// </summary>
+        [Parameter]
+        public SwitchParameter PassThru { get; set; }
+
         #endregion
 
         #region Method overrides
@@ -45,7 +52,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 return;
             }
 
-            RepositorySettings.Remove(Name, out string[] errorList);
+            List<PSRepositoryInfo> removedRepositories = RepositorySettings.Remove(Name, out string[] errorList);
 
             // handle non-terminating errors
             foreach (string error in errorList)
@@ -55,6 +62,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     "ErrorUnregisteringSpecifiedRepo",
                     ErrorCategory.InvalidOperation,
                     this));
+            }
+
+            if (PassThru)
+            {
+                foreach (PSRepositoryInfo repository in removedRepositories)
+                {
+                    WriteObject(repository);                }
             }
         }
 

--- a/src/code/UnregisterPSResourceRepository.cs
+++ b/src/code/UnregisterPSResourceRepository.cs
@@ -68,7 +68,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 foreach (PSRepositoryInfo repository in removedRepositories)
                 {
-                    WriteObject(repository);                }
+                    WriteObject(repository);
+                }
             }
         }
 

--- a/test/SetPSResourceRepository.Tests.ps1
+++ b/test/SetPSResourceRepository.Tests.ps1
@@ -164,4 +164,13 @@ Describe "Test Set-PSResourceRepository" {
         $res.Trusted | Should -Be False
         $res.Priority | Should -Be 50
     }
+
+    It "set repository and see updated repository with -PassThru" {
+        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
+        $res = Set-PSResourceRepository -Name "testRepository" -URL $tmpDir2Path -PassThru
+        $res.Name | Should -Be "testRepository"
+        $res.URL.LocalPath | Should -Contain $tmpDir2Path
+        $res.Priority | Should -Be 50
+        $res.Trusted | Should -Be False
+    }
 }

--- a/test/UnregisterPSResourceRepository.Tests.ps1
+++ b/test/UnregisterPSResourceRepository.Tests.ps1
@@ -5,6 +5,8 @@ Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
 
 Describe "Test Register-PSResourceRepository" {
     BeforeEach {
+        $TestGalleryName = Get-PoshTestGalleryName
+        $TestGalleryUrl = Get-PoshTestGalleryLocation
         Get-NewPSResourceRepositoryFile
         $tmpDir1Path = Join-Path -Path $TestDrive -ChildPath "tmpDir1"
         $tmpDir2Path = Join-Path -Path $TestDrive -ChildPath "tmpDir2"
@@ -58,5 +60,13 @@ Describe "Test Register-PSResourceRepository" {
 
     It "throw error if Name is null" {
         {Unregister-PSResourceRepository -Name $null -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.UnregisterPSResourceRepository"
+    }
+
+    It "unregister repository using -PassThru" {
+        $res = Unregister-PSResourceRepository -Name $TestGalleryName -PassThru
+        $res.Name | Should -Be $TestGalleryName
+        $res.Url | Should -Be $TestGalleryURL
+        $res = Get-PSResourceRepository -Name $TestGalleryName
+        $res | Should -BeNullOrEmpty
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add `-PassThru` support for Unregister-PSResourceRepository cmdlet. I also noticed that Set-PSResourceRepository has `-PassThru` support but no tests for that, so I added a test for `-PassThru` for that cmdlet. 

## PR Context

Now all cmdlets required to support `-PassThru` do and have tests for it. Resolves #132

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
