### PR TITLE
Update nuget client dependency packages

### DIFF
--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -15,12 +15,12 @@
   <ItemGroup>
     <PackageReference Include="LinqKit.Core" Version="1.1.17" />
     <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="NuGet.Commands" Version="5.8.0" />
-    <PackageReference Include="NuGet.Common" Version="5.8.0" />
-    <PackageReference Include="NuGet.Configuration" Version="5.8.0" />
-    <PackageReference Include="NuGet.Packaging" Version="5.8.0" />
-    <PackageReference Include="NuGet.ProjectModel" Version="5.8.0" />
-    <PackageReference Include="NuGet.Protocol" Version="5.8.0" />
+    <PackageReference Include="NuGet.Commands" Version="6.2.1" />
+    <PackageReference Include="NuGet.Common" Version="6.2.1" />
+    <PackageReference Include="NuGet.Configuration" Version="6.2.1" />
+    <PackageReference Include="NuGet.Packaging" Version="6.2.1" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.2.1" />
+    <PackageReference Include="NuGet.Protocol" Version="6.2.1" />
     <PackageReference Include="NuGet.Repositories" Version="4.3.0-beta1-2418" />
     <PackageReference Include="PowerShellStandard.Library" Version="7.0.0-preview.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.6.0-preview3.19128.7" />

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -1008,7 +1008,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 PushRunner.Run(
                         settings: Settings.LoadDefaultSettings(root: null, configFileName: null, machineWideSettings: null),
                         sourceProvider: new PackageSourceProvider(settings),
-                        packagePath: fullNupkgFile,
+                        packagePaths: new List<string> { fullNupkgFile },
                         source: publishLocation,
                         apiKey: ApiKey,
                         symbolSource: null,

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -107,7 +107,7 @@ Describe 'Test Install-PSResource for Module' {
         }
         catch
         {}
-        $Error[0].FullyQualifiedErrorId | Should -be "ResourceNotFoundError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
+        $Error[0].FullyQualifiedErrorId | Should -be "IncorrectVersionFormat,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
 
         $res = Get-PSResource $testModuleName
         $res | Should -BeNullOrEmpty

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -96,6 +96,7 @@ Describe 'Test Install-PSResource for Module' {
         $pkg.Version | Should -Be "3.0.0.0"
     }
 
+    # TODO: Update this test and others like it that use try/catch blocks instead of Should -Throw
     It "Should not install resource with incorrectly formatted version such as exclusive version (1.0.0.0)" {
         $Version = "(1.0.0.0)"
         try {

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -96,18 +96,27 @@ Describe 'Test Install-PSResource for Module' {
         $pkg.Version | Should -Be "3.0.0.0"
     }
 
-    It "Should not install resource with incorrectly formatted version such as <Description>" -TestCases @(
-        @{Version='(1.0.0.0)';       Description="exclusive version (1.0.0.0)"},
-        @{Version='[1-0-0-0]';       Description="version formatted with invalid delimiter [1-0-0-0]"}
-    ) {
-        param($Version, $Description)
-
+    It "Should not install resource with incorrectly formatted version such as exclusive version (1.0.0.0)" {
+        $Version = "(1.0.0.0)"
         try {
             Install-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
         }
         catch
         {}
         $Error[0].FullyQualifiedErrorId | Should -be "IncorrectVersionFormat,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
+
+        $res = Get-PSResource $testModuleName
+        $res | Should -BeNullOrEmpty
+    }
+
+    It "Should not install resource with incorrectly formatted version such as version formatted with invalid delimiter [1-0-0-0]" {
+        $Version="[1-0-0-0]"
+        try {
+            Install-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
+        }
+        catch
+        {}
+        $Error[0].FullyQualifiedErrorId | Should -be "ResourceNotFoundError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
 
         $res = Get-PSResource $testModuleName
         $res | Should -BeNullOrEmpty

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -102,7 +102,7 @@ Describe 'Test Install-PSResource for Module' {
     ) {
         param($Version, $Description)
 
-        Install-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
+        Install-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue -ErrorVariable $ev
         $Error[0].FullyQualifiedErrorId | Should -be "ResourceNotFoundError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
 
         $res = Get-PSResource $testModuleName

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -102,7 +102,11 @@ Describe 'Test Install-PSResource for Module' {
     ) {
         param($Version, $Description)
 
-        Install-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue -ErrorVariable $ev
+        try {
+            Install-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
+        }
+        catch
+        {}
         $Error[0].FullyQualifiedErrorId | Should -be "ResourceNotFoundError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
 
         $res = Get-PSResource $testModuleName

--- a/test/SavePSResource.Tests.ps1
+++ b/test/SavePSResource.Tests.ps1
@@ -99,13 +99,26 @@ Describe 'Test Save-PSResource for PSResources' {
         $pkgDirVersion.Name | Should -Be "3.0.0.0"
     }
 
-    It "Should not save resource with incorrectly formatted version such as <Description>" -TestCases @(
-        @{Version='(1.0.0.0)';       Description="exclusive version (1.0.0.0)"},
-        @{Version='[1-0-0-0]';       Description="version formatted with invalid delimiter [1-0-0-0]"}
-    ) {
-        param($Version, $Description)
+    It "Should not save resource with incorrectly formatted version such as exclusive version (1.0.0.0)" {
+        $Version="(1.0.0.0)"
+        try {
+            Save-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -Path $SaveDir -ErrorAction SilentlyContinue -TrustRepository
+        }
+        catch
+        {}
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir | Should -BeNullOrEmpty
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "ResourceNotFoundError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
+    }
 
-        Save-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -Path $SaveDir -ErrorVariable err -ErrorAction SilentlyContinue -TrustRepository
+    It "Should not save resource with incorrectly formatted version such as version formatted with invalid delimiter [1-0-0-0]" {
+        $Version = "[1-0-0-0]"
+        try {
+            Save-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -Path $SaveDir -ErrorAction SilentlyContinue -TrustRepository
+        }
+        catch
+        {}
         $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
         $pkgDir | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0

--- a/test/SavePSResource.Tests.ps1
+++ b/test/SavePSResource.Tests.ps1
@@ -115,14 +115,14 @@ Describe 'Test Save-PSResource for PSResources' {
     It "Should not save resource with incorrectly formatted version such as version formatted with invalid delimiter [1-0-0-0]"{
         $Version = "[1-0-0-0]"
         try {
-            Save-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -Path $SaveDir -ErrorVariable err -ErrorAction SilentlyContinue -TrustRepository
+            Save-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -Path $SaveDir -ErrorAction SilentlyContinue -TrustRepository
         }
         catch
         {}
         $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
         $pkgDir | Should -BeNullOrEmpty
-        $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "ResourceNotFoundError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
+        $Error.Count | Should -Not -Be 0
+        $Error[0].FullyQualifiedErrorId | Should -BeExactly "ResourceNotFoundError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
     }
 
     It "Save resource when given Name, Version '*', should install the latest version" {

--- a/test/SavePSResource.Tests.ps1
+++ b/test/SavePSResource.Tests.ps1
@@ -109,9 +109,7 @@ Describe 'Test Save-PSResource for PSResources' {
         $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
         $pkgDir | Should -BeNullOrEmpty
         $Error.Count | Should -Not -Be 0
-        Write-Host ($Error[0])
-        Write-Host ($Error[0].FullyQualifiedErrorId)
-        $Error[0].FullyQualifiedErrorId  | Should -Be "ResourceNotFoundError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
+        $Error[0].FullyQualifiedErrorId  | Should -Be "IncorrectVersionFormat,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
     }
 
     It "Should not save resource with incorrectly formatted version such as version formatted with invalid delimiter [1-0-0-0]"{

--- a/test/SavePSResource.Tests.ps1
+++ b/test/SavePSResource.Tests.ps1
@@ -102,14 +102,16 @@ Describe 'Test Save-PSResource for PSResources' {
     It "Should not save resource with incorrectly formatted version such as exclusive version (1.0.0.0)" {
         $Version="(1.0.0.0)"
         try {
-            Save-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -Path $SaveDir -ErrorVariable err -ErrorAction SilentlyContinue -TrustRepository
+            Save-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -Path $SaveDir -ErrorAction SilentlyContinue -TrustRepository
         }
         catch
         {}
         $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
         $pkgDir | Should -BeNullOrEmpty
-        $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "ResourceNotFoundError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
+        $Error.Count | Should -Not -Be 0
+        Write-Host ($Error[0])
+        Write-Host ($Error[0].FullyQualifiedErrorId)
+        $Error[0].FullyQualifiedErrorId  | Should -Be "ResourceNotFoundError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
     }
 
     It "Should not save resource with incorrectly formatted version such as version formatted with invalid delimiter [1-0-0-0]"{

--- a/test/SavePSResource.Tests.ps1
+++ b/test/SavePSResource.Tests.ps1
@@ -102,7 +102,7 @@ Describe 'Test Save-PSResource for PSResources' {
     It "Should not save resource with incorrectly formatted version such as exclusive version (1.0.0.0)" {
         $Version="(1.0.0.0)"
         try {
-            Save-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -Path $SaveDir -ErrorAction SilentlyContinue -TrustRepository
+            Save-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -Path $SaveDir -ErrorVariable err -ErrorAction SilentlyContinue -TrustRepository
         }
         catch
         {}
@@ -112,10 +112,10 @@ Describe 'Test Save-PSResource for PSResources' {
         $err[0].FullyQualifiedErrorId | Should -BeExactly "ResourceNotFoundError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
     }
 
-    It "Should not save resource with incorrectly formatted version such as version formatted with invalid delimiter [1-0-0-0]" {
+    It "Should not save resource with incorrectly formatted version such as version formatted with invalid delimiter [1-0-0-0]"{
         $Version = "[1-0-0-0]"
         try {
-            Save-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -Path $SaveDir -ErrorAction SilentlyContinue -TrustRepository
+            Save-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -Path $SaveDir -ErrorVariable err -ErrorAction SilentlyContinue -TrustRepository
         }
         catch
         {}

--- a/test/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResource.Tests.ps1
@@ -152,7 +152,11 @@ Describe 'Test Uninstall-PSResource for Modules' {
 
         Install-PSResource -Name $testModuleName -Version "1.0.0.0" -Repository $PSGalleryName -TrustRepository
 
-        Uninstall-PSResource -Name $testModuleName -Version $Version -ErrorAction SilentlyContinue
+        try {
+            Uninstall-PSResource -Name $testModuleName -Version $Version -ErrorAction SilentlyContinue
+        }
+        catch
+        {}
         $pkg = Get-PSResource $testModuleName -Version "1.0.0.0"
         $pkg.Version | Should -Be "1.0.0.0"
     }

--- a/test/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResource.Tests.ps1
@@ -152,7 +152,7 @@ Describe 'Test Uninstall-PSResource for Modules' {
 
         Install-PSResource -Name $testModuleName -Version "1.0.0.0" -Repository $PSGalleryName -TrustRepository
 
-        Uninstall-PSResource -Name $testModuleName -Version $Version
+        Uninstall-PSResource -Name $testModuleName -Version $Version -ErrorAction SilentlyContinue
         $pkg = Get-PSResource $testModuleName -Version "1.0.0.0"
         $pkg.Version | Should -Be "1.0.0.0"
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Updating NuGet package dependencies to the latest version.

An older version of PushRunner.Run() takes a string packagePath.  This method is now obsolete and a new method which takes IList<string> packagePaths is recommended.  See: https://github.com/NuGet/NuGet.Client/pull/3739/files#r515863352 for more details.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Dependabot originally opened this PR to update the NuGet.Commands dependency: https://github.com/PowerShell/PowerShellGet/pull/675. 
Because updating that dependency necessitated updating other NuGet dependencies and also updating the PushRunner used in Publish-PSResource, I opened a new PR to encompass all required changes.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
