### PR TITLE
add back tests that were initially removed while cleaning history

### DIFF
--- a/test/PSCredentialInfo.Tests.ps1
+++ b/test/PSCredentialInfo.Tests.ps1
@@ -1,0 +1,125 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
+
+Describe "Create PSCredentialInfo with VaultName and SecretName" -tags 'CI' {
+
+    It "Verifies VaultName is not empty" {
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        { New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("", $randomSecret) } | Should -Throw -ErrorId "ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand"
+    }
+
+    It "Verifies SecretName is not empty" {
+        { New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", "") } | Should -Throw -ErrorId "ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand"
+    }
+
+    It "Creates PSCredentialInfo successfully if VaultName and SecretName are non-empty" {
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        $credentialInfo = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret)
+        $credentialInfo.VaultName | Should -Be "testvault"
+        $credentialInfo.SecretName | Should -Be $randomSecret
+    }
+}
+
+Describe "Create PSCredentialInfo with VaultName, SecretName, and Credential" -tags 'CI' {
+
+    It "Creates PSCredentialInfo successfully if Credential is null" {
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        $credentialInfo = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret)
+        
+        $credentialInfo.VaultName | Should -Be "testvault"
+        $credentialInfo.SecretName | Should -Be $randomSecret
+    }
+
+    It "Creates PSCredentialInfo successfully if Credential is non-null and of type PSCredential" {
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        $randomPassword = [System.IO.Path]::GetRandomFileName()
+        $credential = New-Object System.Management.Automation.PSCredential ("username", (ConvertTo-SecureString $randomPassword -AsPlainText -Force))
+        $credentialInfo = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret, $credential)
+
+        $credentialInfo.VaultName | Should -Be "testvault"
+        $credentialInfo.SecretName | Should -Be $randomSecret
+    }
+}
+
+Describe "Create PSCredentialInfo from a PSObject" -tags 'CI' {
+
+    It "Throws if VaultName is null" {
+        $customObject = New-Object PSObject
+        { New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo $customObject } | Should -Throw -ErrorId "ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand"
+    }
+
+    It "Throws if SecretName is null" {
+        $customObject = New-Object PSObject
+        $customObject | Add-Member -Name "VaultName" -Value "testvault" -MemberType NoteProperty
+        { New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo $customObject } | Should -Throw -ErrorId "ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand"
+    }
+
+    It "Creates PSCredentialInfo successfully from PSObject with VaultName and SecretName" {
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        $properties = [PSCustomObject]@{
+            VaultName = "testvault"
+            SecretName = $randomSecret
+        }
+
+        $credentialInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo] $properties
+
+        $credentialInfo.VaultName | Should -Be "testvault"
+        $credentialInfo.SecretName | Should -Be $randomSecret
+    }
+
+    It "Creates PSCredentialInfo successfully from PSObject with VaultName, SecretName and PSCredential Credential" {
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        $randomPassword = [System.IO.Path]::GetRandomFileName()
+
+        $credential = New-Object System.Management.Automation.PSCredential ("username", (ConvertTo-SecureString $randomPassword -AsPlainText -Force))
+        $properties = [PSCustomObject]@{
+            VaultName = "testvault"
+            SecretName = $randomSecret
+            Credential = [PSCredential] $credential
+        }
+
+        $credentialInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo] $properties
+
+        $credentialInfo.VaultName | Should -Be "testvault"
+        $credentialInfo.SecretName | Should -Be $randomSecret
+        $credentialInfo.Credential.UserName | Should -Be "username"
+        $credentialInfo.Credential.GetNetworkCredential().Password | Should -Be $randomPassword
+    }
+ 
+    It "Creates PSCredentialInfo successfully from PSObject with VaultName, SecretName and string Credential" {
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        $randomPassword = [System.IO.Path]::GetRandomFileName()
+
+        $properties = [PSCustomObject]@{
+            VaultName = "testvault"
+            SecretName = $randomSecret
+            Credential = $randomPassword
+        }
+
+        $credentialInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo] $properties
+
+        $credentialInfo.VaultName | Should -Be "testvault"
+        $credentialInfo.SecretName | Should -Be $randomSecret
+        $credentialInfo.Credential.GetNetworkCredential().Password | Should -Be $randomPassword
+    }
+
+    It "Creates PSCredentialInfo successfully from PSObject with VaultName, SecretName and SecureString Credential" {
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        $randomPassword = [System.IO.Path]::GetRandomFileName()
+
+        $secureString = ConvertTo-SecureString $randomPassword -AsPlainText -Force
+        $properties = [PSCustomObject]@{
+            VaultName = "testvault"
+            SecretName = $randomSecret
+            Credential = $secureString
+        }
+
+        $credentialInfo = [Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo] $properties
+
+        $credentialInfo.VaultName | Should -Be "testvault"
+        $credentialInfo.SecretName | Should -Be $randomSecret
+        $credentialInfo.Credential.GetNetworkCredential().Password | Should -Be $randomPassword
+    }
+}

--- a/test/RegisterPSResourceRepository.Tests.ps1
+++ b/test/RegisterPSResourceRepository.Tests.ps1
@@ -1,0 +1,383 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
+
+Describe "Test Register-PSResourceRepository" {
+    BeforeEach {
+        $PSGalleryName = Get-PSGalleryName
+        $PSGalleryUri = Get-PSGalleryLocation
+        $TestRepoName1 = "testRepository"
+        $TestRepoName2 = "testRepository2"
+        $TestRepoName3 = "testRepository3"
+        $TestRepoName4 = "testRepository4"
+        $relativeCurrentPath = Get-Location
+        Get-NewPSResourceRepositoryFile
+        $tmpDir1Path = Join-Path -Path $TestDrive -ChildPath "tmpDir1"
+        $tmpDir2Path = Join-Path -Path $TestDrive -ChildPath "tmpDir2"
+        $tmpDir3Path = Join-Path -Path $TestDrive -ChildPath "tmpDir3"
+        $tmpDir4Path = Join-Path -Path $TestDrive -ChildPath "tmpDir4"
+        $tmpDirPaths = @($tmpDir1Path, $tmpDir2Path, $tmpDir3Path, $tmpDir4Path)
+        Get-NewTestDirs($tmpDirPaths)
+
+        $relativeCurrentPath = Get-Location
+
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        $randomPassword = [System.IO.Path]::GetRandomFileName()
+        
+        $credentialInfo1 = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret)
+        $secureString = ConvertTo-SecureString $randomPassword -AsPlainText -Force
+        $credential = New-Object pscredential ("testusername", $secureString)
+        $credentialInfo2 = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret, $credential)
+    }
+    AfterEach {
+        Get-RevertPSResourceRepositoryFile
+        $tmpDir1Path = Join-Path -Path $TestDrive -ChildPath "tmpDir1"
+        $tmpDir2Path = Join-Path -Path $TestDrive -ChildPath "tmpDir2"
+        $tmpDir3Path = Join-Path -Path $TestDrive -ChildPath "tmpDir3"
+        $tmpDir4Path = Join-Path -Path $TestDrive -ChildPath "tmpDir4"
+        $tmpDirPaths = @($tmpDir1Path, $tmpDir2Path, $tmpDir3Path, $tmpDir4Path)
+        Get-RemoveTestDirs($tmpDirPaths)
+    }
+
+    It "register repository given Name, Uri (bare minimum for NameParmaterSet)" {
+        $res = Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -PassThru
+        $res.Name | Should -Be $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
+        $res.Trusted | Should -Be False
+        $res.Priority | Should -Be 50
+    }
+
+    It "register repository with Name, Uri, Trusted (NameParameterSet)" {
+        $res = Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -Trusted -PassThru
+        $res.Name | Should -Be $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
+        $res.Trusted | Should -Be True
+        $res.Priority | Should -Be 50
+    }
+
+    It "register repository given Name, Uri, Trusted, Priority (NameParameterSet)" {
+        $res = Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -Trusted -Priority 20 -PassThru
+        $res.Name | Should -Be $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
+        $res.Trusted | Should -Be True
+        $res.Priority | Should -Be 20
+    }
+
+    It "register repository given Name, Uri, Trusted, Priority, CredentialInfo (NameParameterSet)" {
+        $res = Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -Trusted -Priority 20 -CredentialInfo $credentialInfo1 -PassThru
+        $res.Name | Should -Be $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
+        $res.Trusted | Should -Be True
+        $res.Priority | Should -Be 20
+        $res.CredentialInfo.VaultName | Should -Be "testvault"
+        $res.CredentialInfo.SecretName | Should -Be $randomSecret
+    }
+
+    It "register repository with PSGallery parameter (PSGalleryParameterSet)" {
+        Unregister-PSResourceRepository -Name $PSGalleryName
+        $res = Register-PSResourceRepository -PSGallery -PassThru
+        $res.Name | Should -Be $PSGalleryName
+        $res.Uri | Should -Be $PSGalleryUri
+        $res.Trusted | Should -Be False
+        $res.Priority | Should -Be 50
+    }
+
+    It "register repository with PSGallery, Trusted parameters (PSGalleryParameterSet)" {
+        Unregister-PSResourceRepository -Name $PSGalleryName
+        $res = Register-PSResourceRepository -PSGallery -Trusted -PassThru
+        $res.Name | Should -Be $PSGalleryName
+        $res.Uri | Should -Be $PSGalleryUri
+        $res.Trusted | Should -Be True
+        $res.Priority | Should -Be 50
+    }
+
+    It "register repository with PSGallery, Trusted, Priority parameters (PSGalleryParameterSet)" {
+        Unregister-PSResourceRepository -Name $PSGalleryName
+        $res = Register-PSResourceRepository -PSGallery -Trusted -Priority 20 -PassThru
+        $res.Name | Should -Be $PSGalleryName
+        $res.Uri | Should -Be $PSGalleryUri
+        $res.Trusted | Should -Be True
+        $res.Priority | Should -Be 20
+    }
+
+    It "register repositories with -Repository parameter, all name parameter style repositories (RepositoriesParameterSet)" {
+        $hashtable1 = @{Name = $TestRepoName1; Uri = $tmpDir1Path}
+        $hashtable2 = @{Name = $TestRepoName2; Uri = $tmpDir2Path; Trusted = $True}
+        $hashtable3 = @{Name = $TestRepoName3; Uri = $tmpDir3Path; Trusted = $True; Priority = 20}
+        $hashtable4 = @{Name = $TestRepoName4; Uri = $tmpDir4Path; Trusted = $True; Priority = 30; CredentialInfo = (New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret))}
+        $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3, $hashtable4
+
+        Register-PSResourceRepository -Repository $arrayOfHashtables
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
+        $res.Trusted | Should -Be False
+        $res.Priority | Should -Be 50
+
+        $res2 = Get-PSResourceRepository -Name $TestRepoName2
+        $res2.Uri.LocalPath | Should -Contain $tmpDir2Path
+        $res2.Trusted | Should -Be True
+        $res2.Priority | Should -Be 50
+
+        $res3 = Get-PSResourceRepository -Name $TestRepoName3
+        $res3.Uri.LocalPath | Should -Contain $tmpDir3Path
+        $res3.Trusted | Should -Be True
+        $res3.Priority | Should -Be 20
+
+        $res4 = Get-PSResourceRepository -Name $TestRepoName4
+        $res4.Uri.LocalPath | Should -Contain $tmpDir4Path
+        $res4.Trusted | Should -Be True
+        $res4.Priority | Should -Be 30
+        $res4.CredentialInfo.VaultName | Should -Be "testvault"
+        $res4.CredentialInfo.SecretName | Should -Be $randomSecret
+        $res4.CredentialInfo.Credential | Should -BeNullOrEmpty
+    }
+
+    It "register repositories with -Repository parameter, psgallery style repository (RepositoriesParameterSet)" {
+        Unregister-PSResourceRepository -Name $PSGalleryName
+        $hashtable1 = @{PSGallery = $True}
+        Register-PSResourceRepository -Repository $hashtable1
+        $res = Get-PSResourceRepository -Name $PSGalleryName
+        $res.Uri | Should -Be $PSGalleryUri
+        $res.Trusted | Should -Be False
+        $res.Priority | Should -Be 50
+    }
+
+    It "register repositories with -Repository parameter, name and psgallery parameter styles (RepositoriesParameterSet)" {
+        Unregister-PSResourceRepository -Name $PSGalleryName
+        $hashtable1 = @{PSGallery = $True}
+        $hashtable2 = @{Name = $TestRepoName1; Uri = $tmpDir1Path}
+        $hashtable3 = @{Name = $TestRepoName2; Uri = $tmpDir2Path; Trusted = $True}
+        $hashtable4 = @{Name = $TestRepoName3; Uri = $tmpDir3Path; Trusted = $True; Priority = 20}
+        $hashtable5 = @{Name = $TestRepoName4; Uri = $tmpDir4Path; Trusted = $True; Priority = 30; CredentialInfo = (New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret))}
+        $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3, $hashtable4, $hashtable5
+
+        Register-PSResourceRepository -Repository $arrayOfHashtables
+
+        $res1 = Get-PSResourceRepository -Name $PSGalleryName
+        $res1.Uri | Should -Be $PSGalleryUri
+        $res1.Trusted | Should -Be False
+        $res1.Priority | Should -Be 50
+
+        $res2 = Get-PSResourceRepository -Name $TestRepoName1
+        $res2.Uri.LocalPath | Should -Contain $tmpDir1Path
+        $res2.Trusted | Should -Be False
+        $res2.Priority | Should -Be 50
+
+        $res3 = Get-PSResourceRepository -Name $TestRepoName2
+        $res3.Uri.LocalPath | Should -Contain $tmpDir2Path
+        $res3.Trusted | Should -Be True
+        $res3.Priority | Should -Be 50
+
+        $res4 = Get-PSResourceRepository -Name $TestRepoName3
+        $res4.Uri.LocalPath | Should -Contain $tmpDir3Path
+        $res4.Trusted | Should -Be True
+        $res4.Priority | Should -Be 20
+
+        $res5 = Get-PSResourceRepository -Name $TestRepoName4
+        $res5.Uri.LocalPath | Should -Contain $tmpDir4Path
+        $res5.Trusted | Should -Be True
+        $res5.Priority | Should -Be 30
+        $res5.CredentialInfo.VaultName | Should -Be "testvault"
+        $res5.CredentialInfo.SecretName | Should -Be $randomSecret
+        $res5.CredentialInfo.Credential | Should -BeNullOrEmpty
+    }
+
+    It "not register repository when Name is provided but Uri is not" {
+        {Register-PSResourceRepository -Name $TestRepoName1 -Uri "" -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+    }
+
+    It "not register repository when Name is empty but Uri is provided" {
+        {Register-PSResourceRepository -Name "" -Uri $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+    }
+
+    It "not register repository when Name is null but Uri is provided" {
+        {Register-PSResourceRepository -Name $null -Uri $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+    }
+
+    It "not register repository when Name is just whitespace but Uri is provided" {
+        {Register-PSResourceRepository -Name " " -Uri $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+    }
+
+    It "not register PSGallery with NameParameterSet" {
+        {Register-PSResourceRepository -Name $PSGalleryName -Uri $PSGalleryUri -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+    }
+
+    # this error message comes from the parameter cmdlet tags (earliest point of detection)
+    It "not register PSGallery when PSGallery parameter provided with Name, Uri or CredentialInfo" {
+        {Register-PSResourceRepository -PSGallery -Name $PSGalleryName -ErrorAction Stop} | Should -Throw -ErrorId "AmbiguousParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+        {Register-PSResourceRepository -PSGallery -Uri $PSGalleryUri -ErrorAction Stop} | Should -Throw -ErrorId "AmbiguousParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+        {Register-PSResourceRepository -PSGallery -CredentialInfo $credentialInfo1 -ErrorAction Stop} | Should -Throw -ErrorId "AmbiguousParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+    }
+
+    $testCases = @{Type = "Name key specified with PSGallery key"; IncorrectHashTable = @{PSGallery = $True; Name=$PSGalleryName}},
+                 @{Type = "Uri key specified with PSGallery key";  IncorrectHashTable = @{PSGallery = $True; Uri=$PSGalleryUri}},
+                 @{Type = "CredentialInfo key specified with PSGallery key";  IncorrectHashTable = @{PSGallery = $True; CredentialInfo = $credentialInfo1}}
+
+    It "not register incorrectly formatted PSGallery type repo among correct ones when incorrect type is <Type>" -TestCases $testCases {
+        param($Type, $IncorrectHashTable)
+
+        $correctHashtable1 = @{Name = $TestRepoName1; Uri = $tmpDir1Path}
+        $correctHashtable2 = @{Name = $TestRepoName2; Uri = $tmpDir2Path; Trusted = $True}
+        $correctHashtable3 = @{Name = $TestRepoName3; Uri = $tmpDir3Path; Trusted = $True; Priority = 20}
+        $arrayOfHashtables = $correctHashtable1, $correctHashtable2, $IncorrectHashTable, $correctHashtable3
+
+        Unregister-PSResourceRepository -Name $PSGalleryName
+        Register-PSResourceRepository -Repository $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "NotProvideNameUriCredentialInfoForPSGalleryRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res.Name | Should -Be $TestRepoName1
+
+        $res2 = Get-PSResourceRepository -Name $TestRepoName2
+        $res2.Name | Should -Be $TestRepoName2
+
+        $res3 = Get-PSResourceRepository -Name $TestRepoName3
+        $res3.Name | Should -Be $TestRepoName3
+    }
+
+    It "not register incorrectly formatted -Name type repo among correct ones, where incorrect one is missing -Name" {
+        $correctHashtable1 = @{Name = $TestRepoName2; Uri = $tmpDir2Path; Trusted = $True}
+        $correctHashtable2 = @{Name = $TestRepoName3; Uri = $tmpDir3Path; Trusted = $True; Priority = 20}
+        $correctHashtable3 = @{PSGallery = $True; Priority = 30};
+        $IncorrectHashTable = @{Uri = $tmpDir1Path};
+
+        $arrayOfHashtables = $correctHashtable1, $correctHashtable2, $IncorrectHashTable, $correctHashtable3
+        Unregister-PSResourceRepository -Name $PSGalleryName
+        Register-PSResourceRepository -Repository $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
+
+        $ErrorId = "NullNameForRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -Be $ErrorId
+
+        $res = Get-PSResourceRepository -Name $TestRepoName2
+        $res.Name | Should -Be $TestRepoName2
+
+        $res2 = Get-PSResourceRepository -Name $TestRepoName3
+        $res2.Name | Should -Be $TestRepoName3
+
+        $res3 = Get-PSResourceRepository -Name $PSGalleryName
+        $res3.Name | Should -Be $PSGalleryName
+        $res3.Priority | Should -Be 30
+    }
+
+    It "not register incorrectly formatted -Name type repo among correct ones, where incorrect type has -Name of PSGallery" {
+        $correctHashtable1 = @{Name = $TestRepoName2; Uri = $tmpDir2Path; Trusted = $True}
+        $correctHashtable2 = @{Name = $TestRepoName3; Uri = $tmpDir3Path; Trusted = $True; Priority = 20}
+        $correctHashtable3 = @{PSGallery = $True; Priority = 30};
+        $IncorrectHashTable = @{Name = $PSGalleryName; Uri = $tmpDir1Path};  
+
+        $arrayOfHashtables = $correctHashtable1, $correctHashtable2, $IncorrectHashTable, $correctHashtable3
+        Unregister-PSResourceRepository -Name $PSGalleryName
+        Register-PSResourceRepository -Repository $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
+
+        $ErrorId = "PSGalleryProvidedAsNameRepoPSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -Be $ErrorId
+
+        $res = Get-PSResourceRepository -Name $TestRepoName2
+        $res.Name | Should -Be $TestRepoName2
+
+        $res2 = Get-PSResourceRepository -Name $TestRepoName3
+        $res2.Name | Should -Be $TestRepoName3
+
+        $res3 = Get-PSResourceRepository -Name $PSGalleryName
+        $res3.Name | Should -Be $PSGalleryName
+        $res3.Priority | Should -Be 30
+    }
+
+    It "not register incorrectly formatted Name type repo among correct ones when incorrect type is -Uri not specified" {
+        $correctHashtable1 = @{Name = $TestRepoName2; Uri = $tmpDir2Path; Trusted = $True}
+        $correctHashtable2 = @{Name = $TestRepoName3; Uri = $tmpDir3Path; Trusted = $True; Priority = 20}
+        $correctHashtable3 = @{PSGallery = $True; Priority = 30};
+        $IncorrectHashTable = @{Name = $TestRepoName1};
+
+        $arrayOfHashtables = $correctHashtable1, $correctHashtable2, $IncorrectHashTable, $correctHashtable3
+        Unregister-PSResourceRepository -Name $PSGalleryName
+        Register-PSResourceRepository -Repository $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
+
+        $ErrorId = "NullUriForRepositoriesParameterSetRegistration,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -Be $ErrorId
+
+        $res = Get-PSResourceRepository -Name $TestRepoName2
+        $res.Name | Should -Be $TestRepoName2
+
+        $res2 = Get-PSResourceRepository -Name $TestRepoName3
+        $res2.Name | Should -Be $TestRepoName3
+
+        $res3 = Get-PSResourceRepository -Name $PSGalleryName
+        $res3.Name | Should -Be $PSGalleryName
+        $res3.Priority | Should -Be 30
+    }
+
+    It "not register incorrectly formatted Name type repo among correct ones when incorrect type is -Uri is not valid scheme" {
+        $correctHashtable1 = @{Name = $TestRepoName2; Uri = $tmpDir2Path; Trusted = $True}
+        $correctHashtable2 = @{Name = $TestRepoName3; Uri = $tmpDir3Path; Trusted = $True; Priority = 20}
+        $correctHashtable3 = @{PSGallery = $True; Priority = 30};
+        $IncorrectHashTable = @{Name = $TestRepoName1; Uri="www.google.com"};
+
+        $arrayOfHashtables = $correctHashtable1, $correctHashtable2, $IncorrectHashTable, $correctHashtable3
+        Unregister-PSResourceRepository -Name $PSGalleryName
+        Register-PSResourceRepository -Repository $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
+
+        $ErrorId = "InvalidUri,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -Be $ErrorId
+
+        $res = Get-PSResourceRepository -Name $TestRepoName2
+        $res.Name | Should -Be $TestRepoName2
+
+        $res2 = Get-PSResourceRepository -Name $TestRepoName3
+        $res2.Name | Should -Be $TestRepoName3
+
+        $res3 = Get-PSResourceRepository -Name $PSGalleryName
+        $res3.Name | Should -Be $PSGalleryName
+        $res3.Priority | Should -Be 30
+    }
+
+    It "should register repository with relative location provided as Uri" {
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri "./"
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+
+        $res.Name | Should -Be $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $relativeCurrentPath
+        $res.Trusted | Should -Be False
+        $res.Priority | Should -Be 50
+    }
+
+    It "should update a repository if -Force is used" {
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri "./"
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri "./" -Priority 3 -Force
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+
+        $res.Name | Should -Be $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $relativeCurrentPath
+        $res.Trusted | Should -Be False
+        $res.Priority | Should -Be 3
+    }
+
+    It "should register local file share NuGet based repository" {
+        Register-PSResourceRepository -Name "localFileShareTestRepo" -Uri "\\hcgg.rest.of.domain.name\test\ITxx\team\NuGet\"
+        $res = Get-PSResourceRepository -Name "localFileShareTestRepo"
+
+        $res.Name | Should -Be "localFileShareTestRepo"
+        $res.Uri.LocalPath | Should -Contain "\\hcgg.rest.of.domain.name\test\ITxx\team\NuGet\"
+    }
+
+    It "prints a warning if CredentialInfo is passed in without SecretManagement module setup" {
+        $output = Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -Trusted -Priority 20 -CredentialInfo $credentialInfo1 3>&1
+        $output | Should -Match "Microsoft.PowerShell.SecretManagement module cannot be found"
+
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res | Should -Not -BeNullOrEmpty
+    }
+
+    It "throws error if CredentialInfo is passed in with Credential property without SecretManagement module setup" {
+        { Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -Trusted -Priority 20 -CredentialInfo $credentialInfo2 } | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.RegisterPSResourceRepository"
+
+        $res = Get-PSResourceRepository -Name $TestRepoName1 -ErrorAction Ignore
+        $res | Should -BeNullOrEmpty
+    }
+}

--- a/test/SetPSResourceRepository.Tests.ps1
+++ b/test/SetPSResourceRepository.Tests.ps1
@@ -1,0 +1,305 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
+
+Describe "Test Set-PSResourceRepository" {
+    BeforeEach {
+        $PSGalleryName = Get-PSGalleryName
+        $PSGalleryUri = Get-PSGalleryLocation
+        $TestRepoName1 = "testRepository"
+        $TestRepoName2 = "testRepository2"
+        $TestRepoName3 = "testRepository3"
+        $relativeCurrentPath = Get-Location
+        Get-NewPSResourceRepositoryFile
+        $tmpDir1Path = Join-Path -Path $TestDrive -ChildPath "tmpDir1"
+        $tmpDir2Path = Join-Path -Path $TestDrive -ChildPath "tmpDir2"
+        $tmpDir3Path = Join-Path -Path $TestDrive -ChildPath "tmpDir3"
+        $tmpDir4Path = Join-Path -Path $TestDrive -ChildPath "tmpDir4"
+        $tmpDirPaths = @($tmpDir1Path, $tmpDir2Path, $tmpDir3Path, $tmpDir4Path)
+        Get-NewTestDirs($tmpDirPaths)
+
+        $relativeCurrentPath = Get-Location
+
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        $randomPassword = [System.IO.Path]::GetRandomFileName()
+
+        $credentialInfo1 = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret)
+        $secureString = ConvertTo-SecureString $randomPassword -AsPlainText -Force
+        $credential = New-Object pscredential ("testusername", $secureString)
+        $credentialInfo2 = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret, $credential)
+    }
+    AfterEach {
+        Get-RevertPSResourceRepositoryFile
+        $tmpDir1Path = Join-Path -Path $TestDrive -ChildPath "tmpDir1"
+        $tmpDir2Path = Join-Path -Path $TestDrive -ChildPath "tmpDir2"
+        $tmpDir3Path = Join-Path -Path $TestDrive -ChildPath "tmpDir3"
+        $tmpDir4Path = Join-Path -Path $TestDrive -ChildPath "tmpDir4"
+        $tmpDirPaths = @($tmpDir1Path, $tmpDir2Path, $tmpDir3Path, $tmpDir4Path)
+        Get-RemoveTestDirs($tmpDirPaths)
+    }
+
+    It "set repository given Name and Uri parameters" {
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        Set-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir2Path
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res.Name | Should -Be $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $tmpDir2Path
+        $res.Priority | Should -Be 50
+        $res.Trusted | Should -Be False
+        $res.CredentialInfo | Should -BeNullOrEmpty
+    }
+
+    It "set repository given Name and Priority parameters" {
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        Set-PSResourceRepository -Name $TestRepoName1 -Priority 25
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res.Name | Should -Be $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
+        $res.Priority | Should -Be 25
+        $res.Trusted | Should -Be False
+        $res.CredentialInfo | Should -BeNullOrEmpty
+    }
+
+    It "set repository given Name and Trusted parameters" {
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        Set-PSResourceRepository -Name $TestRepoName1 -Trusted
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res.Name | Should -Be $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
+        $res.Priority | Should -Be 50
+        $res.Trusted | Should -Be True
+        $res.CredentialInfo | Should -BeNullOrEmpty
+    }
+
+    It "set repository given pipeline input ValueFromPipelineByPropertyName passed in" {
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        Get-PSResourceRepository -Name $TestRepoName1 | Set-PSResourceRepository -Trusted
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res.Name | Should -Be $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
+        $res.Priority | Should -Be 50
+        $res.Trusted | Should -Be True
+        $res.CredentialInfo | Should -BeNullOrEmpty
+    }
+
+    It "set repository given Name and CredentialInfo parameters" {
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        Set-PSResourceRepository -Name $TestRepoName1 -CredentialInfo $credentialInfo1
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res.Name | Should -Be $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
+        $res.Priority | Should -Be 50
+        $res.Trusted | Should -Be False
+        $res.CredentialInfo.VaultName | Should -Be "testvault"
+        $res.CredentialInfo.SecretName | Should -Be $randomSecret
+        $res.CredentialInfo.Credential | Should -BeNullOrEmpty
+    }
+
+    It "not set repository and write error given just Name parameter" {
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        {Set-PSResourceRepository -Name $TestRepoName1 -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
+    }
+
+    $testCases = @{Type = "contains *";     Name = "test*Repository"; ErrorId = "ErrorInNameParameterSet"},
+                 @{Type = "is whitespace";  Name = " ";               ErrorId = "ErrorInNameParameterSet"},
+                 @{Type = "is null";        Name = $null;             ErrorId = "ParameterArgumentValidationError"}
+
+    It "not set repository and throw error given Name <Type> (NameParameterSet)" -TestCases $testCases {
+        param($Type, $Name)
+
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        {Set-PSResourceRepository -Name $Name -Priority 25 -ErrorAction Stop} | Should -Throw -ErrorId "$ErrorId,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
+    }
+
+    $testCases2 = @{Type = "contains *";     Name = "test*Repository2";  ErrorId = "ErrorSettingRepository"},
+                  @{Type = "is whitespace";  Name = " ";                 ErrorId = "ErrorSettingRepository"},
+                  @{Type = "is null";        Name = $null;               ErrorId = "NullNameForRepositoriesParameterSetRepo"}
+    It "not set repository and write error given Name <Type> (RepositoriesParameterSet)" -TestCases $testCases2 {
+        param($Type, $Name, $ErrorId)
+
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName2 -Uri $tmpDir2Path
+
+        $hashtable1 = @{Name = $TestRepoName1; Uri = $tmpDir3Path}
+        $hashtable2 = @{Name = $TestRepoName2; Priority = 25}
+        $incorrectHashTable = @{Name = $Name; Trusted = $True}
+        $arrayOfHashtables = $hashtable1, $incorrectHashTable, $hashtable2
+
+        Set-PSResourceRepository -Repository $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "$ErrorId,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
+
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $tmpDir3Path
+        $res.Trusted | Should -Be False
+
+        $res2 = Get-PSResourceRepository -Name $TestRepoName2
+        $res2.Priority | Should -Be 25
+        $res2.Trusted | Should -Be False
+    }
+
+    It "set repositories with Repositories parameter" {
+        Unregister-PSResourceRepository -Name $PSGalleryName
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        Register-PSResourceRepository -Name $TestRepoName2 -Uri $tmpDir2Path
+        Register-PSResourceRepository -Name $TestRepoName3 -Uri $tmpDir3Path
+        Register-PSResourceRepository -PSGallery
+
+        $hashtable1 = @{Name = $TestRepoName1; Uri = $tmpDir2Path};
+        $hashtable2 = @{Name = $TestRepoName2; Priority = 25};
+        $hashtable3 = @{Name = $TestRepoName3; CredentialInfo = [PSCustomObject] @{ VaultName = "testvault"; SecretName = $randomSecret }};
+        $hashtable4 = @{Name = $PSGalleryName; Trusted = $True};
+        $arrayOfHashtables = $hashtable1, $hashtable2, $hashtable3, $hashtable4
+
+        Set-PSResourceRepository -Repository $arrayOfHashtables
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res.Name | Should -Be $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $tmpDir2Path
+        $res.Priority | Should -Be 50
+        $res.Trusted | Should -Be False
+        $res.CredentialInfo | Should -BeNullOrEmpty
+
+        $res2 = Get-PSResourceRepository -Name $TestRepoName2
+        $res2.Name | Should -Be $TestRepoName2
+        $res2.Uri.LocalPath | Should -Contain $tmpDir2Path
+        $res2.Priority | Should -Be 25
+        $res2.Trusted | Should -Be False
+        $res2.CredentialInfo | Should -BeNullOrEmpty
+
+        $res3 = Get-PSResourceRepository -Name $TestRepoName3
+        $res3.Name | Should -Be $TestRepoName3
+        $res3.Uri.LocalPath | Should -Contain $tmpDir3Path
+        $res3.Priority | Should -Be 50
+        $res3.Trusted | Should -Be False
+        $res3.CredentialInfo.VaultName | Should -Be "testvault"
+        $res3.CredentialInfo.SecretName | Should -Be $randomSecret
+        $res3.CredentialInfo.Credential | Should -BeNullOrEmpty
+
+        $res4 = Get-PSResourceRepository -Name $PSGalleryName
+        $res4.Name | Should -Be $PSGalleryName
+        $res4.Uri | Should -Contain $PSGalleryUri
+        $res4.Priority | Should -Be 50
+        $res4.Trusted | Should -Be True
+        $res4.CredentialInfo | Should -BeNullOrEmpty
+    }
+
+    It "not set and throw error for trying to set PSGallery Uri (NameParameterSet)" {
+        Unregister-PSResourceRepository -Name $PSGalleryName
+        Register-PSResourceRepository -PSGallery
+        {Set-PSResourceRepository -Name $PSGalleryName -Uri $tmpDir1Path -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
+    }
+
+    It "not set and throw error for trying to set PSGallery CredentialInfo (NameParameterSet)" {
+        Unregister-PSResourceRepository -Name $PSGalleryName
+        Register-PSResourceRepository -PSGallery
+        {Set-PSResourceRepository -Name $PSGalleryName -CredentialInfo $credentialInfo1 -ErrorAction Stop} | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
+    }
+
+    It "not set repository and throw error for trying to set PSGallery Uri (RepositoriesParameterSet)" {
+        Unregister-PSResourceRepository -Name $PSGalleryName
+        Register-PSResourceRepository -PSGallery
+
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+
+        $hashtable1 = @{Name = $PSGalleryName; Uri = $tmpDir1Path}
+        $hashtable2 = @{Name = $TestRepoName1; Priority = 25}
+        $arrayOfHashtables = $hashtable1, $hashtable2
+
+        Set-PSResourceRepository -Repository $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "ErrorSettingRepository,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
+
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
+        $res.Priority | Should -Be 25
+        $res.Trusted | Should -Be False
+    }
+
+    It "should set repository with relative Uri provided" {
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        Set-PSResourceRepository -Name $TestRepoName1 -Uri $relativeCurrentPath
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res.Name | Should -Be $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $relativeCurrentPath
+        $res.Trusted | Should -Be False
+        $res.Priority | Should -Be 50
+    }
+
+    It "not set repository and throw error for trying to set PSGallery CredentialInfo (RepositoriesParameterSet)" {
+        Unregister-PSResourceRepository -Name $PSGalleryName
+        Register-PSResourceRepository -PSGallery
+
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+
+        $hashtable1 = @{Name = $PSGalleryName; CredentialInfo = $credentialInfo1}
+        $hashtable2 = @{Name = $TestRepoName1; Priority = 25}
+        $arrayOfHashtables = $hashtable1, $hashtable2
+
+        Set-PSResourceRepository -Repository $arrayOfHashtables -ErrorVariable err -ErrorAction SilentlyContinue
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "ErrorSettingRepository,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
+
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
+        $res.Priority | Should -Be 25
+        $res.Trusted | Should -Be False
+        $res.CredentialInfo | Should -BeNullOrEmpty
+    }
+
+    It "should set repository with local file share NuGet based Uri" {
+        Register-PSResourceRepository -Name "localFileShareTestRepo" -Uri $tmpDir1Path
+        Set-PSResourceRepository -Name "localFileShareTestRepo" -Uri "\\hcgg.rest.of.domain.name\test\ITxx\team\NuGet\"
+        $res = Get-PSResourceRepository -Name "localFileShareTestRepo"
+        $res.Name | Should -Be "localFileShareTestRepo"
+        $Res.Uri.LocalPath | Should -Contain "\\hcgg.rest.of.domain.name\test\ITxx\team\NuGet\"
+    }
+
+    It "set repository should register repository if it does not already exist" {
+        $testRepoName = "NewForceTestRepo"
+        Set-PSResourceRepository -Name $testRepoName -Uri $tmpDir1Path -PassThru
+
+        $res = Get-PSResourceRepository -Name $testRepoName
+        $res.Name | Should -Be $testRepoName
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
+        $res.Priority | Should -Be 50
+        $res.Trusted | Should -Be False
+    }
+
+    It "set repository given Uri and see updated repository with -PassThru" {
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        $res = Set-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir2Path -PassThru
+        $res.Name | Should -Be $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $tmpDir2Path
+        $res.Priority | Should -Be 50
+        $res.Trusted | Should -Be False
+    }
+
+    It "set repository given Priority and see updated repository with -PassThru" {
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        $res = Set-PSResourceRepository -Name $TestRepoName1 -Priority 30 -PassThru
+        $res.Name | Should -Be $TestRepoName1
+        $Res.Uri.LocalPath | Should -Contain $tmpDir1Path
+        $res.Priority | Should -Be 30
+        $res.Trusted | Should -Be False
+    }
+
+    It "prints a warning if CredentialInfo is passed in without SecretManagement module setup" {
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        $output = Set-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -CredentialInfo $credentialInfo1 3>&1
+        $output | Should -Match "Microsoft.PowerShell.SecretManagement module cannot be found"
+
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res | Should -Not -BeNullOrEmpty
+    }
+
+    It "throws error if CredentialInfo is passed in with Credential property without SecretManagement module setup" {
+        {
+            Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+            Set-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -CredentialInfo $credentialInfo2
+        } | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PowerShellGet.Cmdlets.SetPSResourceRepository"
+
+        $res = Get-PSResourceRepository -Name $TestRepoName1 -ErrorAction Ignore
+        $res.CredentialInfo | Should -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add back tests for Register-PSResourceRepository, Set-PSResourceRepository, and PSCredentialInfo constructor tests that were initially removed while cleaning repo history.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
