### PR TITLE
Bug fix for publishing modules with RequiredModules specified in .psd1

### DIFF
--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -834,7 +834,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 
                 // Search for and return the dependency if it's in the repository.
                 FindHelper findHelper = new FindHelper(_cancellationToken, this);
-                bool depPrerelease = depVersion.Contains("-") ? true : false;
+                bool depPrerelease = depVersion.Contains("-");
+
                 var repository = new[] { repositoryName };
                 var dependencyFound = findHelper.FindByResourceName(depName, ResourceType.Module, depVersion, depPrerelease, null, repository, Credential, false);
                 if (dependencyFound == null || !dependencyFound.Any())

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -452,7 +452,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                             message = "No verison was provided in the module manifest. The module manifest must specify a version, author and description. Run 'Test-ModuleManifest' to validate the file.";
                         }
                     }
-                    else
+
+                    if (string.IsNullOrEmpty(message))
                     {
                         // This will handle version errors
                         var error = pwsh.Streams.Error;

--- a/test/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResource.Tests.ps1
@@ -87,8 +87,8 @@ Describe "Test Publish-PSResource" {
 
         Publish-PSResource -Path $script:PublishModuleBase
 
-        $expectedPath = Join-Path -Path $script:repositoryPath -ChildPath "$script:PublishModuleName.$version.nupkg"
-        Get-ChildItem $script:repositoryPath | select-object -Last 1 | Should -Be $expectedPath
+        $nupkg = Get-ChildItem $script:repositoryPath | select-object -Last 1
+        $nupk.Name | Should Be "$script:PublishModuleName.$version.nupkg"
     }
 
     It "Publish a module with a dependency that is not published, should throw" {

--- a/test/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResource.Tests.ps1
@@ -88,7 +88,7 @@ Describe "Test Publish-PSResource" {
         Publish-PSResource -Path $script:PublishModuleBase
 
         $nupkg = Get-ChildItem $script:repositoryPath | select-object -Last 1
-        $nupk.Name | Should Be "$script:PublishModuleName.$version.nupkg"
+        $nupkg.Name | Should Be "$script:PublishModuleName.$version.nupkg"
     }
 
     It "Publish a module with a dependency that is not published, should throw" {

--- a/test/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResource.Tests.ps1
@@ -74,32 +74,29 @@ Describe "Test Publish-PSResource" {
         (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath
     }
 
-<# Temporarily comment this test out until Find Helper is complete and code within PublishPSResource is uncommented
     It "Publish a module with dependencies" {
         # Create dependency module
         $dependencyVersion = "2.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:DependencyModuleBase -ChildPath "$script:DependencyModuleName.psd1") -ModuleVersion $dependencyVersion -Description "$script:DependencyModuleName module"
 
-        Publish-PSResource -LiteralPath $script:DependencyModuleBase
+        Publish-PSResource -Path $script:DependencyModuleBase
 
         # Create module to test
         $version = "1.0.0"
-        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module" -NestedModules "$script:PublishModuleName.psm1" -RequiredModules @{ModuleName = "$script:DependencyModuleName"; ModuleVersion = "$dependencyVersion" }
+        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module" -RequiredModules @(@{ModuleName = 'PackageManagement'; ModuleVersion = '2.0.0' })
 
-        Publish-PSResource -LiteralPath $script:PublishModuleBase
+        Publish-PSResource -Path $script:PublishModuleBase
 
         $expectedPath = Join-Path -Path $script:repositoryPath -ChildPath "$script:PublishModuleName.$version.nupkg"
         Get-ChildItem $script:repositoryPath | select-object -Last 1 | Should -Be $expectedPath
     }
-#>
 
     It "Publish a module with a dependency that is not published, should throw" {
         $version = "1.0.0"
         $dependencyVersion = "2.0.0"
-        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module" -RequiredModules @(@{ModuleName="PackageManagement"; ModuleVersion="$dependencyVersion"})
+        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module" -RequiredModules @(@{ModuleName = 'PackageManagement'; ModuleVersion = '1.4.4' })
 
-        Publish-PSResource -Path $script:PublishModuleBase -ErrorAction SilentlyContinue
-
+        Publish-PSResource -Path $script:PublishModuleBase -Verbose -ErrorAction SilentlyContinue
         $Error[0].FullyQualifiedErrorId | Should -be "DependencyNotFound,Microsoft.PowerShell.PowerShellGet.Cmdlets.PublishPSResource"
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Currently publishing modules that specify `RequiredModules` in the module manifest fails.  This is due to the fact that `Publish-PSResource` was completed before `FindHelper` was complete, so calls to search for dependency packages in a repository were not available.  This PR properly calls into `FindHelper` to search for the specified dependency modules. 

Error handling has also been updated a bit since there were some bugs found there as well.


## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Closes issue #486, #630, and  #489 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
