### PR TITLE
Remove unneeded inheritance in InstallHelper.cs

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
     /// <summary>
     /// Install helper class
     /// </summary>
-    internal class InstallHelper : PSCmdlet
+    internal class InstallHelper
     {
         #region Members
 
@@ -507,7 +507,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         _cmdletPassedIn,
                         out ErrorRecord errorRecord))
                     {
-                        ThrowTerminatingError(errorRecord);
+                        _cmdletPassedIn.ThrowTerminatingError(errorRecord);
                     }
 
                     if (isModule)
@@ -529,7 +529,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                             manifestInfo: out Hashtable parsedMetadataHashtable,
                             error: out Exception manifestReadError))
                         {
-                            WriteError(
+                            _cmdletPassedIn.WriteError(
                                 new ErrorRecord(
                                     exception: manifestReadError,
                                     errorId: "ManifestFileReadParseError",

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -463,7 +463,8 @@ Describe 'Test Install-PSResource for Module' {
     It "Install module that is not authenticode signed" -Skip:(!(Get-IsWindows)) {
         try 
         {
-            Install-PSResource -Name $testModuleName -Version "5.0.0" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
+            { Install-PSResource -Name $testModuleName -Version "5.0.0" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository } | Should -Throw -ErrorId 'GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource'
+
         }
         catch
         {}

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -461,26 +461,13 @@ Describe 'Test Install-PSResource for Module' {
     # Install module that is not authenticode signed
     # Should FAIL to install the  module
     It "Install module that is not authenticode signed" -Skip:(!(Get-IsWindows)) {
-        try 
-        {
-            { Install-PSResource -Name $testModuleName -Version "5.0.0" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository } | Should -Throw -ErrorId 'GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource'
-
-        }
-        catch
-        {}
-        $Error[0].FullyQualifiedErrorId | Should -be "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
+        { Install-PSResource -Name $testModuleName -Version "5.0.0" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository } | Should -Throw -ErrorId "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
     }
 
     # Install 1.4.4.1 (with incorrect catalog file)
     # Should FAIL to install the  module
     It "Install module with incorrect catalog file" -Skip:(!(Get-IsWindows)) {
-        try
-        {
-            Install-PSResource -Name $PackageManagement -Version "1.4.4.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
-        }
-        catch
-        {}
-        $Error[0].FullyQualifiedErrorId | Should -be "TestFileCatalogError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
+        { Install-PSResource -Name $PackageManagement -Version "1.4.4.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository } | Should -Throw -ErrorId "TestFileCatalogError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
     }
 
     # Install script that is signed
@@ -496,13 +483,7 @@ Describe 'Test Install-PSResource for Module' {
     # Install script that is not signed
     # Should throw
     It "Install script that is not signed" -Skip:(!(Get-IsWindows)) {
-        try
-        {
-            Install-PSResource -Name "TestTestScript" -Version "1.3.1.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
-        }
-        catch
-        {}
-        $Error[0].FullyQualifiedErrorId | Should -be "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
+        { Install-PSResource -Name "TestTestScript" -Version "1.3.1.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository } | Should -Throw -ErrorId "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
     }
 }
 

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -461,14 +461,24 @@ Describe 'Test Install-PSResource for Module' {
     # Install module that is not authenticode signed
     # Should FAIL to install the  module
     It "Install module that is not authenticode signed" -Skip:(!(Get-IsWindows)) {
-        Install-PSResource -Name $testModuleName -Version "5.0.0" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
-        $Error[0].FullyQualifiedErrorId | Should -be "InstallPackageFailed,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
+        try {
+            Install-PSResource -Name $testModuleName -Version "5.0.0" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
+        }
+        catch
+        {}
+        $Error[0].FullyQualifiedErrorId | Should -be "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
     }
+
     # Install 1.4.4.1 (with incorrect catalog file)
     # Should FAIL to install the  module
     It "Install module with incorrect catalog file" -Skip:(!(Get-IsWindows)) {
-        Install-PSResource -Name $PackageManagement -Version "1.4.4.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
-        $Error[0].FullyQualifiedErrorId | Should -be "InstallPackageFailed,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
+        try
+        {
+            Install-PSResource -Name $PackageManagement -Version "1.4.4.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
+        }
+        catch
+        {}
+        $Error[0].FullyQualifiedErrorId | Should -be "TestFileCatalogError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
     }
 
     # Install script that is signed
@@ -484,8 +494,13 @@ Describe 'Test Install-PSResource for Module' {
     # Install script that is not signed
     # Should throw
     It "Install script that is not signed" -Skip:(!(Get-IsWindows)) {
-        Install-PSResource -Name "TestTestScript" -Version "1.3.1.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
-        $Error[0].FullyQualifiedErrorId | Should -be "InstallPackageFailed,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
+        try
+        {
+            Install-PSResource -Name "TestTestScript" -Version "1.3.1.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
+        }
+        catch
+        {}
+        $Error[0].FullyQualifiedErrorId | Should -be "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
     }
 }
 

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -461,7 +461,8 @@ Describe 'Test Install-PSResource for Module' {
     # Install module that is not authenticode signed
     # Should FAIL to install the  module
     It "Install module that is not authenticode signed" -Skip:(!(Get-IsWindows)) {
-        try {
+        try 
+        {
             Install-PSResource -Name $testModuleName -Version "5.0.0" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
         }
         catch

--- a/test/SavePSResource.Tests.ps1
+++ b/test/SavePSResource.Tests.ps1
@@ -257,25 +257,13 @@ Describe 'Test Save-PSResource for PSResources' {
     # Save module that is not authenticode signed
     # Should FAIL to save the module
     It "Save module that is not authenticode signed" -Skip:(!(Get-IsWindows)) {
-        try 
-        {
-            Save-PSResource -Name $testModuleName -Version "5.0.0" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -Path $SaveDir -ErrorAction SilentlyContinue
-        }
-        catch
-        {}
-        $Error[0].FullyQualifiedErrorId | Should -be "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
+        { Save-PSResource -Name $testModuleName -Version "5.0.0" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -Path $SaveDir } | Should -Throw -ErrorId "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
     }
 
     # Save 1.4.4.1 (with incorrect catalog file)
     # Should FAIL to save the module
     It "Save module with incorrect catalog file" -Skip:(!(Get-IsWindows)) {
-        try
-        {
-            Save-PSResource -Name $PackageManagement -Version "1.4.4.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -Path $SaveDir -ErrorAction SilentlyContinue
-        }
-        catch
-        {}
-        $Error[0].FullyQualifiedErrorId | Should -be "TestFileCatalogError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
+        { Save-PSResource -Name $PackageManagement -Version "1.4.4.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -Path $SaveDir } | Should -Throw -ErrorId "TestFileCatalogError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
     }
 
     # Save script that is signed
@@ -292,13 +280,7 @@ Describe 'Test Save-PSResource for PSResources' {
     # Save script that is not signed
     # Should throw
     It "Save script that is not signed" -Skip:(!(Get-IsWindows)) {
-        try
-        {
-            Save-PSResource -Name "TestTestScript" -Version "1.3.1.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
-        }
-        catch
-        {}
-        $Error[0].FullyQualifiedErrorId | Should -be "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
+        { Save-PSResource -Name "TestTestScript" -Version "1.3.1.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository } | Should -Throw -ErrorId "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
     }
 
 <#

--- a/test/SavePSResource.Tests.ps1
+++ b/test/SavePSResource.Tests.ps1
@@ -257,15 +257,25 @@ Describe 'Test Save-PSResource for PSResources' {
     # Save module that is not authenticode signed
     # Should FAIL to save the module
     It "Save module that is not authenticode signed" -Skip:(!(Get-IsWindows)) {
-        Save-PSResource -Name $testModuleName -Version "5.0.0" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -Path $SaveDir -ErrorAction SilentlyContinue
-        $Error[0].FullyQualifiedErrorId | Should -be "InstallPackageFailed,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
+        try 
+        {
+            Save-PSResource -Name $testModuleName -Version "5.0.0" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -Path $SaveDir -ErrorAction SilentlyContinue
+        }
+        catch
+        {}
+        $Error[0].FullyQualifiedErrorId | Should -be "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
     }
 
     # Save 1.4.4.1 (with incorrect catalog file)
     # Should FAIL to save the module
     It "Save module with incorrect catalog file" -Skip:(!(Get-IsWindows)) {
-        Save-PSResource -Name $PackageManagement -Version "1.4.4.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -Path $SaveDir -ErrorAction SilentlyContinue
-        $Error[0].FullyQualifiedErrorId | Should -be "InstallPackageFailed,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
+        try
+        {
+            Save-PSResource -Name $PackageManagement -Version "1.4.4.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -Path $SaveDir -ErrorAction SilentlyContinue
+        }
+        catch
+        {}
+        $Error[0].FullyQualifiedErrorId | Should -be "TestFileCatalogError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
     }
 
     # Save script that is signed
@@ -282,8 +292,13 @@ Describe 'Test Save-PSResource for PSResources' {
     # Save script that is not signed
     # Should throw
     It "Save script that is not signed" -Skip:(!(Get-IsWindows)) {
-        Save-PSResource -Name "TestTestScript" -Version "1.3.1.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
-        $Error[0].FullyQualifiedErrorId | Should -be "InstallPackageFailed,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
+        try
+        {
+            Save-PSResource -Name "TestTestScript" -Version "1.3.1.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
+        }
+        catch
+        {}
+        $Error[0].FullyQualifiedErrorId | Should -be "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.SavePSResource"
     }
 
 <#

--- a/test/UpdatePSResource.Tests.ps1
+++ b/test/UpdatePSResource.Tests.ps1
@@ -351,9 +351,14 @@ Describe 'Test Update-PSResource' {
     # Update to module 1.4.4.1 (with incorrect catalog file)
     # Should FAIL to update the module
     It "Update module with incorrect catalog file" -Skip:(!(Get-IsWindows)) {
-        Install-PSResource -Name $PackageManagement -Version "1.4.2" -Repository $PSGalleryName -TrustRepository
-        Update-PSResource -Name $PackageManagement -Version "1.4.4.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
-        $Error[0].FullyQualifiedErrorId | Should -be "InstallPackageFailed,Microsoft.PowerShell.PowerShellGet.Cmdlets.UpdatePSResource"
+        try
+        {
+            Install-PSResource -Name $PackageManagement -Version "1.4.2" -Repository $PSGalleryName -TrustRepository
+            Update-PSResource -Name $PackageManagement -Version "1.4.4.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
+        }
+        catch 
+        {}
+        $Error[0].FullyQualifiedErrorId | Should -be "TestFileCatalogError,Microsoft.PowerShell.PowerShellGet.Cmdlets.UpdatePSResource"
     }
 
     # Update script that is signed
@@ -370,8 +375,13 @@ Describe 'Test Update-PSResource' {
     # Update script that is not signed
     # Should throw
     It "Update script that is not signed" -Skip:(!(Get-IsWindows)) {
-        Install-PSResource -Name "TestTestScript" -Version "1.0" -Repository $PSGalleryName -TrustRepository
-        Update-PSResource -Name "TestTestScript" -Version "1.3.1.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
-        $Error[0].FullyQualifiedErrorId | Should -be "InstallPackageFailed,Microsoft.PowerShell.PowerShellGet.Cmdlets.UpdatePSResource"
+        try 
+        {
+            Install-PSResource -Name "TestTestScript" -Version "1.0" -Repository $PSGalleryName -TrustRepository
+            Update-PSResource -Name "TestTestScript" -Version "1.3.1.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
+        }
+        catch 
+        {}
+        $Error[0].FullyQualifiedErrorId | Should -be "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.UpdatePSResource"
     }
 }

--- a/test/UpdatePSResource.Tests.ps1
+++ b/test/UpdatePSResource.Tests.ps1
@@ -351,14 +351,8 @@ Describe 'Test Update-PSResource' {
     # Update to module 1.4.4.1 (with incorrect catalog file)
     # Should FAIL to update the module
     It "Update module with incorrect catalog file" -Skip:(!(Get-IsWindows)) {
-        try
-        {
-            Install-PSResource -Name $PackageManagement -Version "1.4.2" -Repository $PSGalleryName -TrustRepository
-            Update-PSResource -Name $PackageManagement -Version "1.4.4.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
-        }
-        catch 
-        {}
-        $Error[0].FullyQualifiedErrorId | Should -be "TestFileCatalogError,Microsoft.PowerShell.PowerShellGet.Cmdlets.UpdatePSResource"
+        Install-PSResource -Name $PackageManagement -Version "1.4.2" -Repository $PSGalleryName -TrustRepository
+        { Update-PSResource -Name $PackageManagement -Version "1.4.4.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository } | Should -Throw -ErrorId "TestFileCatalogError,Microsoft.PowerShell.PowerShellGet.Cmdlets.UpdatePSResource"
     }
 
     # Update script that is signed
@@ -375,13 +369,7 @@ Describe 'Test Update-PSResource' {
     # Update script that is not signed
     # Should throw
     It "Update script that is not signed" -Skip:(!(Get-IsWindows)) {
-        try 
-        {
-            Install-PSResource -Name "TestTestScript" -Version "1.0" -Repository $PSGalleryName -TrustRepository
-            Update-PSResource -Name "TestTestScript" -Version "1.3.1.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
-        }
-        catch 
-        {}
-        $Error[0].FullyQualifiedErrorId | Should -be "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.UpdatePSResource"
+        Install-PSResource -Name "TestTestScript" -Version "1.0" -Repository $PSGalleryName -TrustRepository
+        { Update-PSResource -Name "TestTestScript" -Version "1.3.1.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository } | Should -Throw -ErrorId "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.UpdatePSResource"
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
This PR removes inheritance of the class `InstallHelper` from `PSCmdlet`. This PR also fixes tests in `InstallPSResource`, `SavePSResource`, and `UpdatePSResource` to make sure the errors thrown are matched. 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Resolves #767 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
