### PR TITLE
Script file validation and metadata properties population for Publishing, Installing a script.

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -545,6 +545,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         }
 
                         moduleManifestVersion = parsedMetadataHashtable["ModuleVersion"] as string;
+                        pkg.CompanyName = parsedMetadataHashtable.ContainsKey("CompanyName") ? parsedMetadataHashtable["CompanyName"] as string : String.Empty;
+                        pkg.Copyright = parsedMetadataHashtable.ContainsKey("Copyright") ? parsedMetadataHashtable["Copyright"] as string : String.Empty;
+                        pkg.ReleaseNotes = parsedMetadataHashtable.ContainsKey("ReleaseNotes") ? parsedMetadataHashtable["ReleaseNotes"] as string : String.Empty;
+                        pkg.RepositorySourceLocation = repoUri;
 
                         // Accept License verification
                         if (!_savePkg && !CallAcceptLicense(pkg, moduleManifest, tempInstallPath, newVersion))
@@ -557,6 +561,32 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         {
                             continue;
                         }
+                    }
+                    else
+                    {
+                        // is script
+                        if (!PSScriptFileInfo.TryTestPSScriptFile(
+                            scriptFileInfoPath: scriptPath,
+                            parsedScript: out PSScriptFileInfo scriptToInstall,
+                            out ErrorRecord[] errors,
+                            out string[] _
+                        ))
+                        {
+                            foreach (ErrorRecord error in errors)
+                            {
+                                _cmdletPassedIn.WriteError(error);
+                            }
+
+                            continue;
+                        }
+
+                        Hashtable parsedMetadataHashtable = scriptToInstall.ToHashtable();
+
+                        moduleManifestVersion = parsedMetadataHashtable["ModuleVersion"] as string;
+                        pkg.CompanyName = parsedMetadataHashtable.ContainsKey("CompanyName") ? parsedMetadataHashtable["CompanyName"] as string : String.Empty;
+                        pkg.Copyright = parsedMetadataHashtable.ContainsKey("Copyright") ? parsedMetadataHashtable["Copyright"] as string : String.Empty;
+                        pkg.ReleaseNotes = parsedMetadataHashtable.ContainsKey("ReleaseNotes") ? parsedMetadataHashtable["ReleaseNotes"] as string : String.Empty;
+                        pkg.RepositorySourceLocation = repoUri;
                     }
 
                     // Delete the extra nupkg related files that are not needed and not part of the module/script

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -234,8 +234,8 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
         public Dictionary<string, string> AdditionalMetadata { get; }
         public string Author { get; }
-        public string CompanyName { get; }
-        public string Copyright { get; }
+        public string CompanyName { get; internal set; }
+        public string Copyright { get; internal set; }
         public Dependency[] Dependencies { get; }
         public string Description { get; }
         public Uri IconUri { get; }
@@ -250,9 +250,9 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         public string Prerelease { get; }
         public Uri ProjectUri { get; }
         public DateTime? PublishedDate { get; }
-        public string ReleaseNotes { get; }
+        public string ReleaseNotes { get; internal set; }
         public string Repository { get; }
-        public string RepositorySourceLocation { get; }
+        public string RepositorySourceLocation { get; internal set; }
         public string[] Tags { get; }
         public ResourceType Type { get; }
         public DateTime? UpdatedDate { get; }

--- a/src/code/PSScriptFileInfo.cs
+++ b/src/code/PSScriptFileInfo.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
@@ -487,6 +488,31 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
             psScriptFileContents = fileContentsList.ToArray();
             return fileContentsSuccessfullyCreated;
+        }
+
+
+        internal Hashtable ToHashtable()
+        {
+            Hashtable scriptHashtable = new Hashtable(StringComparer.OrdinalIgnoreCase);
+
+            Hashtable metadataObjectHashtable = ScriptMetadataComment.ToHashtable();
+            foreach(string key in metadataObjectHashtable.Keys)
+            {
+                if (!scriptHashtable.ContainsKey(key))
+                {
+                    // shouldn't have duplicate keys, but just for unexpected error handling
+                    scriptHashtable.Add(key, metadataObjectHashtable[key]);
+                }
+            }
+
+            scriptHashtable.Add(nameof(ScriptHelpComment.Description), ScriptHelpComment.Description);
+
+            if (ScriptRequiresComment.RequiredModules.Length != 0)
+            {
+                scriptHashtable.Add(nameof(ScriptRequiresComment.RequiredModules), ScriptRequiresComment.RequiredModules);
+            }
+
+            return scriptHashtable;
         }
 
         #endregion

--- a/src/code/PSScriptMetadata.cs
+++ b/src/code/PSScriptMetadata.cs
@@ -544,6 +544,29 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             return true;
         }
 
+
+        internal Hashtable ToHashtable()
+        {
+            // Constructor would be called first, which handles empty null values for required properties.
+            Hashtable metadataHashtable = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            metadataHashtable.Add(nameof(Version), Version);
+            metadataHashtable.Add(nameof(Guid), Guid);
+            metadataHashtable.Add(nameof(Author), Author);
+            metadataHashtable.Add(nameof(CompanyName), CompanyName);
+            metadataHashtable.Add(nameof(Copyright), Copyright);
+            metadataHashtable.Add(nameof(Tags), Tags);
+            metadataHashtable.Add(nameof(LicenseUri), LicenseUri);
+            metadataHashtable.Add(nameof(ProjectUri), ProjectUri);
+            metadataHashtable.Add(nameof(IconUri), IconUri);
+            metadataHashtable.Add(nameof(ExternalModuleDependencies), ExternalModuleDependencies);
+            metadataHashtable.Add(nameof(RequiredScripts), RequiredScripts);
+            metadataHashtable.Add(nameof(ExternalScriptDependencies), ExternalScriptDependencies);
+            metadataHashtable.Add(nameof(ReleaseNotes), ReleaseNotes);
+            metadataHashtable.Add(nameof(PrivateData), PrivateData);
+
+            return metadataHashtable;
+        }
+
         #endregion
     }
 }

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -8,6 +8,7 @@ Describe 'Test Install-PSResource for Module' {
 
     BeforeAll {
         $PSGalleryName = Get-PSGalleryName
+        $PSGalleryUri = Get-PSGalleryLocation
         $NuGetGalleryName = Get-NuGetGalleryName
         $testModuleName = "test_module"
         $testModuleName2 = "TestModule99"
@@ -178,6 +179,29 @@ Describe 'Test Install-PSResource for Module' {
         $pkg = Get-PSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName 
         ($env:PSModulePath).Contains($pkg.InstalledLocation)
+    }
+
+    It "Install resource with companyname, copyright and repository source location and validate" {
+        Install-PSResource -Name $testModuleName -Version "5.2.5-alpha001" -Repository PSGallery -TrustRepository
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Version | Should -Be "5.2.5"
+        $pkg.Prerelease | Should -Be "alpha001"
+
+        $pkg.CompanyName | Should -Be "Anam"
+        $pkg.Copyright | Should -Be "(c) Anam Navied. All rights reserved."
+        $pkg.RepositorySourceLocation | Should -Be $PSGalleryUri
+    }
+
+
+    It "Install script with companyname, copyright, and repository source location and validate" {
+        Install-PSResource -Name "Install-VSCode" -Version "1.4.2" -Repository $PSGalleryName -TrustRepository
+
+        $res = Get-PSResource "Install-VSCode" -Version "1.4.2"
+        $res.Name | Should -Be "Install-VSCode"
+        $res.Version | Should -Be "1.4.2.0"
+        $res.CompanyName | Should -Be "Microsoft Corporation"
+        $res.Copyright | Should -Be "(c) Microsoft Corporation"
+        $res.RepositorySourceLocation | Should -Be $PSGalleryUri
     }
 
     # Windows only

--- a/test/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResource.Tests.ps1
@@ -378,6 +378,28 @@ Describe "Test Publish-PSResource" {
         (Get-ChildItem $script:repositoryPath).FullName | Should -Be $expectedPath
     }
 
+    It "should publish a script without lines in between comment blocks locally" {
+        $scriptName = "ScriptWithoutEmptyLinesBetweenCommentBlocks"
+        $scriptVersion = "1.0.0"
+        $scriptPath = (Join-Path -Path $script:testScriptsFolderPath -ChildPath "$scriptName.ps1")
+
+        Publish-PSResource -Path $scriptPath
+
+        $expectedPath = Join-Path -Path $script:repositoryPath  -ChildPath "$scriptName.$scriptVersion.nupkg"
+        (Get-ChildItem $script:repositoryPath).FullName | Should -Be $expectedPath
+    }
+
+    It "should publish a script without lines in help block locally" {
+        $scriptName = "ScriptWithoutEmptyLinesInMetadata"
+        $scriptVersion = "1.0.0"
+        $scriptPath = (Join-Path -Path $script:testScriptsFolderPath -ChildPath "$scriptName.ps1")
+
+        Publish-PSResource -Path $scriptPath
+
+        $expectedPath = Join-Path -Path $script:repositoryPath  -ChildPath "$scriptName.$scriptVersion.nupkg"
+        (Get-ChildItem $script:repositoryPath).FullName | Should -Be $expectedPath
+    }
+
     It "should write error and not publish script when Author property is missing" {
         $scriptName = "InvalidScriptMissingAuthor.ps1"
         $scriptVersion = "1.0.0"
@@ -385,7 +407,7 @@ Describe "Test Publish-PSResource" {
         $scriptFilePath = Join-Path $script:testScriptsFolderPath -ChildPath $scriptName
         Publish-PSResource -Path $scriptFilePath -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "MissingAuthorInScriptMetadata,Microsoft.PowerShell.PowerShellGet.Cmdlets.PublishPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "psScriptMissingAuthor,Microsoft.PowerShell.PowerShellGet.Cmdlets.PublishPSResource"
 
         $publishedPath = Join-Path -Path $script:repositoryPath  -ChildPath "$scriptName.$scriptVersion.nupkg"
         Test-Path -Path $publishedPath | Should -Be $false
@@ -397,7 +419,7 @@ Describe "Test Publish-PSResource" {
         $scriptFilePath = Join-Path $script:testScriptsFolderPath -ChildPath $scriptName
         Publish-PSResource -Path $scriptFilePath -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "MissingVersionInScriptMetadata,Microsoft.PowerShell.PowerShellGet.Cmdlets.PublishPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "psScriptMissingVersion,Microsoft.PowerShell.PowerShellGet.Cmdlets.PublishPSResource"
 
         $publishedPkgs = Get-ChildItem -Path $script:repositoryPath -Filter *.nupkg
         $publishedPkgs.Count | Should -Be 0
@@ -410,7 +432,7 @@ Describe "Test Publish-PSResource" {
         $scriptFilePath = Join-Path $script:testScriptsFolderPath -ChildPath $scriptName
         Publish-PSResource -Path $scriptFilePath -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "MissingGuidInScriptMetadata,Microsoft.PowerShell.PowerShellGet.Cmdlets.PublishPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "psScriptMissingGuid,Microsoft.PowerShell.PowerShellGet.Cmdlets.PublishPSResource"
 
         $publishedPath = Join-Path -Path $script:repositoryPath  -ChildPath "$scriptName.$scriptVersion.nupkg"
         Test-Path -Path $publishedPath | Should -Be $false
@@ -423,7 +445,7 @@ Describe "Test Publish-PSResource" {
         $scriptFilePath = Join-Path $script:testScriptsFolderPath -ChildPath $scriptName
         Publish-PSResource -Path $scriptFilePath -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "MissingOrInvalidDescriptionInScriptMetadata,Microsoft.PowerShell.PowerShellGet.Cmdlets.PublishPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PSScriptInfoMissingDescription,Microsoft.PowerShell.PowerShellGet.Cmdlets.PublishPSResource"
 
         $publishedPath = Join-Path -Path $script:repositoryPath  -ChildPath "$scriptName.$scriptVersion.nupkg"
         Test-Path -Path $publishedPath | Should -Be $false
@@ -437,7 +459,7 @@ Describe "Test Publish-PSResource" {
         $scriptFilePath = Join-Path $script:testScriptsFolderPath -ChildPath $scriptName
         Publish-PSResource -Path $scriptFilePath -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PSScriptMissingHelpContentCommentBlock,Microsoft.PowerShell.PowerShellGet.Cmdlets.PublishPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "missingHelpInfoCommentError,Microsoft.PowerShell.PowerShellGet.Cmdlets.PublishPSResource"
 
         $publishedPath = Join-Path -Path $script:repositoryPath  -ChildPath "$scriptName.$scriptVersion.nupkg"
         Test-Path -Path $publishedPath | Should -Be $false


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR changes script validation and publish and install time to happen from PSScriptFileInfo validation helper method. This accounts for more edge cases for what a valid script file can look like and consolidates validation code.

**Install:**
Additionally, when installing a script, we wish to populate PSResourceInfo with metadata accessible from metadata file (i.e properties like `CompanyName`, `Copyright`, `ReleaseNotes` and `RepositorySourceLocation` from either the `.psd1` or `.ps1` file) and save it to the metadata xml file that gets created for an installed resource. Get-PSResource will now return consistent information for packages installed with Install-PSResource cmdlet after this fix.

**Find:**
Unfortunately, due to NuGet search APIs' limitations and the current version we're at, information on these metadata properties will not be accessible during the Find operation.
`CompanyName` and other metadata information is not easily accessibly via the json metadata (`IPackageSearchMetadata` object returned via NuGet `GetSearchAsync()` and `GetMetadataAsync()` search APIs) and currently is more operational cost than is worth to get this field. Here is a link listing the package information accessible via the package nuspec:
https://docs.microsoft.com/en-us/nuget/reference/nuspec

## PR Context

Resolves #267 #701

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
