### PR TITLE
Implement -Quiet param for Install and Update -PSResource

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -326,31 +326,35 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                     _cmdletPassedIn.WriteVerbose(string.Format("Begin installing package: '{0}'", pkg.Name));
 
-                    int activityId = 0;
-                    string activity = "";
-                    string statusDescription = "";
-
-                    if (pkgNamesToInstall.ToList().Contains(pkg.Name, StringComparer.InvariantCultureIgnoreCase))
+                    // Will suppress progress bar if -Quiet is passed in
+                    if (!_quiet)
                     {
-                        // Installing parent package (one whose name was passed in to install)
-                        activityId = 0;
-                        activity = string.Format("Installing {0}...", pkg.Name);
-                        statusDescription = string.Format("{0}% Complete:", Math.Round(((double) totalPkgsCount/totalPkgs) * 100), 2);
-                        currentPkgNumOfDependentPkgs = pkg.Dependencies.Count();
-                        dependentPkgCount = 1;
-                    }
-                    else
-                    {
-                        // Installing dependent package
-                        activityId = 1;
-                        activity = string.Format("Installing dependent package {0}...", pkg.Name);
-                        statusDescription = string.Format("{0}% Complete:", Math.Round(((double) dependentPkgCount/currentPkgNumOfDependentPkgs) * 100), 2);
-                        dependentPkgCount++;
+                        int activityId = 0;
+                        string activity = "";
+                        string statusDescription = "";
+
+                        if (pkgNamesToInstall.ToList().Contains(pkg.Name, StringComparer.InvariantCultureIgnoreCase))
+                        {
+                            // Installing parent package (one whose name was passed in to install)
+                            activityId = 0;
+                            activity = string.Format("Installing {0}...", pkg.Name);
+                            statusDescription = string.Format("{0}% Complete:", Math.Round(((double)totalPkgsCount / totalPkgs) * 100), 2);
+                            currentPkgNumOfDependentPkgs = pkg.Dependencies.Count();
+                            dependentPkgCount = 1;
+                        }
+                        else
+                        {
+                            // Installing dependent package
+                            activityId = 1;
+                            activity = string.Format("Installing dependent package {0}...", pkg.Name);
+                            statusDescription = string.Format("{0}% Complete:", Math.Round(((double)dependentPkgCount / currentPkgNumOfDependentPkgs) * 100), 2);
+                            dependentPkgCount++;
+                        }
+
+                        var progressRecord = new ProgressRecord(activityId, activity, statusDescription);
+                        _cmdletPassedIn.WriteProgress(progressRecord);
                     }
 
-                    var progressRecord = new ProgressRecord(activityId, activity, statusDescription);
-                    _cmdletPassedIn.WriteProgress(progressRecord);
-                    
                     // Create PackageIdentity in order to download
                     string createFullVersion = pkg.Version.ToString();
                     if (pkg.IsPrerelease)

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -134,6 +134,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         [Parameter]
         public SwitchParameter SkipDependencyCheck { get; set; }
 
+        /// <summary>
+        /// Suppresses progress information.
+        /// </summary>
+        [Parameter(ParameterSetName = NameParameterSet)]
+        [Parameter(ParameterSetName = InputObjectParameterSet)]
+        public SwitchParameter Quiet { get; set; }
+
         #endregion
 
         #region Method overrides
@@ -246,7 +253,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 prerelease: pkgPrerelease, 
                 repository: pkgRepository, 
                 acceptLicense: true, 
-                quiet: true, 
+                quiet: Quiet, 
                 reinstall: true, 
                 force: false, 
                 trustRepository: TrustRepository,


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Implement -Quiet param for Install-PSResource and Update-PSResource.  This suppresses the progress bar display when passed in.

I have not added any test for this since I believe this can only be tested interactively.

Resolves #559 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
