### PR TITLE
Replace exposed hardcoded test secrets with random one

### DIFF
--- a/test/PSCredentialInfo.Tests.ps1
+++ b/test/PSCredentialInfo.Tests.ps1
@@ -6,7 +6,8 @@ Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
 Describe "Create PSCredentialInfo with VaultName and SecretName" -tags 'CI' {
 
     It "Verifies VaultName is not empty" {
-        { New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("", "testsecret") } | Should -Throw -ErrorId "ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand"
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        { New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("", $randomSecret) } | Should -Throw -ErrorId "ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand"
     }
 
     It "Verifies SecretName is not empty" {
@@ -14,27 +15,30 @@ Describe "Create PSCredentialInfo with VaultName and SecretName" -tags 'CI' {
     }
 
     It "Creates PSCredentialInfo successfully if VaultName and SecretName are non-empty" {
-        $credentialInfo = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "testsecret")
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        $credentialInfo = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret)
         $credentialInfo.VaultName | Should -Be "testvault"
-        $credentialInfo.SecretName | Should -Be "testsecret"
+        $credentialInfo.SecretName | Should -Be $randomSecret
     }
 }
 
 Describe "Create PSCredentialInfo with VaultName, SecretName, and Credential" -tags 'CI' {
 
     It "Creates PSCredentialInfo successfully if Credential is null" {
-        $credentialInfo = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "testsecret")
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        $credentialInfo = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret)
         
         $credentialInfo.VaultName | Should -Be "testvault"
-        $credentialInfo.SecretName | Should -Be "testsecret"
+        $credentialInfo.SecretName | Should -Be $randomSecret
     }
 
     It "Creates PSCredentialInfo successfully if Credential is non-null and of type PSCredential" {
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
         $credential = New-Object System.Management.Automation.PSCredential ("username", (ConvertTo-SecureString "password" -AsPlainText -Force))
-        $credentialInfo = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "testsecret", $credential)
+        $credentialInfo = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret, $credential)
 
         $credentialInfo.VaultName | Should -Be "testvault"
-        $credentialInfo.SecretName | Should -Be "testsecret"
+        $credentialInfo.SecretName | Should -Be $randomSecret
     }
 }
 
@@ -52,59 +56,69 @@ Describe "Create PSCredentialInfo from a PSObject" -tags 'CI' {
     }
 
     It "Creates PSCredentialInfo successfully from PSObject with VaultName and SecretName" {
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
         $properties = [PSCustomObject]@{
             VaultName = "testvault"
-            SecretName = "testsecret"
+            SecretName = $randomSecret
         }
 
         $credentialInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo] $properties
 
         $credentialInfo.VaultName | Should -Be "testvault"
-        $credentialInfo.SecretName | Should -Be "testsecret"
+        $credentialInfo.SecretName | Should -Be $randomSecret
     }
 
     It "Creates PSCredentialInfo successfully from PSObject with VaultName, SecretName and PSCredential Credential" {
-        $credential = New-Object System.Management.Automation.PSCredential ("username", (ConvertTo-SecureString "password" -AsPlainText -Force))
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        $randomPassword = [System.IO.Path]::GetRandomFileName()
+
+        $credential = New-Object System.Management.Automation.PSCredential ("username", (ConvertTo-SecureString $randomPassword -AsPlainText -Force))
         $properties = [PSCustomObject]@{
             VaultName = "testvault"
-            SecretName = "testsecret"
+            SecretName = $randomSecret
             Credential = [PSCredential] $credential
         }
 
         $credentialInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo] $properties
 
         $credentialInfo.VaultName | Should -Be "testvault"
-        $credentialInfo.SecretName | Should -Be "testsecret"
+        $credentialInfo.SecretName | Should -Be $randomSecret
         $credentialInfo.Credential.UserName | Should -Be "username"
-        $credentialInfo.Credential.GetNetworkCredential().Password | Should -Be "password"
+        $credentialInfo.Credential.GetNetworkCredential().Password | Should -Be $randomPassword
     }
  
     It "Creates PSCredentialInfo successfully from PSObject with VaultName, SecretName and string Credential" {
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        $randomPassword = [System.IO.Path]::GetRandomFileName()
+
         $properties = [PSCustomObject]@{
             VaultName = "testvault"
-            SecretName = "testsecret"
-            Credential = "password"
+            SecretName = $randomSecret
+            Credential = $randomPassword
         }
 
         $credentialInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo] $properties
 
         $credentialInfo.VaultName | Should -Be "testvault"
-        $credentialInfo.SecretName | Should -Be "testsecret"
-        $credentialInfo.Credential.GetNetworkCredential().Password | Should -Be "password"
+        $credentialInfo.SecretName | Should -Be $randomSecret
+        $credentialInfo.Credential.GetNetworkCredential().Password | Should -Be $randomPassword
     }
 
     It "Creates PSCredentialInfo successfully from PSObject with VaultName, SecretName and SecureString Credential" {
-        $secureString = ConvertTo-SecureString "password" -AsPlainText -Force
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        $randomPassword = [System.IO.Path]::GetRandomFileName()
+
+        $secureString = ConvertTo-SecureString $randomPassword -AsPlainText -Force
         $properties = [PSCustomObject]@{
             VaultName = "testvault"
-            SecretName = "testsecret"
+            SecretName = $randomSecret
             Credential = $secureString
         }
 
         $credentialInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo] $properties
 
         $credentialInfo.VaultName | Should -Be "testvault"
-        $credentialInfo.SecretName | Should -Be "testsecret"
-        $credentialInfo.Credential.GetNetworkCredential().Password | Should -Be "password"
+        $credentialInfo.SecretName | Should -Be $randomSecret
+        $credentialInfo.Credential.GetNetworkCredential().Password | Should -Be $randomPassword
     }
 }

--- a/test/RegisterPSResourceRepository.Tests.ps1
+++ b/test/RegisterPSResourceRepository.Tests.ps1
@@ -22,10 +22,13 @@ Describe "Test Register-PSResourceRepository" {
 
         $relativeCurrentPath = Get-Location
 
-        $credentialInfo1 = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "testsecret")
-        $secureString = ConvertTo-SecureString "testpassword" -AsPlainText -Force
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        $randomPassword = [System.IO.Path]::GetRandomFileName()
+        
+        $credentialInfo1 = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret)
+        $secureString = ConvertTo-SecureString $randomPassword -AsPlainText -Force
         $credential = New-Object pscredential ("testusername", $secureString)
-        $credentialInfo2 = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "testsecret", $credential)
+        $credentialInfo2 = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret, $credential)
     }
     AfterEach {
         Get-RevertPSResourceRepositoryFile
@@ -68,7 +71,7 @@ Describe "Test Register-PSResourceRepository" {
         $res.Trusted | Should -Be True
         $res.Priority | Should -Be 20
         $res.CredentialInfo.VaultName | Should -Be "testvault"
-        $res.CredentialInfo.SecretName | Should -Be "testsecret"
+        $res.CredentialInfo.SecretName | Should -Be $randomSecret
     }
 
     It "register repository with PSGallery parameter (PSGalleryParameterSet)" {
@@ -102,7 +105,7 @@ Describe "Test Register-PSResourceRepository" {
         $hashtable1 = @{Name = $TestRepoName1; Uri = $tmpDir1Path}
         $hashtable2 = @{Name = $TestRepoName2; Uri = $tmpDir2Path; Trusted = $True}
         $hashtable3 = @{Name = $TestRepoName3; Uri = $tmpDir3Path; Trusted = $True; Priority = 20}
-        $hashtable4 = @{Name = $TestRepoName4; Uri = $tmpDir4Path; Trusted = $True; Priority = 30; CredentialInfo = (New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "testsecret"))}
+        $hashtable4 = @{Name = $TestRepoName4; Uri = $tmpDir4Path; Trusted = $True; Priority = 30; CredentialInfo = (New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret))}
         $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3, $hashtable4
 
         Register-PSResourceRepository -Repository $arrayOfHashtables
@@ -126,7 +129,7 @@ Describe "Test Register-PSResourceRepository" {
         $res4.Trusted | Should -Be True
         $res4.Priority | Should -Be 30
         $res4.CredentialInfo.VaultName | Should -Be "testvault"
-        $res4.CredentialInfo.SecretName | Should -Be "testsecret"
+        $res4.CredentialInfo.SecretName | Should -Be $randomSecret
         $res4.CredentialInfo.Credential | Should -BeNullOrEmpty
     }
 
@@ -146,7 +149,7 @@ Describe "Test Register-PSResourceRepository" {
         $hashtable2 = @{Name = $TestRepoName1; Uri = $tmpDir1Path}
         $hashtable3 = @{Name = $TestRepoName2; Uri = $tmpDir2Path; Trusted = $True}
         $hashtable4 = @{Name = $TestRepoName3; Uri = $tmpDir3Path; Trusted = $True; Priority = 20}
-        $hashtable5 = @{Name = $TestRepoName4; Uri = $tmpDir4Path; Trusted = $True; Priority = 30; CredentialInfo = (New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "testsecret"))}
+        $hashtable5 = @{Name = $TestRepoName4; Uri = $tmpDir4Path; Trusted = $True; Priority = 30; CredentialInfo = (New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret))}
         $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3, $hashtable4, $hashtable5
 
         Register-PSResourceRepository -Repository $arrayOfHashtables
@@ -176,7 +179,7 @@ Describe "Test Register-PSResourceRepository" {
         $res5.Trusted | Should -Be True
         $res5.Priority | Should -Be 30
         $res5.CredentialInfo.VaultName | Should -Be "testvault"
-        $res5.CredentialInfo.SecretName | Should -Be "testsecret"
+        $res5.CredentialInfo.SecretName | Should -Be $randomSecret
         $res5.CredentialInfo.Credential | Should -BeNullOrEmpty
     }
 

--- a/test/SetPSResourceRepository.Tests.ps1
+++ b/test/SetPSResourceRepository.Tests.ps1
@@ -21,10 +21,13 @@ Describe "Test Set-PSResourceRepository" {
 
         $relativeCurrentPath = Get-Location
 
-        $credentialInfo1 = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "testsecret")
-        $secureString = ConvertTo-SecureString "testpassword" -AsPlainText -Force
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        $randomPassword = [System.IO.Path]::GetRandomFileName()
+
+        $credentialInfo1 = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret)
+        $secureString = ConvertTo-SecureString $randomPassword -AsPlainText -Force
         $credential = New-Object pscredential ("testusername", $secureString)
-        $credentialInfo2 = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "testsecret", $credential)
+        $credentialInfo2 = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret, $credential)
     }
     AfterEach {
         Get-RevertPSResourceRepositoryFile
@@ -89,7 +92,7 @@ Describe "Test Set-PSResourceRepository" {
         $res.Priority | Should -Be 50
         $res.Trusted | Should -Be False
         $res.CredentialInfo.VaultName | Should -Be "testvault"
-        $res.CredentialInfo.SecretName | Should -Be "testsecret"
+        $res.CredentialInfo.SecretName | Should -Be $randomSecret
         $res.CredentialInfo.Credential | Should -BeNullOrEmpty
     }
 
@@ -145,7 +148,7 @@ Describe "Test Set-PSResourceRepository" {
 
         $hashtable1 = @{Name = $TestRepoName1; Uri = $tmpDir2Path};
         $hashtable2 = @{Name = $TestRepoName2; Priority = 25};
-        $hashtable3 = @{Name = $TestRepoName3; CredentialInfo = [PSCustomObject] @{ VaultName = "testvault"; SecretName = "testsecret" }};
+        $hashtable3 = @{Name = $TestRepoName3; CredentialInfo = [PSCustomObject] @{ VaultName = "testvault"; SecretName = $randomSecret }};
         $hashtable4 = @{Name = $PSGalleryName; Trusted = $True};
         $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3, $hashtable4
 
@@ -170,7 +173,7 @@ Describe "Test Set-PSResourceRepository" {
         $res3.Priority | Should -Be 50
         $res3.Trusted | Should -Be False
         $res3.CredentialInfo.VaultName | Should -Be "testvault"
-        $res3.CredentialInfo.SecretName | Should -Be "testsecret"
+        $res3.CredentialInfo.SecretName | Should -Be $randomSecret
         $res3.CredentialInfo.Credential | Should -BeNullOrEmpty
 
         $res4 = Get-PSResourceRepository -Name $PSGalleryName


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Tests contained exposed hardcoded test secret and passwords. Replace this with a random value so as to not expose anything.

## PR Context

Fixes generated security complaints.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
