### PR TITLE
Change default path to CurrentFileSystemLocation

### DIFF
--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -91,8 +91,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             set
             {
                 string resolvedPath = string.Empty;
-                if (!string.IsNullOrEmpty(value))
+                if (string.IsNullOrEmpty(value))
                 {
+                    // If the user does not specify a path to save to, use the user's current working directory
+                    resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(SessionState.Path.CurrentFileSystemLocation).First().Path;
+                }
+                else {
                     resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
                 }
 
@@ -154,12 +158,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             // Create a repository story (the PSResourceRepository.xml file) if it does not already exist
             // This is to create a better experience for those who have just installed v3 and want to get up and running quickly
             RepositorySettings.CheckRepositoryStore();
-
-            // If the user does not specify a path to save to, use the user's current working directory
-            if (string.IsNullOrWhiteSpace(_path))
-            {
-                _path = SessionState.Path.CurrentLocation.Path;
-            }
 
             _installHelper = new InstallHelper(cmdletPassedIn: this);
         }

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -94,7 +94,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 if (string.IsNullOrEmpty(value))
                 {
                     // If the user does not specify a path to save to, use the user's current working directory
-                    resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(SessionState.Path.CurrentFileSystemLocation).First().Path;
+                    resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(SessionState.Path.CurrentFileSystemLocation.Path).First().Path;
                 }
                 else {
                     resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR changes the default value for the -Path parameter in `Save-PSResource` from `ExecutionContext.SessionState.Path.CurrentLocation`
 to `ExecutionContext.SessionState.Path.CurrentFileSystemLocation` in order to address a bug with default/current paths that are not file system provider paths.
## PR Context

Resolves #702 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [x] [Documentation needed]()
        - [x] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
