### PR TITLE
Update release build images

### DIFF
--- a/.ci/ci_auto.yml
+++ b/.ci/ci_auto.yml
@@ -32,7 +32,7 @@ stages:
     pool:
       name: 1ES
       demands:
-      - ImageOverride -equals MMS2019
+      - ImageOverride -equals PSMMS2019-Secure
 
     steps:
 
@@ -275,7 +275,7 @@ stages:
     pool:
       name: 1ES
       demands:
-      - ImageOverride -equals MMS2019
+      - ImageOverride -equals PSMMS2019-Secure
 
     steps:
     - checkout: self

--- a/.ci/ci_release.yml
+++ b/.ci/ci_release.yml
@@ -21,7 +21,7 @@ stages:
     pool:
       name: 1ES
       demands:
-      - ImageOverride -equals MMS2019
+      - ImageOverride -equals PSMMS2019-Secure
 
     steps:
 
@@ -281,7 +281,7 @@ stages:
     pool:
       name: 1ES
       demands:
-      - ImageOverride -equals MMS2019
+      - ImageOverride -equals PSMMS2019-Secure
 
     steps:
     - checkout: self

--- a/.ci/release.yml
+++ b/.ci/release.yml
@@ -7,7 +7,7 @@ jobs:
   pool:
     name: 1ES
     demands:
-    - ImageOverride -equals MMS2019
+    - ImageOverride -equals PSMMS2019-Secure
   displayName: ${{ parameters.displayName }}
 
   steps:

--- a/doBuild.ps1
+++ b/doBuild.ps1
@@ -50,10 +50,28 @@ function DoBuild
         # Build code and place it in the staging location
         Push-Location "${SrcPath}/code"
         try {
+            # Get dotnet.exe command path.
+            $dotnetCommand = Get-Command -Name 'dotnet' -ErrorAction Ignore
+
+            # Check for dotnet for Windows (we only build on Windows platforms).
+            if ($null -eq $dotnetCommand) {
+                Write-Verbose -Verbose -Message "dotnet.exe cannot be found in current path. Looking in ProgramFiles path."
+                $dotnetCommandPath = Join-Path -Path $env:ProgramFiles -ChildPath "dotnet\dotnet.exe"
+                $dotnetCommand = Get-Command -Name $dotnetCommandPath -ErrorAction Ignore
+                if ($null -eq $dotnetCommand) {
+                    throw "Dotnet.exe cannot be found: $dotnetCommandPath is unavailable for build."
+                }
+            }
+
+            Write-Verbose -Verbose -Message "dotnet.exe command found in path: $($dotnetCommand.Path)"
+
+            # Check dotnet version
+            Write-Verbose -Verbose -Message "DotNet version: $(& ($dotnetCommand) --version)"
+
             # Build source
             Write-Verbose -Verbose -Message "Building with configuration: $BuildConfiguration, framework: $BuildFramework"
             Write-Verbose -Verbose -Message "Build location: PSScriptRoot: $PSScriptRoot, PWD: $pwd"
-            dotnet publish --configuration $BuildConfiguration --framework $BuildFramework --output $BuildSrcPath -warnaserror
+            & ($dotnetCommand) publish --configuration $BuildConfiguration --framework $BuildFramework --output $BuildSrcPath -warnaserror
             if ($LASTEXITCODE -ne 0) {
                 throw "Build failed with exit code: $LASTEXITCODE"
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update release build images.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
