### PR TITLE
WIP: Populate companyname and other properties for PSResourceInfo

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -328,6 +328,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 totalInstalledPkgCount++;
                 var tempInstallPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+                
                 try
                 {
                     // Create a temp directory to install to
@@ -540,6 +541,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         }
 
                         moduleManifestVersion = parsedMetadataHashtable["ModuleVersion"] as string;
+                        pkg.CompanyName = parsedMetadataHashtable["CompanyName"] as string;
+                        pkg.Copyright = parsedMetadataHashtable["Copyright"] as string;
+                        pkg.ReleaseNotes = parsedMetadataHashtable["ReleaseNotes"] as string;
+                        pkg.RepositorySourceLocation = repoUri;
 
                         // Accept License verification
                         if (!_savePkg && !CallAcceptLicense(pkg, moduleManifest, tempInstallPath, newVersion))
@@ -552,6 +557,28 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         {
                             continue;
                         }
+                    }
+                    else
+                    {
+                        // is script
+                        if (!PSScriptFileInfo.TryTestPSScriptFile(
+                            scriptFileInfoPath: scriptPath,
+                            out PSScriptFileInfo parsedScript,
+                            out ErrorRecord[] errors,
+                            out string[] _))
+                        {
+                            foreach (ErrorRecord parseError in errors)
+                            {
+                                WriteError(parseError);
+                            }
+
+                            continue;
+                        }
+
+                        pkg.CompanyName = parsedScript.ScriptMetadataComment.CompanyName;
+                        pkg.Copyright = parsedScript.ScriptMetadataComment.Copyright;
+                        pkg.ReleaseNotes = parsedScript.ScriptMetadataComment.ReleaseNotes;
+                        pkg.RepositorySourceLocation = repoUri;
                     }
 
                     // Delete the extra nupkg related files that are not needed and not part of the module/script

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -328,7 +328,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 totalInstalledPkgCount++;
                 var tempInstallPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-                
                 try
                 {
                     // Create a temp directory to install to

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -234,8 +234,8 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
         public Dictionary<string, string> AdditionalMetadata { get; }
         public string Author { get; }
-        public string CompanyName { get; }
-        public string Copyright { get; }
+        public string CompanyName { get; internal set; }
+        public string Copyright { get; internal set; }
         public Dependency[] Dependencies { get; }
         public string Description { get; }
         public Uri IconUri { get; }
@@ -250,9 +250,9 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         public string Prerelease { get; }
         public Uri ProjectUri { get; }
         public DateTime? PublishedDate { get; }
-        public string ReleaseNotes { get; }
+        public string ReleaseNotes { get; internal set; }
         public string Repository { get; }
-        public string RepositorySourceLocation { get; }
+        public string RepositorySourceLocation { get; internal set; }
         public string[] Tags { get; }
         public ResourceType Type { get; }
         public DateTime? UpdatedDate { get; }

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -9,6 +9,7 @@ Describe 'Test Install-PSResource for Module' {
     BeforeAll {
         $PSGalleryName = Get-PSGalleryName
         $NuGetGalleryName = Get-NuGetGalleryName
+        $PSGalleryUri = Get-PSGalleryLocation
         $testModuleName = "test_module"
         $testModuleName2 = "TestModule99"
         $testScriptName = "test_script"
@@ -171,6 +172,17 @@ Describe 'Test Install-PSResource for Module' {
         $pkg = Get-PSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName 
         $pkg.Version | Should -Be "5.0.0.0"
+    }
+
+    It "Install resource with companyname, copyright and repository source location and validate" {
+        Install-PSResource -Name $testModuleName -Version "5.2.5-alpha001" -Repository PSGallery -TrustRepository
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Version | Should -Be "5.2.5"
+        $pkg.Prerelease | Should -Be "alpha001"
+
+        $pkg.CompanyName | Should -Be "Anam"
+        $pkg.Copyright | Should -Be "(c) Anam Navied. All rights reserved."
+        $pkg.RepositorySourceLocation | Should -Be $PSGalleryUri
     }
 
     # Windows only


### PR DESCRIPTION
When installing a package, save companyname, copyright and other metadata information to metadata xml file. Also change setters access levels for these properties of the PSResourceInfo class. Get-PSResource will now return consistent information for packages installed with Install-PSResource cmdlet after this fix.

When finding a package, companyname and other related information is not easily accessibly via the json metadata (IPackageSearchMetadata object returned via NuGet GetSearchAsync() and GetMetadataAsync() search APIs and currently is more operational cost than is worth to get this field. Here is a link listing the package information accessible via the package nuspec (note company name is not listed):
https://docs.microsoft.com/en-us/nuget/reference/nuspec

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Resolves #267 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
