### PR TITLE
Update CHANGELOG for `3.0.18-beta18`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 3.0.18-beta18
+
+### New Features
+
+### Bug Fixes
+
 ## 3.0.17-beta17
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # CHANGELOG
 
-## 3.0.18-beta18
-
-### New Features
-
-### Bug Fixes
-
 ## 3.0.17-beta17
 
 ### New Features

--- a/tool/releaseTools.psm1
+++ b/tool/releaseTools.psm1
@@ -145,7 +145,7 @@ function New-ReleasePR {
         Title = "Update CHANGELOG for ``$Version``"
         Body = @($PRTemplate[0..4]
                 "Updates CHANGELOG.md file"
-                $PRTemplate[5..$PRTemplate.Length])
+                $PRTemplate[5..$PRTemplate.Length]).ToString()
     }
 
     $PR = $Repo | New-GitHubPullRequest @Params

--- a/tool/releaseTools.psm1
+++ b/tool/releaseTools.psm1
@@ -139,10 +139,11 @@ function New-ReleasePR {
     }
 
     $Repo = Get-GitHubRepository -OwnerName PowerShell -RepositoryName PowerShellGet
+    Write-Host "Gotten repo $($Repo)"
 
     $Params = @{
-        Head = "release"
-        Base = "master"
+        Head = "alyss1303/PowerShellGet:release"
+        Base = "PowerShell/PowerShellGet:master"
         Draft = $true
         Title = "Update CHANGELOG for $($Version)"
     }

--- a/tool/releaseTools.psm1
+++ b/tool/releaseTools.psm1
@@ -1,0 +1,103 @@
+# requires -Version 6.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#using module PowerShellForGitHub
+using namespace System.Management.Automation
+
+function Get-Bullet {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [PSCustomObject]$PullRequest
+    )
+
+    $PullRequest | -Process { ("-", $_.title, ("(#" + $_.PullRequestNumber + ")") -join " ").Trim() }
+}
+
+<#
+.SYNOPSIS
+  Gets the unpublished content from the changelog.
+.DESCRIPTION
+  This is used so that we can manually touch-up the automatically updated
+  changelog, and then bring its contents into the extension's changelog or
+  the GitHub release. It just gets the first header's contents.
+#>
+function Get-FirstChangelog {
+    $ChangelogFile = ".\CHANGELOG.md"
+    $Changelog = Get-Content -Path $ChangelogFile
+    
+    # NOTE: The space after the header marker is important! Otherwise ### matches.
+    $Header = $Changelog.Where({$_.StartsWith("## ")}, "First")
+    $Changelog.Where(
+        { $_ -eq $Header }, "SkipUntil"
+    ).Where(
+        { $_.StartsWith("## ") -and $_ -ne $Header }, "Until"
+    )
+}
+
+<#
+.SYNOPSIS
+  Gets current version from changelog as `[semver]`.
+#>
+function Get-Version {
+    $Version = (Get-FirstChangelog)[0]
+    if ($Version -match '## (?<version>\d+\.\d+\.\d+(-beta\d*)?)') {
+        return $Matches.version
+    } else {
+        Write-Error "Couldn't find version from changelog!"
+    }
+}
+
+<#
+.SYNOPSIS
+  Updates the CHANGELOG file with PRs merged since the last release.
+.DESCRIPTION
+  Uses the local Git repositories but does not pull, so ensure HEAD is where you
+  want it. Creates the branch `release` if not already checked out. Handles any
+  merge option for PRs, but is a little slow as it queries all PRs.
+#>
+function Update-Changelog {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        # TODO: Validate version style for each repo.
+        [Parameter(Mandatory)]
+        [string]$Version
+    )
+
+    $RepositoryName = 'PowerShellGet'
+    $Repo = Get-GitHubRepository -OwnerName PowerShell -RepositoryName $RepositoryName
+
+    $BugFixes = @()
+    $NewFeatures = @()
+    # This will take some time because it has to pull all PRs and then filter
+    $PullRequests = $Repo | Get-GitHubPullRequest -State 'closed' |
+        Where-Object { $_.labels.LabelName -match 'Release' } |
+        Where-Object { -not $_.title.StartsWith("[WIP]") } | 
+        Where-Object { -not $_.title.StartsWith("WIP") } |
+        if ($_.labels.LabelName -match 'PR-Bug') {
+            $BugFixes += Get-Bullet($_)
+        }
+        else {
+            $NewFeatures += Get-Bullet($_)
+        }
+        
+    $NewSection = switch ($PullRequests.labels.LabelName) {
+        'PR-Bug' {
+
+        }
+    }
+}
+
+
+
+$allIssues = $Repo | Get-GitHubIssue -State 'closed'
+$closedIssues = $allIssues | Where-Object { $_.pull_request -eq $null }
+$labelledIssues = $closedIssues | Where-Object { $_.labels.LabelName -match 'Issue-Bug|feature_request' }
+
+# Get all GitHub labels and filter the labels for release
+$labels = Get-GitHubLabel -OwnerName PowerShell -RepositoryName PowerShellGet
+$labels | Where-Object { $_.color -match 'B2F74F' }
+
+# Remove a label from a pull request
+Remove-GitHubIssueLabel -OwnerName PowerShell -RepositoryName PowerShellGet -Label Release -Issue 806

--- a/tool/releaseTools.psm1
+++ b/tool/releaseTools.psm1
@@ -1,17 +1,19 @@
-# requires -Version 6.0
-# Copyright (c) Microsoft Corporation.
+# Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
 using module PowerShellForGitHub
 using namespace System.Management.Automation
 
 $PullRequests = @()
+$BugFixes = @()
+$NewFeatures = @()
 $Repo = Get-GitHubRepository -OwnerName PowerShell -RepositoryName PowerShellGet
 $Path = (Get-Item $PSScriptRoot).Parent.FullName
 $ChangelogFile = "$Path/CHANGELOG.md"
 
 function Update-Branch {
     [CmdletBinding(SupportsShouldProcess)]
+    param()
     $Branch = git branch --show-current
     if ($Branch -ne "release") {
         if ($PSCmdlet.ShouldProcess("release", "git checkout -B")) {
@@ -26,46 +28,12 @@ function Get-Bullet {
         [Parameter(Mandatory, ValueFromPipeline)]
         [PSCustomObject]$PullRequest
     )
-
     ("-", $PullRequest.title, ("(#" + $PullRequest.PullRequestNumber + ")") -join " ").Trim() 
 }
 
 <#
 .SYNOPSIS
-  Gets the unpublished content from the changelog.
-.DESCRIPTION
-  This is used so that we can manually touch-up the automatically updated
-  changelog, and then bring its contents into the extension's changelog or
-  the GitHub release. It just gets the first header's contents.
-#>
-function Get-FirstChangelog {
-    $Changelog = Get-Content -Path $ChangelogFile
-    
-    # NOTE: The space after the header marker is important! Otherwise ### matches.
-    $Header = $Changelog.Where({$_.StartsWith("## ")}, "First")
-    $Changelog.Where(
-        { $_ -eq $Header }, "SkipUntil"
-    ).Where(
-        { $_.StartsWith("## ") -and $_ -ne $Header }, "Until"
-    )
-}
-
-<#
-.SYNOPSIS
-  Gets current version from changelog as `[semver]`.
-#>
-function Get-Version {
-    $Version = (Get-FirstChangelog)[0]
-    if ($Version -match '## (?<version>\d+\.\d+\.\d+(-beta\d*)?)') {
-        return $Matches.version
-    } else {
-        Write-Error "Couldn't find version from changelog!"
-    }
-}
-
-<#
-.SYNOPSIS
-  Updates the CHANGELOG file with PRs merged since the last release.
+  Creates the CHANGELOG content with PRs merged since the last release.
 .DESCRIPTION
   Uses the local Git repositories but does not pull, so ensure HEAD is where you
   want it. Creates the branch `release` if not already checked out. Handles any
@@ -78,11 +46,8 @@ function Get-Changelog {
         [Parameter(Mandatory)]
         [string]$Version
     )
-
-    $BugFixes = @()
-    $NewFeatures = @()
+    
     # This will take some time because it has to pull all PRs and then filter
-
     $PullRequests = $Repo | Get-GitHubPullRequest -State 'closed' |
     Where-Object { $_.labels.LabelName -match 'Release' } |
     Where-Object { -not $_.title.StartsWith("[WIP]") } | 
@@ -96,7 +61,9 @@ function Get-Changelog {
             $NewFeatures += Get-Bullet($_)
         }
     }
+}
 
+function Set-Changelog {
     @(
         "## $Version"
         ""
@@ -109,27 +76,60 @@ function Get-Changelog {
     )
 }
 
+<#
+.SYNOPSIS
+  Updates the CHANGELOG file given a version
+#>
 function Update-Changelog {
     [CmdletBinding(SupportsShouldProcess)]
     param(
-        # TODO: Validate version style for each repo.
         [Parameter(Mandatory)]
         [string]$Version
     )
 
+    Get-Changelog $Version
     $CurrentChangeLog = Get-Content -Path $ChangelogFile
     @(
         $CurrentChangeLog[0..1]
-        Get-Changelog $Version
+        Set-Changelog $Version
         $CurrentChangeLog[2..$CurrentChangeLog.Length]
     ) | Set-Content -Encoding utf8NoBOM -Path $ChangelogFile
+
+    if ($PSCmdlet.ShouldProcess("$ChangelogFile", "git commit")) {
+        git add $ChangelogFile
+        git commit -m "Update CHANGELOG for ``$Version``"
+    }
+}
+
+function Update-PSDFile {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Version
+    )
+    $CurrentPSDFile = Get-Content -Path ".\src\PowerShellGet.psd1"
+    $Header = $CurrentPSDFile.Where({$_.StartsWith("## ")}, "First")
+
+    @(
+        $CurrentPSDFile.Where({ $_ -eq $Header }, "Until")
+        Set-Changelog $Version
+        $CurrentPSDFile.Where({ $_ -eq $Header }, "SkipUntil")
+    )
+
+    if ($PSCmdlet.ShouldProcess(".\src\PowerShellGet.psd1", "git commit")) {
+        git add "src\PowerShellGet.psd1"
+        git commit -m "Update CHANGELOG for ``$Version``"
+    }
 }
 
 function New-ReleasePR {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)]
-        [string]$Version
+        [string]$Version,
+
+        [Parameter(Mandatory)]
+        [string]$Username
     )
 
     Update-Branch
@@ -138,13 +138,16 @@ function New-ReleasePR {
         git push --force-with-lease origin release
     }
 
-    $Repo = Get-GitHubRepository -OwnerName PowerShell -RepositoryName PowerShellGet
+    $PRTemplate = Get-Content -Path ".\.github\PULL_REQUEST_TEMPLATE.md"
 
     $Params = @{
-        Head = "release"
+        Head = "``$Username``:release"
         Base = "master"
         Draft = $true
-        Title = "Update CHANGELOG for $($Version)"
+        Title = "Update CHANGELOG for ``$Version``"
+        Body = @($PRTemplate[0..4]
+                "Updates CHANGELOG.md file"
+                $PRTemplate[5..$PRTemplate.Length])
     }
 
     $PR = $Repo | New-GitHubPullRequest @Params
@@ -156,7 +159,3 @@ function Remove-Release-Label {
         $Repo | Remove-GitHubIssueLabel -Label Release -Issue $_.PullRequestNumber
     }
 }
-
-# Get all GitHub labels and filter the labels for release
-$labels = Get-GitHubLabel -OwnerName PowerShell -RepositoryName PowerShellGet
-$labels | Where-Object { $_.color -match 'B2F74F' } #>

--- a/tool/releaseTools.psm1
+++ b/tool/releaseTools.psm1
@@ -97,7 +97,6 @@ function Update-Changelog {
 
     if ($PSCmdlet.ShouldProcess("$ChangelogFile", "git commit")) {
         git add $ChangelogFile
-        git commit -m "Update CHANGELOG for ``$Version``"
     }
 }
 
@@ -114,11 +113,10 @@ function Update-PSDFile {
         $CurrentPSDFile.Where({ $_ -eq $Header }, "Until")
         Set-Changelog $Version
         $CurrentPSDFile.Where({ $_ -eq $Header }, "SkipUntil")
-    )
+    ) | Set-Content -Encoding utf8NoBOM -Path ".\src\PowerShellGet.psd1"
 
     if ($PSCmdlet.ShouldProcess(".\src\PowerShellGet.psd1", "git commit")) {
         git add "src\PowerShellGet.psd1"
-        git commit -m "Update CHANGELOG for ``$Version``"
     }
 }
 

--- a/tool/setupReleaseTools.ps1
+++ b/tool/setupReleaseTools.ps1
@@ -7,8 +7,8 @@ param(
 )
 
 Write-Host "Install and import PowerShell modules"
-Set-PSRepository -Name PSGallery -InstallationPolicy Trusted | Out-Null
-Install-Module -Name PowerShellForGitHub -Scope CurrentUser -Force
+#Set-PSRepository -Name PSGallery -InstallationPolicy Trusted | Out-Null
+#Install-Module -Name PowerShellForGitHub -Scope CurrentUser -Force
 Import-Module $PSScriptRoot/releaseTools.psm1
 
 Write-Host "Setup authentication"

--- a/tool/setupReleaseTools.ps1
+++ b/tool/setupReleaseTools.ps1
@@ -8,8 +8,8 @@ param(
 
 Write-Host "Install and import PowerShell modules"
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted | Out-Null
-#Install-Module -Name PowerShellForGitHub -Scope CurrentUser -Force
-#Import-Module $PSScriptRoot/ReleaseTools.psm1
+Install-Module -Name PowerShellForGitHub -Scope CurrentUser -Force
+Import-Module $PSScriptRoot/releaseTools.psm1
 
 Write-Host "Setup authentication"
 Set-GitHubConfiguration -SuppressTelemetryReminder

--- a/tool/setupReleaseTools.ps1
+++ b/tool/setupReleaseTools.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation.
+# Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
 param(

--- a/tool/setupReleaseTools.ps1
+++ b/tool/setupReleaseTools.ps1
@@ -1,0 +1,17 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [Parameter(Mandatory)]
+    [string]$Token
+)
+
+Write-Host "Install and import PowerShell modules"
+Set-PSRepository -Name PSGallery -InstallationPolicy Trusted | Out-Null
+#Install-Module -Name PowerShellForGitHub -Scope CurrentUser -Force
+#Import-Module $PSScriptRoot/ReleaseTools.psm1
+
+Write-Host "Setup authentication"
+Set-GitHubConfiguration -SuppressTelemetryReminder
+$password = ConvertTo-SecureString -String $Token -AsPlainText -Force
+Set-GitHubAuthentication -Credential (New-Object System.Management.Automation.PSCredential ("token", $password))


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. --># PR Summary<!-- Summarize your PR between here and the checklist. -->Updates CHANGELOG.md file## PR Context<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->## PR Checklist- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)    - Use the present tense and imperative mood when describing your changes- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**    - [ ] None    - **OR**    - [ ] [Documentation needed]()        - [ ] Issue filed: <!-- Number/link of that issue here -->- **User-facing changes**    - [ ] Not Applicable    - **OR**    - [ ] [Documentation needed]()        - [ ] Issue filed: <!-- Number/link of that issue here -->- **Testing - New and feature**    - [ ] N/A or can only be tested interactively    - **OR**    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)- **Tooling**    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.    - **OR**    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.