### PR TITLE
[WIP] Add feature request to use env var to set temp installation paths

### DIFF
--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -217,9 +217,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         private const string InputObjectParameterSet = "InputObjectParameterSet";
         private const string RequiredResourceFileParameterSet = "RequiredResourceFileParameterSet";
         private const string RequiredResourceParameterSet = "RequiredResourceParameterSet";
-        List<string> _pathsToInstallPkg;
         private string _requiredResourceFile;
         private string _requiredResourceJson;
+        private string tmpPath;
+        List<string> _pathsToInstallPkg;
         private Hashtable _requiredResourceHash;
         VersionRange _versionRange;
         InstallHelper _installHelper;
@@ -236,6 +237,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             RepositorySettings.CheckRepositoryStore();
 
             _pathsToInstallPkg = Utils.GetAllInstallationPaths(this, Scope);
+            
+            // Get or create temp directory for those who want to specify where 
+            // temporary resource installations go before moved to their final destination.
+            tmpPath = Environment.GetEnvironmentVariable("PSGetTempPath");
 
             _installHelper = new InstallHelper(cmdletPassedIn: this);
         }
@@ -521,6 +526,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 skipDependencyCheck: SkipDependencyCheck,
                 authenticodeCheck: AuthenticodeCheck,
                 savePkg: false,
+                tmpPath: tmpPath,
                 pathsToInstallPkg: _pathsToInstallPkg);
 
             if (PassThru)

--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -15,12 +15,12 @@
   <ItemGroup>
     <PackageReference Include="LinqKit.Core" Version="1.1.17" />
     <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="NuGet.Commands" Version="5.8.0" />
-    <PackageReference Include="NuGet.Common" Version="5.8.0" />
-    <PackageReference Include="NuGet.Configuration" Version="5.8.0" />
-    <PackageReference Include="NuGet.Packaging" Version="5.8.0" />
-    <PackageReference Include="NuGet.ProjectModel" Version="5.8.0" />
-    <PackageReference Include="NuGet.Protocol" Version="5.8.0" />
+    <PackageReference Include="NuGet.Commands" Version="6.2.1" />
+    <PackageReference Include="NuGet.Common" Version="6.2.1" />
+    <PackageReference Include="NuGet.Configuration" Version="6.2.1" />
+    <PackageReference Include="NuGet.Packaging" Version="6.2.1" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.2.1" />
+    <PackageReference Include="NuGet.Protocol" Version="6.2.1" />
     <PackageReference Include="NuGet.Repositories" Version="4.3.0-beta1-2418" />
     <PackageReference Include="PowerShellStandard.Library" Version="7.0.0-preview.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.6.0-preview3.19128.7" />

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -20,15 +20,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     [Cmdlet(VerbsData.Save, "PSResource", DefaultParameterSetName = "NameParameterSet", SupportsShouldProcess = true)]
     public sealed class SavePSResource : PSCmdlet
     {
-        #region Members
-
-        private const string NameParameterSet = "NameParameterSet";
-        private const string InputObjectParameterSet = "InputObjectParameterSet";
-        VersionRange _versionRange;
-        InstallHelper _installHelper;
-        
-        #endregion
-
         #region Parameters 
 
         /// <summary>
@@ -147,6 +138,16 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         #endregion
 
+        #region Members
+
+        private const string NameParameterSet = "NameParameterSet";
+        private const string InputObjectParameterSet = "InputObjectParameterSet";
+        private string tmpPath;
+        VersionRange _versionRange;
+        InstallHelper _installHelper;
+
+        #endregion
+
         #region Method overrides
 
         protected override void BeginProcessing()
@@ -160,6 +161,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 _path = SessionState.Path.CurrentLocation.Path;
             }
+
+            // Get or create temp directory for those who want to specify where 
+            // temporary resource installations go before moved to their final destination.
+            tmpPath = Environment.GetEnvironmentVariable("PSGetTempPath");
 
             _installHelper = new InstallHelper(cmdletPassedIn: this);
         }
@@ -268,6 +273,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 skipDependencyCheck: SkipDependencyCheck,
                 authenticodeCheck: AuthenticodeCheck,
                 savePkg: true,
+                tmpPath: tmpPath,
                 pathsToInstallPkg: new List<string> { _path });
 
             if (PassThru)

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -5,6 +5,7 @@ using Microsoft.PowerShell.PowerShellGet.UtilClasses;
 using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using System.Threading;
@@ -21,14 +22,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         SupportsShouldProcess = true)]
     public sealed class UpdatePSResource : PSCmdlet
     {
-        #region Members
-        private List<string> _pathsToInstallPkg;
-        private CancellationTokenSource _cancellationTokenSource;
-        private FindHelper _findHelper;
-        private InstallHelper _installHelper;
-
-        #endregion
-
         #region Parameters
 
         /// <summary>
@@ -120,6 +113,15 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         #endregion
 
+        #region Members
+        private string tmpPath;
+        private List<string> _pathsToInstallPkg;
+        private CancellationTokenSource _cancellationTokenSource;
+        private FindHelper _findHelper;
+        private InstallHelper _installHelper;
+
+        #endregion
+
         #region Override Methods
 
         protected override void BeginProcessing()
@@ -135,7 +137,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 cancellationToken: _cancellationTokenSource.Token, 
                 cmdletPassedIn: this);
 
-             _installHelper = new InstallHelper(cmdletPassedIn: this);
+            // Get or create temp directory for those who want to specify where 
+            // temporary resource installations go before moved to their final destination.
+            tmpPath = Environment.GetEnvironmentVariable("PSGetTempPath");
+
+            _installHelper = new InstallHelper(cmdletPassedIn: this);
         }
 
         protected override void ProcessRecord()
@@ -187,6 +193,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 skipDependencyCheck: SkipDependencyCheck,
                 authenticodeCheck: AuthenticodeCheck,
                 savePkg: false,
+                tmpPath: tmpPath,
                 pathsToInstallPkg: _pathsToInstallPkg);
 
             if (PassThru)

--- a/test/UpdatePSResource.Tests.ps1
+++ b/test/UpdatePSResource.Tests.ps1
@@ -24,6 +24,7 @@ Describe 'Test Update-PSResource' {
 
     AfterAll {
         Get-RevertPSResourceRepositoryFile
+        Remove-Item $TestDrive -Recurse -Force
     }
 
     It "update resource installed given Name parameter" {
@@ -373,5 +374,20 @@ Describe 'Test Update-PSResource' {
         Install-PSResource -Name "TestTestScript" -Version "1.0" -Repository $PSGalleryName -TrustRepository
         Update-PSResource -Name "TestTestScript" -Version "1.3.1.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
         $Error[0].FullyQualifiedErrorId | Should -be "InstallPackageFailed,Microsoft.PowerShell.PowerShellGet.Cmdlets.UpdatePSResource"
+    }
+
+    It "Update should use enviornment variable PSGetTempPath" {
+        Install-PSResource -Name $testModuleName -Version "1.0.0.0" -Repository $PSGalleryName -TrustRepository
+
+        $tmpDirPath = Join-Path -Path $TestDrive -ChildPath "tmpDirPath"
+        $Env:PSGetTempPath = $tmpDirPath;
+
+        $logFile = Join-Path -Path $TestDrive -ChildPath "logfile.txt"
+        Update-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository -Verbose 4>> $logFile
+
+        $results = Get-Content -Path $logFile -Raw
+        $results.Contains($tmpDirPath) | Should -Be $true
+
+        $Env:PSGetTempPath = "";
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Add a configurable new environment variable called `PSGetTempPath` that PowerShellGet checks upon use of `Install-PSResource', 'Save-PSResource' and 'Update-PSResource'.  If a path is provided in this environment variable, PowerShellGet will use this path as a temp directory instead of the random default temp directory it creates. 

## PR Context
Feature request from Azure Functions
> In Azure Functions, we use the Save-Module cmdlet to download the function app dependencies. At times, the modules to be installed are very large and the operation fails because there is not enough space in the temp directory. Having the ability to set an alternative to the temp directory via an environment variable could help us in this scenario. 

see issue: #650 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
