### PR TITLE
Update .psd1 PSData file read and conversion to Hashtable

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -520,9 +520,18 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                             continue;
                         }
 
-                        if (!Utils.TryParsePSDataFile(moduleManifest, _cmdletPassedIn, out Hashtable parsedMetadataHashtable))
+                        if (!Utils.TryReadManifestFile(
+                            manifestFilePath: moduleManifest,
+                            manifestInfo: out Hashtable parsedMetadataHashtable,
+                            error: out Exception manifestReadError))
                         {
-                            // Ran into errors parsing the module manifest file which was found in Utils.ParseModuleManifest() and written.
+                            WriteError(
+                                new ErrorRecord(
+                                    exception: manifestReadError,
+                                    errorId: "ManifestFileReadParseError",
+                                    errorCategory: ErrorCategory.ReadError,
+                                    this));
+
                             continue;
                         }
 

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -477,12 +477,19 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             // a module will still need the module manifest to be parsed.
             if (!isScript)
             {
-                // Parse the module manifest and *replace* the passed-in metadata with the module manifest metadata.
-                if (!Utils.TryParsePSDataFile(
-                    moduleFileInfo: filePath,
-                    cmdletPassedIn: this,
-                    parsedMetadataHashtable: out parsedMetadataHash))
+                // Use the parsed module manifest data as 'parsedMetadataHash' instead of the passed-in data.
+                if (!Utils.TryReadManifestFile(
+                    manifestFilePath: filePath,
+                    manifestInfo: out parsedMetadataHash,
+                    error: out Exception manifestReadError))
                 {
+                    WriteError(
+                        new ErrorRecord(
+                            exception: manifestReadError,
+                            errorId: "ManifestFileReadParseForNuspecError",
+                            errorCategory: ErrorCategory.ReadError,
+                            this));
+                    
                     return string.Empty;
                 }
             }

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -728,53 +728,94 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
         #endregion
 
-        #region Manifest methods
+        #region PSDataFile parsing
 
-        public static bool TryParsePSDataFile(
-            string moduleFileInfo,
-            PSCmdlet cmdletPassedIn,
-            out Hashtable parsedMetadataHashtable)
+        private static readonly string[] ManifestFileVariables = new string[] { "PSEdition", "PSScriptRoot" };
+
+        /// <summary>
+        /// Read psd1 manifest file contents and return as Hashtable object.
+        /// </summary>
+        /// <param name="manifestFilePath">File path to manfiest psd1 file.</param>
+        /// <param name="manifestInfo">Hashtable of manifest file contents.</param>
+        /// <param name="error">Error exception on failure.</param>
+        /// <returns>True on success.</returns>
+        public static bool TryReadManifestFile(
+            string manifestFilePath,
+            out Hashtable manifestInfo,
+            out Exception error)
         {
-            parsedMetadataHashtable = new Hashtable();
-            bool successfullyParsed = false;
+            return TryReadPSDataFile(
+                filePath: manifestFilePath,
+                allowedVariables: ManifestFileVariables,
+                allowedCommands: Utils.EmptyStrArray,
+                allowEnvironmentVariables: false,
+                out manifestInfo,
+                out error);
+        }
 
-            // A script will already  have the metadata parsed into the parsedMetadatahash,
-            // a module will still need the module manifest to be parsed.
-            if (moduleFileInfo.EndsWith(PSDataFileExt, StringComparison.OrdinalIgnoreCase))
+        /// <summary>
+        /// Read psd1 required resource file contents and return as Hashtable object.
+        /// </summary>
+        /// <param name="resourceFilePath">File path to required resource psd1 file.</param>
+        /// <param name="resourceInfo">Hashtable of required resource file contents.</param>
+        /// <param name="error">Error exception on failure.</param>
+        /// <returns>True on success.</returns>
+        public static bool TryReadRequiredResourceFile(
+            string resourceFilePath,
+            out Hashtable resourceInfo,
+            out Exception error)
+        {
+            return TryReadPSDataFile(
+                filePath: resourceFilePath,
+                allowedVariables: Utils.EmptyStrArray,
+                allowedCommands: Utils.EmptyStrArray,
+                allowEnvironmentVariables: false,
+                out resourceInfo,
+                out error);
+        }
+
+        private static bool TryReadPSDataFile(
+            string filePath,
+            string[] allowedVariables,
+            string[] allowedCommands,
+            bool allowEnvironmentVariables,
+            out Hashtable dataFileInfo,
+            out Exception error)
+        {
+            try
             {
-                // Parse the module manifest
-                var ast = Parser.ParseFile(
-                    moduleFileInfo,
-                    out Token[] tokens,
-                    out ParseError[] errors);
+                if (filePath is null)
+                {
+                    throw new PSArgumentNullException(nameof(filePath));
+                }
 
-                if (errors.Length > 0)
+                string contents = System.IO.File.ReadAllText(filePath);
+                var scriptBlock = System.Management.Automation.ScriptBlock.Create(contents);
+
+                // Ensure that the content script block is safe to convert into a PSDataFile Hashtable.
+                // This will throw for unsafe content.
+                scriptBlock.CheckRestrictedLanguage(
+                    allowedCommands: allowedCommands,
+                    allowedVariables: allowedVariables,
+                    allowEnvironmentVariables: allowEnvironmentVariables);
+                
+                // Convert contents into PSDataFile Hashtable by executing content as script.
+                object result = scriptBlock.InvokeReturnAsIs();
+                if (result is PSObject psObject)
                 {
-                    var message = String.Format("Could not parse '{0}' as a PowerShell data file.", moduleFileInfo);
-                    var ex = new ArgumentException(message);
-                    var psdataParseError = new ErrorRecord(ex, "psdataParseError", ErrorCategory.ParserError, null);
-                    cmdletPassedIn.WriteError(psdataParseError);
-                    return successfullyParsed;
+                    result = psObject.BaseObject;
                 }
-                else
-                {
-                    var data = ast.Find(a => a is HashtableAst, false);
-                    if (data != null)
-                    {
-                        parsedMetadataHashtable = (Hashtable)data.SafeGetValue();
-                        successfullyParsed = true;
-                    }
-                    else
-                    {
-                        var message = String.Format("Could not parse as PowerShell data file-- no hashtable root for file '{0}'", moduleFileInfo);
-                        var ex = new ArgumentException(message);
-                        var psdataParseError = new ErrorRecord(ex, "psdataParseError", ErrorCategory.ParserError, null);
-                        cmdletPassedIn.WriteError(psdataParseError);
-                    }
-                }
+
+                dataFileInfo = (Hashtable) result;
+                error = null;
+                return true;
             }
-
-            return successfullyParsed;
+            catch (Exception ex)
+            {
+                dataFileInfo = null;
+                error = ex;
+                return false;
+            }
         }
 
         #endregion


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR updates the .psd1 file read and convert to Hashtable to follow PowerShell best practices.

## PR Context

The psd1 file reader code now uses the `CheckRestrictedLanguage` method before converting content to Hashtable object.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
