### PR TITLE
Downgrade NuGet client packages to v5.11.2

### DIFF
--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -20,7 +20,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// </summary>
     [Cmdlet(VerbsCommon.Find,
         "PSResource",
-        DefaultParameterSetName = ResourceNameParameterSet)]
+        DefaultParameterSetName = ResourceNameParameterSet,
+        SupportsShouldProcess = true)]
     [OutputType(typeof(PSResourceInfo), typeof(PSCommandResourceInfo))]
     public sealed class FindPSResource : PSCmdlet
     {

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -20,8 +20,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// </summary>
     [Cmdlet(VerbsCommon.Find,
         "PSResource",
-        DefaultParameterSetName = ResourceNameParameterSet,
-        SupportsShouldProcess = true)]
+        DefaultParameterSetName = ResourceNameParameterSet)]
     [OutputType(typeof(PSResourceInfo), typeof(PSCommandResourceInfo))]
     public sealed class FindPSResource : PSCmdlet
     {

--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -15,12 +15,12 @@
   <ItemGroup>
     <PackageReference Include="LinqKit.Core" Version="1.1.17" />
     <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="NuGet.Commands" Version="6.2.1" />
-    <PackageReference Include="NuGet.Common" Version="6.2.1" />
-    <PackageReference Include="NuGet.Configuration" Version="6.2.1" />
-    <PackageReference Include="NuGet.Packaging" Version="6.2.1" />
-    <PackageReference Include="NuGet.ProjectModel" Version="6.2.1" />
-    <PackageReference Include="NuGet.Protocol" Version="6.2.1" />
+    <PackageReference Include="NuGet.Commands" Version="5.11.2" />
+    <PackageReference Include="NuGet.Common" Version="5.11.2" />
+    <PackageReference Include="NuGet.Configuration" Version="5.11.2" />
+    <PackageReference Include="NuGet.Packaging" Version="5.11.2" />
+    <PackageReference Include="NuGet.ProjectModel" Version="5.11.2" />
+    <PackageReference Include="NuGet.Protocol" Version="5.11.2" />
     <PackageReference Include="NuGet.Repositories" Version="4.3.0-beta1-2418" />
     <PackageReference Include="PowerShellStandard.Library" Version="7.0.0-preview.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.6.0-preview3.19128.7" />


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Downgrade the NuGet client dependency packages to 5.11.2.


## PR Context

The NuGet client packages that PSGet take a dependency can currently only be updated to v5.11.2.  All versions later than this take a dependency on Newtonsoft.Json v13.0.1, which results in runtime errors in versions of PowerShell below 7.2, due to the fact that PS needs a lower version of the assembly. 

There are a few options to consider here:
- creating multiple build targets
- using a dependency resolver that points to the correct assembly
- moving off the NuGet client packages to http requests. 

For now, simple fix is to downgrade the packages until a permanent solution is decided and implemented.
## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
