### PR TITLE
WIP: Interface design for Find

### DIFF
--- a/src/code/IFindPSResource.cs
+++ b/src/code/IFindPSResource.cs
@@ -1,0 +1,118 @@
+using Microsoft.PowerShell.PowerShellGet.UtilClasses;
+using NuGet.Versioning;
+
+public interface IFindPSResource
+{
+    #region Properties
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Find method which allows for searching for all packages from a repository and returns latest version for each.
+    /// Examples: Search -Repository PSGallery
+    /// </summary>
+    void FindAll(string repositoryName);
+
+    /// <summary>
+    /// Find method which allows for searching for packages with tag(s) from a repository and returns latest version for each.
+    /// Examples: Search -Tag "JSON" -Repository PSGallery
+    /// </summary>
+    void FindTags(string[] tags, string repositoryName);
+
+    /// <summary>
+    /// Find method which allows for searching for packages with resource type specified from a repository and returns latest version for each.
+    /// Name: supports wildcards
+    /// Type: Module, Script, Command, DSCResource (can take multiple)
+    /// Examples: Search -Type Module -Repository PSGallery
+    ///           Search "Az*" -Type Module -Repository PSGallery
+    /// </summary>
+    void FindTypes(ResourceType packageResourceType, string packageName, string repositoryName);
+
+    /// <summary>
+    /// Find method which allows for searching for command names and returns latest version of matching packages.
+    /// Name: supports wildcards
+    /// Examples: Search -Name "Command1", "Command2" -Repository PSGallery
+    /// </summary>
+    void FindCommandName(string[] commandNames, string repositoryName);
+
+    /// <summary>
+    /// Find method which allows for searching for DSC Resource names and returns latest version of matching packages.
+    /// Name: supports wildcards
+    /// Examples: Search -Name "DSCResource1", "DSCResource2" -Repository PSGallery
+    void FindDSCResourceName(string[] dscResourceName, string repositoryName);
+
+    /// <summary>
+    /// Find method which allows for searching for single name and returns latest version.
+    /// Name: no wildcard support
+    /// Examples: Search "PowerShellGet"
+    /// </summary>
+    void FindName(string packageName, string repositoryName);
+
+    /// <summary>
+    /// Find method which allows for searching for single name with wildcards and returns latest version.
+    /// Name: supports wildcards
+    /// Examples: Search "PowerShell*"
+    /// </summary>
+    void FindNameGlobbing(string packageName, string repositoryName);
+
+    /// <summary>
+    /// Find method which allows for searching for single name with version range.
+    /// Name: no wildcard support
+    /// Version: supports wildcards
+    /// Examples: Search "PowerShellGet" "[3.0.0.0, 5.0.0.0]"
+    ///           Search "PowerShellGet" "3.*"
+    /// </summary>
+    void FindVersionGlobbing(string packageName, VersionRange versionRange, string repositoryName);
+
+    /// <summary>
+    /// Find method which allows for searching for single name with specific version.
+    /// Name: no wildcard support
+    /// Version: no wildcard support
+    /// Examples: Search "PowerShellGet" "3.0.0.0"
+    /// </summary>
+    void FindVersion(string packageName, NuGetVersion version, string repositoryName);
+
+    /// <summary>
+    /// Find method which allows for searching for single name with wildcards with version range.
+    /// Name: supports wildcards
+    /// Version: support wildcards
+    /// Examples: Search "PowerShell*" "[3.0.0.0, 5.0.0.0]"
+    ///           Search "PowerShell*" "3.*"
+    /// </summary>
+    void FindNameGlobbingAndVersionGlobbing(string packageName, VersionRange versionRange, string repositoryName);
+
+    /// <summary>
+    /// Find method which allows for searching for single name with wildcards with specific version.
+    /// Name: supports wildcards
+    /// Version: no wildcard support
+    /// Examples: Search "PowerShell*" "3.0.0.0"
+    /// </summary>
+    void FindNameGlobbingAndVersion(string packageName, NuGetVersion version, string repositoryName);
+
+    /// <summary>
+    /// Find method which allows for searching for multiple names and returns latest version for each.
+    /// Name: supports wildcards
+    /// Examples: Search "PowerShellGet", "Package*", "PSReadLine"
+    /// </summary>
+    void FindNamesGlobbing(string[] packageNames, string repositoryName);
+
+    /// <summary>
+    /// Find method which allows for searching for multiple names with specific version.
+    /// Name: supports wildcards
+    /// Version: no wildcard support
+    /// Examples: Search "PowerShellGet", "Package*", "PSReadLine" "3.0.0.0"
+    /// </summary>
+    void FindNamesGlobbingAndVersion(string[] packageNames, NuGetVersion version, string repositoryName);
+
+    /// <summary>
+    /// Find method which allows for searching for multiple names with version range.
+    /// Name: supports wildcards
+    /// Version: support wildcards
+    /// Examples: Search "PowerShellGet", "Package*", "PSReadLine" "[3.0.0.0, 5.0.0.0]"
+    ///           Search "PowerShellGet", "Package*", "PSReadLine" "3.*"
+    /// </summary>
+    void FindNamesGlobbingAndVersionGlobbing(string[] packageNames, VersionRange versionRange, string repositoryName); 
+
+    #endregion
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

WIP: Interface design to separate implementation of Find, Install APIs from cmdlet code. This would allow us to eventually move off of NuGet APIs.

## PR Context

Resolves #655 

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
