### PR TITLE
Add -TemporaryPath parameter to Install-PSResource, Save-PSResource, and Update-PSResource

### DIFF
--- a/help/Install-PSResource.md
+++ b/help/Install-PSResource.md
@@ -17,7 +17,7 @@ Installs resources from a registered repository.
 
 ```
 Install-PSResource [-Name] <string[]> [-Version <string>] [-Prerelease] [-Repository <string[]>]
- [-Credential <pscredential>] [-Scope <ScopeType>] [-TrustRepository] [-Reinstall] [-Quiet]
+ [-Credential <pscredential>] [-Scope <ScopeType>] [-TemporaryPath <string>] [-TrustRepository] [-Reinstall] [-Quiet]
  [-AcceptLicense] [-NoClobber] [-SkipDependencyCheck] [-AuthenticodeCheck] [-PassThru] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
@@ -220,6 +220,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemporaryPath
+
+Specifies the path to temporarily install the resource before actual installation. If no temporary path is provided, the resource is temporarily installed in the current user's temporary folder. 
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/help/Save-PSResource.md
+++ b/help/Save-PSResource.md
@@ -17,7 +17,7 @@ Saves resources (modules and scripts) from a registered repository onto the mach
 
 ```
 Save-PSResource [-Name] <string[]> [-Version <string>] [-Prerelease] [-Repository <string[]>]
- [-Credential <pscredential>] [-AsNupkg] [-IncludeXML] [-Path <string>] [-TrustRepository]
+ [-Credential <pscredential>] [-AsNupkg] [-IncludeXML] [-Path <string>] [-TemporaryPath <string>] [-TrustRepository]
  [-PassThru] [-SkipDependencyCheck] [-AuthenticodeCheck] [-Quiet] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
@@ -194,6 +194,22 @@ Accept wildcard characters: False
 
 Specifies the path to save the resource to. If no path is provided, the resource is saved to the
 current location.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemporaryPath
+
+Specifies the path to temporarily install the resource before saving. If no temporary path is provided, the resource is temporarily installed in the current user's temporary folder. 
 
 ```yaml
 Type: System.String

--- a/help/Update-PSResource.md
+++ b/help/Update-PSResource.md
@@ -17,7 +17,7 @@ Downloads and installs the newest version of a package already installed on the 
 
 ```
 Update-PSResource [[-Name] <string[]>] [-Version <string>] [-Prerelease] [-Repository <string[]>]
- [-Scope <ScopeType>] [-TrustRepository] [-Credential <pscredential>] [-Quiet] [-AcceptLicense]
+ [-Scope <ScopeType>] [-TemporaryPath <string>] [-TrustRepository] [-Credential <pscredential>] [-Quiet] [-AcceptLicense]
  [-Force] [-PassThru] [-SkipDependencyCheck] [-AuthenticodeCheck] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
@@ -158,6 +158,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemporaryPath
+
+Specifies the path to temporarily install the resource before actual installatoin. If no temporary path is provided, the resource is temporarily installed in the current user's temporary folder. 
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -53,6 +53,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         private bool _savePkg;
         List<string> _pathsToSearch;
         List<string> _pkgNamesToInstall;
+        private string _tmpPath;
 
         #endregion
 
@@ -82,7 +83,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             bool skipDependencyCheck,
             bool authenticodeCheck,
             bool savePkg,
-            List<string> pathsToInstallPkg)
+            List<string> pathsToInstallPkg,
+            string tmpPath)
         {
             _cmdletPassedIn.WriteVerbose(string.Format("Parameters passed in >>> Name: '{0}'; Version: '{1}'; Prerelease: '{2}'; Repository: '{3}'; " +
                 "AcceptLicense: '{4}'; Quiet: '{5}'; Reinstall: '{6}'; TrustRepository: '{7}'; NoClobber: '{8}'; AsNupkg: '{9}'; IncludeXml '{10}'; SavePackage '{11}'",
@@ -113,6 +115,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             _includeXml = includeXml;
             _savePkg = savePkg;
             _pathsToInstallPkg = pathsToInstallPkg;
+            _tmpPath = tmpPath;
 
             // Create list of installation paths to search.
             _pathsToSearch = new List<string>();

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -87,7 +87,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             string tmpPath)
         {
             _cmdletPassedIn.WriteVerbose(string.Format("Parameters passed in >>> Name: '{0}'; Version: '{1}'; Prerelease: '{2}'; Repository: '{3}'; " +
-                "AcceptLicense: '{4}'; Quiet: '{5}'; Reinstall: '{6}'; TrustRepository: '{7}'; NoClobber: '{8}'; AsNupkg: '{9}'; IncludeXml '{10}'; SavePackage '{11}'",
+                "AcceptLicense: '{4}'; Quiet: '{5}'; Reinstall: '{6}'; TrustRepository: '{7}'; NoClobber: '{8}'; AsNupkg: '{9}'; IncludeXml '{10}'; SavePackage '{11}'; TemporaryPath '{12}'",
                 string.Join(",", names),
                 versionRange != null ? (versionRange.OriginalString != null ? versionRange.OriginalString : string.Empty) : string.Empty,
                 prerelease.ToString(),
@@ -99,7 +99,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 noClobber.ToString(),
                 asNupkg.ToString(),
                 includeXml.ToString(),
-                savePkg.ToString()));
+                savePkg.ToString(),
+                tmpPath != null ? tmpPath.ToString() : string.Empty));
 
             _versionRange = versionRange;
             _prerelease = prerelease;
@@ -115,7 +116,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             _includeXml = includeXml;
             _savePkg = savePkg;
             _pathsToInstallPkg = pathsToInstallPkg;
-            _tmpPath = tmpPath;
+            _tmpPath = tmpPath ?? Path.GetTempPath();
 
             // Create list of installation paths to search.
             _pathsToSearch = new List<string>();
@@ -330,7 +331,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             foreach (PSResourceInfo pkg in pkgsToInstall)
             {
                 currentInstalledPkgCount++;
-                var tempInstallPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+                var tempInstallPath = Path.Combine(_tmpPath, Guid.NewGuid().ToString());
                 try
                 {
                     // Create a temp directory to install to

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -100,7 +100,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 asNupkg.ToString(),
                 includeXml.ToString(),
                 savePkg.ToString(),
-                tmpPath != null ? tmpPath.ToString() : string.Empty));
+                tmpPath ?? string.Empty));
+
 
             _versionRange = versionRange;
             _prerelease = prerelease;

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -65,12 +65,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// Specifies the scope of installation.
         /// </summary>
         [Parameter]
+        [ValidateNotNullOrEmpty]
         public ScopeType Scope { get; set; }
 
         /// <summary>
         /// The destination where the resource is to be temporarily installed
         /// </summary>
         [Parameter]
+        [ValidateNotNullOrEmpty]
         public string TemporaryPath
         {
             get

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -68,6 +68,31 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         public ScopeType Scope { get; set; }
 
         /// <summary>
+        /// The destination where the resource is to be temporarily installed
+        /// </summary>
+        [Parameter]
+        public string TemporaryPath
+        {
+            get
+            { return _tmpPath; }
+
+            set
+            {
+                if (!string.IsNullOrEmpty(value))
+                {
+                    string resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
+
+                    // Path where resource is temporarily saved must be a directory
+                    if (Directory.Exists(resolvedPath))
+                    {
+                        _tmpPath = resolvedPath;
+                    }
+                }
+            }
+        }
+        private string _tmpPath;
+
+        /// <summary>
         /// Suppresses being prompted for untrusted sources.
         /// </summary>
         [Parameter]
@@ -528,7 +553,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 skipDependencyCheck: SkipDependencyCheck,
                 authenticodeCheck: AuthenticodeCheck,
                 savePkg: false,
-                pathsToInstallPkg: _pathsToInstallPkg);
+                pathsToInstallPkg: _pathsToInstallPkg,
+                tmpPath: _tmpPath);
 
             if (PassThru)
             {

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -79,16 +79,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             set
             {
-                if (!string.IsNullOrEmpty(value))
-                {
-                    string resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
-
-                    // Path where resource is temporarily saved must be a directory
-                    if (Directory.Exists(resolvedPath))
-                    {
-                        _tmpPath = resolvedPath;
-                    }
-                }
+                if (WildcardPattern.ContainsWildcardCharacters(value)) 
+                { 
+                    throw new PSArgumentException("Wildcard characters are not allowed in the temporary path."); 
+                } 
+                
+                // This will throw if path cannot be resolved
+                _tmpPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
             }
         }
         private string _tmpPath;

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -65,7 +65,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// Specifies the scope of installation.
         /// </summary>
         [Parameter]
-        [ValidateNotNullOrEmpty]
         public ScopeType Scope { get; set; }
 
         /// <summary>

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -110,7 +110,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         private string _path;
 
         /// <summary>
-        /// The destination where the resource is to be temporarily installed
+        /// The destination where the resource is to be temporarily saved to.
+
         /// </summary>
         [Parameter]
         [ValidateNotNullOrEmpty]

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -113,6 +113,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// The destination where the resource is to be temporarily installed
         /// </summary>
         [Parameter]
+        [ValidateNotNullOrEmpty]
         public string TemporaryPath
         {
             get

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -109,6 +109,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         }
         private string _path;
 
+        /// <summary>
+        /// The destination where the resource is to be temporarily installed
+        /// </summary>
+        [Parameter]
         public string TemporaryPath
         {
             get
@@ -116,20 +120,15 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             set
             {
-                string resolvedPath;
-                if (string.IsNullOrEmpty(value))
+                if (!string.IsNullOrEmpty(value))
                 {
-                    // If the user does not specify a path to save to, use the user's default temporary directory
-                    resolvedPath = System.IO.Path.GetTempPath();
-                }
-                else {
-                    resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
-                }
+                    string resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
 
-                // Path where resource is saved must be a directory
-                if (Directory.Exists(resolvedPath))
-                {
-                    _tmpPath = resolvedPath;
+                    // Path where resource is temporarily saved must be a directory
+                    if (Directory.Exists(resolvedPath))
+                    {
+                        _tmpPath = resolvedPath;
+                    }
                 }
             }
         }

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -109,6 +109,32 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         }
         private string _path;
 
+        public string TemporaryPath
+        {
+            get
+            { return _tmpPath; }
+
+            set
+            {
+                string resolvedPath;
+                if (string.IsNullOrEmpty(value))
+                {
+                    // If the user does not specify a path to save to, use the user's default temporary directory
+                    resolvedPath = System.IO.Path.GetTempPath();
+                }
+                else {
+                    resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
+                }
+
+                // Path where resource is saved must be a directory
+                if (Directory.Exists(resolvedPath))
+                {
+                    _tmpPath = resolvedPath;
+                }
+            }
+        }
+        private string _tmpPath;
+
         /// <summary>
         /// Suppresses being prompted for untrusted sources.
         /// </summary>
@@ -266,7 +292,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 skipDependencyCheck: SkipDependencyCheck,
                 authenticodeCheck: AuthenticodeCheck,
                 savePkg: true,
-                pathsToInstallPkg: new List<string> { _path });
+                pathsToInstallPkg: new List<string> { _path },
+                tmpPath: _tmpPath);
 
             if (PassThru)
             {

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -122,16 +122,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             set
             {
-                if (!string.IsNullOrEmpty(value))
-                {
-                    string resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
-
-                    // Path where resource is temporarily saved must be a directory
-                    if (Directory.Exists(resolvedPath))
-                    {
-                        _tmpPath = resolvedPath;
-                    }
-                }
+                if (WildcardPattern.ContainsWildcardCharacters(value)) 
+                { 
+                    throw new PSArgumentException("Wildcard characters are not allowed in the temporary path."); 
+                } 
+                
+                // This will throw if path cannot be resolved
+                _tmpPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
             }
         }
         private string _tmpPath;

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -70,7 +70,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         public ScopeType Scope { get; set; }
 
         /// <summary>
-        /// The destination where the resource is to be temporarily installed
+        /// The destination where the resource is to be temporarily installed to while updating.
+
         /// </summary>
         [Parameter]
         [ValidateNotNullOrEmpty]

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -82,16 +82,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             set
             {
-                if (!string.IsNullOrEmpty(value))
-                {
-                    string resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
-
-                    // Path where resource is temporarily saved must be a directory
-                    if (Directory.Exists(resolvedPath))
-                    {
-                        _tmpPath = resolvedPath;
-                    }
-                }
+                if (WildcardPattern.ContainsWildcardCharacters(value)) 
+                { 
+                    throw new PSArgumentException("Wildcard characters are not allowed in the temporary path."); 
+                } 
+                
+                // This will throw if path cannot be resolved
+                _tmpPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
             }
         }
         private string _tmpPath;

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -73,6 +73,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// The destination where the resource is to be temporarily installed
         /// </summary>
         [Parameter]
+        [ValidateNotNullOrEmpty]
         public string TemporaryPath
         {
             get

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -5,6 +5,7 @@ using Microsoft.PowerShell.PowerShellGet.UtilClasses;
 using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using System.Threading;
@@ -67,6 +68,31 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// </summary>
         [Parameter]
         public ScopeType Scope { get; set; }
+
+        /// <summary>
+        /// The destination where the resource is to be temporarily installed
+        /// </summary>
+        [Parameter]
+        public string TemporaryPath
+        {
+            get
+            { return _tmpPath; }
+
+            set
+            {
+                if (!string.IsNullOrEmpty(value))
+                {
+                    string resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
+
+                    // Path where resource is temporarily saved must be a directory
+                    if (Directory.Exists(resolvedPath))
+                    {
+                        _tmpPath = resolvedPath;
+                    }
+                }
+            }
+        }
+        private string _tmpPath;
 
         /// <summary>
         /// When specified, suppresses prompting for untrusted sources.
@@ -187,7 +213,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 skipDependencyCheck: SkipDependencyCheck,
                 authenticodeCheck: AuthenticodeCheck,
                 savePkg: false,
-                pathsToInstallPkg: _pathsToInstallPkg);
+                pathsToInstallPkg: _pathsToInstallPkg,
+                tmpPath: _tmpPath);
 
             if (PassThru)
             {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
This PR adds a parameter called `-TemporaryPath` for `Install-PSResource`, `Save-PSResource`, and `Update-PSResource` cmdlets, which allows users to set the directory for temporary installation.  

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Resolves #650 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
