### PR TITLE
Add OutputType attributes to Get-PSResource and Get-PSResourceRepository

### DIFF
--- a/src/code/GetPSResource.cs
+++ b/src/code/GetPSResource.cs
@@ -14,6 +14,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// Returns a single resource or multiple resource.
     /// </summary>
     [Cmdlet(VerbsCommon.Get, "PSResource")]
+    [OutputType(typeof(PSResourceInfo))]
     public sealed class GetPSResource : PSCmdlet
     {
         #region Members

--- a/src/code/GetPSResourceRepository.cs
+++ b/src/code/GetPSResourceRepository.cs
@@ -16,6 +16,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// It returns PSRepositoryInfo objects which describe each resource item found.
     /// </summary>
     [Cmdlet(VerbsCommon.Get, "PSResourceRepository")]
+    [OutputType(typeof(PSRepositoryInfo))]
     public sealed class GetPSResourceRepository : PSCmdlet
     {
         #region Parameters


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add OutputType attributes to `Get-PSResource` and `Get-PSResourceRepository` 

## PR Context

Resolves #635 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
