### PR TITLE
Bug fix in Publish-PSResource when creating nuspec

### DIFF
--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -566,7 +566,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         }
 
                         // defaults to false
-                        string requireLicenseAcceptance = psData.ContainsKey("requirelicenseacceptance") ? psData["ReleaseNotes"] as string  : "false";
+                        string requireLicenseAcceptance = psData.ContainsKey("requirelicenseacceptance") ? psData["requirelicenseacceptance"] : "false";
+
                         metadataElementsDictionary.Add("requireLicenseAcceptance", requireLicenseAcceptance);
 
 

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -540,10 +540,36 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 {
                     if (privateData["PSData"] is Hashtable psData)
                     {
-                        if (psData.ContainsKey("Prerelease") && psData["Prerelease"] is string preReleaseVersion)
+                        if (psData.ContainsKey("prerelease") && psData["prerelease"] is string preReleaseVersion)
                         {
                             version = string.Format(@"{0}-{1}", version, preReleaseVersion);
                         }
+
+                        if (psData.ContainsKey("licenseUri") && psData["licenseuri"] is string licenseUri)
+                        {
+                            metadataElementsDictionary.Add("licenseUrl", licenseUri.Trim());
+                        }
+
+                        if (psData.ContainsKey("projecturi") && psData["projecturi"] is string projectUri)
+                        {
+                            metadataElementsDictionary.Add("projectUrl", projectUri.Trim());
+                        }
+
+                        if (psData.ContainsKey("iconuri") && psData["iconuri"] is string iconUri)
+                        {
+                            metadataElementsDictionary.Add("iconUrl", iconUri.Trim());
+                        }
+
+                        if (psData.ContainsKey("releasenotes") && psData["releasenotes"] is string releaseNotes)
+                        {
+                            metadataElementsDictionary.Add("releaseNotes", releaseNotes.Trim());
+                        }
+
+                        // defaults to false
+                        string requireLicenseAcceptance = psData.ContainsKey("requirelicenseacceptance") ? psData["ReleaseNotes"] as string  : "false";
+                        metadataElementsDictionary.Add("requireLicenseAcceptance", requireLicenseAcceptance);
+
+
                         if (psData.ContainsKey("Tags") && psData["Tags"] is Array manifestTags)
                         {
                             var tagArr = new List<string>();
@@ -572,19 +598,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 metadataElementsDictionary.Add("owners", parsedMetadataHash["companyname"].ToString().Trim());
             }
 
-            // defaults to false
-            var requireLicenseAcceptance = parsedMetadataHash.ContainsKey("requirelicenseacceptance") ? parsedMetadataHash["requirelicenseacceptance"].ToString().ToLower().Trim()
-                : "false";
-            metadataElementsDictionary.Add("requireLicenseAcceptance", requireLicenseAcceptance);
-
             if (parsedMetadataHash.ContainsKey("description"))
             {
                 metadataElementsDictionary.Add("description", parsedMetadataHash["description"].ToString().Trim());
-            }
-
-            if (parsedMetadataHash.ContainsKey("releasenotes"))
-            {
-                metadataElementsDictionary.Add("releaseNotes", parsedMetadataHash["releasenotes"].ToString().Trim());
             }
 
             if (parsedMetadataHash.ContainsKey("copyright"))
@@ -602,20 +618,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
             metadataElementsDictionary.Add("tags", tags);
 
-            if (parsedMetadataHash.ContainsKey("licenseuri"))
-            {
-                metadataElementsDictionary.Add("licenseUrl", parsedMetadataHash["licenseuri"].ToString().Trim());
-            }
-
-            if (parsedMetadataHash.ContainsKey("projecturi"))
-            {
-                metadataElementsDictionary.Add("projectUrl", parsedMetadataHash["projecturi"].ToString().Trim());
-            }
-
-            if (parsedMetadataHash.ContainsKey("iconuri"))
-            {
-                metadataElementsDictionary.Add("iconUrl", parsedMetadataHash["iconuri"].ToString().Trim());
-            }
 
             // Example nuspec:
             /*

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -547,7 +547,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                         if (psData.ContainsKey("licenseUri") && psData["licenseuri"] is string licenseUri)
                         {
-                            metadataElementsDictionary.Add("licenseUrl", licenseUri.Trim());
+                            metadataElementsDictionary.Add("license", licenseUri.Trim());
                         }
 
                         if (psData.ContainsKey("projecturi") && psData["projecturi"] is string projectUri)
@@ -630,7 +630,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 <owners>Microsoft,PowerShell</owners>
                 <requireLicenseAcceptance>false</requireLicenseAcceptance>
                 <license type="expression">MIT</license>
-                <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+                <license>https://licenses.nuget.org/MIT</license>
                 <icon>Powershell_black_64.png</icon>
                 <projectUrl>https://github.com/PowerShell/PowerShell</projectUrl>
                 <description>Example description here</description>

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -602,19 +602,19 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
             metadataElementsDictionary.Add("tags", tags);
 
-            if (parsedMetadataHash.ContainsKey("licenseurl"))
+            if (parsedMetadataHash.ContainsKey("licenseuri"))
             {
-                metadataElementsDictionary.Add("licenseUrl", parsedMetadataHash["licenseurl"].ToString().Trim());
+                metadataElementsDictionary.Add("licenseUrl", parsedMetadataHash["licenseuri"].ToString().Trim());
             }
 
-            if (parsedMetadataHash.ContainsKey("projecturl"))
+            if (parsedMetadataHash.ContainsKey("projecturi"))
             {
-                metadataElementsDictionary.Add("projectUrl", parsedMetadataHash["projecturl"].ToString().Trim());
+                metadataElementsDictionary.Add("projectUrl", parsedMetadataHash["projecturi"].ToString().Trim());
             }
 
-            if (parsedMetadataHash.ContainsKey("iconurl"))
+            if (parsedMetadataHash.ContainsKey("iconuri"))
             {
-                metadataElementsDictionary.Add("iconUrl", parsedMetadataHash["iconurl"].ToString().Trim());
+                metadataElementsDictionary.Add("iconUrl", parsedMetadataHash["iconuri"].ToString().Trim());
             }
 
             // Example nuspec:

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -545,7 +545,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                             version = string.Format(@"{0}-{1}", version, preReleaseVersion);
                         }
 
-                        if (psData.ContainsKey("licenseUri") && psData["licenseuri"] is string licenseUri)
+                        if (psData.ContainsKey("licenseuri") && psData["licenseuri"] is string licenseUri)
+
                         {
                             metadataElementsDictionary.Add("license", licenseUri.Trim());
                         }

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -561,13 +561,20 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                             metadataElementsDictionary.Add("iconUrl", iconUri.Trim());
                         }
 
-                        if (psData.ContainsKey("releasenotes") && psData["releasenotes"] is string releaseNotes)
+                        if (psData.ContainsKey("releasenotes"))
                         {
-                            metadataElementsDictionary.Add("releaseNotes", releaseNotes.Trim());
+                            if (psData["releasenotes"] is string releaseNotes)
+                            {
+                                metadataElementsDictionary.Add("releaseNotes", releaseNotes.Trim());
+                            }
+                            else if (psData["releasenotes"] is string[] releaseNotesArr)
+                            {
+                                metadataElementsDictionary.Add("releaseNotes", string.Join("\n", releaseNotesArr));
+                            }
                         }
 
                         // defaults to false
-                        string requireLicenseAcceptance = psData.ContainsKey("requirelicenseacceptance") ? psData["requirelicenseacceptance"] : "false";
+                        string requireLicenseAcceptance = psData.ContainsKey("requirelicenseacceptance") ? psData["requirelicenseacceptance"].ToString() : "false";
 
                         metadataElementsDictionary.Add("requireLicenseAcceptance", requireLicenseAcceptance);
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
In module manifests, properties are labeled "LicenseUri", "ProjectUri", and "IconUri", however in a nuspec the same properties are "LicenseUrl", "ProjectUrl", and "IconUrl", respectively.  This PR updates references to "url" and changes them to "uri" where appropriate.   

All of these properties, as well as "ReleaseNotes"  are found under the "PSData" section of a module manifest, so the code is moved under that section to reflect this and so we can properly extract the respective values.

Only those nuspec properties which exist in the module manifest get added to the nuspec.  See below for all properties that are allowed in a nuspec:
https://docs.microsoft.com/en-us/nuget/reference/nuspec


## PR Context

Resolves #603 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
