### PR TITLE
Incorporate ACR feeds in Register-PSResourceRepository

### DIFF
--- a/src/code/PSRepositoryInfo.cs
+++ b/src/code/PSRepositoryInfo.cs
@@ -13,13 +13,31 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
     {
         #region Constructor
 
-        public PSRepositoryInfo(string name, Uri uri, int priority, bool trusted, PSCredentialInfo credentialInfo)
+        public PSRepositoryInfo(
+            string name, 
+            Uri uri, 
+            int priority, 
+            bool trusted, 
+            RepositoryProviderType repositoryProvider, 
+            PSCredentialInfo credentialInfo)
         {
             Name = name;
             Uri = uri;
             Priority = priority;
             Trusted = trusted;
+            RepositoryProvider = repositoryProvider;
             CredentialInfo = credentialInfo;
+        }
+
+        #endregion
+
+        #region Enum
+
+        public enum RepositoryProviderType
+        {
+            None,
+            ACR,
+            AzureDevOps
         }
 
         #endregion
@@ -46,6 +64,11 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         /// </summary>
         [ValidateRange(0, 100)]
         public int Priority { get; }
+
+        /// <summary>
+        /// the type of repository provider (eg, AzureDevOps, ACR, etc.)
+        /// </summary>
+        public RepositoryProviderType RepositoryProvider { get; }
 
         /// <summary>
         /// the credential information for repository authentication


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
We have modified `RepositorySettings` and `PSRepositoryInfo` to accommodate for ACR endpoints (eg: 'https://testacr.azurecr.io').  This allows users to register ACR endpoints with PowerShellGet.  We've also added a new `PSRepositoryInfo` type/property called `RepositoryProviderType` which is an enum that represents the repository "provider".  Because this new type is in the PSRepositoryInfo class, you can now access the type via `Get-PSResourceRepository`.

## PR Context
This is for hackathon prototyping for a private gallery ACR. 

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
