### PR TITLE
Add ACR access token integration w/ secret management

### DIFF
--- a/src/code/FindACR.cs
+++ b/src/code/FindACR.cs
@@ -98,7 +98,30 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 if (repo.RepositoryProvider == PSRepositoryInfo.RepositoryProviderType.ACR) 
                 {
+                    string accessToken = string.Empty;
+                    string tenantID = string.Empty;
+
+                    // Need to set up secret management vault before hand 
+                    var repositoryCredentialInfo = repo.CredentialInfo;
+                    if (repositoryCredentialInfo != null)
+                    {
+                        accessToken = Utils.GetACRAccessTokenFromSecretManagement(
+                            repo.Name,
+                            repositoryCredentialInfo,
+                            this);
+                        
+                        WriteVerbose("Access token retrieved.");
+
+                        tenantID = Utils.GetSecretInfoFromSecretManagement(
+                            repo.Name,
+                            repositoryCredentialInfo,
+                            this);
+                    }
+
                     AcrSearchHelper(repo); 
+
+                    WriteVerbose("AccessToken: " + accessToken);
+                    WriteVerbose("Tenant ID: " + tenantID);
                 }
             }
         }

--- a/src/code/FindACR.cs
+++ b/src/code/FindACR.cs
@@ -124,8 +124,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                             this);
                     }
 
-                    WriteVerbose("AccessToken: " + accessToken);
-                    WriteVerbose("Tenant ID: " + tenantID);
                     AcrSearchHelper(repo);
                 }
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This integration allows for ACR access tokens and tenant ids that are saved into a Secret Management vault to be retrieved automatically when PSGet searches through repositories. 

Note that this assumes the vault is properly configured with both the Access Token AND the Tenant ID (saved within the secret's metadata).

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
