### PR TITLE
Tests and error handling

### DIFF
--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -181,8 +181,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             var pkgFileOrDir = new DirectoryInfo(_path);
             bool isScript = _path.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase);
 
-            // TODO: think about including the repository the resource is being published to
-            if (!ShouldProcess(string.Format("Publish resource '{0}' from the machine.", _path)))
+            if (!ShouldProcess(string.Format("Publish resource '{0}' from the machine", _path)))
             {
                 WriteVerbose("ShouldProcess is set to false.");
                 return;

--- a/src/code/UnregisterPSResourceRepository.cs
+++ b/src/code/UnregisterPSResourceRepository.cs
@@ -45,8 +45,18 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         }
         protected override void ProcessRecord()
         {
+            Name = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool nameContainsWildcard);
+            if (nameContainsWildcard)
+            {
+                var message = String.Format("Name: '{0}, cannot contain wildcards", String.Join(", ", Name));
+                var ex = new ArgumentException(message);
+                var NameContainsWildCardError = new ErrorRecord(ex, "nameContainsWildCardError", ErrorCategory.ReadError, null);
+                WriteError(NameContainsWildCardError);
+                return;
+            }
+
             string nameArrayAsString = string.Join(", ", Name);
-            WriteVerbose(String.Format("removing repository {0}. Calling Remove() API now", nameArrayAsString));
+            WriteVerbose(String.Format("removing repository {0}. Calling Remove() API now", string.Join(", ", Name)));
             if (!ShouldProcess(nameArrayAsString, "Unregister repositories from repository store"))
             {
                 return;

--- a/src/code/UnregisterPSResourceRepository.cs
+++ b/src/code/UnregisterPSResourceRepository.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
 
             string nameArrayAsString = string.Join(", ", Name);
-            WriteVerbose(String.Format("removing repository {0}. Calling Remove() API now", string.Join(", ", Name)));
+            WriteVerbose(String.Format("removing repository {0}. Calling Remove() API now", nameArrayAsString));
             if (!ShouldProcess(nameArrayAsString, "Unregister repositories from repository store"))
             {
                 return;

--- a/src/code/UnregisterPSResourceRepository.cs
+++ b/src/code/UnregisterPSResourceRepository.cs
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         }
         protected override void ProcessRecord()
         {
-            Name = Utils.ProcessNameWildcards(Name, out string[] errorMsgs, out bool nameContainsWildcard);
+            Name = Utils.ProcessNameWildcards(Name, out string[] _, out bool nameContainsWildcard);
             if (nameContainsWildcard)
             {
                 var message = String.Format("Name: '{0}, cannot contain wildcards", String.Join(", ", Name));

--- a/test/FindPSResource.Tests.ps1
+++ b/test/FindPSResource.Tests.ps1
@@ -72,7 +72,7 @@ Describe 'Test Find-PSResource for Module' {
                 $foundTestScript = $True
             }
 
-            if(-not [string]::IsNullOrEmpty($item.PrereleaseLabel))
+            if($item.IsPrerelease)
             {
                 $foundPreview = $True
             }
@@ -101,7 +101,7 @@ Describe 'Test Find-PSResource for Module' {
                 $foundTestScript = $True
             }
 
-            if(-not [string]::IsNullOrEmpty($item.PrereleaseLabel))
+            if($item.IsPrerelease)
             {
                 $foundPreview = $True
             }

--- a/test/FindPSResource.Tests.ps1
+++ b/test/FindPSResource.Tests.ps1
@@ -210,10 +210,10 @@ Describe 'Test Find-PSResource for Module' {
 
     It "find resource with latest (including prerelease) version given Prerelease parameter" {
         # test_module resource's latest version is a prerelease version, before that it has a non-prerelease version
-        $res = Find-PSResource -Name "test_module" -Repository $TestGalleryName
+        $res = Find-PSResource -Name $testModuleName -Repository $TestGalleryName
         $res.Version | Should -Be "5.0.0.0"
 
-        $resPrerelease = Find-PSResource -Name "test_module" -Prerelease -Repository $TestGalleryName
+        $resPrerelease = Find-PSResource -Name $testModuleName -Prerelease -Repository $TestGalleryName
         $resPrerelease.Version | Should -Be "5.2.5.0"
         $resPrerelease.PrereleaseLabel | Should -Be "alpha001"
     }

--- a/test/GetPSResourceRepository.Tests.ps1
+++ b/test/GetPSResourceRepository.Tests.ps1
@@ -5,6 +5,9 @@ Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
 
 Describe "Test Register-PSResourceRepository" {
     BeforeEach {
+        $TestRepoName1 = "testRepository"
+        $TestRepoName2 = "testRepository2"
+        $TestRepoName3 = "testRepository3"
         Get-NewPSResourceRepositoryFile
         $tmpDir1Path = Join-Path -Path $TestDrive -ChildPath "tmpDir1"
         $tmpDir2Path = Join-Path -Path $TestDrive -ChildPath "tmpDir2"
@@ -22,16 +25,16 @@ Describe "Test Register-PSResourceRepository" {
     }
 
     It "get single already registered repo" {
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
-        $res = Get-PSResourceRepository -Name "testRepository"
+        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        $res = Get-PSResourceRepository -Name $TestRepoName1
         $res | Should -Not -BeNullOrEmpty
-        $res.Name | Should -Be "testRepository"
+        $res.Name | Should -Be $TestRepoName1
     }
 
     It "get all repositories matching single wildcard name" {
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
-        Register-PSResourceRepository -Name "testRepository2" -URL $tmpDir2Path
-        Register-PSResourceRepository -Name "testRepository3" -URL $tmpDir3Path
+        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName2 -URL $tmpDir2Path
+        Register-PSResourceRepository -Name $TestRepoName3 -URL $tmpDir3Path
         $res = Get-PSResourceRepository -Name "testReposit*"
         foreach ($entry in $res) {
             $entry.Name | Should -Match "testReposit"
@@ -39,8 +42,8 @@ Describe "Test Register-PSResourceRepository" {
     }
 
     It "get all repositories matching multiple wildcard names" {
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
-        Register-PSResourceRepository -Name "testRepository2" -URL $tmpDir2Path
+        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName2 -URL $tmpDir2Path
         Register-PSResourceRepository -Name "MyGallery" -URL $tmpDir3Path
 
         $res = Get-PSResourceRepository -Name "testReposit*","*Gallery"
@@ -50,12 +53,12 @@ Describe "Test Register-PSResourceRepository" {
     }
 
     It "get all repositories matching multiple valid names provided" {
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
         Register-PSResourceRepository -Name "MyGallery" -URL $tmpDir2Path
 
-        $res = Get-PSResourceRepository -Name "testRepository","MyGallery"
+        $res = Get-PSResourceRepository -Name $TestRepoName1,"MyGallery"
         foreach ($entry in $res) {
-            $entry.Name | Should -BeIn "testRepository","MyGallery"
+            $entry.Name | Should -BeIn $TestRepoName1,"MyGallery"
         }
     }
 
@@ -70,16 +73,16 @@ Describe "Test Register-PSResourceRepository" {
     It "given invalid and valid Names, get valid ones and write error for non valid ones" {
         $nonRegisteredRepoName = "nonRegisteredRepository"
 
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
-        Register-PSResourceRepository -Name "testRepository2" -URL $tmpDir2Path
+        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName2 -URL $tmpDir2Path
 
-        $res = Get-PSResourceRepository -Name "testRepository",$nonRegisteredRepoName,"testRepository2" -ErrorVariable err -ErrorAction SilentlyContinue
+        $res = Get-PSResourceRepository -Name $TestRepoName1,$nonRegisteredRepoName,$TestRepoName2 -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "ErrorGettingSpecifiedRepo,Microsoft.PowerShell.PowerShellGet.Cmdlets.GetPSResourceRepository"
 
         # should have successfully got the other valid/registered repositories with no error
         foreach ($entry in $res) {
-            $entry.Name | Should -BeIn "testRepository","testRepository2"
+            $entry.Name | Should -BeIn $TestRepoName1,$TestRepoName2
         }
     }
 

--- a/test/RegisterPSResourceRepository.Tests.ps1
+++ b/test/RegisterPSResourceRepository.Tests.ps1
@@ -7,14 +7,16 @@ Describe "Test Register-PSResourceRepository" {
     BeforeEach {
         $PSGalleryName = Get-PSGalleryName
         $PSGalleryURL = Get-PSGalleryLocation
+        $TestRepoName1 = "testRepository"
+        $TestRepoName2 = "testRepository2"
+        $TestRepoName3 = "testRepository3"
+        $relativeCurrentPath = Get-Location
         Get-NewPSResourceRepositoryFile
         $tmpDir1Path = Join-Path -Path $TestDrive -ChildPath "tmpDir1"
         $tmpDir2Path = Join-Path -Path $TestDrive -ChildPath "tmpDir2"
         $tmpDir3Path = Join-Path -Path $TestDrive -ChildPath "tmpDir3"
         $tmpDirPaths = @($tmpDir1Path, $tmpDir2Path, $tmpDir3Path)
         Get-NewTestDirs($tmpDirPaths)
-
-        $relativeCurrentPath = Get-Location
     }
     AfterEach {
         Get-RevertPSResourceRepositoryFile
@@ -26,24 +28,24 @@ Describe "Test Register-PSResourceRepository" {
     }
 
     It "register repository given Name, URL (bare minimum for NameParmaterSet)" {
-        $res = Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path -PassThru
-        $res.Name | Should -Be "testRepository"
+        $res = Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path -PassThru
+        $res.Name | Should -Be $TestRepoName1
         $res.URL.LocalPath | Should -Contain $tmpDir1Path
         $res.Trusted | Should -Be False
         $res.Priority | Should -Be 50
     }
 
     It "register repository with Name, URL, Trusted (NameParameterSet)" {
-        $res = Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path -Trusted -PassThru
-        $res.Name | Should -Be "testRepository"
+        $res = Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path -Trusted -PassThru
+        $res.Name | Should -Be $TestRepoName1
         $res.URL.LocalPath | Should -Contain $tmpDir1Path
         $res.Trusted | Should -Be True
         $res.Priority | Should -Be 50
     }
 
     It "register repository given Name, URL, Trusted, Priority (NameParameterSet)" {
-        $res = Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path -Trusted -Priority 20 -PassThru
-        $res.Name | Should -Be "testRepository"
+        $res = Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path -Trusted -Priority 20 -PassThru
+        $res.Name | Should -Be $TestRepoName1
         $res.URL.LocalPath | Should -Contain $tmpDir1Path
         $res.Trusted | Should -Be True
         $res.Priority | Should -Be 20
@@ -77,23 +79,23 @@ Describe "Test Register-PSResourceRepository" {
     }
 
     It "register repositories with Repositories parameter, all name parameter style repositories (RepositoriesParameterSet)" {
-        $hashtable1 = @{Name = "testRepository"; URL = $tmpDir1Path}
-        $hashtable2 = @{Name = "testRepository2"; URL = $tmpDir2Path; Trusted = $True}
-        $hashtable3 = @{Name = "testRepository3"; URL = $tmpDir3Path; Trusted = $True; Priority = 20}
+        $hashtable1 = @{Name = $TestRepoName1; URL = $tmpDir1Path}
+        $hashtable2 = @{Name = $TestRepoName2; URL = $tmpDir2Path; Trusted = $True}
+        $hashtable3 = @{Name = $TestRepoName3; URL = $tmpDir3Path; Trusted = $True; Priority = 20}
         $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3
 
         Register-PSResourceRepository -Repositories $arrayOfHashtables
-        $res = Get-PSResourceRepository -Name "testRepository"
+        $res = Get-PSResourceRepository -Name $TestRepoName1
         $res.URL.LocalPath | Should -Contain $tmpDir1Path
         $res.Trusted | Should -Be False
         $res.Priority | Should -Be 50
 
-        $res2 = Get-PSResourceRepository -Name "testRepository2"
+        $res2 = Get-PSResourceRepository -Name $TestRepoName2
         $res2.URL.LocalPath | Should -Contain $tmpDir2Path
         $res2.Trusted | Should -Be True
         $res2.Priority | Should -Be 50
 
-        $res3 = Get-PSResourceRepository -Name "testRepository3"
+        $res3 = Get-PSResourceRepository -Name $TestRepoName3
         $res3.URL.LocalPath | Should -Contain $tmpDir3Path
         $res3.Trusted | Should -Be True
         $res3.Priority | Should -Be 20
@@ -112,9 +114,9 @@ Describe "Test Register-PSResourceRepository" {
     It "register repositories with Repositories parameter, name and psgallery parameter styles (RepositoriesParameterSet)" {
         Unregister-PSResourceRepository -Name $PSGalleryName
         $hashtable1 = @{PSGallery = $True}
-        $hashtable2 = @{Name = "testRepository"; URL = $tmpDir1Path}
-        $hashtable3 = @{Name = "testRepository2"; URL = $tmpDir2Path; Trusted = $True}
-        $hashtable4 = @{Name = "testRepository3"; URL = $tmpDir3Path; Trusted = $True; Priority = 20}
+        $hashtable2 = @{Name = $TestRepoName1; URL = $tmpDir1Path}
+        $hashtable3 = @{Name = $TestRepoName2; URL = $tmpDir2Path; Trusted = $True}
+        $hashtable4 = @{Name = $TestRepoName3; URL = $tmpDir3Path; Trusted = $True; Priority = 20}
         $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3, $hashtable4
 
         Register-PSResourceRepository -Repositories $arrayOfHashtables
@@ -124,24 +126,24 @@ Describe "Test Register-PSResourceRepository" {
         $res1.Trusted | Should -Be False
         $res1.Priority | Should -Be 50
 
-        $res2 = Get-PSResourceRepository -Name "testRepository"
+        $res2 = Get-PSResourceRepository -Name $TestRepoName1
         $res2.URL.LocalPath | Should -Contain $tmpDir1Path
         $res2.Trusted | Should -Be False
         $res2.Priority | Should -Be 50
 
-        $res3 = Get-PSResourceRepository -Name "testRepository2"
+        $res3 = Get-PSResourceRepository -Name $TestRepoName2
         $res3.URL.LocalPath | Should -Contain $tmpDir2Path
         $res3.Trusted | Should -Be True
         $res3.Priority | Should -Be 50
 
-        $res4 = Get-PSResourceRepository -Name "testRepository3"
+        $res4 = Get-PSResourceRepository -Name $TestRepoName3
         $res4.URL.LocalPath | Should -Contain $tmpDir3Path
         $res4.Trusted | Should -Be True
         $res4.Priority | Should -Be 20
     }
 
     It "not register repository when Name is provided but URL is not" {
-        {Register-PSResourceRepository -Name "testRepository" -URL "" -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+        {Register-PSResourceRepository -Name $TestRepoName1 -URL "" -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
     }
 
     It "not register repository when Name is empty but URL is provided" {
@@ -172,24 +174,24 @@ Describe "Test Register-PSResourceRepository" {
     It "not register incorrectly formatted PSGallery type repo among correct ones when incorrect type is <Type>" -TestCases $testCases {
         param($Type, $IncorrectHashTable)
 
-        $correctHashtable1 = @{Name = "testRepository"; URL = $tmpDir1Path}
-        $correctHashtable2 = @{Name = "testRepository2"; URL = $tmpDir2Path; Trusted = $True}
-        $correctHashtable3 = @{Name = "testRepository3"; URL = $tmpDir3Path; Trusted = $True; Priority = 20}
+        $correctHashtable1 = @{Name = $TestRepoName1; URL = $tmpDir1Path}
+        $correctHashtable2 = @{Name = $TestRepoName2; URL = $tmpDir2Path; Trusted = $True}
+        $correctHashtable3 = @{Name = $TestRepoName3; URL = $tmpDir3Path; Trusted = $True; Priority = 20}
         $arrayOfHashtables = $correctHashtable1, $correctHashtable2, $IncorrectHashTable, $correctHashtable3
 
-        Unregister-PSResourceRepository -Name "PSGallery"
+        Unregister-PSResourceRepository -Name $PSGalleryName
         Register-PSResourceRepository -Repositories $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "NotProvideNameUrlForPSGalleryRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
 
-        $res = Get-PSResourceRepository -Name "testRepository"
-        $res.Name | Should -Be "testRepository"
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res.Name | Should -Be $TestRepoName1
 
-        $res2 = Get-PSResourceRepository -Name "testRepository2"
-        $res2.Name | Should -Be "testRepository2"
+        $res2 = Get-PSResourceRepository -Name $TestRepoName2
+        $res2.Name | Should -Be $TestRepoName2
 
-        $res3 = Get-PSResourceRepository -Name "testRepository3"
-        $res3.Name | Should -Be "testRepository3"
+        $res3 = Get-PSResourceRepository -Name $TestRepoName3
+        $res3.Name | Should -Be $TestRepoName3
     }
 
     $testCases2 = @{Type = "-Name is not specified";                 IncorrectHashTable = @{URL = $tmpDir1Path};                             ErrorId = "NullNameForRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"},
@@ -200,32 +202,32 @@ Describe "Test Register-PSResourceRepository" {
     It "not register incorrectly formatted Name type repo among correct ones when incorrect type is <Type>" -TestCases $testCases2 {
         param($Type, $IncorrectHashTable, $ErrorId)
 
-        $correctHashtable1 = @{Name = "testRepository2"; URL = $tmpDir2Path; Trusted = $True}
-        $correctHashtable2 = @{Name = "testRepository3"; URL = $tmpDir3Path; Trusted = $True; Priority = 20}
+        $correctHashtable1 = @{Name = $TestRepoName2; URL = $tmpDir2Path; Trusted = $True}
+        $correctHashtable2 = @{Name = $TestRepoName3; URL = $tmpDir3Path; Trusted = $True; Priority = 20}
         $correctHashtable3 = @{PSGallery = $True; Priority = 30};
 
         $arrayOfHashtables = $correctHashtable1, $correctHashtable2, $IncorrectHashTable, $correctHashtable3
-        Unregister-PSResourceRepository -Name "PSGallery"
+        Unregister-PSResourceRepository -Name $PSGalleryName
         Register-PSResourceRepository -Repositories $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly $ErrorId
 
-        $res = Get-PSResourceRepository -Name "testRepository2"
-        $res.Name | Should -Be "testRepository2"
+        $res = Get-PSResourceRepository -Name $TestRepoName2
+        $res.Name | Should -Be $TestRepoName2
 
-        $res2 = Get-PSResourceRepository -Name "testRepository3"
-        $res2.Name | Should -Be "testRepository3"
+        $res2 = Get-PSResourceRepository -Name $TestRepoName3
+        $res2.Name | Should -Be $TestRepoName3
 
-        $res3 = Get-PSResourceRepository -Name "PSGallery"
-        $res3.Name | Should -Be "PSGallery"
+        $res3 = Get-PSResourceRepository -Name $PSGalleryName
+        $res3.Name | Should -Be $PSGalleryName
         $res3.Priority | Should -Be 30
     }
 
     It "should register repository with relative location provided as URL" {
-        Register-PSResourceRepository -Name "testRepository" -URL "./"
-        $res = Get-PSResourceRepository -Name "testRepository"
+        Register-PSResourceRepository -Name $TestRepoName1 -URL "./"
+        $res = Get-PSResourceRepository -Name $TestRepoName1
 
-        $res.Name | Should -Be "testRepository"
+        $res.Name | Should -Be $TestRepoName1
         $res.URL.LocalPath | Should -Contain $relativeCurrentPath
         $res.Trusted | Should -Be False
         $res.Priority | Should -Be 50

--- a/test/SavePSResource.Tests.ps1
+++ b/test/SavePSResource.Tests.ps1
@@ -10,6 +10,8 @@ Describe 'Test Save-PSResource for PSResources' {
         $PSGalleryName = Get-PSGalleryName
         $NuGetGalleryName = Get-NuGetGalleryName
         $testModuleName = "test_module"
+        $testModuleName2 = "TestModule"
+        $testScriptName = "TestTestScript"
         Get-NewPSResourceRepositoryFile
         Register-LocalRepos
 
@@ -27,14 +29,14 @@ Describe 'Test Save-PSResource for PSResources' {
     }
 
     It "Save specific module resource by name" {
-        Save-PSResource -Name "TestModule" -Repository $TestGalleryName -Path $SaveDir
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        Save-PSResource -Name $testModuleName2 -Repository $TestGalleryName -Path $SaveDir
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName2
         $pkgDir | Should -Not -BeNullOrEmpty
         (Get-ChildItem $pkgDir.FullName).Count | Should -Be 1
     }
 
     It "Save specific script resource by name" {
-        Save-PSResource -Name "TestTestScript" -Repository $TestGalleryName -Path $SaveDir
+        Save-PSResource -Name $testScriptName -Repository $TestGalleryName -Path $SaveDir
         $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestTestScript.ps1"
         $pkgDir | Should -Not -BeNullOrEmpty
         (Get-ChildItem $pkgDir.FullName).Count | Should -Be 1
@@ -63,32 +65,32 @@ Describe 'Test Save-PSResource for PSResources' {
 
     # Do some version testing, but Find-PSResource should be doing thorough testing
     It "Should save resource given name and exact version" {
-        Save-PSResource -Name "TestModule" -Version "1.2.0" -Repository $TestGalleryName -Path $SaveDir
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        Save-PSResource -Name $testModuleName2 -Version "1.2.0" -Repository $TestGalleryName -Path $SaveDir
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName2
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "1.2.0"
     }
 
     It "Should save resource given name and exact version with bracket syntax" {
-        Save-PSResource -Name "TestModule" -Version "[1.2.0]" -Repository $TestGalleryName -Path $SaveDir
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        Save-PSResource -Name $testModuleName2 -Version "[1.2.0]" -Repository $TestGalleryName -Path $SaveDir
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName2
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "1.2.0"
     }
 
     It "Should save resource given name and exact range inclusive [1.0.0, 1.1.1]" {
-        Save-PSResource -Name "TestModule" -Version "[1.0.0, 1.1.1]" -Repository $TestGalleryName -Path $SaveDir
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        Save-PSResource -Name $testModuleName2 -Version "[1.0.0, 1.1.1]" -Repository $TestGalleryName -Path $SaveDir
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName2
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "1.1.1"
     }
 
     It "Should save resource given name and exact range exclusive (1.0.0, 1.1.1)" {
-        Save-PSResource -Name "TestModule" -Version "(1.0.0, 1.1.1)" -Repository $TestGalleryName -Path $SaveDir
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        Save-PSResource -Name $testModuleName2 -Version "(1.0.0, 1.1.1)" -Repository $TestGalleryName -Path $SaveDir
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName2
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "1.1"
@@ -100,14 +102,14 @@ Describe 'Test Save-PSResource for PSResources' {
     ) {
         param($Version, $Description)
 
-        Save-PSResource -Name "TestModule" -Version $Version -Repository $TestGalleryName -Path $SaveDir
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        Save-PSResource -Name $testModuleName2 -Version $Version -Repository $TestGalleryName -Path $SaveDir
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName2
         $pkgDir | Should -BeNullOrEmpty
     }
 
     It "Save resource when given Name, Version '*', should install the latest version" {
-        Save-PSResource -Name "TestModule" -Version "*" -Repository $TestGalleryName -Path $SaveDir
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        Save-PSResource -Name $testModuleName2 -Version "*" -Repository $TestGalleryName -Path $SaveDir
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName2
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "1.3.0"
@@ -137,8 +139,8 @@ Describe 'Test Save-PSResource for PSResources' {
     }
 
     It "Save resource via InputObject by piping from Find-PSresource" {
-        Find-PSResource -Name "TestModule" -Repository $TestGalleryName | Save-PSResource -Path $SaveDir
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        Find-PSResource -Name $testModuleName2 -Repository $TestGalleryName | Save-PSResource -Path $SaveDir
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName2
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "1.3.0"
@@ -147,8 +149,8 @@ Describe 'Test Save-PSResource for PSResources' {
     It "Save resource should not prompt 'trust repository' if repository is not trusted but -TrustRepository is used" {
         try {
             Set-PSResourceRepository PoshTestGallery -Trusted:$false
-            Save-PSResource -Name "TestModule" -Repository $TestGalleryName -TrustRepository -Path $SaveDir
-            $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+            Save-PSResource -Name $testModuleName2 -Repository $TestGalleryName -TrustRepository -Path $SaveDir
+            $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName2
             $pkgDir | Should -Not -BeNullOrEmpty
             $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
             $pkgDirVersion.Name | Should -Be "1.3.0"
@@ -176,14 +178,14 @@ Describe 'Test Save-PSResource for PSResources' {
         Set-PSResourceRepository "psgettestlocal2" -Trusted:$True
 
         Save-PSResource -Name "TestModule" -Path $SaveDir
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName2
         $pkgDir | Should -Not -BeNullOrEmpty 
         (Get-ChildItem -Path $pkgDir.FullName).Count | Should -Be 1
     }
 
     It "Save PSResourceInfo object piped in" {
-        Find-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName | Save-PSResource -Path $SaveDir
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        Find-PSResource -Name $testModuleName2 -Version "1.1.0.0" -Repository $TestGalleryName | Save-PSResource -Path $SaveDir
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName2
         $pkgDir | Should -Not -BeNullOrEmpty 
         (Get-ChildItem -Path $pkgDir.FullName).Count | Should -Be 1   
     }
@@ -196,7 +198,7 @@ Describe 'Test Save-PSResource for PSResources' {
     }
 
     It "Save module as a nupkg" {
-        Save-PSResource -Name "TestModule" -Version "1.3.0" -Repository $TestGalleryName -Path $SaveDir -AsNupkg
+        Save-PSResource -Name $testModuleName2 -Version "1.3.0" -Repository $TestGalleryName -Path $SaveDir -AsNupkg
         write-host $SaveDir
         write-host 
         $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "testmodule.1.3.0.nupkg"
@@ -204,14 +206,14 @@ Describe 'Test Save-PSResource for PSResources' {
     }
 
     It "Save script as a nupkg" {
-        Save-PSResource -Name "TestTestScript" -Version "1.3.1" -Repository $TestGalleryName -Path $SaveDir -AsNupkg
+        Save-PSResource -Name $testScriptName -Version "1.3.1" -Repository $TestGalleryName -Path $SaveDir -AsNupkg
         $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "testtestscript.1.3.1.nupkg"
         $pkgDir | Should -Not -BeNullOrEmpty
     }
 
     It "Save module and include XML metadata file" {
-        Save-PSResource -Name "TestModule" -Version "1.3.0" -Repository $TestGalleryName -Path $SaveDir -IncludeXML
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "TestModule"
+        Save-PSResource -Name $testModuleName2 -Version "1.3.0" -Repository $TestGalleryName -Path $SaveDir -IncludeXML
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName2
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "1.3.0"
@@ -220,15 +222,15 @@ Describe 'Test Save-PSResource for PSResources' {
     }
 
     It "Save module using -PassThru" {
-        $res = Save-PSResource -Name "TestModule" -Version "1.3.0" -Repository $TestGalleryName -Path $SaveDir -PassThru
-        $res.Name | Should -Be "TestModule"
+        $res = Save-PSResource -Name $testModuleName2 -Version "1.3.0" -Repository $TestGalleryName -Path $SaveDir -PassThru
+        $res.Name | Should -Be $testModuleName2
         $res.Version | Should -Be "1.3.0.0"
     }
 <#
     # Tests should not write to module directory
     It "Save specific module resource by name if no -Path param is specifed" {
-        Save-PSResource -Name "TestModule" -Repository $TestGalleryName
-        $pkgDir = Get-ChildItem -Path . | Where-Object Name -eq "TestModule"
+        Save-PSResource -Name $testModuleName2 -Repository $TestGalleryName
+        $pkgDir = Get-ChildItem -Path . | Where-Object Name -eq $testModuleName2
         $pkgDir | Should -Not -BeNullOrEmpty
         (Get-ChildItem $pkgDir.FullName).Count | Should -Be 1
 
@@ -244,10 +246,10 @@ Describe 'Test Save-PSResource for PSResources' {
     It "Install resource should prompt 'trust repository' if repository is not trusted" {
         Set-PSResourceRepository PoshTestGallery -Trusted:$false
 
-        Install-PSResource -Name "TestModule" -Repository $TestGalleryName -confirm:$false
+        Install-PSResource -Name $testModuleName2 -Repository $TestGalleryName -confirm:$false
         
-        $pkg = Get-Module "TestModule" -ListAvailable
-        $pkg.Name | Should -Be "TestModule" 
+        $pkg = Get-Module $testModuleName2 -ListAvailable
+        $pkg.Name | Should -Be $testModuleName2
 
         Set-PSResourceRepository PoshTestGallery -Trusted
     }

--- a/test/SetPSResourceRepository.Tests.ps1
+++ b/test/SetPSResourceRepository.Tests.ps1
@@ -7,14 +7,15 @@ Describe "Test Set-PSResourceRepository" {
     BeforeEach {
         $PSGalleryName = Get-PSGalleryName
         $PSGalleryURL = Get-PSGalleryLocation
+        $TestRepoName1 = "testRepository"
+        $TestRepoName2 = "testRepository2"
+        $relativeCurrentPath = Get-Location
         Get-NewPSResourceRepositoryFile
         $tmpDir1Path = Join-Path -Path $TestDrive -ChildPath "tmpDir1"
         $tmpDir2Path = Join-Path -Path $TestDrive -ChildPath "tmpDir2"
         $tmpDir3Path = Join-Path -Path $TestDrive -ChildPath "tmpDir3"
         $tmpDirPaths = @($tmpDir1Path, $tmpDir2Path, $tmpDir3Path)
         Get-NewTestDirs($tmpDirPaths)
-
-        $relativeCurrentPath = Get-Location
     }
     AfterEach {
         Get-RevertPSResourceRepositoryFile
@@ -26,38 +27,38 @@ Describe "Test Set-PSResourceRepository" {
     }
 
     It "set repository given Name and URL parameters" {
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
-        Set-PSResourceRepository -Name "testRepository" -URL $tmpDir2Path
-        $res = Get-PSResourceRepository -Name "testRepository"
-        $res.Name | Should -Be "testRepository"
+        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        Set-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir2Path
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res.Name | Should -Be $TestRepoName1
         $res.URL.LocalPath | Should -Contain $tmpDir2Path
         $res.Priority | Should -Be 50
         $res.Trusted | Should -Be False
     }
 
     It "set repository given Name and Priority parameters" {
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
-        Set-PSResourceRepository -Name "testRepository" -Priority 25
-        $res = Get-PSResourceRepository -Name "testRepository"
-        $res.Name | Should -Be "testRepository"
+        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        Set-PSResourceRepository -Name $TestRepoName1 -Priority 25
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res.Name | Should -Be $TestRepoName1
         $res.URL.LocalPath | Should -Contain $tmpDir1Path
         $res.Priority | Should -Be 25
         $res.Trusted | Should -Be False
     }
 
     It "set repository given Name and Trusted parameters" {
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
-        Set-PSResourceRepository -Name "testRepository" -Trusted
-        $res = Get-PSResourceRepository -Name "testRepository"
-        $res.Name | Should -Be "testRepository"
+        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        Set-PSResourceRepository -Name $TestRepoName1 -Trusted
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res.Name | Should -Be $TestRepoName1
         $res.URL.LocalPath | Should -Contain $tmpDir1Path
         $res.Priority | Should -Be 50
         $res.Trusted | Should -Be True
     }
 
     It "not set repository and write error given just Name parameter" {
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
-        {Set-PSResourceRepository -Name "testRepository" -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
+        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        {Set-PSResourceRepository -Name $TestRepoName1 -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
     }
 
     $testCases = @{Type = "contains *";     Name = "test*Repository"; ErrorId = "ErrorInNameParameterSet"},
@@ -67,7 +68,7 @@ Describe "Test Set-PSResourceRepository" {
     It "not set repository and throw error given Name <Type> (NameParameterSet)" -TestCases $testCases {
         param($Type, $Name)
 
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
         {Set-PSResourceRepository -Name $Name -Priority 25 -ErrorAction Stop} | Should -Throw -ErrorId "$ErrorId,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
     }
 
@@ -77,11 +78,11 @@ Describe "Test Set-PSResourceRepository" {
     It "not set repository and write error given Name <Type> (RepositoriesParameterSet)" -TestCases $testCases2 {
         param($Type, $Name, $ErrorId)
 
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
-        Register-PSResourceRepository -Name "testRepository2" -URL $tmpDir2Path
+        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName2 -URL $tmpDir2Path
 
-        $hashtable1 = @{Name = "testRepository"; URL = $tmpDir3Path}
-        $hashtable2 = @{Name = "testRepository2"; Priority = 25}
+        $hashtable1 = @{Name = $TestRepoName1; URL = $tmpDir3Path}
+        $hashtable2 = @{Name = $TestRepoName2; Priority = 25}
         $incorrectHashTable = @{Name = $Name; Trusted = $True}
         $arrayOfHashtables = $hashtable1, $incorrectHashTable, $hashtable2
 
@@ -89,35 +90,35 @@ Describe "Test Set-PSResourceRepository" {
         $err.Count | Should -Not -Be 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "$ErrorId,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
 
-        $res = Get-PSResourceRepository -Name "testRepository"
+        $res = Get-PSResourceRepository -Name $TestRepoName1
         $res.URL.LocalPath | Should -Contain $tmpDir3Path
         $res.Trusted | Should -Be False
 
-        $res2 = Get-PSResourceRepository -Name "testRepository2"
+        $res2 = Get-PSResourceRepository -Name $TestRepoName2
         $res2.Priority | Should -Be 25
         $res2.Trusted | Should -Be False
     }
 
     It "set repositories with Repositories parameter" {
-        Unregister-PSResourceRepository -Name "PSGallery"
-        Register-PSResourceRepository -Name "testRepository1" -URL $tmpDir1Path
-        Register-PSResourceRepository -Name "testRepository2" -URL $tmpDir2Path
+        Unregister-PSResourceRepository -Name $PSGalleryName
+        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName2 -URL $tmpDir2Path
         Register-PSResourceRepository -PSGallery
 
-        $hashtable1 = @{Name = "testRepository1"; URL = $tmpDir2Path};
-        $hashtable2 = @{Name = "testRepository2"; Priority = 25};
-        $hashtable3 = @{Name = "PSGallery"; Trusted = $True};
+        $hashtable1 = @{Name = $TestRepoName1; URL = $tmpDir2Path};
+        $hashtable2 = @{Name = $TestRepoName2; Priority = 25};
+        $hashtable3 = @{Name = $PSGalleryName; Trusted = $True};
         $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3
 
         Set-PSResourceRepository -Repositories $arrayOfHashtables
-        $res = Get-PSResourceRepository -Name "testRepository1"
-        $res.Name | Should -Be "testRepository1"
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res.Name | Should -Be $TestRepoName1
         $res.URL.LocalPath | Should -Contain $tmpDir2Path
         $res.Priority | Should -Be 50
         $res.Trusted | Should -Be False
 
-        $res2 = Get-PSResourceRepository -Name "testRepository2"
-        $res2.Name | Should -Be "testRepository2"
+        $res2 = Get-PSResourceRepository -Name $TestRepoName2
+        $res2.Name | Should -Be $TestRepoName2
         $res2.URL.LocalPath | Should -Contain $tmpDir2Path
         $res2.Priority | Should -Be 25
         $res2.Trusted | Should -Be False
@@ -130,45 +131,53 @@ Describe "Test Set-PSResourceRepository" {
     }
 
     It "not set and throw error for trying to set PSGallery URL (NameParameterSet)" {
-        Unregister-PSResourceRepository -Name "PSGallery"
+        Unregister-PSResourceRepository -Name $PSGalleryName
         Register-PSResourceRepository -PSGallery
-        {Set-PSResourceRepository -Name "PSGallery" -URL $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
+        {Set-PSResourceRepository -Name $PSGalleryName -URL $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
     }
 
     It "not set repository and throw error for trying to set PSGallery URL (RepositoriesParameterSet)" {
-        Unregister-PSResourceRepository -Name "PSGallery"
+        Unregister-PSResourceRepository -Name $PSGalleryName
         Register-PSResourceRepository -PSGallery
 
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
 
-        $hashtable1 = @{Name = "PSGallery"; URL = $tmpDir1Path}
-        $hashtable2 = @{Name = "testRepository"; Priority = 25}
+        $hashtable1 = @{Name = $PSGalleryName; URL = $tmpDir1Path}
+        $hashtable2 = @{Name = $TestRepoName1; Priority = 25}
         $arrayOfHashtables = $hashtable1, $hashtable2
 
         Set-PSResourceRepository -Repositories $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "ErrorSettingIndividualRepoFromRepositories,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
 
-        $res = Get-PSResourceRepository -Name "testRepository"
+        $res = Get-PSResourceRepository -Name $TestRepoName1
         $res.URL.LocalPath | Should -Contain $tmpDir1Path
         $res.Priority | Should -Be 25
         $res.Trusted | Should -Be False
     }
 
     It "should set repository with relative URL provided" {
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
-        Set-PSResourceRepository -Name "testRepository" -URL $relativeCurrentPath
-        $res = Get-PSResourceRepository -Name "testRepository"
-        $res.Name | Should -Be "testRepository"
+        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        Set-PSResourceRepository -Name $TestRepoName1 -URL $relativeCurrentPath
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res.Name | Should -Be $TestRepoName1
         $res.URL.LocalPath | Should -Contain $relativeCurrentPath
         $res.Trusted | Should -Be False
         $res.Priority | Should -Be 50
     }
 
+    It "should set repository with local file share NuGet based Uri" {
+        Register-PSResourceRepository -Name "localFileShareTestRepo" -URL $tmpDir1Path
+        Set-PSResourceRepository -Name "localFileShareTestRepo" -URL "\\hcgg.rest.of.domain.name\test\ITxx\team\NuGet\"
+        $res = Get-PSResourceRepository -Name "localFileShareTestRepo"
+        $res.Name | Should -Be "localFileShareTestRepo"
+        $res.URL.LocalPath | Should -Contain "\\hcgg.rest.of.domain.name\test\ITxx\team\NuGet\"
+    }
+
     It "set repository and see updated repository with -PassThru" {
-        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
-        $res = Set-PSResourceRepository -Name "testRepository" -URL $tmpDir2Path -PassThru
-        $res.Name | Should -Be "testRepository"
+        Register-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir1Path
+        $res = Set-PSResourceRepository -Name $TestRepoName1 -URL $tmpDir2Path -PassThru
+        $res.Name | Should -Be $TestRepoName1
         $res.URL.LocalPath | Should -Contain $tmpDir2Path
         $res.Priority | Should -Be 50
         $res.Trusted | Should -Be False

--- a/test/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResource.Tests.ps1
@@ -175,7 +175,7 @@ Describe 'Test Uninstall-PSResource for Modules' {
     }
 
     It "Do not Uninstall module that is a dependency for another module" {
-        $null = Install-PSResource "test_module" -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
+        $null = Install-PSResource $testModuleName -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
     
         Uninstall-PSResource -Name "RequiredModule1" -ErrorVariable ev -ErrorAction SilentlyContinue
 
@@ -186,7 +186,7 @@ Describe 'Test Uninstall-PSResource for Modules' {
     }
 
     It "Uninstall module that is a dependency for another module using -SkipDependencyCheck" {
-        $null = Install-PSResource "test_module" -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
+        $null = Install-PSResource $testModuleName -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
 
         Uninstall-PSResource -Name "RequiredModule1" -SkipDependencyCheck
         

--- a/test/UnregisterPSResourceRepository.Tests.ps1
+++ b/test/UnregisterPSResourceRepository.Tests.ps1
@@ -46,6 +46,14 @@ Describe "Test Register-PSResourceRepository" {
 
     }
 
+    It "not register when -Name contains wildcard" {
+        Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
+        Register-PSResourceRepository -Name "testRepository2" -URL $tmpDir2Path
+        Unregister-PSResourceRepository -Name "testRepository*" -ErrorVariable err -ErrorAction SilentlyContinue
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "nameContainsWildCardError,Microsoft.PowerShell.PowerShellGet.Cmdlets.UnregisterPSResourceRepository"
+    }
+
     It "when multiple repo Names provided, if one name isn't valid unregister the rest and write error message" {
         $nonRegisteredRepoName = "nonRegisteredRepository"
         Register-PSResourceRepository -Name "testRepository" -URL $tmpDir1Path
@@ -66,7 +74,9 @@ Describe "Test Register-PSResourceRepository" {
         $res = Unregister-PSResourceRepository -Name $TestGalleryName -PassThru
         $res.Name | Should -Be $TestGalleryName
         $res.Url | Should -Be $TestGalleryURL
-        $res = Get-PSResourceRepository -Name $TestGalleryName
+        $res = Get-PSResourceRepository -Name $TestGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "ErrorGettingSpecifiedRepo,Microsoft.PowerShell.PowerShellGet.Cmdlets.GetPSResourceRepository"
     }
 }

--- a/test/UpdatePSResource.Tests.ps1
+++ b/test/UpdatePSResource.Tests.ps1
@@ -9,6 +9,7 @@ Describe 'Test Update-PSResource' {
     BeforeAll{
         $TestGalleryName = Get-PoshTestGalleryName
         $NuGetGalleryName = Get-NuGetGalleryName
+        $testModuleName = "TestModule"
         Get-NewPSResourceRepositoryFile
         Get-PSResourceRepository
     }
@@ -22,10 +23,10 @@ Describe 'Test Update-PSResource' {
     }
 
     It "update resource installed given Name parameter" {
-        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName
+        Install-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName
 
-        Update-PSResource -Name "TestModule" -Repository $TestGalleryName
-        $res = Get-PSResource -Name "TestModule"
+        Update-PSResource -Name $testModuleName -Repository $TestGalleryName
+        $res = Get-PSResource -Name $testModuleName
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)
@@ -40,7 +41,7 @@ Describe 'Test Update-PSResource' {
     }
 
     It "update resources installed given Name (with wildcard) parameter" {
-        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName
+        Install-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName
         Install-PSResource -Name "TestModule99" -Version "0.0.4.0" -Repository $TestGalleryName
 
         Update-PSResource -Name "TestModule*" -Repository $TestGalleryName
@@ -53,7 +54,7 @@ Describe 'Test Update-PSResource' {
         {
             if ([System.Version]$item.Version -gt [System.Version]$inputHashtable[$item.Name])
             {
-                if ($item.Name -like "TestModule")
+                if ($item.Name -like $testModuleName)
                 {
                     $isTestModuleUpdated = $true
                 }
@@ -69,10 +70,10 @@ Describe 'Test Update-PSResource' {
     }
 
     It "update resource installed given Name and Version (specific) parameters" {
-        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName
+        Install-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName
 
-        Update-PSResource -Name "TestModule" -Version "1.2.0.0" -Repository $TestGalleryName
-        $res = Get-PSResource -Name "TestModule"
+        Update-PSResource -Name $testModuleName -Version "1.2.0.0" -Repository $TestGalleryName
+        $res = Get-PSResource -Name $testModuleName
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -99,13 +100,13 @@ Describe 'Test Update-PSResource' {
     It "update resource when given Name to <Reason> <Version>" -TestCases $testCases2{
         param($Version, $ExpectedVersions)
 
-        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName
-        Update-PSResource -Name "TestModule" -Version $Version -Repository $TestGalleryName
+        Install-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName
+        Update-PSResource -Name $testModuleName -Version $Version -Repository $TestGalleryName
 
-        $res = Get-PSResource -Name "TestModule"
+        $res = Get-PSResource -Name $testModuleName
 
         foreach ($item in $res) {
-            $item.Name | Should -Be "TestModule"
+            $item.Name | Should -Be $testModuleName
             $ExpectedVersions | Should -Contain $item.Version
         }
     }
@@ -117,10 +118,10 @@ Describe 'Test Update-PSResource' {
     It "Should not update resource with incorrectly formatted version such as <Description>" -TestCases $testCases{
         param($Version, $Description)
 
-        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName
-        Update-PSResource -Name "TestModule" -Version $Version -Repository $TestGalleryName
+        Install-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName
+        Update-PSResource -Name $testModuleName -Version $Version -Repository $TestGalleryName
 
-        $res = Get-PSResource -Name "TestModule"
+        $res = Get-PSResource -Name $testModuleName
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -156,12 +157,12 @@ Describe 'Test Update-PSResource' {
     # Windows only
     It "update resource under CurrentUser scope" -skip:(!$IsWindows) {
         # TODO: perhaps also install TestModule with the highest version (the one above 1.2.0.0) to the AllUsers path too
-        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName -Scope AllUsers
-        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName -Scope CurrentUser
+        Install-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName -Scope AllUsers
+        Install-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName -Scope CurrentUser
 
-        Update-PSResource -Name "TestModule" -Version "1.2.0.0" -Repository $TestGalleryName -Scope CurrentUser
+        Update-PSResource -Name $testModuleName -Version "1.2.0.0" -Repository $TestGalleryName -Scope CurrentUser
 
-        $res = Get-PSResource -Name "TestModule"
+        $res = Get-PSResource -Name $testModuleName
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)
@@ -178,12 +179,12 @@ Describe 'Test Update-PSResource' {
 
     # Windows only
     It "update resource under AllUsers scope" -skip:(!($IsWindows -and (Test-IsAdmin))) {
-        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName -Scope AllUsers
-        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName -Scope CurrentUser
+        Install-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName -Scope AllUsers
+        Install-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName -Scope CurrentUser
 
-        Update-PSResource -Name "TestModule" -Version "1.2.0.0" -Repository $TestGalleryName -Scope AllUsers
+        Update-PSResource -Name $testModuleName -Version "1.2.0.0" -Repository $TestGalleryName -Scope AllUsers
 
-        $res = Get-PSResource -Name "TestModule"
+        $res = Get-PSResource -Name $testModuleName
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -199,10 +200,10 @@ Describe 'Test Update-PSResource' {
 
     # Windows only
     It "update resource under no specified scope" -skip:(!$IsWindows) {
-        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName
-        Update-PSResource -Name "TestModule" -Version "1.2.0.0" -Repository $TestGalleryName
+        Install-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName
+        Update-PSResource -Name $testModuleName -Version "1.2.0.0" -Repository $TestGalleryName
 
-        $res = Get-PSResource -Name "TestModule"
+        $res = Get-PSResource -Name $testModuleName
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)
@@ -222,11 +223,11 @@ Describe 'Test Update-PSResource' {
     It "Update resource under CurrentUser scope - Unix only" -Skip:(Get-IsWindows) {
         # this line is commented out because AllUsers scope requires sudo and that isn't supported in CI yet
         # Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName -Scope AllUsers
-        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName -Scope CurrentUser
+        Install-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName -Scope CurrentUser
 
-        Update-PSResource -Name "TestModule" -Repository $TestGalleryName -Scope CurrentUser
+        Update-PSResource -Name $testModuleName -Repository $TestGalleryName -Scope CurrentUser
 
-        $res = Get-PSResource -Name "TestModule"
+        $res = Get-PSResource -Name $testModuleName
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)
@@ -245,12 +246,12 @@ Describe 'Test Update-PSResource' {
     # Expected path should be similar to: '/usr/local/share/powershell/Modules'
     # this test is skipped because it requires sudo to run and has yet to be resolved in CI
     It "Update resource under AllUsers scope - Unix only" -Skip:($true) {
-        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName -Scope AllUsers
-        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName -Scope CurrentUser
+        Install-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName -Scope AllUsers
+        Install-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName -Scope CurrentUser
 
-        Update-PSResource -Name "TestModule" -Repository $TestGalleryName -Scope AllUsers
+        Update-PSResource -Name $testModuleName -Repository $TestGalleryName -Scope AllUsers
 
-        $res = Get-PSResource -Name "TestModule"
+        $res = Get-PSResource -Name $testModuleName
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)
@@ -270,11 +271,11 @@ Describe 'Test Update-PSResource' {
     It "Update resource under no specified scope - Unix only" -Skip:(Get-IsWindows) {
         # this is commented out because it requires sudo to run with AllUsers scope and this hasn't been resolved in CI yet
         # Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName -Scope AllUsers
-        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName -Scope CurrentUser
+        Install-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName -Scope CurrentUser
 
-        Update-PSResource -Name "TestModule" -Repository $TestGalleryName
+        Update-PSResource -Name $testModuleName -Repository $TestGalleryName
 
-        $res = Get-PSResource -Name "TestModule"
+        $res = Get-PSResource -Name $testModuleName
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)
@@ -307,12 +308,12 @@ Describe 'Test Update-PSResource' {
     }
 
     It "update resource should not prompt 'trust repository' if repository is not trusted but -TrustRepository is used" {
-        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName
+        Install-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName
 
         Set-PSResourceRepository PoshTestGallery -Trusted:$false
 
-        Update-PSResource -Name "TestModule" -Version "1.2.0.0" -Repository $TestGalleryName -TrustRepository
-        $res = Get-PSResource -Name "TestModule"
+        Update-PSResource -Name $testModuleName -Version "1.2.0.0" -Repository $TestGalleryName -TrustRepository
+        $res = Get-PSResource -Name $testModuleName
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)
@@ -328,10 +329,10 @@ Describe 'Test Update-PSResource' {
     }
 
     It "Update module using -WhatIf, should not update the module" {
-        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName
-        Update-PSResource -Name "TestModule" -WhatIf
+        Install-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName
+        Update-PSResource -Name $testModuleName -WhatIf
 
-        $res = Get-PSResource -Name "TestModule"
+        $res = Get-PSResource -Name $testModuleName
 
         $isPkgUpdated = $false
         foreach ($pkg in $res)
@@ -346,10 +347,10 @@ Describe 'Test Update-PSResource' {
     }
 
     It "update resource installed given -Name and -PassThru parameters" {
-        Install-PSResource -Name "TestModule" -Version "1.1.0.0" -Repository $TestGalleryName
+        Install-PSResource -Name $testModuleName -Version "1.1.0.0" -Repository $TestGalleryName
 
-        $res = Update-PSResource -Name "TestModule" -Version "1.3.0.0" -Repository $TestGalleryName -PassThru
-        $res.Name | Should -Be "TestModule"
+        $res = Update-PSResource -Name $testModuleName -Version "1.3.0.0" -Repository $TestGalleryName -PassThru
+        $res.Name | Should -Be $testModuleName
         $res.Version | Should -Be "1.3.0.0"
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Clean up tests. Ensure tests exist for PassThru and error handling scenarios.

## PR Context

Last pass clean up of tests before release. Ensure cmdlets have appropriate error handling.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
