### PR TITLE
Convert IEnumerables to Lists for perf improvements

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -384,7 +384,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     yield break;
                 }
 
-                foundPackagesMetadata.AddRange(retrievedPkgs.ToList());
+                foundPackagesMetadata.AddRange(retrievedPkgs);
 
                 // _pkgsLeftToFind.Remove(pkgName);
 
@@ -427,7 +427,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                                 skip: SearchAsyncMaxTake,
                                 take: GalleryMax,
                                 log: NullLogger.Instance,
-                                cancellationToken: _cancellationToken).GetAwaiter().GetResult().ToList());
+                                cancellationToken: _cancellationToken).GetAwaiter().GetResult());
                     }
                 }
                 catch (HttpRequestException ex)
@@ -450,7 +450,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 // perhaps validate in Find-PSResource, and use debugassert here?
                 WildcardPattern nameWildcardPattern = new WildcardPattern(pkgName, WildcardOptions.IgnoreCase);
                 foundPackagesMetadata.AddRange(wildcardPkgs.Where(
-                    p => nameWildcardPattern.IsMatch(p.Identity.Id)).ToList());
+                    p => nameWildcardPattern.IsMatch(p.Identity.Id)));
 
                 if (!_repositoryNameContainsWildcard)
                 {

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         #region Public methods
 
-        public IEnumerable<PSResourceInfo> FindByResourceName(
+        public List<PSResourceInfo> FindByResourceName(
             string[] name,
             ResourceType type,
             string version,
@@ -86,12 +86,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             _tag = tag;
             _credential = credential;
             _includeDependencies = includeDependencies;
-
-            Dbg.Assert(name.Length != 0, "Name length cannot be 0");
-
             _pkgsLeftToFind = name.ToList();
-
             List<PSRepositoryInfo> repositoriesToSearch;
+            List<PSResourceInfo> packagesFound = new List<PSResourceInfo>();
+
+            if (name.Length == 0)
+            {
+                  _cmdletPassedIn.WriteVerbose("No name was provided to FindByResourceName.");
+            }
 
             //determine if repository array of names of repositories input to be searched contains wildcard
             if (repository != null)
@@ -126,7 +128,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     "ErrorLoadingRepositoryStoreFile",
                     ErrorCategory.InvalidArgument,
                     this));
-                yield break;
+                 return packagesFound;
             }
 
             // loop through repositoriesToSearch and if PSGallery or PoshTestGallery add its Scripts endpoint repo
@@ -185,9 +187,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     repositoryUri: repositoriesToSearch[i].Uri,
                     repositoryCredentialInfo: repositoriesToSearch[i].CredentialInfo))
                 {
-                    yield return pkg;
+                    packagesFound.Add(pkg);
                 }
             }
+
+            return packagesFound; 
         }
 
         #endregion

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -192,7 +192,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 var isLocalRepo = repo.Uri.AbsoluteUri.StartsWith(Uri.UriSchemeFile + Uri.SchemeDelimiter, StringComparison.OrdinalIgnoreCase);
 
                 // Finds parent packages and dependencies
-                IEnumerable<PSResourceInfo> pkgsFromRepoToInstall = findHelper.FindByResourceName(
+                List<PSResourceInfo> pkgsFromRepoToInstall = findHelper.FindByResourceName(
                     name: _pkgNamesToInstall.ToArray(),
                     type: ResourceType.None,
                     version: _versionRange != null ? _versionRange.OriginalString : null,
@@ -200,7 +200,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     tag: null,
                     repository: new string[] { repoName },
                     credential: credential,
-                    includeDependencies: !skipDependencyCheck);
+                    includeDependencies: !skipDependencyCheck).ToList();
 
                 if (!pkgsFromRepoToInstall.Any())
                 {
@@ -222,7 +222,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 // Check to see if the pkgs (including dependencies) are already installed (ie the pkg is installed and the version satisfies the version range provided via param)
                 if (!_reinstall)
                 {
-                    pkgsFromRepoToInstall = FilterByInstalledPkgs(pkgsFromRepoToInstall);
+                    pkgsFromRepoToInstall = FilterByInstalledPkgs(pkgsFromRepoToInstall).ToList();
                 }
 
                 if (!pkgsFromRepoToInstall.Any())
@@ -261,7 +261,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         }
 
         // Check if any of the pkg versions are already installed, if they are we'll remove them from the list of packages to install
-        private IEnumerable<PSResourceInfo> FilterByInstalledPkgs(IEnumerable<PSResourceInfo> packages)
+        private List<PSResourceInfo> FilterByInstalledPkgs(List<PSResourceInfo> packages)
         {
             // Create list of installation paths to search.
             List<string> _pathsToSearch = new List<string>();
@@ -286,11 +286,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             GetHelper getHelper = new GetHelper(_cmdletPassedIn);
             // Get currently installed packages.
             // selectPrereleaseOnly is false because even if Prerelease is true we want to include both stable and prerelease, never select prerelease only.
-            IEnumerable<PSResourceInfo> pkgsAlreadyInstalled = getHelper.GetPackagesFromPath(
+            List<PSResourceInfo> pkgsAlreadyInstalled = getHelper.GetPackagesFromPath(
                 name: filteredPackages.Keys.ToArray(),
                 versionRange: _versionRange,
                 pathsToSearch: _pathsToSearch,
-                selectPrereleaseOnly: false);
+                selectPrereleaseOnly: false).ToList();
+
             if (!pkgsAlreadyInstalled.Any())
             {
                 return packages;
@@ -308,11 +309,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 _pkgNamesToInstall.RemoveAll(x => x.Equals(pkg.Name, StringComparison.InvariantCultureIgnoreCase));
             }
 
-            return filteredPackages.Values.ToArray();
+            return filteredPackages.Values.ToList();
         }
 
         private List<PSResourceInfo> InstallPackage(
-            IEnumerable<PSResourceInfo> pkgsToInstall, // those found to be required to be installed (includes Dependency packages as well)
+            List<PSResourceInfo> pkgsToInstall, // those found to be required to be installed (includes Dependency packages as well)
             string repoName,
             string repoUri,
             PSCredentialInfo repoCredentialInfo,
@@ -689,11 +690,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             bool foundClobber = false;
             GetHelper getHelper = new GetHelper(_cmdletPassedIn);
             // selectPrereleaseOnly is false because even if Prerelease is true we want to include both stable and prerelease, never select prerelease only.
-            IEnumerable<PSResourceInfo> pkgsAlreadyInstalled = getHelper.GetPackagesFromPath(
+            List<PSResourceInfo> pkgsAlreadyInstalled = getHelper.GetPackagesFromPath(
                 name: new string[] { "*" },
                 versionRange: VersionRange.All,
                 pathsToSearch: _pathsToSearch,
-                selectPrereleaseOnly: false);
+                selectPrereleaseOnly: false).ToList();
             // user parsed metadata hash
             List<string> listOfCmdlets = new List<string>();
             foreach (var cmdletName in parsedMetadataHashtable["CmdletsToExport"] as object[])

--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -15,12 +15,12 @@
   <ItemGroup>
     <PackageReference Include="LinqKit.Core" Version="1.1.17" />
     <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="NuGet.Commands" Version="5.8.0" />
-    <PackageReference Include="NuGet.Common" Version="5.8.0" />
-    <PackageReference Include="NuGet.Configuration" Version="5.8.0" />
-    <PackageReference Include="NuGet.Packaging" Version="5.8.0" />
-    <PackageReference Include="NuGet.ProjectModel" Version="5.8.0" />
-    <PackageReference Include="NuGet.Protocol" Version="5.8.0" />
+    <PackageReference Include="NuGet.Commands" Version="6.2.1" />
+    <PackageReference Include="NuGet.Common" Version="6.2.1" />
+    <PackageReference Include="NuGet.Configuration" Version="6.2.1" />
+    <PackageReference Include="NuGet.Packaging" Version="6.2.1" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.2.1" />
+    <PackageReference Include="NuGet.Protocol" Version="6.2.1" />
     <PackageReference Include="NuGet.Repositories" Version="4.3.0-beta1-2418" />
     <PackageReference Include="PowerShellStandard.Library" Version="7.0.0-preview.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.6.0-preview3.19128.7" />

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -329,13 +329,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 // Results is a collection of PSModuleInfo objects that contain a property listing module dependencies, "RequiredModules".
                 // RequiredModules is collection of PSModuleInfo objects that need to be iterated through to see if any of them are the pkg we're trying to uninstall
                 // If we anything from the final call gets returned, there is a dependency on this pkg.
-                IEnumerable<PSObject> pkgsWithRequiredModules = new List<PSObject>();
+                List<PSObject> pkgsWithRequiredModules = new List<PSObject>();
                 errorRecord = null;
                 try
                 {
-                    pkgsWithRequiredModules = results.Where(
+                    pkgsWithRequiredModules = (results.Where(
                         pkg => ((ReadOnlyCollection<PSModuleInfo>)pkg.Properties["RequiredModules"].Value).Where(
-                            rm => rm.Name.Equals(pkgName, StringComparison.InvariantCultureIgnoreCase)).Any());
+                            rm => rm.Name.Equals(pkgName, StringComparison.InvariantCultureIgnoreCase)).Any())).ToList();
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Pervasive use of IEnumerables in primarily FindHelper and InstallHelper were causing some unexpected performances degradations.   Occasionally the same call was (unexpectedly) occurring multiple times due to the fact that IEnumerable does not return a collection.  This was particularly painful because it meant multiple, unnecessary server calls, which can hit the server hard, but also decreases performance of PowerShellGet.

## PR Context
Resolves #654:

- LINQ is generics and can cause multiple compiled methods calling search APIs.
- Find code always returned IEnumerable interface, causing LINQ calls to call search APIs multiple times to manipulate IEnumerable as collections. 
- Dependency search returns IEnumerable which is then used as collection and calls server X times.
retrievedPkgs = pkgMetadataResource.GetMetadataAsync(...)
if (retrievedPkgs == null || retrievedPkgs.Count() == 0) ...
foundPackagesMetadata.AddRange(retrievedPkgs.ToList());

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
