### PR TITLE
Implement RequiredResourceFile and RequiredResource parameters

### DIFF
--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
+using Microsoft.PowerShell.Commands;
 
 using Dbg = System.Diagnostics.Debug;
 
@@ -271,8 +272,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     Hashtable pkgsInJsonFile = null;
                     try
                     {
-                        pkgsInJsonFile = JsonConvert.DeserializeObject<Hashtable>(requiredResourceFileStream, new JsonSerializerSettings { MaxDepth = 6 });
-
+                        pkgsInJsonFile = Utils.ConvertJsonToHashtable(this, requiredResourceFileStream);
                     }
                     catch (Exception)
                     {
@@ -303,7 +303,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         Hashtable pkgsHash = null;
                         try
                         {
-                            pkgsHash = JsonConvert.DeserializeObject<Hashtable>(_requiredResourceJson, new JsonSerializerSettings { MaxDepth = 6 });
+                            pkgsHash = Utils.ConvertJsonToHashtable(this, _requiredResourceJson);
                         }
                         catch (Exception)
                         {
@@ -353,21 +353,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 var pkgParamInfo = reqResourceHash[pkgName];
 
-                // Input format was json, and not a hashtable
+                // Format should now be a hashtable, whether the original input format was json or hashtable
                 if (!(pkgParamInfo is Hashtable pkgInstallInfo))
-                {
-                    pkgInstallInfo = new Hashtable { };
-
-                    // Input format was JSON
-                    var pkgParamJTokens = pkgParamInfo as Newtonsoft.Json.Linq.JToken;
-                    foreach (Newtonsoft.Json.Linq.JProperty val in pkgParamJTokens)
-                    {
-                        pkgInstallInfo[val.Name] = val.Value.ToString();
-                    }
-                }
-                // Otherwise, the input format is a hashtable
-
-                if (pkgInstallInfo == null)
                 {
                     return;
                 }

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -2,9 +2,12 @@
 // Licensed under the MIT License.
 
 using Microsoft.PowerShell.PowerShellGet.UtilClasses;
+using Newtonsoft.Json;
 using NuGet.Versioning;
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Management.Automation;
 
@@ -113,6 +116,62 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         [ValidateNotNullOrEmpty]
         public PSResourceInfo InputObject { get; set; }
 
+        /// <summary>
+        /// Installs resources based on input from a JSON file.
+        /// </summary>
+        [Parameter(ParameterSetName = RequiredResourceFileParameterSet)]
+        [ValidateNotNullOrEmpty]
+        public String RequiredResourceFile
+        {
+            get {
+                return _requiredResourceFile;
+            }
+            set
+            {
+                string resolvedPath = string.Empty;
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
+                }
+
+                if (!File.Exists(resolvedPath))
+                {
+                    var exMessage = String.Format("The RequiredResourceFile does not exist.  Please try specifying a path to a valid .json or .psd1 file");
+                    var ex = new ArgumentException(exMessage);
+                    var RequiredResourceFileDoesNotExist = new ErrorRecord(ex, "RequiredResourceFileDoesNotExist", ErrorCategory.ObjectNotFound, null);
+
+                    ThrowTerminatingError(RequiredResourceFileDoesNotExist);
+                }
+
+                _requiredResourceFile = resolvedPath;
+            }
+        }
+
+        /// <summary>
+        ///  Installs resources in a hashtable or JSON string format.
+        /// </summary>
+        [Parameter(ParameterSetName = RequiredResourceParameterSet)]
+        public Object RequiredResource  // takes either string (json) or hashtable
+        {
+            get { return _requiredResourceHash != null ? (Object)_requiredResourceHash : (Object)_requiredResourceJson; }
+
+            set
+            {
+                if (value.GetType().Name.Equals("String"))
+                {
+                    _requiredResourceJson = (String)value;
+                }
+                else if (value.GetType().Name.Equals("Hashtable"))
+                {
+                    _requiredResourceHash = (Hashtable)value;
+                }
+                else
+                {
+                    throw new ParameterBindingException("Object is not a JSON or Hashtable");
+                }
+            }
+        }
+
         #endregion
 
         #region Members
@@ -122,6 +181,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         private const string RequiredResourceFileParameterSet = "RequiredResourceFileParameterSet";
         private const string RequiredResourceParameterSet = "RequiredResourceParameterSet";
         List<string> _pathsToInstallPkg;
+        private string _requiredResourceFile;
+        private string _requiredResourceJson;
+        private Hashtable _requiredResourceHash;
         VersionRange _versionRange;
         InstallHelper _installHelper;
 
@@ -161,8 +223,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                     ProcessInstallHelper(
                         pkgNames: Name,
+                        pkgVersion: _versionRange,
                         pkgPrerelease: Prerelease,
-                        pkgRepository: Repository);
+                        pkgRepository: Repository,
+                        pkgCredential: Credential,
+                        reqResourceParams: null);
                     break;
                     
                 case InputObjectParameterSet:
@@ -177,24 +242,98 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                     ProcessInstallHelper(
                         pkgNames: new string[] { InputObject.Name },
+                        pkgVersion: _versionRange,
                         pkgPrerelease: InputObject.IsPrerelease,
-                        pkgRepository: new string[]{ InputObject.Repository });
+                        pkgRepository: new string[]{ InputObject.Repository },
+                        pkgCredential: Credential,
+                        reqResourceParams: null);
                     break;
 
                 case RequiredResourceFileParameterSet:
-                    ThrowTerminatingError(new ErrorRecord(
-                                           new PSNotImplementedException("RequiredResourceFileParameterSet is not yet implemented. Please rerun cmdlet with other parameter set."),
-                                           "CommandParameterSetNotImplementedYet",
-                                           ErrorCategory.NotImplemented,
-                                           this));
+                    /* json file contents should look like:
+                       {
+                          "Pester": {
+                            "allowPrerelease": true,
+                            "version": "[4.4.2,4.7.0]",
+                            "repository": "PSGallery",
+                            "credential": null
+                          }
+                        }
+                    */
+                    
+                    string requiredResourceFileStream = string.Empty;
+                    using (StreamReader sr = new StreamReader(_requiredResourceFile))
+                    {
+                        requiredResourceFileStream = sr.ReadToEnd();
+                    }
+                    
+                    Hashtable pkgsInJsonFile = null;
+                    try
+                    {
+                        pkgsInJsonFile = JsonConvert.DeserializeObject<Hashtable>(requiredResourceFileStream, new JsonSerializerSettings { MaxDepth = 6 });
+
+                    }
+                    catch (Exception e)
+                    {
+                        var exMessage = String.Format("Argument for parameter -RequiredResourceFile is not in proper json format.  Make sure argument is either a valid json file.");
+                        var ex = new ArgumentException(exMessage);
+                        var RequiredResourceFileNotInProperJsonFormat = new ErrorRecord(ex, "RequiredResourceFileNotInProperJsonFormat", ErrorCategory.InvalidData, null);
+
+                        ThrowTerminatingError(RequiredResourceFileNotInProperJsonFormat);
+                    }
+                    
+                    RequiredResourceHelper(pkgsInJsonFile);
                     break;
 
                 case RequiredResourceParameterSet:
-                    ThrowTerminatingError(new ErrorRecord(
-                                           new PSNotImplementedException("RequiredResourceParameterSet is not yet implemented. Please rerun cmdlet with other parameter set."),
-                                           "CommandParameterSetNotImplementedYet",
-                                           ErrorCategory.NotImplemented,
-                                           this));
+                    if (!string.IsNullOrWhiteSpace(_requiredResourceJson))
+                    {
+                        /* json would look like:
+                           {
+                              "Pester": {
+                                "allowPrerelease": true,
+                                "version": "[4.4.2,4.7.0]",
+                                "repository": "PSGallery",
+                                "credential": null
+                              }
+                            }
+                        */
+                                              
+                        Hashtable pkgsInJson = null;
+                        try
+                        {
+                            //pkgsInJson = JsonConvert.DeserializeObject<Dictionary<string, InstallPkgParams>>(_requiredResourceJson, new JsonSerializerSettings { MaxDepth = 6 });
+                            pkgsInJson = JsonConvert.DeserializeObject<Hashtable>(_requiredResourceJson, new JsonSerializerSettings { MaxDepth = 6 });
+
+                        }
+                        catch (Exception e)
+                        {
+                            var exMessage = String.Format("Argument for parameter -RequiredResource is not in proper json format.  Make sure argument is either a valid json file.");
+                            var ex = new ArgumentException(exMessage);
+                            var RequiredResourceFileNotInProperJsonFormat = new ErrorRecord(ex, "RequiredResourceFileNotInProperJsonFormat", ErrorCategory.InvalidData, null);
+
+                            ThrowTerminatingError(RequiredResourceFileNotInProperJsonFormat);
+                        }
+
+                        RequiredResourceHelper(pkgsInJson);
+                    }
+
+                    if (_requiredResourceHash != null)
+                    {
+                        /* hashtable would look like:
+                            @{
+                                "Configuration" =  @{ version = "[4.4.2,4.7.0]" }
+                                "Pester" = @{
+                                    version = "[4.4.2,4.7.0]"
+                                    repository = PSGallery
+                                    credential = $cred
+                                    prerelease = $true
+                                  }
+                            }
+                        */
+
+                        RequiredResourceHelper(_requiredResourceHash);
+                    }
                     break;
 
                 default:
@@ -202,12 +341,91 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     break;
             }
         }
-        
+
         #endregion
 
         #region Methods
 
-        private void ProcessInstallHelper(string[] pkgNames, bool pkgPrerelease, string[] pkgRepository)
+        private void RequiredResourceHelper(Hashtable reqResourceHash)
+        {
+            var pkgNames = reqResourceHash.Keys;
+
+            foreach (string pkgName in pkgNames)
+            {
+                var pkgParamInfo = reqResourceHash[pkgName];
+                Hashtable pkgInstallInfo = new Hashtable { };
+
+                if (pkgParamInfo is Hashtable)
+                {
+                    // Input format was Hashtable
+                    pkgInstallInfo = pkgParamInfo as Hashtable;
+                }
+                else
+                {
+                    // Input format was JSON
+                    var pkgParamJTokens = pkgParamInfo as Newtonsoft.Json.Linq.JToken;
+                    foreach (Newtonsoft.Json.Linq.JProperty val in pkgParamJTokens)
+                    {
+                        pkgInstallInfo[val.Name] = val.Value.ToString();
+                    }
+                }
+
+                if (pkgInstallInfo == null)
+                {
+                    return;
+                }
+
+                InstallPkgParams pkgParams = new InstallPkgParams();
+                var pkgParamNames = pkgInstallInfo.Keys;
+
+                PSCredential pkgCredential = Credential;
+                foreach (string paramName in pkgParamNames)
+                {
+                    if (string.Equals(paramName, "credential", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        WriteVerbose("Credential specified for required resource");
+                        pkgCredential = pkgInstallInfo[paramName] as PSCredential;
+                    }
+
+                    pkgParams.SetProperty(paramName, pkgInstallInfo[paramName] as string, out ErrorRecord IncorrectVersionFormat);
+
+                    if (IncorrectVersionFormat != null)
+                    {
+                        ThrowTerminatingError(IncorrectVersionFormat);
+                    }
+                }
+                    
+                if (pkgParams.Scope == ScopeType.AllUsers)
+                {
+                    _pathsToInstallPkg = Utils.GetAllInstallationPaths(this, pkgParams.Scope);
+                }
+
+                VersionRange pkgVersion;
+                // If no Version specified, install latest version for the package.
+                // Otherwise validate Version can be parsed out successfully.
+                if (pkgInstallInfo["version"] == null || string.IsNullOrWhiteSpace(pkgInstallInfo["version"].ToString()))
+                {
+                    pkgVersion = VersionRange.All;
+                }
+                else if (!Utils.TryParseVersionOrVersionRange(pkgInstallInfo["version"].ToString(), out pkgVersion))
+                {
+                    var exMessage = "Argument for Version parameter is not in the proper format.";
+                    var ex = new ArgumentException(exMessage);
+                    var IncorrectVersionFormat = new ErrorRecord(ex, "IncorrectVersionFormat", ErrorCategory.InvalidArgument, null);
+                    ThrowTerminatingError(IncorrectVersionFormat);
+                }
+
+                ProcessInstallHelper(
+                    pkgNames: new string[] { pkgName },
+                    pkgVersion: pkgVersion,
+                    pkgPrerelease: pkgParams.Prerelease,
+                    pkgRepository: new string[] { pkgParams.Repository },
+                    pkgCredential: pkgCredential,
+                    reqResourceParams: pkgParams);
+            }
+        }
+
+        private void ProcessInstallHelper(string[] pkgNames, VersionRange pkgVersion, bool pkgPrerelease, string[] pkgRepository, PSCredential pkgCredential, InstallPkgParams reqResourceParams)
         {
             var inputNameToInstall = Utils.ProcessNameWildcards(pkgNames, out string[] errorMsgs, out bool nameContainsWildcard);
             if (nameContainsWildcard)
@@ -244,7 +462,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             var installedPkgs = _installHelper.InstallPackages(
                 names: pkgNames,
-                versionRange: _versionRange,
+                versionRange: pkgVersion,
                 prerelease: pkgPrerelease,
                 repository: pkgRepository,
                 acceptLicense: AcceptLicense,
@@ -253,7 +471,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 force: false,
                 trustRepository: TrustRepository,
                 noClobber: NoClobber,
-                credential: Credential,
+                credential: pkgCredential,
                 asNupkg: false,
                 includeXML: true,
                 skipDependencyCheck: SkipDependencyCheck,

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -273,7 +273,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         pkgsInJsonFile = JsonConvert.DeserializeObject<Hashtable>(requiredResourceFileStream, new JsonSerializerSettings { MaxDepth = 6 });
 
                     }
-                    catch (Exception e)
+                    catch (Exception)
                     {
                         var exMessage = String.Format("Argument for parameter -RequiredResourceFile is not in proper json format.  Make sure argument is either a valid json file.");
                         var ex = new ArgumentException(exMessage);
@@ -306,7 +306,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                             pkgsInJson = JsonConvert.DeserializeObject<Hashtable>(_requiredResourceJson, new JsonSerializerSettings { MaxDepth = 6 });
 
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             var exMessage = String.Format("Argument for parameter -RequiredResource is not in proper json format.  Make sure argument is either a valid json file.");
                             var ex = new ArgumentException(exMessage);

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -123,7 +123,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         [ValidateNotNullOrEmpty]
         public String RequiredResourceFile
         {
-            get {
+            get
+            {
                 return _requiredResourceFile;
             }
             set

--- a/src/code/InstallPkgParams.cs
+++ b/src/code/InstallPkgParams.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using Microsoft.PowerShell.PowerShellGet.UtilClasses;
 using NuGet.Versioning;
 using System;

--- a/src/code/InstallPkgParams.cs
+++ b/src/code/InstallPkgParams.cs
@@ -1,0 +1,97 @@
+using Microsoft.PowerShell.PowerShellGet.UtilClasses;
+using NuGet.Versioning;
+using System;
+using System.Collections;
+using System.Management.Automation;
+
+public class InstallPkgParams
+{
+    public string Name { get; set; }
+    public VersionRange Version { get; set; }
+    public string Repository { get; set; }
+    public bool AcceptLicense { get; set; } 
+    public bool Prerelease { get; set; }
+    public ScopeType Scope { get; set; }
+    public bool Quiet { get; set; }
+    public bool Reinstall { get; set; }
+    public bool Force { get; set; }
+    public bool TrustRepository { get; set; }
+    public bool NoClobber { get; set; }
+	public bool SkipDependencyCheck { get; set; }
+
+
+    #region Private methods
+
+    public void SetProperty(string propertyName, string propertyValue, out ErrorRecord IncorrectVersionFormat)
+    {
+        IncorrectVersionFormat = null;
+        switch (propertyName.ToLower())
+        {
+            case "name":
+                Name = propertyValue.Trim();
+                break;
+
+            case "version":
+                // If no Version specified, install latest version for the package.
+                // Otherwise validate Version can be parsed out successfully.
+                VersionRange versionTmp = VersionRange.None;
+                if (string.IsNullOrWhiteSpace(propertyValue))
+                {
+                    Version = VersionRange.All;
+                }
+                else if (!Utils.TryParseVersionOrVersionRange(propertyValue, out versionTmp))
+                {
+                    var exMessage = "Argument for Version parameter is not in the proper format.";
+                    var ex = new ArgumentException(exMessage);
+                    IncorrectVersionFormat = new ErrorRecord(ex, "IncorrectVersionFormat", ErrorCategory.InvalidArgument, null);
+                }
+                Version = versionTmp;
+                break;
+
+            case "repository":
+                Repository = propertyValue.Trim();
+                break;
+
+            case "acceptlicense":
+                bool.TryParse(propertyValue, out bool acceptLicenseTmp);
+                AcceptLicense = acceptLicenseTmp;
+                break;
+
+            case "prerelease":
+                bool.TryParse(propertyValue, out bool prereleaseTmp);
+                Prerelease = prereleaseTmp;
+                break;
+
+            case "scope":
+                ScopeType scope = (ScopeType)Enum.Parse(typeof(ScopeType), propertyValue, ignoreCase: true);
+                Scope = scope;
+                break;
+
+            case "quiet":
+                bool.TryParse(propertyValue, out bool quietTmp);
+                Quiet = quietTmp;
+                break;
+
+            case "reinstall":
+                bool.TryParse(propertyValue, out bool reinstallTmp);
+                Reinstall = reinstallTmp;
+                break;
+
+            case "trustrepository":
+                bool.TryParse(propertyValue, out bool trustRepositoryTmp);
+                TrustRepository = trustRepositoryTmp;
+                break;
+
+            case "noclobber":
+                bool.TryParse(propertyValue, out bool noClobberTmp);
+                NoClobber = noClobberTmp;
+                break;
+
+            case "skipdependencycheck":
+                bool.TryParse(propertyValue, out bool skipDependencyCheckTmp);
+                SkipDependencyCheck = skipDependencyCheckTmp;
+                break;
+        }
+    }
+    #endregion
+}

--- a/src/code/InstallPkgParams.cs
+++ b/src/code/InstallPkgParams.cs
@@ -20,7 +20,7 @@ public class InstallPkgParams
     public bool Force { get; set; }
     public bool TrustRepository { get; set; }
     public bool NoClobber { get; set; }
-public bool SkipDependencyCheck { get; set; }
+    public bool SkipDependencyCheck { get; set; }
 
 
 
@@ -94,6 +94,10 @@ public bool SkipDependencyCheck { get; set; }
             case "skipdependencycheck":
                 bool.TryParse(propertyValue, out bool skipDependencyCheckTmp);
                 SkipDependencyCheck = skipDependencyCheckTmp;
+                break;
+
+            default:
+                // write error
                 break;
         }
     }

--- a/src/code/InstallPkgParams.cs
+++ b/src/code/InstallPkgParams.cs
@@ -20,7 +20,8 @@ public class InstallPkgParams
     public bool Force { get; set; }
     public bool TrustRepository { get; set; }
     public bool NoClobber { get; set; }
-	public bool SkipDependencyCheck { get; set; }
+public bool SkipDependencyCheck { get; set; }
+
 
 
     #region Private methods

--- a/test/TestRequiredResourceFile.json
+++ b/test/TestRequiredResourceFile.json
@@ -1,0 +1,13 @@
+{
+  "TestModule": {
+    "version": "[0.0.1,1.3.0)",
+    "repository": "PoshTestGallery"
+  },
+  "TestModulePrerelease": {
+    "version": "[0.0.0,0.0.5]",
+    "repository": "PoshTestGallery",
+    "prerelease": "true"
+  },
+  "TestModule99": {
+  }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This is the implementation for the -RequiredResourceFile and -RequiredResource parameters as specified in the [RFC](https://github.com/PowerShell/PowerShell-RFC/blob/17ecbf7c091dca0c00bad7eb5054491d9d5a0639/2-Draft-Accepted/RFCxxxx-PowerShellGet-3.0.md#dependencies-and-version-management).

One note here:  the RFC specifies that -RequiredResourceFile take in a .psd1.  This is not implemented yet as the specs defining what exactly should be done here is not yet complete.  The idea behind accepting a .psd1 file is to mimic the behavior of [PSDepend](https://www.powershellgallery.com/packages/PSDepend/0.3.2).  Again, because there's still a lot of unknowns here, I've chosen to leave that out of this PR.   

## PR Context

This resolves issues https://github.com/PowerShell/PowerShellGet/issues/515, https://github.com/PowerShell/PowerShellGet/issues/275, and https://github.com/PowerShell/PowerShellGet/issues/146.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
