### PR TITLE
Rename -FilePath parameter to -Path for *-PSScriptFileInfo cmdlets

### DIFF
--- a/help/New-PSScriptFileInfo.md
+++ b/help/New-PSScriptFileInfo.md
@@ -16,7 +16,7 @@ The cmdlet creates a new script file, including metadata about the script.
 ### __AllParameterSets
 
 ```
-New-PSScriptFileInfo [-FilePath] <string> -Description <string> [-Version <string>]
+New-PSScriptFileInfo [-Path] <string> -Description <string> [-Version <string>]
  [-Author <string>] [-Guid <guid>] [-CompanyName <string>] [-Copyright <string>]
  [-RequiredModules <hashtable[]>] [-ExternalModuleDependencies <string[]>]
  [-RequiredScripts <string[]>] [-ExternalScriptDependencies <string[]>] [-Tags <string[]>]
@@ -33,12 +33,12 @@ package.
 
 ### Example 1: Creating an empty script with minimal information
 
-This example runs the cmdlet using only required parameters. The **FilePath** parameter specifies
+This example runs the cmdlet using only required parameters. The **Path** parameter specifies
 the nane and location of the script. The **Description** parameter provide the description used in
 the comment-based help for the script.
 
 ```powershell
-New-PSScriptFileInfo -FilePath ./test_script.ps1 -Description "This is a test script."
+New-PSScriptFileInfo -Path ./test_script.ps1 -Description "This is a test script."
 Get-Content ./test_script.ps1
 ```
 
@@ -96,7 +96,7 @@ of hashtables. The **ModuleName** key in the hashtable is required. You can also
 
 ```powershell
 $parameters = @{
-    FilePath = './test_script2.ps1'
+    Path = './test_script2.ps1'
     Description = 'This is a test script.'
     Version = '2.0.0.0'
     Author = 'janedoe'
@@ -255,7 +255,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -FilePath
+### -Path
 
 The filename and location where the script is created.
 

--- a/help/Test-PSScriptFileInfo.md
+++ b/help/Test-PSScriptFileInfo.md
@@ -15,7 +15,7 @@ Tests the comment-based metadata in a `.ps1` file to ensure it's valid for publi
 ### __AllParameterSets
 
 ```
-Test-PSScriptFileInfo [-FilePath] <string> [<CommonParameters>]
+Test-PSScriptFileInfo [-Path] <string> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -31,8 +31,8 @@ This example creates a new script file then runs `Test-PSScriptFileInfo` to vali
 in the script.
 
 ```powershell
-New-PSScriptFileInfo -FilePath "C:\MyScripts\test_script.ps1" -Description "this is a test script"
-Test-PSScriptFileInfo -FilePath "C:\MyScripts\test_script.ps1"
+New-PSScriptFileInfo -Path "C:\MyScripts\test_script.ps1" -Description "this is a test script"
+Test-PSScriptFileInfo -Path "C:\MyScripts\test_script.ps1"
 True
 ```
 
@@ -43,7 +43,7 @@ the required **Author** metadata. The cmdlet writes a warning message and return
 `Get-Content` is used to view the contents of the script file.
 
 ```powershell
-Test-PSScriptFileInfo -FilePath "C:\MyScripts\invalid_test_script.ps1"
+Test-PSScriptFileInfo -Path "C:\MyScripts\invalid_test_script.ps1"
 Get-Content "C:\MyScripts\invalid_test_script.ps1"
 ```
 
@@ -93,7 +93,7 @@ this is a test script
 
 ## PARAMETERS
 
-### -FilePath
+### -Path
 
 The path to `.ps1` script file.
 

--- a/help/Update-PSScriptFileInfo.md
+++ b/help/Update-PSScriptFileInfo.md
@@ -16,7 +16,7 @@ This cmdlet updates the comment-based metadata in an existing script `.ps1` file
 ### __AllParameterSets
 
 ```
-Update-PSScriptFileInfo [-FilePath] <string> [-Author <string>] [-CompanyName <string>]
+Update-PSScriptFileInfo [-Path] <string> [-Author <string>] [-CompanyName <string>]
  [-Copyright <string>] [-Description <string>] [-ExternalModuleDependencies <string[]>]
  [-ExternalScriptDependencies <string[]>] [-Guid <guid>] [-IconUri <string>]
  [-LicenseUri <string>] [-PrivateData <string>] [-ProjectUri <string>] [-ReleaseNotes <string>]
@@ -38,8 +38,8 @@ changes the **Version**' to `2.0.0.0`. The `Get-Content` cmdlet shows the update
 script.
 
 ```powershell
-New-PSScriptFileInfo -FilePath "C:\Users\johndoe\MyScripts\test_script.ps1" -Version "1.0.0.0" -Description "this is a test script"
-Update-PSScriptFileInfo -FilePath "C:\Users\johndoe\MyScripts\test_script.ps1" -Version "2.0.0.0"
+New-PSScriptFileInfo -Path "C:\Users\johndoe\MyScripts\test_script.ps1" -Version "1.0.0.0" -Description "this is a test script"
+Update-PSScriptFileInfo -Path "C:\Users\johndoe\MyScripts\test_script.ps1" -Version "2.0.0.0"
 Get-Content "C:\Users\johndoe\MyScripts\test_script.ps1"
 ```
 
@@ -184,7 +184,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -FilePath
+### -Path
 
 The filename and location of the script.
 

--- a/src/code/NewPSScriptFileInfo.cs
+++ b/src/code/NewPSScriptFileInfo.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// </summary>
         [Parameter(Position = 0, Mandatory = true)]
         [ValidateNotNullOrEmpty]
-        public string FilePath { get; set; }
+        public string Path { get; set; }
 
         /// <summary>
         /// The version of the script.
@@ -177,7 +177,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 ThrowTerminatingError(iconErrorRecord);
             }
 
-            if (!FilePath.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase))
+            if (!Path.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase))
             {
                 var exMessage = "Path needs to end with a .ps1 file. Example: C:/Users/john/x/MyScript.ps1";
                 var ex = new ArgumentException(exMessage);
@@ -185,8 +185,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 ThrowTerminatingError(InvalidPathError);   
             }
 
-            var resolvedFilePath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(FilePath);
-            if (String.IsNullOrEmpty(resolvedFilePath))
+            var resolvedPath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(Path);
+            if (String.IsNullOrEmpty(resolvedPath))
             {
                 var exMessage = "Error: Could not resolve provided Path argument into a single path.";
                 var ex = new PSArgumentException(exMessage);
@@ -194,7 +194,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 ThrowTerminatingError(InvalidPathArgumentError);
             }
             
-            if (File.Exists(resolvedFilePath) && !Force)
+            if (File.Exists(resolvedPath) && !Force)
             {
                 // .ps1 file at specified location already exists and Force parameter isn't used to rewrite the file
                 var exMessage = ".ps1 file at specified path already exists. Specify a different location or use -Force parameter to overwrite the .ps1 file.";
@@ -250,7 +250,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 return;
             }
 
-            File.WriteAllLines(resolvedFilePath, psScriptFileContents);       
+            File.WriteAllLines(resolvedPath, psScriptFileContents);       
         }
 
         #endregion

--- a/src/code/TestPSScriptFileInfo.cs
+++ b/src/code/TestPSScriptFileInfo.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// </summary>
         [Parameter(Position = 0, Mandatory = true)]
         [ValidateNotNullOrEmpty]
-        public string FilePath { get; set; }
+        public string Path { get; set; }
 
         #endregion
 
@@ -31,7 +31,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void EndProcessing()
         {
-            if (!FilePath.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase))
+            if (!Path.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase))
             {
                 var exMessage = "Path needs to end with a .ps1 file. Example: C:/Users/john/x/MyScript.ps1";
                 var ex = new ArgumentException(exMessage);
@@ -39,7 +39,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 ThrowTerminatingError(InvalidPathError);   
             }
 
-            var resolvedPaths = SessionState.Path.GetResolvedPSPathFromPSPath(FilePath);
+            var resolvedPaths = SessionState.Path.GetResolvedPSPathFromPSPath(Path);
             if (resolvedPaths.Count != 1)
             {
                 var exMessage = "Error: Could not resolve provided Path argument into a single path.";
@@ -48,9 +48,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 ThrowTerminatingError(InvalidPathArgumentError);
             }
 
-            var resolvedFilePath = resolvedPaths[0].Path;
+            var resolvedPath = resolvedPaths[0].Path;
 
-            if (!File.Exists(resolvedFilePath))
+            if (!File.Exists(resolvedPath))
             {
                 var exMessage = "A .ps1 file does not exist at the location specified.";
                 var ex = new ArgumentException(exMessage);
@@ -59,7 +59,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
 
             bool isValidScript = PSScriptFileInfo.TryTestPSScriptFile(
-                scriptFileInfoPath: resolvedFilePath,
+                scriptFileInfoPath: resolvedPath,
                 parsedScript: out PSScriptFileInfo _,
                 errors: out ErrorRecord[] errors,
                 out string[] verboseMsgs);               

--- a/src/code/UpdatePSScriptFileInfo.cs
+++ b/src/code/UpdatePSScriptFileInfo.cs
@@ -86,7 +86,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// </summary>
         [Parameter(Position = 0, Mandatory = true)]
         [ValidateNotNullOrEmpty]
-        public string FilePath { get; set; }
+        public string Path { get; set; }
 
         /// <summary>
         /// The private data associated with the script.
@@ -177,7 +177,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 ThrowTerminatingError(iconErrorRecord);
             }
 
-            if (!FilePath.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase))
+            if (!Path.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase))
             {
                     var exMessage = "File path needs to end with a .ps1 extension. Example: C:/Users/john/x/MyScript.ps1";
                     var ex = new ArgumentException(exMessage);
@@ -185,7 +185,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     ThrowTerminatingError(InvalidOrNonExistantPathError);   
             }
 
-            var resolvedPaths = SessionState.Path.GetResolvedPSPathFromPSPath(FilePath);
+            var resolvedPaths = SessionState.Path.GetResolvedPSPathFromPSPath(Path);
             if (resolvedPaths.Count != 1)
             {
                 var exMessage = "Error: Could not resolve provided Path argument into a single path.";
@@ -194,9 +194,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 ThrowTerminatingError(InvalidPathArgumentError);
             }
 
-            string resolvedFilePath = resolvedPaths[0].Path;
+            string resolvedPath = resolvedPaths[0].Path;
 
-            if (!File.Exists(resolvedFilePath))
+            if (!File.Exists(resolvedPath))
             {
                 var exMessage = "A script file does not exist at the location specified";
                 var ex = new ArgumentException(exMessage);
@@ -222,7 +222,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
 
             if (!PSScriptFileInfo.TryTestPSScriptFile(
-                scriptFileInfoPath: resolvedFilePath,
+                scriptFileInfoPath: resolvedPath,
                 parsedScript: out PSScriptFileInfo parsedScriptInfo,
                 errors: out ErrorRecord[] errors,
                 out string[] verboseMsgs))
@@ -284,13 +284,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 return;
             }
                   
-            string tempScriptFilePath = null;
+            string tempScriptPath = null;
             try
             {
-                tempScriptFilePath = Path.GetTempFileName();
+                tempScriptPath = System.IO.Path.GetTempFileName();
 
-                File.WriteAllLines(tempScriptFilePath, updatedPSScriptFileContents); 
-                File.Copy(tempScriptFilePath, resolvedFilePath, overwrite: true);     
+                File.WriteAllLines(tempScriptPath, updatedPSScriptFileContents); 
+                File.Copy(tempScriptPath, resolvedPath, overwrite: true);     
             }
             catch(Exception e)
             {
@@ -302,9 +302,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
             finally
             {
-                if (tempScriptFilePath != null)
+                if (tempScriptPath != null)
                 {
-                    File.Delete(tempScriptFilePath);
+                    File.Delete(tempScriptPath);
                 }
             }
 

--- a/test/NewPSScriptFileInfo.Tests.ps1
+++ b/test/NewPSScriptFileInfo.Tests.ps1
@@ -22,8 +22,8 @@ Describe "Test New-PSScriptFileInfo" {
 
     It "Create .ps1 file with minimal required fields" {    
         $description = "Test description"
-        New-PSScriptFileInfo -FilePath  $script:testScriptFilePath -Description $description
-        Test-PSScriptFileInfo -FilePath $script:testScriptFilePath | Should -BeTrue
+        New-PSScriptFileInfo -Path  $script:testScriptFilePath -Description $description
+        Test-PSScriptFileInfo -Path $script:testScriptFilePath | Should -BeTrue
     }
 
     It "Create .ps1 file with relative path" {
@@ -31,9 +31,9 @@ Describe "Test New-PSScriptFileInfo" {
         $scriptFilePath = Join-Path -Path $relativeCurrentPath -ChildPath "$script:PSScriptInfoName.ps1"
 
         $description = "Test description"
-        New-PSScriptFileInfo -FilePath $scriptFilePath -Description $description
+        New-PSScriptFileInfo -Path $scriptFilePath -Description $description
 
-        Test-PSScriptFileInfo -FilePath $scriptFilePath | Should -BeTrue
+        Test-PSScriptFileInfo -Path $scriptFilePath | Should -BeTrue
         Remove-Item -Path $scriptFilePath
     }
 
@@ -41,7 +41,7 @@ Describe "Test New-PSScriptFileInfo" {
         $version =  "2.0.0.0"
         $description = "Test description"
 
-        New-PSScriptFileInfo -FilePath $script:testScriptFilePath -Version $version -Description $description
+        New-PSScriptFileInfo -Path $script:testScriptFilePath -Version $version -Description $description
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
         $results = Get-Content -Path $script:testScriptFilePath -Raw
@@ -53,7 +53,7 @@ Describe "Test New-PSScriptFileInfo" {
         $guid = [guid]::NewGuid()
         $description = "Test description"
 
-        New-PSScriptFileInfo -FilePath  $script:testScriptFilePath -Guid $guid -Description $description
+        New-PSScriptFileInfo -Path  $script:testScriptFilePath -Guid $guid -Description $description
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
         $results = Get-Content -Path $script:testScriptFilePath -Raw
@@ -65,7 +65,7 @@ Describe "Test New-PSScriptFileInfo" {
         $author = "Test Author" 
         $description = "Test description"
 
-        New-PSScriptFileInfo -FilePath  $script:testScriptFilePath -Author $author -Description $description
+        New-PSScriptFileInfo -Path  $script:testScriptFilePath -Author $author -Description $description
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
         $results = Get-Content -Path $script:testScriptFilePath -Raw
@@ -76,7 +76,7 @@ Describe "Test New-PSScriptFileInfo" {
     It "Create new .ps1 given Description parameter" {
         $description = "PowerShellGet test description"
 
-        New-PSScriptFileInfo -FilePath $script:testScriptFilePath -Description $description
+        New-PSScriptFileInfo -Path $script:testScriptFilePath -Description $description
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
         $results = Get-Content -Path $script:testScriptFilePath -Raw
@@ -88,7 +88,7 @@ Describe "Test New-PSScriptFileInfo" {
         $companyName =  "Microsoft"
         $description = "Test description"
 
-        New-PSScriptFileInfo -FilePath $script:testScriptFilePath -CompanyName $companyName -Description $description
+        New-PSScriptFileInfo -Path $script:testScriptFilePath -CompanyName $companyName -Description $description
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
         $results = Get-Content -Path $script:testScriptFilePath -Raw
@@ -100,7 +100,7 @@ Describe "Test New-PSScriptFileInfo" {
         $copyright =  "(c) Test Corporation"
         $description = "Test description"
 
-        New-PSScriptFileInfo -FilePath $script:testScriptFilePath -Copyright $copyright -Description $description
+        New-PSScriptFileInfo -Path $script:testScriptFilePath -Copyright $copyright -Description $description
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
         $results = Get-Content -Path $script:testScriptFilePath -Raw
@@ -115,7 +115,7 @@ Describe "Test New-PSScriptFileInfo" {
 
         $description = "Test description"        
 
-        New-PSScriptFileInfo -FilePath $script:testScriptFilePath -RequiredModules $RequiredModules -Description $Description 
+        New-PSScriptFileInfo -Path $script:testScriptFilePath -RequiredModules $RequiredModules -Description $Description 
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
         $results = Get-Content -Path $script:testScriptFilePath -Raw
@@ -128,7 +128,7 @@ Describe "Test New-PSScriptFileInfo" {
         $description = "Test Description"
         $releaseNotes = "Release notes for script."
 
-        New-PSScriptFileInfo -FilePath $script:testScriptFilePath -ReleaseNotes $releaseNotes -Description $description 
+        New-PSScriptFileInfo -Path $script:testScriptFilePath -ReleaseNotes $releaseNotes -Description $description 
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
         $results = Get-Content -Path $script:testScriptFilePath -Raw
@@ -141,7 +141,7 @@ Describe "Test New-PSScriptFileInfo" {
         $tag1 = "tag1"
         $tag2 = "tag2"
 
-        New-PSScriptFileInfo -FilePath $script:testScriptFilePath -Tags $tag1, $tag2 -Description $description 
+        New-PSScriptFileInfo -Path $script:testScriptFilePath -Tags $tag1, $tag2 -Description $description 
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
         $results = Get-Content -Path $script:testScriptFilePath -Raw
@@ -154,7 +154,7 @@ Describe "Test New-PSScriptFileInfo" {
         $description = "Test Description"
         $projectUri = "https://www.testprojecturi.com/"
 
-        New-PSScriptFileInfo -FilePath $script:testScriptFilePath -ProjectUri $projectUri -Description $description 
+        New-PSScriptFileInfo -Path $script:testScriptFilePath -ProjectUri $projectUri -Description $description 
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
         $results = Get-Content -Path $script:testScriptFilePath -Raw
@@ -166,7 +166,7 @@ Describe "Test New-PSScriptFileInfo" {
         $description = "Test Description"
         $licenseUri = "https://www.testlicenseuri.com/"
 
-        New-PSScriptFileInfo -FilePath $script:testScriptFilePath -LicenseUri $licenseUri -Description $description 
+        New-PSScriptFileInfo -Path $script:testScriptFilePath -LicenseUri $licenseUri -Description $description 
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
         $results = Get-Content -Path $script:testScriptFilePath -Raw
@@ -178,7 +178,7 @@ Describe "Test New-PSScriptFileInfo" {
         $description = "Test Description"
         $iconUri = "https://www.testiconuri.com/"
 
-        New-PSScriptFileInfo -FilePath $script:testScriptFilePath -IconUri $iconUri -Description $description 
+        New-PSScriptFileInfo -Path $script:testScriptFilePath -IconUri $iconUri -Description $description 
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
         $results = Get-Content -Path $script:testScriptFilePath -Raw
@@ -191,7 +191,7 @@ Describe "Test New-PSScriptFileInfo" {
         $externalModuleDep1 = "ExternalModuleDep1"
         $externalModuleDep2 = "ExternalModuleDep2"
 
-        New-PSScriptFileInfo -FilePath $script:testScriptFilePath -ExternalModuleDependencies $externalModuleDep1, $externalModuleDep2 -Description $description
+        New-PSScriptFileInfo -Path $script:testScriptFilePath -ExternalModuleDependencies $externalModuleDep1, $externalModuleDep2 -Description $description
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
         $results = Get-Content -Path $script:testScriptFilePath -Raw
@@ -205,7 +205,7 @@ Describe "Test New-PSScriptFileInfo" {
         $requiredScript1 = "RequiredScript1"
         $requiredScript2 = "RequiredScript2"
 
-        New-PSScriptFileInfo -FilePath $script:testScriptFilePath -RequiredScripts $requiredScript1, $requiredScript2 -Description $description
+        New-PSScriptFileInfo -Path $script:testScriptFilePath -RequiredScripts $requiredScript1, $requiredScript2 -Description $description
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
         $results = Get-Content -Path $script:testScriptFilePath -Raw
@@ -219,7 +219,7 @@ Describe "Test New-PSScriptFileInfo" {
         $externalScriptDep1 = "ExternalScriptDep1"
         $externalScriptDep2 = "ExternalScriptDep2"
 
-        New-PSScriptFileInfo -FilePath $script:testScriptFilePath -ExternalScriptDependencies $externalScriptDep1, $externalScriptDep2 -Description $description
+        New-PSScriptFileInfo -Path $script:testScriptFilePath -ExternalScriptDependencies $externalScriptDep1, $externalScriptDep2 -Description $description
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
         $results = Get-Content -Path $script:testScriptFilePath -Raw
@@ -231,7 +231,7 @@ Describe "Test New-PSScriptFileInfo" {
     It "Create new .ps1 given PrivateData parameter" {
         $description = "Test Description"
         $privateData = @{"PrivateDataEntry1" = "PrivateDataValue1"}
-        New-PSScriptFileInfo -FilePath $script:testScriptFilePath -PrivateData $privateData -Description $description 
+        New-PSScriptFileInfo -Path $script:testScriptFilePath -PrivateData $privateData -Description $description 
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
         $results = Get-Content -Path $script:testScriptFilePath -Raw

--- a/test/TestPSScriptFileInfo.Tests.ps1
+++ b/test/TestPSScriptFileInfo.Tests.ps1
@@ -19,7 +19,7 @@ Describe "Test Test-PSScriptFileInfo" {
     It "determine script file with minimal required fields as valid" {    
         $scriptFilePath = Join-Path -Path $tmpDir1Path -ChildPath "testscript.ps1"
         $scriptDescription = "this is a test script"
-        New-PSScriptFileInfo -FilePath $scriptFilePath -Description $scriptDescription
+        New-PSScriptFileInfo -Path $scriptFilePath -Description $scriptDescription
         Test-PSScriptFileInfo $scriptFilePath | Should -Be $true
     }
 

--- a/test/UpdatePSScriptFileInfo.Tests.ps1
+++ b/test/UpdatePSScriptFileInfo.Tests.ps1
@@ -22,7 +22,7 @@ Describe "Test Update-PSScriptFileInfo" {
         $script:psScriptInfoName = "test_script"
         $scriptDescription = "this is a test script"
         $script:testScriptFilePath = Join-Path -Path $tmpDir1Path -ChildPath "$script:psScriptInfoName.ps1"
-        New-PSScriptFileInfo -FilePath $script:testScriptFilePath -Description $scriptDescription
+        New-PSScriptFileInfo -Path $script:testScriptFilePath -Description $scriptDescription
     }
 
     AfterEach {
@@ -37,10 +37,10 @@ Describe "Test Update-PSScriptFileInfo" {
         $scriptFilePath = Join-Path -Path $relativeCurrentPath -ChildPath "$script:psScriptInfoName.ps1"
         $oldDescription = "Old description for test script"
         $newDescription = "New description for test script"
-        New-PSScriptFileInfo -FilePath $scriptFilePath -Description $oldDescription
+        New-PSScriptFileInfo -Path $scriptFilePath -Description $oldDescription
         
-        Update-PSScriptFileInfo -FilePath $scriptFilePath -Description $newDescription
-        Test-PSScriptFileInfo -FilePath $scriptFilePath | Should -BeTrue
+        Update-PSScriptFileInfo -Path $scriptFilePath -Description $newDescription
+        Test-PSScriptFileInfo -Path $scriptFilePath | Should -BeTrue
 
         Test-Path -Path $scriptFilePath  | Should -BeTrue
         $results = Get-Content -Path $scriptFilePath -Raw
@@ -60,10 +60,10 @@ Describe "Test Update-PSScriptFileInfo" {
         $relativeCurrentPath = Get-Location
         $scriptFilePath = Join-Path -Path $relativeCurrentPath -ChildPath "$script:psScriptInfoName.ps1"
 
-        New-PSScriptFileInfo -FilePath $scriptFilePath -Description $description -Version $version -Author $author -ProjectUri $projectUri
-        Update-PSScriptFileInfo -FilePath $scriptFilePath -Author $newAuthor
+        New-PSScriptFileInfo -Path $scriptFilePath -Description $description -Version $version -Author $author -ProjectUri $projectUri
+        Update-PSScriptFileInfo -Path $scriptFilePath -Author $newAuthor
 
-        Test-PSScriptFileInfo -FilePath $scriptFilePath | Should -BeTrue
+        Test-PSScriptFileInfo -Path $scriptFilePath | Should -BeTrue
         $results = Get-Content -Path $scriptFilePath -Raw
         $results.Contains($newAuthor) | Should -BeTrue
         $results.Contains(".AUTHOR $newAuthor") | Should -BeTrue
@@ -83,7 +83,7 @@ Describe "Test Update-PSScriptFileInfo" {
 
     It "update script file Author property" {    
         $author = "New Author"
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -Author $author
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -Author $author
         Test-PSScriptFileInfo $script:testScriptFilePath | Should -Be $true
 
         Test-Path -Path $script:testScriptFilePath  | Should -BeTrue
@@ -94,7 +94,7 @@ Describe "Test Update-PSScriptFileInfo" {
 
     It "update script file Version property" {
         $version = "2.0.0.0"
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -Version $version
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -Version $version
         Test-PSScriptFileInfo $script:testScriptFilePath | Should -Be $true
 
         Test-Path -Path $script:testScriptFilePath  | Should -BeTrue
@@ -105,7 +105,7 @@ Describe "Test Update-PSScriptFileInfo" {
 
     It "update script file Version property with prerelease version" {
         $version = "3.0.0-alpha"
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -Version $version
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -Version $version
         Test-PSScriptFileInfo $script:testScriptFilePath | Should -Be $true
 
         Test-Path -Path $script:testScriptFilePath  | Should -BeTrue
@@ -115,14 +115,14 @@ Describe "Test Update-PSScriptFileInfo" {
     }
 
     It "not update script file with invalid version" {
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -Version "4.0.0.0.0" -ErrorVariable err -ErrorAction SilentlyContinue
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -Version "4.0.0.0.0" -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "VersionParseIntoNuGetVersion,Microsoft.PowerShell.PowerShellGet.Cmdlets.UpdatePSScriptFileInfo"
     }
 
     It "update script file Description property" {
         $description = "this is an updated test script"
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -Description $description
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -Description $description
         Test-PSScriptFileInfo $script:testScriptFilePath | Should -Be $true
 
         Test-Path -Path $script:testScriptFilePath  | Should -BeTrue
@@ -133,7 +133,7 @@ Describe "Test Update-PSScriptFileInfo" {
 
     It "update script file Guid property" {
         $guid = [Guid]::NewGuid();
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -Guid $guid
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -Guid $guid
         Test-PSScriptFileInfo $script:testScriptFilePath | Should -Be $true
 
         Test-Path -Path $script:testScriptFilePath  | Should -BeTrue
@@ -144,7 +144,7 @@ Describe "Test Update-PSScriptFileInfo" {
 
     It "update script file CompanyName property" {
         $companyName = "New Corporation"
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -CompanyName $companyName
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -CompanyName $companyName
         Test-PSScriptFileInfo $script:testScriptFilePath | Should -Be $true
 
         Test-Path -Path $script:testScriptFilePath  | Should -BeTrue
@@ -155,7 +155,7 @@ Describe "Test Update-PSScriptFileInfo" {
 
     It "update script file Copyright property" {
         $copyright = "(c) 2022 New Corporation. All rights reserved"
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -Copyright $copyright
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -Copyright $copyright
         Test-PSScriptFileInfo $script:testScriptFilePath | Should -Be $true
 
         Test-Path -Path $script:testScriptFilePath  | Should -BeTrue
@@ -167,7 +167,7 @@ Describe "Test Update-PSScriptFileInfo" {
     It "update script file ExternalModuleDependencies property" {
         $externalModuleDep1 = "ExternalModuleDep1"
         $externalModuleDep2 = "ExternalModuleDep2"
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -ExternalModuleDependencies $externalModuleDep1,$externalModuleDep2
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -ExternalModuleDependencies $externalModuleDep1,$externalModuleDep2
         Test-PSScriptFileInfo $script:testScriptFilePath | Should -Be $true
 
         Test-Path -Path $script:testScriptFilePath  | Should -BeTrue
@@ -180,7 +180,7 @@ Describe "Test Update-PSScriptFileInfo" {
     It "update script file ExternalScriptDependencies property" {
         $externalScriptDep1 = "ExternalScriptDep1"
         $externalScriptDep2 = "ExternalScriptDep2"
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -ExternalScriptDependencies $externalScriptDep1,$externalScriptDep2
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -ExternalScriptDependencies $externalScriptDep1,$externalScriptDep2
         Test-PSScriptFileInfo $script:testScriptFilePath | Should -Be $true
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
@@ -192,7 +192,7 @@ Describe "Test Update-PSScriptFileInfo" {
 
     It "update script file IconUri property" {
         $iconUri = "https://testscript.com/icon"
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -IconUri $iconUri
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -IconUri $iconUri
         Test-PSScriptFileInfo $script:testScriptFilePath | Should -Be $true
 
         Test-Path -Path $script:testScriptFilePath  | Should -BeTrue
@@ -203,7 +203,7 @@ Describe "Test Update-PSScriptFileInfo" {
 
     It "update script file LicenseUri property" {
         $licenseUri = "https://testscript.com/license"
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -LicenseUri $licenseUri
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -LicenseUri $licenseUri
         Test-PSScriptFileInfo $script:testScriptFilePath | Should -Be $true
 
         Test-Path -Path $script:testScriptFilePath  | Should -BeTrue
@@ -214,7 +214,7 @@ Describe "Test Update-PSScriptFileInfo" {
 
     It "update script file ProjectUri property" {
         $projectUri = "https://testscript.com/"
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -ProjectUri $projectUri
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -ProjectUri $projectUri
         Test-PSScriptFileInfo $script:testScriptFilePath | Should -Be $true
 
         Test-Path -Path $script:testScriptFilePath  | Should -BeTrue
@@ -225,7 +225,7 @@ Describe "Test Update-PSScriptFileInfo" {
 
     It "update script file PrivateData property" {
         $privateData = "this is some private data"
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -PrivateData $privateData
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -PrivateData $privateData
         Test-PSScriptFileInfo $script:testScriptFilePath | Should -Be $true
 
         Test-Path -Path $script:testScriptFilePath  | Should -BeTrue
@@ -236,7 +236,7 @@ Describe "Test Update-PSScriptFileInfo" {
 
     It "update script file ReleaseNotes property" {
         $releaseNotes = "Release notes for script."
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -ReleaseNotes $releaseNotes
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -ReleaseNotes $releaseNotes
         Test-PSScriptFileInfo $script:testScriptFilePath | Should -Be $true
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
@@ -252,7 +252,7 @@ Describe "Test Update-PSScriptFileInfo" {
         $hashtable4 = @{ModuleName = "RequiredModule4"; ModuleVersion = "1.1.0.0"; MaximumVersion = "2.0.0.0"}
         $requiredModules = $hashtable1, $hashtable2, $hashtable3, $hashtable4 
 
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -RequiredModules $requiredModules
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -RequiredModules $requiredModules
         Test-PSScriptFileInfo $script:testScriptFilePath | Should -Be $true
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
@@ -264,7 +264,7 @@ Describe "Test Update-PSScriptFileInfo" {
     It "update script file RequiredScripts property" {
         $requiredScript1 = "RequiredScript1"
         $requiredScript2 = "RequiredScript2"
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -RequiredScripts $requiredScript1, $requiredScript2
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -RequiredScripts $requiredScript1, $requiredScript2
         Test-PSScriptFileInfo $script:testScriptFilePath | Should -Be $true
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
@@ -277,7 +277,7 @@ Describe "Test Update-PSScriptFileInfo" {
     It "update script file Tags property" {
         $tag1 = "tag1"
         $tag2 = "tag2"
-        Update-PSScriptFileInfo -FilePath $script:testScriptFilePath -Tags $tag1, $tag2
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -Tags $tag1, $tag2
         Test-PSScriptFileInfo $script:testScriptFilePath | Should -Be $true
 
         Test-Path -Path $script:testScriptFilePath | Should -BeTrue
@@ -297,7 +297,7 @@ Describe "Test Update-PSScriptFileInfo" {
         $null = Copy-Item -Path $scriptFilePath -Destination $TestDrive
         $tmpScriptFilePath = Join-Path -Path $TestDrive -ChildPath $scriptName
 
-        { Update-PSScriptFileInfo -FilePath $tmpScriptFilePath -Version "2.0.0.0" } | Should -Throw -ErrorId "ScriptToBeUpdatedContainsSignature,Microsoft.PowerShell.PowerShellGet.Cmdlets.UpdatePSScriptFileInfo"
+        { Update-PSScriptFileInfo -Path $tmpScriptFilePath -Version "2.0.0.0" } | Should -Throw -ErrorId "ScriptToBeUpdatedContainsSignature,Microsoft.PowerShell.PowerShellGet.Cmdlets.UpdatePSScriptFileInfo"
     }
 
     It "update signed script when using RemoveSignature parameter" {
@@ -308,7 +308,7 @@ Describe "Test Update-PSScriptFileInfo" {
         $null = Copy-Item -Path $scriptFilePath -Destination $TestDrive
         $tmpScriptFilePath = Join-Path -Path $TestDrive -ChildPath $scriptName
 
-        Update-PSScriptFileInfo -FilePath $tmpScriptFilePath -Version "2.0.0.0" -RemoveSignature
-        Test-PSScriptFileInfo -FilePath $tmpScriptFilePath | Should -Be $true
+        Update-PSScriptFileInfo -Path $tmpScriptFilePath -Version "2.0.0.0" -RemoveSignature
+        Test-PSScriptFileInfo -Path $tmpScriptFilePath | Should -Be $true
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
This PR renames `-FilePath` parameter to `-Path` for `New-PSScriptFileInfo`, `Test-PSScriptFileInfo`, and `Update-PSScriptFileInfo`.
This PR also updates the corresponding test files and .md files.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Resolves #761 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
