### PR TITLE
Remove unneeded derivation from pscmdlet

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// <summary>
     /// Install helper class
     /// </summary>
-    internal class InstallHelper : PSCmdlet
+    internal class InstallHelper
     {
         #region Members
 
@@ -507,7 +507,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         _cmdletPassedIn,
                         out ErrorRecord errorRecord))
                     {
-                        ThrowTerminatingError(errorRecord);
+                        _cmdletPassedIn.ThrowTerminatingError(errorRecord);
                     }
 
                     if (isModule)
@@ -529,7 +529,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                             manifestInfo: out Hashtable parsedMetadataHashtable,
                             error: out Exception manifestReadError))
                         {
-                            WriteError(
+                            _cmdletPassedIn.WriteError(
                                 new ErrorRecord(
                                     exception: manifestReadError,
                                     errorId: "ManifestFileReadParseError",


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

InstallHelper class does not need to derive from PSCmdlet
Issue #767 

## PR Context

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
