### PR TITLE
Add PSModulePath paths when retrieving resource paths

### DIFF
--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -604,14 +604,15 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             return new DirectoryInfo(pkgPath).Parent.Name;
         }
 
-        public static List<string> GetAllResourcePaths(
+        // Find all potential resource paths 
+        public static List<string> GetPathsFromEnvVarAndScope(
             PSCmdlet psCmdlet,
-            ScopeType? scope = null)
+            ScopeType? scope)
         {
             GetStandardPlatformPaths(
-                psCmdlet,
-                out string myDocumentsPath,
-                out string programFilesPath);
+               psCmdlet,
+               out string myDocumentsPath,
+               out string programFilesPath);
 
             List<string> resourcePaths = new List<string>();
 
@@ -634,6 +635,15 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 resourcePaths.Add(Path.Combine(programFilesPath, "Scripts"));
             }
 
+            return resourcePaths;
+        }
+
+        public static List<string> GetAllResourcePaths(
+            PSCmdlet psCmdlet,
+            ScopeType? scope = null)
+        {
+            List<String> resourcePaths = GetPathsFromEnvVarAndScope(psCmdlet, scope);
+            
             // resourcePaths should now contain, eg:
             // ./PowerShell/Scripts
             // ./PowerShell/Modules
@@ -680,26 +690,10 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         // Find all potential installation paths given a scope
         public static List<string> GetAllInstallationPaths(
             PSCmdlet psCmdlet,
-            ScopeType scope)
+            ScopeType? scope)
         {
-            GetStandardPlatformPaths(
-                psCmdlet,
-                out string myDocumentsPath,
-                out string programFilesPath);
-
-            // The default user scope is CurrentUser
-            var installationPaths = new List<string>();
-            if (scope == ScopeType.AllUsers)
-            {
-                installationPaths.Add(Path.Combine(programFilesPath, "Modules"));
-                installationPaths.Add(Path.Combine(programFilesPath, "Scripts"));
-            }
-            else
-            {
-                installationPaths.Add(Path.Combine(myDocumentsPath, "Modules"));
-                installationPaths.Add(Path.Combine(myDocumentsPath, "Scripts"));
-            }
-
+            List<String> installationPaths = GetPathsFromEnvVarAndScope(psCmdlet, scope);
+            
             installationPaths = installationPaths.Distinct(StringComparer.InvariantCultureIgnoreCase).ToList();
             installationPaths.ForEach(dir => psCmdlet.WriteVerbose(string.Format("All paths to search: '{0}'", dir)));
 

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -173,6 +173,13 @@ Describe 'Test Install-PSResource for Module' {
         $pkg.Version | Should -Be "5.0.0.0"
     }
 
+    It "Install resource under specified in PSModulePath" {
+        Install-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName 
+        ($env:PSModulePath).Contains($pkg.InstalledLocation)
+    }
+
     # Windows only
     It "Install resource under CurrentUser scope - Windows only" -Skip:(!(Get-IsWindows)) {
         Install-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository -Scope CurrentUser


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR priorities installing to module paths that are specified in the environment variable `PSModulePath`.  The Util methods 
`GetAllResourcePaths` and `GetAllInstallationPaths` now first check all paths listed under `PSModulePath`, and then check the locations for the scope specified (AllUsers, CurrentUser, or default). 

Due to the fact that thorough testing requires chaning the `PSModulePath` environment variable, I've added a basic test to validate functionality.

## PR Context
Resolves #605
 
## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
