### PR TITLE
update CHANGELOG.md and module manifest before release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # CHANGELOG
 
+## 3.0.12-beta
+
+### Changes
+- Support searching for all packages from a repository (i.e `Find-PSResource -Name “*”`). Note, wildcard search is not supported for AzureDevOps feed repositories and will write an error message accordingly).
+- Packages found are now unique by Name,Version,Repository.
+- Support searching for and returning packages found across multiple repositories when using wildcard with Repository parameter (i.e `Find-PSResource “PackageExistingInMultipleRepos” -Repository “*”` will perform an exhaustive search).
+- Add consistent pipeline input support.
+  - PSResourceInfo objects can be piped into: Install-PSResource, Uninstall-PSResource, Save-PSResource. PSRepositoryInfo objects can be piped into: Unregister-PSResourceRepository
+- For more consistent pipeline support, the following cmdlets have pipeline support for the listed parameter(s):
+  - Find-PSResource (Name param, ValueFromPipeline)
+  - Get-PSResource (Name param, ValueFromPipeline)
+  - Install-PSResource (Name param, ValueFromPipeline)
+  - Publish-PSResource (None)
+  - Save-PSResource (Name param, ValueFromPipeline)
+  - Uninstall-PSResource (Name param, ValueFromPipeline)
+  - Update-PSResource (Name param, ValueFromPipeline)
+  - Get-PSResourceRepository (Name param, ValueFromPipeline)
+  - Set-PSResourceRepository (Name param, ValueFromPipeline)
+  - Register-PSResourceRepository (None)
+  - Unregister-PSResourceRepository (Name param, ValueFromPipelineByPropertyName)
+- Implement `-Tag` parameter set for Find-PSResource (i.e `Find-PSResource -Tag “JSON”`)
+- Implement `-Type` parameter set for Find-PSResource (i.e `Find-PSResource -Type Module`)
+- Implement CommandName and DSCResourceName parameter sets for Find-PSResource (i.e Find-PSResource -CommandName “Get-TargetResource”).
+- Add consistent pre-release version support for cmdlets, including Uninstall-PSResource and Get-PSResource. For example, running `Get-PSResource “MyPackage” -Version “2.0.0-beta”` would only return MyPackage with version “2.0.0” and prerelease “beta”, NOT MyPackage with version “2.0.0.0” (i.e a stable version).
+- Add progress bar for installation completion for Install-PSResource, Update-PSResource and Save-PSResource.
+- Implement `-Quiet` param for Install-PSResource and Update-PSResource. This suppresses the progress bar display when passed in.
+- Implement `-PassThru` parameter for all appropriate cmdlets. Install-PSResource, Save-PSResource, Update-PSResource and Unregister-PSResourceRepository cmdlets now have `-PassThru` support thus completing this goal.
+- Implement `-SkipDependencies` parameter for Install-PSResource, Save-PSResource, and Update-PSResource cmdlets.
+- Implement `-AsNupkg` and `-IncludeXML` parameters for Save-PSResource.
+- Implement `-DestinationPath` parameter for Publish-PSResource
+- Add `-NoClobber` functionality to Install-PSResource.
+- Add thorough error handling to Update-PSResource to cover more cases and gracefully write errors when updates can’t be performed.
+- Add thorough error handling to Install-PSResource to cover more cases and not fail silently when installation could not happen successfully. Also fixes bug where package would install even if it was already installed and `-Reinstall` parameter was not specified.
+- Restore package if installation attempt fails when reinstalling a package.
+- Fix bug with some Modules installing as Scripts.
+- Fix bug with separating `$env:PSModulePath` to now work with path separators across all OS systems including Unix.
+- Fix bug to register repositories with local file share paths, ensuring repositories with valid URIs can be registered.
+- Revert cmdlet name ‘Get-InstalledPSResource’ to ‘Get-PSResource’
+- Remove DSCResources from PowerShellGet.
+- Remove unnecessary assemblies.
+
+### Notes
+In this release, all cmdlets have been reviewed and implementation code refactored as needed.
+Missing implementation from the past prerelease has been completed for parameters and parameter sets.
+High priority bugs which were either outstanding or from the last prerelease have also been addressed.
+All tests have been reviewed and rewritten as needed.
+Please note, that wildcard search for AzureDevOps feed repositories is not supported at this time.
+
 ## 3.0.11-beta
 
 ### Changes

--- a/src/PowerShellGet.psd1
+++ b/src/PowerShellGet.psd1
@@ -85,6 +85,8 @@ Please note, that wildcard search for AzureDevOps feed repositories is not suppo
 - Revert cmdlet name ‘Get-InstalledPSResource’ to ‘Get-PSResource’
 - Remove DSCResources from PowerShellGet.
 - Remove unnecessary assemblies.
+
+For a full list of previous changes see: https://github.com/PowerShell/PowerShellGet/blob/master/CHANGELOG.md
 '@
         }
     }

--- a/src/PowerShellGet.psd1
+++ b/src/PowerShellGet.psd1
@@ -41,29 +41,50 @@
             LicenseUri = 'https://go.microsoft.com/fwlink/?LinkId=829061'
             ReleaseNotes = @'
 
-### 3.0.11
+### 3.0.12
 In this release, all cmdlets have been reviewed and implementation code refactored as needed.
-Cmdlets have most of their functionality, but some parameters are not yet implemented and will be added in future releases.
+Missing implementation from the past prerelease has been completed for parameters and parameter sets.
+High priority bugs which were either outstanding or from the last prerelease have also been addressed.
 All tests have been reviewed and rewritten as needed.
+Please note, that wildcard search for AzureDevOps feed repositories is not supported at this time.
 
-- Graceful handling of paths that do not exist
-- The repository store (PSResourceRepository.xml) is auto-generated if it does not already exist. It also automatically registers the PowerShellGallery with a default priority of 50 and a default trusted value of false. 
-- Better Linux support, including graceful exits when paths do not exist
-- Better pipeline input support all cmdlets
-- General wildcard support for all cmdlets
-- WhatIf support for all cmdlets
-- All cmdlets output concrete return types
-- Better help documentation for all cmdlets
-- Using an exact prerelease version with Find, Install, or Save no longer requires `-Prerelease` tag
-- Support for finding, installing, saving, and updating PowerShell resources from Azure Artifact feeds
-- Publish-PSResource now properly dispays 'Tags' in nuspec
-- Find-PSResource quickly cancels transactions with 'CTRL + C'
-- Register-PSRepository now handles relative paths
-- Find-PSResource and Save-PSResource deduplicates dependencies
-- Install-PSResource no longer creates version folder with the prerelease tag
-- Update-PSResource can now update all resources, and no longer requires name param
-- Save-PSResource properly handles saving scripts
-- Get-PSResource uses default PowerShell paths
+- Support searching for all packages from a repository (i.e `Find-PSResource -Name “*”`). Note, wildcard search is not supported for AzureDevOps feed repositories and will write an error message accordingly).
+- Packages found are now unique by Name,Version,Repository.
+- Support searching for and returning packages found across multiple repositories when using wildcard with Repository parameter (i.e `Find-PSResource “PackageExistingInMultipleRepos” -Repository “*”` will perform an exhaustive search).
+- Add consistent pipeline input support.
+  - PSResourceInfo objects can be piped into: Install-PSResource, Uninstall-PSResource, Save-PSResource. PSRepositoryInfo objects can be piped into: Unregister-PSResourceRepository
+- For more consistent pipeline support, the following cmdlets have pipeline support for the listed parameter(s):
+  - Find-PSResource (Name param, ValueFromPipeline)
+  - Get-PSResource (Name param, ValueFromPipeline)
+  - Install-PSResource (Name param, ValueFromPipeline)
+  - Publish-PSResource (None)
+  - Save-PSResource (Name param, ValueFromPipeline)
+  - Uninstall-PSResource (Name param, ValueFromPipeline)
+  - Update-PSResource (Name param, ValueFromPipeline)
+  - Get-PSResourceRepository (Name param, ValueFromPipeline)
+  - Set-PSResourceRepository (Name param, ValueFromPipeline)
+  - Register-PSResourceRepository (None)
+  - Unregister-PSResourceRepository (Name param, ValueFromPipelineByPropertyName)
+- Implement `-Tag` parameter set for Find-PSResource (i.e `Find-PSResource -Tag “JSON”`)
+- Implement `-Type` parameter set for Find-PSResource (i.e `Find-PSResource -Type Module`)
+- Implement CommandName and DSCResourceName parameter sets for Find-PSResource (i.e Find-PSResource -CommandName “Get-TargetResource”).
+- Add consistent pre-release version support for cmdlets, including Uninstall-PSResource and Get-PSResource. For example, running `Get-PSResource “MyPackage” -Version “2.0.0-beta”` would only return MyPackage with version “2.0.0” and prerelease “beta”, NOT MyPackage with version “2.0.0.0” (i.e a stable version).
+- Add progress bar for installation completion for Install-PSResource, Update-PSResource and Save-PSResource.
+- Implement `-Quiet` param for Install-PSResource and Update-PSResource. This suppresses the progress bar display when passed in.
+- Implement `-PassThru` parameter for all appropriate cmdlets. Install-PSResource, Save-PSResource, Update-PSResource and Unregister-PSResourceRepository cmdlets now have `-PassThru` support thus completing this goal.
+- Implement `-SkipDependencies` parameter for Install-PSResource, Save-PSResource, and Update-PSResource cmdlets.
+- Implement `-AsNupkg` and `-IncludeXML` parameters for Save-PSResource.
+- Implement `-DestinationPath` parameter for Publish-PSResource
+- Add `-NoClobber` functionality to Install-PSResource.
+- Add thorough error handling to Update-PSResource to cover more cases and gracefully write errors when updates can’t be performed.
+- Add thorough error handling to Install-PSResource to cover more cases and not fail silently when installation could not happen successfully. Also fixes bug where package would install even if it was already installed and `-Reinstall` parameter was not specified.
+- Restore package if installation attempt fails when reinstalling a package.
+- Fix bug with some Modules installing as Scripts.
+- Fix bug with separating `$env:PSModulePath` to now work with path separators across all OS systems including Unix.
+- Fix bug to register repositories with local file share paths, ensuring repositories with valid URIs can be registered.
+- Revert cmdlet name ‘Get-InstalledPSResource’ to ‘Get-PSResource’
+- Remove DSCResources from PowerShellGet.
+- Remove unnecessary assemblies.
 '@
         }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update CHANGELOG.md and PowerShellGet.psd1 before release for 3.0.12-beta.

## PR Context

Updating these before release.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
