### PR TITLE
Fix tests errors being written out to output

### DIFF
--- a/test/SavePSResource.Tests.ps1
+++ b/test/SavePSResource.Tests.ps1
@@ -52,9 +52,11 @@ Describe 'Test Save-PSResource for PSResources' {
     }
 
     It "Should not save resource given nonexistant name" {
-        Save-PSResource -Name NonExistentModule -Repository $TestGalleryName -Path $SaveDir
+        Save-PSResource -Name NonExistentModule -Repository $TestGalleryName -Path $SaveDir -ErrorVariable err -ErrorAction SilentlyContinue
         $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "NonExistentModule"
         $pkgDir.Name | Should -BeNullOrEmpty
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "ResourceNotFoundError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
     }
 
     It "Not Save module with Name containing wildcard" {
@@ -102,9 +104,11 @@ Describe 'Test Save-PSResource for PSResources' {
     ) {
         param($Version, $Description)
 
-        Save-PSResource -Name $testModuleName2 -Version $Version -Repository $TestGalleryName -Path $SaveDir
+        Save-PSResource -Name $testModuleName2 -Version $Version -Repository $TestGalleryName -Path $SaveDir -ErrorVariable err -ErrorAction SilentlyContinue
         $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName2
         $pkgDir | Should -BeNullOrEmpty
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "ResourceNotFoundError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
     }
 
     It "Save resource when given Name, Version '*', should install the latest version" {

--- a/test/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResource.Tests.ps1
@@ -43,14 +43,22 @@ Describe 'Test Uninstall-PSResource for Modules' {
     }
 
     It "Uninstall a specific script by name" {
-        $null = Install-PSResource "test_script" -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
+        $null = Install-PSResource "test_script" -Repository $TestGalleryName -TrustRepository
+        $res = Get-PSResource -Name "test_script"
+        $res.Name | Should -Be "test_script"
+
         Uninstall-PSResource -name "test_script"
         $res = Get-PSResource -Name "test_script"
         $res | Should -BeNullOrEmpty
     }
 
     It "Uninstall a list of scripts by name" {
-        $null = Install-PSResource "test_script", "TestTestScript" -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
+        $null = Install-PSResource "test_script", "TestTestScript" -Repository $TestGalleryName -TrustRepository
+        $res = Get-PSResource -Name "test_script"
+        $res2 = Get-PSResource -Name "TestTestScript"
+        $res.Name | Should -Be "test_script"
+        $res2.Name | Should -Be "TestTestScript"
+
         Uninstall-PSResource -Name "test_script", "TestTestScript"
         $res = Get-PSResource -Name "test_script"
         $res2 = Get-PSResource -Name "TestTestScript"

--- a/test/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResource.Tests.ps1
@@ -43,15 +43,19 @@ Describe 'Test Uninstall-PSResource for Modules' {
     }
 
     It "Uninstall a specific script by name" {
-        $null = Install-PSResource Test-RPC -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
-
-        Uninstall-PSResource -name Test-RPC 
+        $null = Install-PSResource "test_script" -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
+        Uninstall-PSResource -name "test_script"
+        $res = Get-PSResource -Name "test_script"
+        $res | Should -BeNullOrEmpty
     }
 
     It "Uninstall a list of scripts by name" {
-        $null = Install-PSResource adsql, airoute -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
-
-        Uninstall-PSResource -Name adsql, airoute 
+        $null = Install-PSResource "test_script", "TestTestScript" -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
+        Uninstall-PSResource -Name "test_script", "TestTestScript"
+        $res = Get-PSResource -Name "test_script"
+        $res2 = Get-PSResource -Name "TestTestScript"
+        $res | Should -BeNullOrEmpty
+        $res2 | Should -BeNullOrEmpty
     }
 
     It "Uninstall a module when given name and specifying all versions" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Errors being written due to tests should be written to an error variable and surpressed.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
