### PR TITLE
Rename PSResourceInfo's PrereleaseLabel property to match Prerelease column displayed

### DIFF
--- a/help/Get-PSResource.md
+++ b/help/Get-PSResource.md
@@ -135,7 +135,7 @@ PSResourceInfo : {
     Name
     PackageManagementProvider
     PowerShellGetFormatVersion
-    PrereleaseLabel
+    Prerelease
     ProjectUri
     PublishedDate
     ReleaseNotes

--- a/src/PSGet.Format.ps1xml
+++ b/src/PSGet.Format.ps1xml
@@ -19,7 +19,7 @@
                         <TableColumnItems>
                             <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
                             <TableColumnItem><PropertyName>Version</PropertyName></TableColumnItem>
-                            <TableColumnItem><PropertyName>PrereleaseLabel</PropertyName></TableColumnItem>
+                            <TableColumnItem><PropertyName>Prerelease</PropertyName></TableColumnItem>
                             <TableColumnItem><PropertyName>Repository</PropertyName></TableColumnItem>
                             <TableColumnItem><PropertyName>Description</PropertyName></TableColumnItem>
                         </TableColumnItems>
@@ -53,7 +53,7 @@
             <TableColumnItems>
                 <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
             <TableColumnItem><ScriptBlock>$_.ParentResource.Version</ScriptBlock></TableColumnItem>
-            <TableColumnItem><ScriptBlock>$_.ParentResource.PrereleaseLabel</ScriptBlock></TableColumnItem>
+            <TableColumnItem><ScriptBlock>$_.ParentResource.Prerelease</ScriptBlock></TableColumnItem>
             <TableColumnItem><ScriptBlock>$_.ParentResource.Name</ScriptBlock></TableColumnItem>
             <TableColumnItem><ScriptBlock>$_.ParentResource.Repository</ScriptBlock></TableColumnItem>
             </TableColumnItems>

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -343,7 +343,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     string createFullVersion = pkg.Version.ToString();
                     if (pkg.IsPrerelease)
                     {
-                        createFullVersion = pkg.Version.ToString() + "-" + pkg.PrereleaseLabel;
+                        createFullVersion = pkg.Version.ToString() + "-" + pkg.Prerelease;
                     }
 
                     if (!NuGetVersion.TryParse(createFullVersion, out NuGetVersion pkgVersion))
@@ -433,11 +433,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                     // pkgIdentity.Version.Version gets the version without metadata or release labels.      
                     string newVersion = pkgIdentity.Version.ToNormalizedString();
-                    string normalizedVersionNoPrereleaseLabel = newVersion;
+                    string normalizedVersionNoPrerelease = newVersion;
                     if (pkgIdentity.Version.IsPrerelease)
                     {
                         // eg: 2.0.2
-                        normalizedVersionNoPrereleaseLabel = pkgIdentity.Version.ToNormalizedString().Substring(0, pkgIdentity.Version.ToNormalizedString().IndexOf('-'));
+                        normalizedVersionNoPrerelease = pkgIdentity.Version.ToNormalizedString().Substring(0, pkgIdentity.Version.ToNormalizedString().IndexOf('-'));
                     }
                     
                     string tempDirNameVersion = isLocalRepo ? tempInstallPath : Path.Combine(tempInstallPath, pkgIdentity.Id.ToLower(), newVersion);

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -166,7 +166,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     break;
                     
                 case InputObjectParameterSet:
-                    string normalizedVersionString = Utils.GetNormalizedVersionString(InputObject.Version.ToString(), InputObject.PrereleaseLabel);
+                    string normalizedVersionString = Utils.GetNormalizedVersionString(InputObject.Version.ToString(), InputObject.Prerelease);
                     if (!Utils.TryParseVersionOrVersionRange(normalizedVersionString, out _versionRange))
                     {
                         var exMessage = String.Format("Version '{0}' for resource '{1}' cannot be parsed.", normalizedVersionString, InputObject.Name);

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -247,7 +247,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         public string Name { get; }
         public string PackageManagementProvider { get; }
         public string PowerShellGetFormatVersion { get; }
-        public string PrereleaseLabel { get; }
+        public string Prerelease { get; }
         public Uri ProjectUri { get; }
         public DateTime? PublishedDate { get; }
         public string ReleaseNotes { get; }
@@ -280,7 +280,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             string name,
             string packageManagementProvider,
             string powershellGetFormatVersion,
-            string prereleaseLabel,
+            string prerelease,
             Uri projectUri,
             DateTime? publishedDate,
             string releaseNotes,
@@ -306,7 +306,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             Name = name ?? string.Empty;
             PackageManagementProvider = packageManagementProvider ?? string.Empty;
             PowerShellGetFormatVersion = powershellGetFormatVersion ?? string.Empty;
-            PrereleaseLabel = prereleaseLabel ?? string.Empty;
+            Prerelease = prerelease ?? string.Empty;
             ProjectUri = projectUri;
             PublishedDate = publishedDate;
             ReleaseNotes = releaseNotes ?? string.Empty;
@@ -394,7 +394,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                         filePath));
 
                 var additionalMetadata = GetProperty<Dictionary<string,string>>(nameof(PSResourceInfo.AdditionalMetadata), psObjectInfo);
-                Version version = GetVersionInfo(psObjectInfo, additionalMetadata, out string prereleaseLabel);
+                Version version = GetVersionInfo(psObjectInfo, additionalMetadata, out string prerelease);
 
                 psGetInfo = new PSResourceInfo(
                     additionalMetadata: additionalMetadata,
@@ -412,7 +412,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                     name: GetStringProperty(nameof(PSResourceInfo.Name), psObjectInfo),
                     packageManagementProvider: GetStringProperty(nameof(PSResourceInfo.PackageManagementProvider), psObjectInfo),
                     powershellGetFormatVersion: GetStringProperty(nameof(PSResourceInfo.PowerShellGetFormatVersion), psObjectInfo),
-                    prereleaseLabel: prereleaseLabel,
+                    prerelease: prerelease,
                     projectUri: GetProperty<Uri>(nameof(PSResourceInfo.ProjectUri), psObjectInfo),
                     publishedDate: GetProperty<DateTime>(nameof(PSResourceInfo.PublishedDate), psObjectInfo),
                     releaseNotes: GetStringProperty(nameof(PSResourceInfo.ReleaseNotes), psObjectInfo),
@@ -449,10 +449,10 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         private static Version GetVersionInfo(
             PSObject psObjectInfo,
             Dictionary<string, string> additionalMetadata,
-            out string prereleaseLabel)
+            out string prerelease)
         {
             string versionString = GetProperty<string>(nameof(PSResourceInfo.Version), psObjectInfo);
-            prereleaseLabel = String.Empty;
+            prerelease = String.Empty;
 
             if (!String.IsNullOrEmpty(versionString) ||
                 additionalMetadata.TryGetValue("NormalizedVersion", out versionString))
@@ -472,7 +472,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                         // versionStringParsed.Length > 1 (because string contained '-' so couldn't be 0)
                         // versionString: "1.2.0-alpha1"
                         pkgVersion = versionStringParsed[0];
-                        prereleaseLabel = versionStringParsed[1];
+                        prerelease = versionStringParsed[1];
                     }
                 }
 
@@ -480,7 +480,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 // parse the pkgVersion parsed out above into a System.Version object
                 if (!Version.TryParse(pkgVersion, out Version parsedVersion))
                 {
-                    prereleaseLabel = String.Empty;
+                    prerelease = String.Empty;
                     return null;
                 }
                 else
@@ -491,7 +491,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
             // version could not be parsed as string, it was written to XML file as a System.Version object
             // V3 code briefly did so, I believe so we provide support for it
-            prereleaseLabel = String.Empty;
+            prerelease = String.Empty;
             return GetProperty<Version>(nameof(PSResourceInfo.Version), psObjectInfo);
         }
 
@@ -536,7 +536,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                     name: ParseMetadataName(metadataToParse),
                     packageManagementProvider: null,
                     powershellGetFormatVersion: null,
-                    prereleaseLabel: ParsePrerelease(metadataToParse),
+                    prerelease: ParsePrerelease(metadataToParse),
                     projectUri: ParseMetadataProjectUri(metadataToParse),
                     publishedDate: ParseMetadataPublishedDate(metadataToParse),
                     releaseNotes: null,
@@ -887,7 +887,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         {
             // 1.0.0-alpha1
             // 1.0.0.0
-            string NormalizedVersion = IsPrerelease ? ConcatenateVersionWithPrerelease(Version.ToString(), PrereleaseLabel) : Version.ToString();
+            string NormalizedVersion = IsPrerelease ? ConcatenateVersionWithPrerelease(Version.ToString(), Prerelease) : Version.ToString();
 
             var additionalMetadata = new PSObject();
 

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -183,7 +183,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     break;
 
                 case InputObjectParameterSet:
-                    string normalizedVersionString = Utils.GetNormalizedVersionString(InputObject.Version.ToString(), InputObject.PrereleaseLabel);
+                    string normalizedVersionString = Utils.GetNormalizedVersionString(InputObject.Version.ToString(), InputObject.Prerelease);
                     if (!Utils.TryParseVersionOrVersionRange(normalizedVersionString, out _versionRange))
                     {
                         var exMessage = String.Format("Version '{0}' for resource '{1}' cannot be parsed.", normalizedVersionString, InputObject.Name);

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -113,8 +113,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     break;
 
                 case InputObjectParameterSet:
-                    string inputObjectPrereleaseLabel = InputObject.PrereleaseLabel;
-                    string inputObjectVersion = String.IsNullOrEmpty(inputObjectPrereleaseLabel) ? InputObject.Version.ToString() : Utils.GetNormalizedVersionString(versionString: InputObject.Version.ToString(), prerelease: inputObjectPrereleaseLabel);
+                    string inputObjectPrerelease = InputObject.Prerelease;
+                    string inputObjectVersion = String.IsNullOrEmpty(inputObjectPrerelease) ? InputObject.Version.ToString() : Utils.GetNormalizedVersionString(versionString: InputObject.Version.ToString(), prerelease: inputObjectPrerelease);
                     if (!Utils.TryParseVersionOrVersionRange(
                         version: inputObjectVersion,
                         versionRange: out _versionRange))

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -207,10 +207,10 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             }
 
             string version = psGetInfo.Version.ToString();
-            string prereleaseLabel = psGetInfo.PrereleaseLabel;
+            string prerelease = psGetInfo.Prerelease;
 
             if (!NuGetVersion.TryParse(
-                    value: String.IsNullOrEmpty(prereleaseLabel) ? version : GetNormalizedVersionString(version, prereleaseLabel),
+                    value: String.IsNullOrEmpty(prerelease) ? version : GetNormalizedVersionString(version, prerelease),
                     version: out pkgNuGetVersion))
             {
                 cmdletPassedIn.WriteVerbose(String.Format("Leaf directory in path '{0}' cannot be parsed into a version.", installedPkgPath));

--- a/test/FindPSResource.Tests.ps1
+++ b/test/FindPSResource.Tests.ps1
@@ -215,7 +215,7 @@ Describe 'Test Find-PSResource for Module' {
 
         $resPrerelease = Find-PSResource -Name $testModuleName -Prerelease -Repository $TestGalleryName
         $resPrerelease.Version | Should -Be "5.2.5.0"
-        $resPrerelease.PrereleaseLabel | Should -Be "alpha001"
+        $resPrerelease.Prerelease | Should -Be "alpha001"
     }
 
     It "find resources, including Prerelease version resources, when given Prerelease parameter" {

--- a/test/GetInstalledPSResource.Tests.ps1
+++ b/test/GetInstalledPSResource.Tests.ps1
@@ -117,7 +117,7 @@ $testCases =
         $res = Get-PSResource -Name $testModuleName -Version "5.2.5-alpha001"
         $res.Name | Should -Be $testModuleName
         $res.Version | Should -Be "5.2.5"
-        $res.PrereleaseLabel | Should -Be "alpha001"
+        $res.Prerelease | Should -Be "alpha001"
     }
 
     It "Get prerelease version script when version with correct prerelease label is specified" {
@@ -127,6 +127,6 @@ $testCases =
         $res = Get-PSResource -Name $testScriptName -Version "3.0.0-alpha001"
         $res.Name | Should -Be $testScriptName
         $res.Version | Should -Be "3.0.0"
-        $res.PrereleaseLabel | Should -Be "alpha001"
+        $res.Prerelease | Should -Be "alpha001"
     }
 }

--- a/test/PSGetTestUtils.psm1
+++ b/test/PSGetTestUtils.psm1
@@ -555,7 +555,7 @@ function CheckForExpectedPSGetInfo
     $psGetInfo.Description | Should -BeLike 'This module provides a convenient way for a user to store*'
     $psGetInfo.IconUri | Should -BeNullOrEmpty
     $psGetInfo.IsPrerelease | Should -Be $True
-    $psGetInfo.PrereleaseLabel | Should -Be "preview2"
+    $psGetInfo.Prerelease | Should -Be "preview2"
     $psGetInfo.Includes.Cmdlet | Should -HaveCount 10
     $psGetInfo.Includes.Cmdlet[0] | Should -BeExactly 'Register-SecretVault'
     $psGetInfo.InstalledDate.Year | Should -BeExactly 2021

--- a/test/UpdatePSResource.Tests.ps1
+++ b/test/UpdatePSResource.Tests.ps1
@@ -147,7 +147,7 @@ Describe 'Test Update-PSResource' {
         {
             if ([System.Version]$pkg.Version -gt [System.Version]"1.0.2.0")
             {
-                $pkg.PrereleaseLabel | Should -Be "alpha1"
+                $pkg.Prerelease | Should -Be "alpha1"
                 $isPkgUpdated = $true
             }
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When PSResourceInfo object is returned and displayed, the formatter displayes the "PrereleaseLabel" property to "Prerelease". So users who may try to filter or sort by Prerelease property won't find it intuitive. We should change the property name to be consistent and clear.

## PR Context

Resolves #578 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
