### PR TITLE
Suppress progress bar during testing

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -332,16 +332,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     if (!_quiet)
                     {
                         int activityId = 0;
-                        string activity = "";
-                        string statusDescription = "";
-
-                        // Installing parent package (one whose name was passed in to install)
-                        activityId = 0;
-                        activity = string.Format("Installing {0}...", pkg.Name);
-                        statusDescription = string.Format("{0}% Complete:", Math.Round(((double)totalInstalledPkgCount / totalPkgs) * 100), 2);
-                        
-                        var progressRecord = new ProgressRecord(activityId, activity, statusDescription);
-                        _cmdletPassedIn.WriteProgress(progressRecord);
+                        int percentComplete = ((totalInstalledPkgCount * 100) / totalPkgs);
+                        string activity = string.Format("Installing {0}...", pkg.Name);
+                        string statusDescription = string.Format("{0}% Complete", percentComplete);
+                        _cmdletPassedIn.WriteProgress(
+                            new ProgressRecord(activityId, activity, statusDescription));
                     }
 
                     // Create PackageIdentity in order to download

--- a/test/GetInstalledPSResource.Tests.ps1
+++ b/test/GetInstalledPSResource.Tests.ps1
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+$ProgressPreference = "SilentlyContinue"
 Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
 
 Describe 'Test Get-PSResource for Module' {

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -1,13 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+$ProgressPreference = "SilentlyContinue"
 Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
 
 Describe 'Test Install-PSResource for Module' {
 
     BeforeAll {
-        $OldProgressPreference = $ProgressPreference
-        $ProgressPreference = "SilentlyContinue"
         $TestGalleryName = Get-PoshTestGalleryName
         $PSGalleryName = Get-PSGalleryName
         $NuGetGalleryName = Get-NuGetGalleryName
@@ -23,7 +22,6 @@ Describe 'Test Install-PSResource for Module' {
     }
 
     AfterAll {
-        $ProgressPreference = $OldProgressPreference
         Get-RevertPSResourceRepositoryFile
     }
 

--- a/test/SavePSResource.Tests.ps1
+++ b/test/SavePSResource.Tests.ps1
@@ -1,11 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+$ProgressPreference = "SilentlyContinue"
 Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
 
 Describe 'Test Save-PSResource for PSResources' {
 
-    BeforeAll{
+    BeforeAll {
         $TestGalleryName = Get-PoshTestGalleryName
         $PSGalleryName = Get-PSGalleryName
         $NuGetGalleryName = Get-NuGetGalleryName
@@ -52,7 +53,7 @@ Describe 'Test Save-PSResource for PSResources' {
     }
 
     It "Should not save resource given nonexistant name" {
-        Save-PSResource -Name NonExistentModule -Repository $TestGalleryName -Path $SaveDir
+        Save-PSResource -Name NonExistentModule -Repository $TestGalleryName -Path $SaveDir -ErrorAction SilentlyContinue
         $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "NonExistentModule"
         $pkgDir.Name | Should -BeNullOrEmpty
     }
@@ -102,13 +103,13 @@ Describe 'Test Save-PSResource for PSResources' {
     ) {
         param($Version, $Description)
 
-        Save-PSResource -Name $testModuleName2 -Version $Version -Repository $TestGalleryName -Path $SaveDir
+        Save-PSResource -Name $testModuleName2 -Version $Version -Repository $TestGalleryName -Path $SaveDir -ErrorAction SilentlyContinue
         $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName2
         $pkgDir | Should -BeNullOrEmpty
     }
 
     It "Save resource when given Name, Version '*', should install the latest version" {
-        Save-PSResource -Name $testModuleName2 -Version "*" -Repository $TestGalleryName -Path $SaveDir
+        Save-PSResource -Name $testModuleName2 -Version "*" -Repository $TestGalleryName -Path $SaveDir -ErrorAction SilentlyContinue
         $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName2
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName

--- a/test/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResource.Tests.ps1
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+$ProgressPreference = "SilentlyContinue"
 Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
 
 Describe 'Test Uninstall-PSResource for Modules' {
@@ -13,9 +14,11 @@ Describe 'Test Uninstall-PSResource for Modules' {
         Get-NewPSResourceRepositoryFile
         Uninstall-PSResource -name ContosoServer -Version "*"
     }
-    BeforeEach{
+
+    BeforeEach {
         $null = Install-PSResource ContosoServer -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
     }
+
     AfterAll {
         Get-RevertPSResourceRepositoryFile
     }
@@ -36,14 +39,14 @@ Describe 'Test Uninstall-PSResource for Modules' {
     }
 
     It "Uninstall a list of modules by name" {
-        $null = Install-PSResource BaseTestPackage -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
+        $null = Install-PSResource BaseTestPackage -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue -SkipDependencyCheck
 
         Uninstall-PSResource -Name BaseTestPackage, ContosoServer 
         Get-Module ContosoServer, BaseTestPackage -ListAvailable | Should -be $null
     }
 
     It "Uninstall a specific script by name" {
-        $null = Install-PSResource Test-RPC -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue
+        $null = Install-PSResource Test-RPC -Repository $TestGalleryName -TrustRepository -WarningAction SilentlyContinue -SkipDependencyCheck
 
         Uninstall-PSResource -name Test-RPC 
     }

--- a/test/UpdatePSResource.Tests.ps1
+++ b/test/UpdatePSResource.Tests.ps1
@@ -1,12 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+$ProgressPreference = "SilentlyContinue"
 Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
 
 Describe 'Test Update-PSResource' {
 
 
-    BeforeAll{
+    BeforeAll {
         $TestGalleryName = Get-PoshTestGalleryName
         $NuGetGalleryName = Get-NuGetGalleryName
         $testModuleName = "TestModule"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
