### PR TITLE
Change -Repositories param to -Repository in Register-PSResourceRepository

### DIFF
--- a/help/Register-PSResourceRepository.md
+++ b/help/Register-PSResourceRepository.md
@@ -26,7 +26,7 @@ Register-PSResourceRepository [-PSGallery] [-Trusted] [-Priority <Int32>] [-Pass
 
 ### RepositoriesParameterSet
 ```
-Register-PSResourceRepository -Repositories <Hashtable[]> [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+Register-PSResourceRepository -Repository <Hashtable[]> [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -59,7 +59,7 @@ This example registers the "PSGallery" repository, with the 'PSGallery' paramete
 ### Example 3
 ```
 PS C:\> $arrayOfHashtables = @{Name = "psgettestlocal"; Uri = "c:/code/testdir"}, @{PSGallery = $True}
-PS C:\> Register-PSResourceRepository -Repositories $arrayOfHashtables
+PS C:\> Register-PSResourceRepository -Repository $arrayOfHashtables
 PS C:\> Get-PSResourceRepository
         Name             Uri                                          Trusted   Priority
         ----             ---                                          -------   --------
@@ -68,7 +68,7 @@ PS C:\> Get-PSResourceRepository
 
 ```
 
-This example registers multiple repositories at once. To do so, we use the `-Repositories` parameter and provide an array of hashtables. Each hashtable can only have keys associated with parameters for the NameParameterSet or the PSGalleryParameterSet. Upon running the command we can see that the "psgettestlocal" and "PSGallery" repositories have been succesfully registered.
+This example registers multiple repositories at once. To do so, we use the `-Repository` parameter and provide an array of hashtables. Each hashtable can only have keys associated with parameters for the NameParameterSet or the PSGalleryParameterSet. Upon running the command we can see that the "psgettestlocal" and "PSGallery" repositories have been succesfully registered.
 
 ## PARAMETERS
 
@@ -119,7 +119,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Repositories
+### -Repository
 Specifies an array of hashtables which contains repository information and is used to register multiple repositories at once.
 
 ```yaml

--- a/help/Set-PSResourceRepository.md
+++ b/help/Set-PSResourceRepository.md
@@ -19,7 +19,7 @@ Set-PSResourceRepository [-Name] <String> [-Uri <String>] [-Trusted] [-Priority 
 
 ### RepositoriesParameterSet
 ```
-Set-PSResourceRepository -Repositories <Hashtable[]> [-Priority <Int32>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-PSResourceRepository -Repository <Hashtable[]> [-Priority <Int32>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -65,14 +65,14 @@ PS C:\> Get-PSResourceRepository -Name "*"
 
 PS C:\> $arrayOfHashtables = @{Name = "PSGallery"; Trusted = $True}, @{Name = "PoshTestGallery"; Uri = "c:/code/testdir"}
 
-PS C:\> Set-PSResourceRepository -Repositories $arrayOfHashtables -PassThru
+PS C:\> Set-PSResourceRepository -Repository $arrayOfHashtables -PassThru
         Name             Uri                                          Trusted   Priority
         ----             ---                                          -------   --------
         PSGallery        https://www.powershellgallery.com/api/v2        True         50
         PoshTestGallery  file:///c:/code/testdir                        False         50
 ```
 
-This example first checks for all registered repositories. We wish to set the properties for multiple repositories at once (i.e the PSGallery and PoshTestGallery repositories), so we run Set-PSResourceRepository with the `-Repositories` parameter. This parameter takes an array of hashtables, where each hashtable contains information for a repository we wish to set information for. We also use the `-PassThru` parameter to see the changed repositories.
+This example first checks for all registered repositories. We wish to set the properties for multiple repositories at once (i.e the PSGallery and PoshTestGallery repositories), so we run Set-PSResourceRepository with the `-Repository` parameter. This parameter takes an array of hashtables, where each hashtable contains information for a repository we wish to set information for. We also use the `-PassThru` parameter to see the changed repositories.
 
 ## PARAMETERS
 

--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// </summary>
         [Parameter(Mandatory = true, ParameterSetName = RepositoriesParameterSet)]
         [ValidateNotNullOrEmpty]
-        public Hashtable[] Repositories {get; set;}
+        public Hashtable[] Repository {get; set;}
 
         /// <summary>
         /// Specifies whether the repository should be trusted.
@@ -270,7 +270,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         private List<PSRepositoryInfo> RepositoriesParameterSetHelper()
         {
             List<PSRepositoryInfo> reposAddedFromHashTable = new List<PSRepositoryInfo>();
-            foreach (Hashtable repo in Repositories)
+            foreach (Hashtable repo in Repository)
             {
                 if (repo.ContainsKey(PSGalleryRepoName))
                 {

--- a/src/code/SetPSResourceRepository.cs
+++ b/src/code/SetPSResourceRepository.cs
@@ -236,7 +236,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         private List<PSRepositoryInfo> RepositoriesParameterSetHelper()
         {
             List<PSRepositoryInfo> reposUpdatedFromHashtable = new List<PSRepositoryInfo>();
-            foreach (Hashtable repo in Repositories)
+            foreach (Hashtable repo in Repository)
             {
                 if (!repo.ContainsKey("Name") || repo["Name"] == null || String.IsNullOrEmpty(repo["Name"].ToString()))
                 {

--- a/src/code/SetPSResourceRepository.cs
+++ b/src/code/SetPSResourceRepository.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// </summary>
         [Parameter(Mandatory = true, ParameterSetName = RepositoriesParameterSet)]
         [ValidateNotNullOrEmpty]
-        public Hashtable[] Repositories { get; set; }
+        public Hashtable[] Repository { get; set; }
 
         /// <summary>
         /// Specifies whether the repository should be trusted.

--- a/test/RegisterPSResourceRepository.Tests.ps1
+++ b/test/RegisterPSResourceRepository.Tests.ps1
@@ -98,14 +98,14 @@ Describe "Test Register-PSResourceRepository" {
         $res.Priority | Should -Be 20
     }
 
-    It "register repositories with Repositories parameter, all name parameter style repositories (RepositoriesParameterSet)" {
+    It "register repositories with -Repository parameter, all name parameter style repositories (RepositoriesParameterSet)" {
         $hashtable1 = @{Name = $TestRepoName1; Uri = $tmpDir1Path}
         $hashtable2 = @{Name = $TestRepoName2; Uri = $tmpDir2Path; Trusted = $True}
         $hashtable3 = @{Name = $TestRepoName3; Uri = $tmpDir3Path; Trusted = $True; Priority = 20}
         $hashtable4 = @{Name = $TestRepoName4; Uri = $tmpDir4Path; Trusted = $True; Priority = 30; CredentialInfo = (New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "testsecret"))}
         $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3, $hashtable4
 
-        Register-PSResourceRepository -Repositories $arrayOfHashtables
+        Register-PSResourceRepository -Repository $arrayOfHashtables
         $res = Get-PSResourceRepository -Name $TestRepoName1
         $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
         $res.Trusted | Should -Be False
@@ -130,17 +130,17 @@ Describe "Test Register-PSResourceRepository" {
         $res4.CredentialInfo.Credential | Should -BeNullOrEmpty
     }
 
-    It "register repositories with Repositories parameter, psgallery style repository (RepositoriesParameterSet)" {
+    It "register repositories with -Repository parameter, psgallery style repository (RepositoriesParameterSet)" {
         Unregister-PSResourceRepository -Name $PSGalleryName
         $hashtable1 = @{PSGallery = $True}
-        Register-PSResourceRepository -Repositories $hashtable1
+        Register-PSResourceRepository -Repository $hashtable1
         $res = Get-PSResourceRepository -Name $PSGalleryName
         $res.Uri | Should -Be $PSGalleryUri
         $res.Trusted | Should -Be False
         $res.Priority | Should -Be 50
     }
 
-    It "register repositories with Repositories parameter, name and psgallery parameter styles (RepositoriesParameterSet)" {
+    It "register repositories with -Repository parameter, name and psgallery parameter styles (RepositoriesParameterSet)" {
         Unregister-PSResourceRepository -Name $PSGalleryName
         $hashtable1 = @{PSGallery = $True}
         $hashtable2 = @{Name = $TestRepoName1; Uri = $tmpDir1Path}
@@ -149,7 +149,7 @@ Describe "Test Register-PSResourceRepository" {
         $hashtable5 = @{Name = $TestRepoName4; Uri = $tmpDir4Path; Trusted = $True; Priority = 30; CredentialInfo = (New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "testsecret"))}
         $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3, $hashtable4, $hashtable5
 
-        Register-PSResourceRepository -Repositories $arrayOfHashtables
+        Register-PSResourceRepository -Repository $arrayOfHashtables
 
         $res1 = Get-PSResourceRepository -Name $PSGalleryName
         $res1.Uri | Should -Be $PSGalleryUri
@@ -220,7 +220,7 @@ Describe "Test Register-PSResourceRepository" {
         $arrayOfHashtables = $correctHashtable1, $correctHashtable2, $IncorrectHashTable, $correctHashtable3
 
         Unregister-PSResourceRepository -Name $PSGalleryName
-        Register-PSResourceRepository -Repositories $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
+        Register-PSResourceRepository -Repository $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "NotProvideNameUriCredentialInfoForPSGalleryRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
 
@@ -248,7 +248,7 @@ Describe "Test Register-PSResourceRepository" {
 
         $arrayOfHashtables = $correctHashtable1, $correctHashtable2, $IncorrectHashTable, $correctHashtable3
         Unregister-PSResourceRepository -Name $PSGalleryName
-        Register-PSResourceRepository -Repositories $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
+        Register-PSResourceRepository -Repository $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly $ErrorId
 

--- a/test/SetPSResourceRepository.Tests.ps1
+++ b/test/SetPSResourceRepository.Tests.ps1
@@ -112,7 +112,7 @@ Describe "Test Set-PSResourceRepository" {
         $incorrectHashTable = @{Name = $Name; Trusted = $True}
         $arrayOfHashtables = $hashtable1, $incorrectHashTable, $hashtable2
 
-        Set-PSResourceRepository -Repositories $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
+        Set-PSResourceRepository -Repository $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "$ErrorId,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
 
@@ -138,7 +138,7 @@ Describe "Test Set-PSResourceRepository" {
         $hashtable4 = @{Name = $PSGalleryName; Trusted = $True};
         $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3, $hashtable4
 
-        Set-PSResourceRepository -Repositories $arrayOfHashtables
+        Set-PSResourceRepository -Repository $arrayOfHashtables
         $res = Get-PSResourceRepository -Name $TestRepoName1
         $res.Name | Should -Be $TestRepoName1
         $Res.Uri.LocalPath | Should -Contain $tmpDir2Path
@@ -192,7 +192,7 @@ Describe "Test Set-PSResourceRepository" {
         $hashtable2 = @{Name = $TestRepoName1; Priority = 25}
         $arrayOfHashtables = $hashtable1, $hashtable2
 
-        Set-PSResourceRepository -Repositories $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
+        Set-PSResourceRepository -Repository $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "ErrorSettingIndividualRepoFromRepositories,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
 
@@ -222,7 +222,7 @@ Describe "Test Set-PSResourceRepository" {
         $hashtable2 = @{Name = $TestRepoName1; Priority = 25}
         $arrayOfHashtables = $hashtable1, $hashtable2
 
-        Set-PSResourceRepository -Repositories $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
+        Set-PSResourceRepository -Repository $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "ErrorSettingIndividualRepoFromRepositories,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Changing the parameter `-Repositories` to the singular `-Repository` in `Register-PSResourceRepository` in order to stay consistent with PowerShell styling.  Note, `-Repositories` takes in a hashtable, unlike the `-Repository` parameter in other cmdlets, which take an array. 

## PR Context
Closes issue #588 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
