### PR TITLE
Add String and SecureString to acceptable credential types in PSCredentialInfo

### DIFF
--- a/src/code/PSCredentialInfo.cs
+++ b/src/code/PSCredentialInfo.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             {
                 Credential = new PSCredential("PSGetUser", credSS);
             }
-            else if (credentialAttr is PSCredential)
+            else if (credentialAttr is PSCredential psCred)
             {
                 Credential = (PSCredential)credentialAttr;
             }

--- a/src/code/PSCredentialInfo.cs
+++ b/src/code/PSCredentialInfo.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             var credentialAttr = psObject.Properties[PSCredentialInfo.CredentialAttribute]?.Value;
             if (credentialAttr is string credStr)
             {
-                Credential = new PSCredential("PSGetUser", new NetworkCredential("", (String) credentialAttr).SecurePassword);
+                Credential = new PSCredential("PSGetUser", new NetworkCredential("", credStr).SecurePassword);
             }
             else if ((credentialAttr as PSObject)?.BaseObject is SecureString)
             {

--- a/src/code/PSCredentialInfo.cs
+++ b/src/code/PSCredentialInfo.cs
@@ -94,7 +94,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             {
                 Credential = new PSCredential("PSGetUser", new NetworkCredential("", (String) credentialAttr).SecurePassword);
             }
-            else if ((credentialAttr as PSObject).BaseObject is SecureString)
+            else if ((credentialAttr as PSObject)?.BaseObject is SecureString)
             {
                 Credential = new PSCredential("PSGetUser", (credentialAttr as PSObject).BaseObject as SecureString);
             }

--- a/src/code/PSCredentialInfo.cs
+++ b/src/code/PSCredentialInfo.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             SecretName = (string) psObject.Properties[PSCredentialInfo.SecretNameAttribute]?.Value;
 
             var credentialAttr = psObject.Properties[PSCredentialInfo.CredentialAttribute]?.Value;
-            if (credentialAttr is String)
+            if (credentialAttr is string credStr)
             {
                 Credential = new PSCredential("PSGetUser", new NetworkCredential("", (String) credentialAttr).SecurePassword);
             }

--- a/src/code/PSCredentialInfo.cs
+++ b/src/code/PSCredentialInfo.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Management.Automation;
+using System.Net;
+using System.Security;
 
 namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 {
@@ -26,6 +28,36 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             VaultName = vaultName;
             SecretName = secretName;
             Credential = credential;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the PSCredentialInfo class with
+        /// vaultName and secretName of type string, and
+        /// credential of type String.
+        /// </summary>
+        /// <param name="vaultName"></param>
+        /// <param name="secretName"></param>
+        /// <param name="credential"></param>
+        public PSCredentialInfo(string vaultName, string secretName, string credential)
+        {
+            VaultName = vaultName;
+            SecretName = secretName;
+            Credential = new PSCredential("PSGetUser", new NetworkCredential("", credential).SecurePassword);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the PSCredentialInfo class with
+        /// vaultName and secretName of type string, and
+        /// credential of type SecureString.
+        /// </summary>
+        /// <param name="vaultName"></param>
+        /// <param name="secretName"></param>
+        /// <param name="credential"></param>
+        public PSCredentialInfo(string vaultName, string secretName, SecureString credential)
+        {
+            VaultName = vaultName;
+            SecretName = secretName;
+            Credential = new PSCredential("PSGetUser", credential);
         }
 
         /// <summary>

--- a/src/code/PSCredentialInfo.cs
+++ b/src/code/PSCredentialInfo.cs
@@ -17,60 +17,17 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
         /// <summary>
         /// Initializes a new instance of the PSCredentialInfo class with
-        /// vaultName and secretName of type string
-        /// </summary>
-        /// <param name="vaultName"></param>
-        /// <param name="secretName"></param>
-        public PSCredentialInfo(string vaultName, string secretName)
-        {
-            VaultName = vaultName;
-            SecretName = secretName;
-            Credential = null;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the PSCredentialInfo class with
         /// vaultName and secretName of type string, and
-        /// credential of type PSCredential.
+        /// (optionally) credential of type PSCredential.
         /// </summary>
         /// <param name="vaultName"></param>
         /// <param name="secretName"></param>
         /// <param name="credential"></param>
-        public PSCredentialInfo(string vaultName, string secretName, PSCredential credential)
+        public PSCredentialInfo(string vaultName, string secretName, PSCredential credential = null)
         {
             VaultName = vaultName;
             SecretName = secretName;
             Credential = credential;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the PSCredentialInfo class with
-        /// vaultName and secretName of type string, and
-        /// credential of type String.
-        /// </summary>
-        /// <param name="vaultName"></param>
-        /// <param name="secretName"></param>
-        /// <param name="credential"></param>
-        public PSCredentialInfo(string vaultName, string secretName, string credential)
-        {
-            VaultName = vaultName;
-            SecretName = secretName;
-            Credential = new PSCredential("PSGetUser", new NetworkCredential("", credential).SecurePassword);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the PSCredentialInfo class with
-        /// vaultName and secretName of type string, and
-        /// credential of type SecureString.
-        /// </summary>
-        /// <param name="vaultName"></param>
-        /// <param name="secretName"></param>
-        /// <param name="credential"></param>
-        public PSCredentialInfo(string vaultName, string secretName, SecureString credential)
-        {
-            VaultName = vaultName;
-            SecretName = secretName;
-            Credential = new PSCredential("PSGetUser", credential);
         }
 
         /// <summary>

--- a/src/code/PSCredentialInfo.cs
+++ b/src/code/PSCredentialInfo.cs
@@ -31,12 +31,12 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         /// <summary>
         /// Initializes a new instance of the PSCredentialInfo class with
         /// vaultName and secretName of type string, and
-        /// (optionally) credential of type PSCredential.
+        /// credential of type PSCredential.
         /// </summary>
         /// <param name="vaultName"></param>
         /// <param name="secretName"></param>
         /// <param name="credential"></param>
-        public PSCredentialInfo(string vaultName, string secretName, PSCredential credential = null)
+        public PSCredentialInfo(string vaultName, string secretName, PSCredential credential)
         {
             VaultName = vaultName;
             SecretName = secretName;

--- a/src/code/PSCredentialInfo.cs
+++ b/src/code/PSCredentialInfo.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             }
             else if (credentialAttr is PSCredential psCred)
             {
-                Credential = (PSCredential)credentialAttr;
+                Credential = psCred;
             }
         }
 

--- a/src/code/PSCredentialInfo.cs
+++ b/src/code/PSCredentialInfo.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             }
             else if ((credentialAttr as PSObject)?.BaseObject is SecureString credSS)
             {
-                Credential = new PSCredential("PSGetUser", (credentialAttr as PSObject).BaseObject as SecureString);
+                Credential = new PSCredential("PSGetUser", credSS);
             }
             else if (credentialAttr is PSCredential)
             {

--- a/src/code/PSCredentialInfo.cs
+++ b/src/code/PSCredentialInfo.cs
@@ -17,6 +17,19 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
         /// <summary>
         /// Initializes a new instance of the PSCredentialInfo class with
+        /// vaultName and secretName of type string
+        /// </summary>
+        /// <param name="vaultName"></param>
+        /// <param name="secretName"></param>
+        public PSCredentialInfo(string vaultName, string secretName)
+        {
+            VaultName = vaultName;
+            SecretName = secretName;
+            Credential = null;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the PSCredentialInfo class with
         /// vaultName and secretName of type string, and
         /// (optionally) credential of type PSCredential.
         /// </summary>

--- a/src/code/PSCredentialInfo.cs
+++ b/src/code/PSCredentialInfo.cs
@@ -88,7 +88,20 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
             VaultName = (string) psObject.Properties[PSCredentialInfo.VaultNameAttribute]?.Value;
             SecretName = (string) psObject.Properties[PSCredentialInfo.SecretNameAttribute]?.Value;
-            Credential = (PSCredential) psObject.Properties[PSCredentialInfo.CredentialAttribute]?.Value;
+
+            var credentialAttr = psObject.Properties[PSCredentialInfo.CredentialAttribute]?.Value;
+            if (credentialAttr is String)
+            {
+                Credential = new PSCredential("PSGetUser", new NetworkCredential("", (String) credentialAttr).SecurePassword);
+            }
+            else if ((credentialAttr as PSObject).BaseObject is SecureString)
+            {
+                Credential = new PSCredential("PSGetUser", (credentialAttr as PSObject).BaseObject as SecureString);
+            }
+            else if (credentialAttr is PSCredential)
+            {
+                Credential = (PSCredential)credentialAttr;
+            }
         }
 
         #endregion

--- a/src/code/PSCredentialInfo.cs
+++ b/src/code/PSCredentialInfo.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             {
                 Credential = new PSCredential("PSGetUser", new NetworkCredential("", credStr).SecurePassword);
             }
-            else if ((credentialAttr as PSObject)?.BaseObject is SecureString)
+            else if ((credentialAttr as PSObject)?.BaseObject is SecureString credSS)
             {
                 Credential = new PSCredential("PSGetUser", (credentialAttr as PSObject).BaseObject as SecureString);
             }

--- a/test/PSCredentialInfo.Tests.ps1
+++ b/test/PSCredentialInfo.Tests.ps1
@@ -63,7 +63,7 @@ Describe "Create PSCredentialInfo from a PSObject" -tags 'CI' {
         $credentialInfo.SecretName | Should -Be "testsecret"
     }
 
-    It "Creates PSCredentialInfo successfully from PSObject with VaultName, SecretName and Credential" {
+    It "Creates PSCredentialInfo successfully from PSObject with VaultName, SecretName and PSCredential Credential" {
         $credential = New-Object System.Management.Automation.PSCredential ("username", (ConvertTo-SecureString "password" -AsPlainText -Force))
         $properties = [PSCustomObject]@{
             VaultName = "testvault"
@@ -77,6 +77,36 @@ Describe "Create PSCredentialInfo from a PSObject" -tags 'CI' {
         $credentialInfo.SecretName | Should -Be "testsecret"
         $credentialInfo.Credential.UserName | Should -Be "username"
         $credentialInfo.Credential.GetNetworkCredential().Password | Should -Be "password"
-        
+    }
+
+    It "Creates PSCredentialInfo successfully from PSObject with VaultName, SecretName and string Credential" {
+        $properties = [PSCustomObject]@{
+            VaultName = "testvault"
+            SecretName = "testsecret"
+            Credential = "password"
+        }
+
+        $credentialInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo] $properties
+
+        $credentialInfo.VaultName | Should -Be "testvault"
+        $credentialInfo.SecretName | Should -Be "testsecret"
+        $credentialInfo.Credential.UserName | Should -Be "username"
+        $credentialInfo.Credential.GetNetworkCredential().Password | Should -Be "password"
+    }
+
+    It "Creates PSCredentialInfo successfully from PSObject with VaultName, SecretName and SecureString Credential" {
+        $secureString = ConvertTo-SecureString "password" -AsPlainText -Force
+        $properties = [PSCustomObject]@{
+            VaultName = "testvault"
+            SecretName = "testsecret"
+            Credential = $secureString
+        }
+
+        $credentialInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo] $properties
+
+        $credentialInfo.VaultName | Should -Be "testvault"
+        $credentialInfo.SecretName | Should -Be "testsecret"
+        $credentialInfo.Credential.UserName | Should -Be "username"
+        $credentialInfo.Credential.GetNetworkCredential().Password | Should -Be "password"
     }
 }

--- a/test/PSCredentialInfo.Tests.ps1
+++ b/test/PSCredentialInfo.Tests.ps1
@@ -78,7 +78,7 @@ Describe "Create PSCredentialInfo from a PSObject" -tags 'CI' {
         $credentialInfo.Credential.UserName | Should -Be "username"
         $credentialInfo.Credential.GetNetworkCredential().Password | Should -Be "password"
     }
-
+ 
     It "Creates PSCredentialInfo successfully from PSObject with VaultName, SecretName and string Credential" {
         $properties = [PSCustomObject]@{
             VaultName = "testvault"
@@ -90,7 +90,6 @@ Describe "Create PSCredentialInfo from a PSObject" -tags 'CI' {
 
         $credentialInfo.VaultName | Should -Be "testvault"
         $credentialInfo.SecretName | Should -Be "testsecret"
-        $credentialInfo.Credential.UserName | Should -Be "username"
         $credentialInfo.Credential.GetNetworkCredential().Password | Should -Be "password"
     }
 
@@ -106,7 +105,6 @@ Describe "Create PSCredentialInfo from a PSObject" -tags 'CI' {
 
         $credentialInfo.VaultName | Should -Be "testvault"
         $credentialInfo.SecretName | Should -Be "testsecret"
-        $credentialInfo.Credential.UserName | Should -Be "username"
         $credentialInfo.Credential.GetNetworkCredential().Password | Should -Be "password"
     }
 }

--- a/test/PSCredentialInfo.Tests.ps1
+++ b/test/PSCredentialInfo.Tests.ps1
@@ -23,7 +23,7 @@ Describe "Create PSCredentialInfo with VaultName and SecretName" -tags 'CI' {
 Describe "Create PSCredentialInfo with VaultName, SecretName, and Credential" -tags 'CI' {
 
     It "Creates PSCredentialInfo successfully if Credential is null" {
-        $credentialInfo = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "testsecret", $null)
+        $credentialInfo = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "testsecret")
         
         $credentialInfo.VaultName | Should -Be "testvault"
         $credentialInfo.SecretName | Should -Be "testsecret"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Currently `Register-PSResourceRepository` and `Set-PSResourceRepository` both have a `-CredentialInfo` parameter, which takes a type of `PSCredentialInfo`.  This type includes the vault name, secret name, and `PSCredential` object, all used to configure credential persistence with SecretManagement.  

This PR allows for credentials of type `String` and `SecureString` to be passed in as a `Credential` within `PSCredentialInfo`

## PR Context

Resolves #652 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
