### PR TITLE
Fixes for use of IEnumerable and dependent module re-install issues

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -629,8 +629,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                 if (dep.VersionRange == VersionRange.All)
                 {
-                    // return latest version
-                    IPackageSearchMetadata depPkgLatestVersion = depPkgs.First();
+                    // Return latest version, which is first in the list.
+                    IPackageSearchMetadata depPkgLatestVersion = depPkgs[0];
 
                     if (!PSResourceInfo.TryConvert(
                         metadataToParse: depPkgLatestVersion,
@@ -656,9 +656,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                             p.Identity.Version, VersionComparer.VersionRelease)).OrderByDescending(
                                 p => p.Identity.Version).ToList();
 
-                    if (pkgVersionsInRange.Count() > 0)
+                    if (pkgVersionsInRange.Count > 0)
                     {
-                        IPackageSearchMetadata depPkgLatestInRange = pkgVersionsInRange.First();
+                        IPackageSearchMetadata depPkgLatestInRange = pkgVersionsInRange[0];
                         if (depPkgLatestInRange != null)
                         {
                             if (!PSResourceInfo.TryConvert(

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -217,24 +217,19 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 return;
             }            
 
-            List<PSResourceInfo> foundPackages = new List<PSResourceInfo>();
-
-            foreach (PSResourceInfo package in _findHelper.FindByResourceName(
-                Name,
-                Type,
-                Version,
-                Prerelease,
-                Tag,
-                Repository,
-                Credential,
-                IncludeDependencies))
-            {
-                foundPackages.Add(package);
-            }
+            List<PSResourceInfo> foundPackages = _findHelper.FindByResourceName(
+                name: Name,
+                type: Type,
+                version: Version,
+                prerelease: Prerelease,
+                tag: Tag,
+                repository: Repository,
+                credential: Credential,
+                includeDependencies: IncludeDependencies);
 
             foreach (var uniquePackageVersion in foundPackages.GroupBy(
                 m => new {m.Name, m.Version, m.Repository}).Select(
-                    group => group.First()).ToList())
+                    group => group.First()))
             {
                 WriteObject(uniquePackageVersion);
             }
@@ -292,21 +287,15 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 moduleNamesToSearch = new string[] {"*"};
             }
 
-            List<PSResourceInfo> foundPackages = new List<PSResourceInfo>();
-
-            foreach (PSResourceInfo package in _findHelper.FindByResourceName(
+            List<PSResourceInfo> foundPackages = _findHelper.FindByResourceName(
                 name: moduleNamesToSearch,
-                // provide type so Scripts endpoint for PSGallery won't be searched
                 type: isSearchingForCommands? ResourceType.Command : ResourceType.DscResource,
                 version: Version,
                 prerelease: Prerelease,
                 tag: Tag,
                 repository: Repository,
                 credential: Credential,
-                includeDependencies: IncludeDependencies))
-            {
-                foundPackages.Add(package);
-            }
+                includeDependencies: IncludeDependencies);
 
             // if a single package contains multiple commands we are interested in, return a unique entry for each:
             // Command1 , PackageA

--- a/src/code/GetPSResource.cs
+++ b/src/code/GetPSResource.cs
@@ -127,15 +127,15 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     this));
             }
 
-            // this catches the case where Name wasn't passed in as null or empty,
-            // but after filtering out unsupported wildcard names in BeginProcessing() there are no elements left in Name
+            // This catches the case where Name wasn't passed in as null or empty,
+            // but after filtering out unsupported wildcard names in BeginProcessing() there are no elements left in Name.
             if (namesToSearch.Length == 0)
             {
                  return;
             }
 
+            // SelectPrereleaseOnly is false because we want both stable and prerelease versions all the time..
             GetHelper getHelper = new GetHelper(this);
-            // selectPrereleaseOnly is false because we want both stable and prerelease versions all the time.
             foreach (PSResourceInfo pkg in getHelper.GetPackagesFromPath(
                 name: namesToSearch,
                 versionRange: _versionRange,

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -302,7 +302,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 if (!installedPackageNames.Contains(pkg.Name))
                 {
+                    // Add packages that still need to be installed.
                     filteredPackages.Add(pkg);
+                }
+                else
+                {
+                    // Remove from list package versions that are already installed.
+                    _pkgNamesToInstall.RemoveAll(x => x.Equals(pkg.Name, StringComparison.InvariantCultureIgnoreCase));
                 }
             }
 

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -192,20 +192,19 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 var isLocalRepo = repo.Uri.AbsoluteUri.StartsWith(Uri.UriSchemeFile + Uri.SchemeDelimiter, StringComparison.OrdinalIgnoreCase);
 
                 // Finds parent packages and dependencies
-                IEnumerable<PSResourceInfo> pkgsFromRepoToInstall = findHelper.FindByResourceName(
+                List<PSResourceInfo> pkgsFromRepoToInstall = findHelper.FindByResourceName(
                     name: _pkgNamesToInstall.ToArray(),
                     type: ResourceType.None,
-                    version: _versionRange != null ? _versionRange.OriginalString : null,
+                    version: _versionRange?.OriginalString,
                     prerelease: _prerelease,
                     tag: null,
                     repository: new string[] { repoName },
                     credential: credential,
                     includeDependencies: !skipDependencyCheck);
 
-                if (!pkgsFromRepoToInstall.Any())
+                if (pkgsFromRepoToInstall.Count == 0)
                 {
                     _cmdletPassedIn.WriteVerbose(string.Format("None of the specified resources were found in the '{0}' repository.", repoName));
-                    // Check in the next repository
                     continue;
                 }
 
@@ -261,54 +260,53 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         }
 
         // Check if any of the pkg versions are already installed, if they are we'll remove them from the list of packages to install
-        private IEnumerable<PSResourceInfo> FilterByInstalledPkgs(IEnumerable<PSResourceInfo> packages)
+        private List<PSResourceInfo> FilterByInstalledPkgs(List<PSResourceInfo> packages)
         {
-            // Create list of installation paths to search.
-            List<string> _pathsToSearch = new List<string>();
-            // _pathsToInstallPkg will only contain the paths specified within the -Scope param (if applicable)
-            // _pathsToSearch will contain all resource package subdirectories within _pathsToInstallPkg path locations
+            // Package install paths.
+            // _pathsToInstallPkg will only contain the paths specified within the -Scope param (if applicable).
+            // _pathsToSearch will contain all resource package subdirectories within _pathsToInstallPkg path locations.
             // e.g.:
             // ./InstallPackagePath1/PackageA
             // ./InstallPackagePath1/PackageB
             // ./InstallPackagePath2/PackageC
             // ./InstallPackagePath3/PackageD
-            foreach (var path in _pathsToInstallPkg)
-            {
-                _pathsToSearch.AddRange(Utils.GetSubDirectories(path));
-            }
 
-            var filteredPackages = new Dictionary<string, PSResourceInfo>();
+            // Get package names
+            var packageNames = new HashSet<string>(StringComparer.CurrentCultureIgnoreCase);
             foreach (var pkg in packages)
             {
-                filteredPackages.Add(pkg.Name, pkg);
+                packageNames.Add(pkg.Name);
             }
 
-            GetHelper getHelper = new GetHelper(_cmdletPassedIn);
             // Get currently installed packages.
-            // selectPrereleaseOnly is false because even if Prerelease is true we want to include both stable and prerelease, never select prerelease only.
-            IEnumerable<PSResourceInfo> pkgsAlreadyInstalled = getHelper.GetPackagesFromPath(
-                name: filteredPackages.Keys.ToArray(),
+            // SelectPrereleaseOnly is false because even if Prerelease is true we want to include both stable and prerelease, never select prerelease only.
+            var getHelper = new GetHelper(_cmdletPassedIn);
+            var installedPackageNames = new HashSet<string>(StringComparer.CurrentCultureIgnoreCase);
+            foreach (var installedPkg in getHelper.GetPackagesFromPath(
+                name: packageNames.ToArray(),
                 versionRange: _versionRange,
                 pathsToSearch: _pathsToSearch,
-                selectPrereleaseOnly: false);
-            if (!pkgsAlreadyInstalled.Any())
+                selectPrereleaseOnly: false))
+            {
+                installedPackageNames.Add(installedPkg.Name);
+            }
+
+            if (installedPackageNames.Count is 0)
             {
                 return packages;
             }
 
-            // Remove from list package versions that are already installed.
-            foreach (PSResourceInfo pkg in pkgsAlreadyInstalled)
+            // Return only packages that are not already installed.
+            var filteredPackages = new List<PSResourceInfo>();
+            foreach (var pkg in packages)
             {
-                _cmdletPassedIn.WriteWarning(
-                    string.Format("Resource '{0}' with version '{1}' is already installed.  If you would like to reinstall, please run the cmdlet again with the -Reinstall parameter",
-                    pkg.Name,
-                    pkg.Version));
-
-                filteredPackages.Remove(pkg.Name);
-                _pkgNamesToInstall.RemoveAll(x => x.Equals(pkg.Name, StringComparison.InvariantCultureIgnoreCase));
+                if (!installedPackageNames.Contains(pkg.Name))
+                {
+                    filteredPackages.Add(pkg);
+                }
             }
 
-            return filteredPackages.Values.ToArray();
+            return filteredPackages;
         }
 
         private List<PSResourceInfo> InstallPackage(

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -222,7 +222,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     pkgsFromRepoToInstall = FilterByInstalledPkgs(pkgsFromRepoToInstall);
                 }
 
-                if (!pkgsFromRepoToInstall.Any())
+                if (pkgsFromRepoToInstall.Count is 0)
                 {
                     continue;
                 }

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -236,7 +236,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 try
                 {
                     Utils.ValidateModuleManifest(resourceFilePath, out errorMsgs);
-
                 }
                 finally {
                     if (errorMsgs.Length > 0)

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -895,7 +895,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     credential: Credential,
                     includeDependencies: false);
 
-                if (foundDependencies.Count > 0)
+                if (foundDependencies.Count is 0)
                 {
                     var message = String.Format("Dependency '{0}' was not found in repository '{1}'.  Make sure the dependency is published to the repository before publishing this module.", dependency, repositoryName);
                     var ex = new ArgumentException(message);

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -885,9 +885,17 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 FindHelper findHelper = new FindHelper(_cancellationToken, this);
                 bool depPrerelease = depVersion.Contains("-");
 
-                var repository = new[] { repositoryName };
-                var dependencyFound = findHelper.FindByResourceName(depName, ResourceType.Module, depVersion, depPrerelease, null, repository, Credential, false);
-                if (dependencyFound == null || !dependencyFound.Any())
+                var foundDependencies = findHelper.FindByResourceName(
+                    name: depName,
+                    type: ResourceType.Module,
+                    version: depVersion,
+                    prerelease: depPrerelease,
+                    tag: null,
+                    repository: new[] { repositoryName },
+                    credential: Credential,
+                    includeDependencies: false);
+
+                if (foundDependencies.Count > 0)
                 {
                     var message = String.Format("Dependency '{0}' was not found in repository '{1}'.  Make sure the dependency is published to the repository before publishing this module.", dependency, repositoryName);
                     var ex = new ArgumentException(message);
@@ -897,6 +905,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     return false;
                 }
             }
+
             return true;
         }
 

--- a/test/FindPSResource.Tests.ps1
+++ b/test/FindPSResource.Tests.ps1
@@ -122,7 +122,7 @@ Describe 'Test Find-PSResource for Module' {
     ) {
         param($Version, $Description)
 
-        $res = Find-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName
+        $res = Find-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName 2>$null
         $res | Should -BeNullOrEmpty
     }
 

--- a/test/UpdatePSResource.Tests.ps1
+++ b/test/UpdatePSResource.Tests.ps1
@@ -123,7 +123,7 @@ Describe 'Test Update-PSResource' {
         param($Version, $Description)
 
         Install-PSResource -Name $testModuleName -Version "1.0.0.0" -Repository $PSGalleryName -TrustRepository
-        Update-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -TrustRepository
+        Update-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -TrustRepository 2>$null
 
         $res = Get-PSResource -Name $testModuleName
         $isPkgUpdated = $false


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR contains fixes for unneeded use of IEnumerable interface and dependent module re-install bug.

## PR Context

There are some cases where we use the IEnumerable interface when we are really performing multiple operations on a collection.  The result is that the enumerator is instantiated multiple times and can cause performance degradation.  In these cases I just return a collection object instead of a IEnumerable interface.

Also fix some places where ToList() is used unnecessarily because a simple iterator is all that is needed.

Also found a bug in the module dependency check where dependent modules were re-installed unnecessarily (`-Reinstall` parameter not specified), because of an incorrect version check.  Fix is to create a utility method that performs the specific version check.  This could have a significant performance affect.

Also fixed minor code style issues.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
