### PR TITLE
Add error message for failure to install after choosing not to trust repository

### DIFF
--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -20,8 +20,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// </summary>
     [Cmdlet(VerbsCommon.Find,
         "PSResource",
-        DefaultParameterSetName = ResourceNameParameterSet,
-        SupportsShouldProcess = true)]
+        DefaultParameterSetName = ResourceNameParameterSet)]
     [OutputType(typeof(PSResourceInfo), typeof(PSCommandResourceInfo))]
     public sealed class FindPSResource : PSCmdlet
     {

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -157,6 +157,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             var findHelper = new FindHelper(_cancellationToken, _cmdletPassedIn);
             List<PSResourceInfo> allPkgsInstalled = new List<PSResourceInfo>();
+            bool sourceTrusted = true;
 
             foreach (var repo in listOfRepositories)
             {
@@ -168,7 +169,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                 // Source is only trusted if it's set at the repository level to be trusted, -TrustRepository flag is true, -Force flag is true
                 // OR the user issues trust interactively via console.
-                var sourceTrusted = true;
                 if (repo.Trusted == false && !trustRepository && !_force)
                 {
                     _cmdletPassedIn.WriteVerbose("Checking if untrusted repository should be used");
@@ -249,9 +249,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             // At this only package names left were those which could not be found in registered repositories
             foreach (string pkgName in _pkgNamesToInstall)
             {
-                var message = String.Format("Package '{0}' with requested version range {1} could not be installed as it was not found in any registered repositories",
-                    pkgName,
-                    _versionRange.ToString());
+                string message = !sourceTrusted ? $"Package '{pkgName}' with requested version range '{_versionRange.ToString()}' could not be found in any trusted repositories" :
+                                                    $"Package '{pkgName}' with requested version range '{_versionRange.ToString()}' could not be installed as it was not found in any registered repositories";
+
                 var ex = new ArgumentException(message);
                 var ResourceNotFoundError = new ErrorRecord(ex, "ResourceNotFoundError", ErrorCategory.ObjectNotFound, null);
                 _cmdletPassedIn.WriteError(ResourceNotFoundError);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When a user is prompted as to whether they trust a repository or not, if the user selects not to trust the repository, they receive an error message that "Package '<name>' with requested version range '<version>' could not be installed as it was not found in any registered repositories".  This is incorrect information and should actually state that the repository is not trusted and that is why the package failed to install.  This PR adds the correct error message if the user chooses not to trust a repo.

## PR Context

Resolves #687 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
