### PR TITLE
WIP: Add -Proxy and -ProxyCredential params to all cmdlets with network connection

### DIFF
--- a/help/Find-PSResource.md
+++ b/help/Find-PSResource.md
@@ -14,31 +14,31 @@ Searches for packages from a repository (local or remote), based on `-Name` and 
 
 ### ResourceNameParameterSet (Default)
 ``` PowerShell
-[[-Name] <string[]>] [-Type <Microsoft.PowerShell.PowerShellGet.UtilClasses.ResourceType[]>] [-Version <string>] [-Prerelease] [-Tag <string[]>] [-Repository <string[]>] [-Credential <pscredential>] [-IncludeDependencies] [-WhatIf] [-Confirm] [<CommonParameters>]
+[[-Name] <string[]>] [-Type <Microsoft.PowerShell.PowerShellGet.UtilClasses.ResourceType[]>] [-Version <string>] [-Prerelease] [-Tag <string[]>] [-Repository <string[]>] [-Credential <pscredential>] [-IncludeDependencies] [-Proxy <string>] [-ProxyCredential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### CommandNameParameterSet
 ``` PowerShell
 [[-CommandName] <string[]>] [-ModuleName <string[]>] [-Version <string>] [-Prerelease] [-Tag <string[]>]
-[-Repository <string[]>] [-Credential <pscredential>] [-IncludeDependencies] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-Repository <string[]>] [-Credential <pscredential>] [-IncludeDependencies] [-Proxy <string>] [-ProxyCredential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### DscResourceNameParameterSet
 ``` PowerShell
 [[-DscResourceName] <string[]>] [-ModuleName <string[]>] [-Version <string>] [-Prerelease] [-Tag <string[]>]
-[-Repository <string[]>] [-Credential <pscredential>] [-IncludeDependencies] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-Repository <string[]>] [-Credential <pscredential>] [-IncludeDependencies] [-Proxy <string>] [-ProxyCredential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TagParameterSet
 ``` PowerShell
 [[-Name <string>][-Tag <string[]>] [-Prerelease]
-[-Repository <string[]>] [-Credential <pscredential>] [-IncludeDependencies] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-Repository <string[]>] [-Credential <pscredential>] [-IncludeDependencies] [-Proxy <string>] [-ProxyCredential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### TypeParameterSet
 ``` PowerShell
 [[Name <string>] [-Prerelease]  [-Type <Microsoft.PowerShell.PowerShellGet.UtilClasses.ResourceType[]>]
-[-Repository <string[]>] [-Credential <pscredential>] [-IncludeDependencies] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-Repository <string[]>] [-Credential <pscredential>] [-IncludeDependencies] [-Proxy <string>] [-ProxyCredential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -261,6 +261,36 @@ the version range.
 
 ```yaml
 Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Proxy
+Specifies a proxy server for the request, rather than a direct connection to the internet resource.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProxyCredential
+Specifies a user account that has permission to use the proxy server that is specified by the Proxy parameter.
+
+```yaml
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases:
 

--- a/help/Install-PSResource.md
+++ b/help/Install-PSResource.md
@@ -16,13 +16,13 @@ Installs resources (modules and scripts) from a registered repository onto the m
 ```
 Install-PSResource [-Name] <String[]> [-Version <String>] [-Prerelease]
  [-Repository <String[]>] [-Credential <PSCredential>] [-Scope <ScopeType>] [-TrustRepository]
- [-Reinstall] [-Quiet] [-AcceptLicense] [-NoClobber] [-SkipDependencyCheck] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Reinstall] [-Quiet] [-AcceptLicense] [-NoClobber] [-SkipDependencyCheck] [-PassThru] [-Proxy <string>] [-ProxyCredential <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### InputObjectParameterSet
 ```
 Install-PSResource [-InputObject <PSResourceInfo>] [-Credential <PSCredential>] [-Scope <ScopeType>] [-TrustRepository]
- [-Reinstall] [-Quiet] [-AcceptLicense] [-NoClobber] [-SkipDependencyCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Reinstall] [-Quiet] [-AcceptLicense] [-NoClobber] [-SkipDependencyCheck] [-Proxy <String>] [-ProxyCredential <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -275,6 +275,36 @@ Used for pipeline input.
 Type: Microsoft.PowerShell.PowerShellGet.UtilClasses.PSResourceInfo
 Parameter Sets: (All)
 Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Proxy
+Specifies a proxy server for the request, rather than a direct connection to the internet resource.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProxyCredential
+Specifies a user account that has permission to use the proxy server that is specified by the Proxy parameter.
+
+```yaml
+Type: System.Management.Automation.PSCredential
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/help/Publish-PSResource.md
+++ b/help/Publish-PSResource.md
@@ -14,7 +14,7 @@ Publishes a specified module from the local computer to PSResource repository.
 
 ```
 Publish-PSResource [-APIKey <String>] [-Repository <String>] [-Path] <String> [-DestinationPath] <String>
- [-Credential <PSCredential>] [-SkipDependenciesCheck]
+ [-Credential <PSCredential>] [-SkipDependenciesCheck] [-Proxy <String>] [-ProxyCredential <PSCredential>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -121,6 +121,36 @@ Bypasses the default check that all dependencies are present on the repository w
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Proxy
+Specifies a proxy server for the request, rather than a direct connection to the internet resource.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProxyCredential
+Specifies a user account that has permission to use the proxy server that is specified by the Proxy parameter.
+
+```yaml
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases:
 

--- a/help/Save-PSResource.md
+++ b/help/Save-PSResource.md
@@ -15,13 +15,13 @@ Saves resources (modules and scripts) from a registered repository onto the mach
 ### NameParameterSet
 ```
 Save-PSResource [-Name] <String[]> [-Version <String>] [-Prerelease] [-Repository <String[]>]
- [-Credential <PSCredential>] [-AsNupkg] [-IncludeXML] [-Path <String>] [-TrustRepository] [-SkipDependencyCheck] [-PassThru] [-Quiet] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Credential <PSCredential>] [-AsNupkg] [-IncludeXML] [-Path <String>] [-TrustRepository] [-SkipDependencyCheck] [-PassThru] [-Proxy <String>] [-ProxyCredential <PSCredential>] [-Quiet] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### InputObjectParameterSet
 ```
 Save-PSResource [-InputObject] <PSResourceInfo> [-Credential <PSCredential>] [-AsNupkg]
- [-IncludeXML] [-Path <String>] [-TrustRepository] [-SkipDependencyCheck] [-PassThru] [-Quiet] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-IncludeXML] [-Path <String>] [-TrustRepository] [-SkipDependencyCheck] [-PassThru] [-Proxy <String>] [-ProxyCredential <PSCredential>] [-Quiet] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -252,6 +252,36 @@ Used for pipeline input.
 Type: Microsoft.PowerShell.PowerShellGet.UtilClasses.PSResourceInfo
 Parameter Sets: (All)
 Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Proxy
+Specifies a proxy server for the request, rather than a direct connection to the internet resource.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProxyCredential
+Specifies a user account that has permission to use the proxy server that is specified by the Proxy parameter.
+
+```yaml
+Type: System.Management.Automation.PSCredential
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/help/Update-PSResource.md
+++ b/help/Update-PSResource.md
@@ -15,7 +15,7 @@ Updates a package already installed on the user's machine.
 ### NameParameterSet (Default)
 ```
 Update-PSResource [-Name] <String[]> [-Version <String>] [-Prerelease] [-Repository <String[]>]
- [-Scope <Microsoft.PowerShell.PowerShellGet.UtilClasses.ScopeType>] [-TrustRepository] [-Credential <PSCredential>] [-Quiet] [-AcceptLicense] [-Force] [-PassThru] [-SkipDependencyCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Scope <Microsoft.PowerShell.PowerShellGet.UtilClasses.ScopeType>] [-TrustRepository] [-Credential <PSCredential>] [-Quiet] [-AcceptLicense] [-Force] [-PassThru] [-SkipDependencyCheck] [-Proxy <String>] [-ProxyCredential <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -227,6 +227,36 @@ Skips the check for resource dependencies, so that only found resources are upda
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Proxy
+Specifies a proxy server for the request, rather than a direct connection to the internet resource.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProxyCredential
+Specifies a user account that has permission to use the proxy server that is specified by the Proxy parameter.
+
+```yaml
+Type: System.Management.Automation.PSCredential
 Parameter Sets: (All)
 Aliases:
 

--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -91,19 +91,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         public PSCredentialInfo CredentialInfo { get; set; }
 
         /// <summary>
-        /// Specifies a proxy server for the request, rather than a direct connection to the internet resource.
-        /// </summary>
-        [Parameter]
-        [ValidateNotNullOrEmpty]
-        public Uri Proxy { get; set; }
-
-        /// <summary>
-        /// Specifies a user account that has permission to use the proxy server that is specified by the Proxy parameter.
-        /// </summary>
-        [Parameter]
-        public PSCredential ProxyCredential { get; set; }
-
-        /// <summary>
         /// When specified, displays the succcessfully registered repository and its information
         /// </summary>
         [Parameter]
@@ -115,15 +102,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void BeginProcessing()
         {
-            if (Proxy != null || ProxyCredential != null)
-            {
-                ThrowTerminatingError(new ErrorRecord(
-                    new PSNotImplementedException("Proxy and ProxyCredential are not yet implemented. Please rerun cmdlet with other parameters."),
-                    "ParametersNotImplementedYet",
-                    ErrorCategory.NotImplemented,
-                    this));
-            }
-            
             RepositorySettings.CheckRepositoryStore();
         }
         protected override void ProcessRecord()

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
+using System.Net;
 using System.Threading;
 
 namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
@@ -22,10 +23,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     public sealed class UpdatePSResource : PSCmdlet
     {
         #region Members
+
         private List<string> _pathsToInstallPkg;
         private CancellationTokenSource _cancellationTokenSource;
         private FindHelper _findHelper;
         private InstallHelper _installHelper;
+        private bool proxyEnvVarModified;
+        private string proxyEnv;
 
         #endregion
 
@@ -110,12 +114,57 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         [Parameter]
         public SwitchParameter SkipDependencyCheck { get; set; }
 
+        /// <summary>
+        /// Specifies a proxy server for the request, rather than a direct connection to the internet resource.
+        /// </summary>
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        public String Proxy { get; set; }
+
+        /// <summary>
+        /// Specifies a user account that has permission to use the proxy server that is specified by the Proxy parameter.
+        /// </summary>
+        [Parameter]
+        public PSCredential ProxyCredential { get; set; }
+
         #endregion
 
         #region Override Methods
 
         protected override void BeginProcessing()
         {
+            // First see if the env variables contain values
+            // Try reading from the environment variable http_proxy. This would be specified as http://<username>:<password>@proxy.com
+            try
+            {
+                proxyEnv = Environment.GetEnvironmentVariable(Utils.ProxyEnvName);
+            }
+            catch (Exception)
+            {
+                WriteVerbose(string.Format("Unable to retrieve environment variable '{0}'", Utils.ProxyEnvName));
+            }
+
+            // Set proxy and proxy credentials if passed in
+            if (!string.IsNullOrWhiteSpace(Proxy) && ProxyCredential != null)
+            {
+                string password = new NetworkCredential(string.Empty, ProxyCredential.Password).Password;
+                string proxyNamePassword = string.Concat(Proxy, ':', password);
+
+                // Temporarily setting the env var to the proxy and proxy credential passed in via parameters
+                try
+                {
+                    Environment.SetEnvironmentVariable(Utils.ProxyEnvName, proxyNamePassword);
+                    proxyEnvVarModified = true;
+                }
+                catch (Exception ex)
+                {
+                    // throw terminating failure, unable to use creds 
+                    throw new ArgumentException(
+                            $"Unable to set the environment variable {Utils.ProxyEnvName}: {ex.Message}",
+                            ex);
+                }
+            }
+
             // Create a repository story (the PSResourceRepository.xml file) if it does not already exist
             // This is to create a better experience for those who have just installed v3 and want to get up and running quickly
             RepositorySettings.CheckRepositoryStore();
@@ -198,6 +247,23 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             _cancellationTokenSource.Dispose();
             _cancellationTokenSource = null;
+            
+            // Set the proxy env var back to its original value
+            if (proxyEnvVarModified)
+            {
+                try
+                {
+                    Environment.SetEnvironmentVariable(Utils.ProxyEnvName, proxyEnv);
+                    proxyEnvVarModified = true;
+                }
+                catch (Exception ex)
+                {
+                    // throw terminating failure, unable to use creds 
+                    throw new ArgumentException(
+                            $"Unable to set the environment variable {Utils.ProxyEnvName} back to its original value: {ex.Message}",
+                            ex);
+                }
+            }
         }
 
         #endregion

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -24,6 +24,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         #region String fields
 
         public static readonly string[] EmptyStrArray = Array.Empty<string>();
+        public static readonly string ProxyEnvName = "http_proxy";
 
         private const string ConvertJsonToHashtableScript = @"
             param (


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Implement `-Proxy` and `-ProxyCredential` params to Find-PSResource, Install-PSResource, Publish-PSResource, Save-PSResource, and Update-PSResource.  Needed for backwards compatibility with PowerShellGet v2. 

## PR Context
The implementation is based off NuGet implementation and use of proxies (see reference in the [NuGet.Configuration package repo](https://github.com/NuGet/NuGet.Client/blob/f24bad0668193ce21a1db8cabd1ce95ba509c7f0/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs#L110))

It uses the `http_proxy` environment variable to read proxy and proxy credentials.  
Users may configure this environment variable themselves or can use the `-Proxy` and `-ProxyCredential` parameters.  The proxy parameters will temporarily set the environment variable to a value in the format of `http://<username>:<password>@proxy.com`. 

The value in environment variable will only be looked at if `-Proxy` and `-ProxyCredential` are not used.

As specified in the .Net documentation [here](https://docs.microsoft.com/en-us/dotnet/api/system.environment.setenvironmentvariable?view=net-6.0), this is only modifying the "environment variable stored in the current process."

NuGet documentation on how the environment variable is used is located [here](https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-environment-variables).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
