### PR TITLE
Begin implementation for converting response Xml into PSResourceInfo obj

### DIFF
--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -182,6 +182,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         private void ProcessResourceNameParameterSet()
         {
+            // This is for testing/debugging purposes, will be removed later
+            HttpFindPSResource httpFindPSResource = new HttpFindPSResource();
+            httpFindPSResource.FindName(Name.FirstOrDefault(), Repository.FirstOrDefault(), Prerelease, out string errRecord);
+
+
             if (!MyInvocation.BoundParameters.ContainsKey(nameof(Name)))
             {
                 // only cases where Name is allowed to not be specified is if Type or Tag parameters are

--- a/src/code/IFindPSResource.cs
+++ b/src/code/IFindPSResource.cs
@@ -54,7 +54,8 @@ public interface IFindPSResource
     /// - Include prerelease: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
     /// Implementation Note: Need to filter further for latest version (prerelease or non-prerelease dependening on user preference)
     /// </summary>
-    PSResourceInfo FindName(string packageName, PSRepositoryInfo repository, bool includePrerelease, out string errRecord);
+    /// // TODO:  change repository from string to PSRepositoryInfo
+    PSResourceInfo FindName(string packageName, string repository, bool includePrerelease, out string errRecord);
 
     /// <summary>
     /// Find method which allows for searching for single name with wildcards and returns latest version.

--- a/src/code/IServerAPICalls.cs
+++ b/src/code/IServerAPICalls.cs
@@ -92,7 +92,8 @@ public interface IServerAPICalls
     /// - Include prerelease: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
     /// Implementation Note: Need to filter further for latest version (prerelease or non-prerelease dependening on user preference)
     /// </summary>
-    string FindName(string packageName, PSRepositoryInfo repository, out string errRecord);
+    /// // TODO:  change repository from string to PSRepositoryInfo
+    string FindName(string packageName, string repository, out string errRecord);
 
     /// <summary>
     /// Find method which allows for searching for single name with version range.
@@ -114,7 +115,6 @@ public interface IServerAPICalls
     /// Implementation Note: filter additionally and verify ONLY package name was a match.
     /// </summary>
     string FindNameGlobbingWithPrerelease(string packageName, PSRepositoryInfo repository, out string errRecord);
-    {
 
 
     /// <summary>

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -1,3 +1,4 @@
+using System.Xml;
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
@@ -9,6 +10,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Management.Automation;
+using System.Xml.Serialization;
 
 using Dbg = System.Diagnostics.Debug;
 
@@ -535,7 +537,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                     licenseUri: ParseMetadataLicenseUri(metadataToParse),
                     name: ParseMetadataName(metadataToParse),
                     packageManagementProvider: null,
-                    powershellGetFormatVersion: null,
+                    powershellGetFormatVersion: null,   
                     prerelease: ParsePrerelease(metadataToParse),
                     projectUri: ParseMetadataProjectUri(metadataToParse),
                     publishedDate: ParseMetadataPublishedDate(metadataToParse),
@@ -555,6 +557,45 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 errorMsg = string.Format(
                     CultureInfo.InvariantCulture,
                     @"TryReadPSGetInfo: Cannot parse PSResourceInfo from IPackageSearchMetadata with error: {0}",
+                    ex.Message);
+                return false;
+            }
+        }
+
+        // TODO:  in progress
+        // write a serializer
+        public static bool TryConvertFromXml(
+            XmlNode entry,  // XmlDocument doc  that is already loaded
+            out PSResourceInfo2 psGetInfo,
+            string repositoryName,
+            ResourceType? type,
+            out string errorMsg)
+        {
+            psGetInfo = null;
+            errorMsg = String.Empty;
+
+            if (entry == null)
+            {
+                errorMsg = "TryConvertXmlToPSResourceInfo: Invalid XmlNodeList object. Object cannot be null.";
+                return false;
+            }
+            
+            try
+            {
+                //XmlNodeList elemList = doc.GetElementsByTagName("m:properties");
+
+                var xNodeReader = new XmlNodeReader(entry);
+                var xmlSerializer = new XmlSerializer(typeof(PSResourceInfo2));
+                psGetInfo = xmlSerializer.Deserialize(xNodeReader) as PSResourceInfo2;
+                
+                // Note:  still need to add some info to the psGetInfo obj, 
+                return true;
+            }
+            catch (Exception ex)
+            {
+                errorMsg = string.Format(
+                    CultureInfo.InvariantCulture,
+                    @"TryReadPSGetInfo: Cannot parse PSResourceInfo from XmlNode with error: {0}",
                     ex.Message);
                 return false;
             }
@@ -947,6 +988,94 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         #endregion
     }
 
+    #endregion
+
+    // TODO: tmp class for testing/debugging 
+    #region PSResourceInfo2
+
+    public sealed class PSResourceInfo2
+    {
+        #region Properties
+
+        public string Author { get; set;}
+        public string Copyright { get; set; }
+        public string Description { get; set;}
+        public string IconUri { get; set; }
+        public ResourceIncludes Includes { get; set;}
+        public DateTime? InstalledDate { get; set; }
+        public string InstalledLocation { get; set; }
+        public bool IsPrerelease { get; set;}
+        public string LicenseUri { get; set;}
+        public string Name { get; set;}
+        public string PackageManagementProvider { get; set;}
+        public string PowerShellGetFormatVersion { get; set;}
+        public string Prerelease { get; set;}
+        public string ProjectUri { get; set;}
+        public DateTime? PublishedDate { get; set;}
+        public string ReleaseNotes { get; set;}
+        public string Repository { get; set; }
+        public string RepositorySourceLocation { get;  set; }
+        public string[] Tags { get; set;}
+        public ResourceType Type { get; set;}
+        public DateTime? UpdatedDate { get; set;}
+        public Version Version { get; set;}
+
+        #endregion
+
+        #region Constructors
+
+        private PSResourceInfo2() { }
+
+        private PSResourceInfo2(
+            string author,
+            string copyright,
+            string description,
+            string iconUri,
+            ResourceIncludes includes,
+            DateTime? installedDate,
+            string installedLocation,
+            bool isPrelease,
+            string licenseUri,
+            string name,
+            string packageManagementProvider,
+            string powershellGetFormatVersion,
+            string prerelease,
+            string projectUri,
+            DateTime? publishedDate,
+            string releaseNotes,
+            string repository,
+            string repositorySourceLocation,
+            string[] tags,
+            ResourceType type,
+            DateTime? updatedDate,
+            Version version)
+        {
+            Author = author ?? string.Empty;
+            Copyright = copyright ?? string.Empty;
+            Description = description ?? string.Empty;
+            IconUri = iconUri;
+            Includes = includes ?? new ResourceIncludes();
+            InstalledDate = installedDate;
+            InstalledLocation = installedLocation ?? string.Empty;
+            IsPrerelease = isPrelease;
+            LicenseUri = licenseUri;
+            Name = name ?? string.Empty;
+            PackageManagementProvider = packageManagementProvider ?? string.Empty;
+            PowerShellGetFormatVersion = powershellGetFormatVersion ?? string.Empty;
+            Prerelease = prerelease ?? string.Empty;
+            ProjectUri = projectUri;
+            PublishedDate = publishedDate;
+            ReleaseNotes = releaseNotes ?? string.Empty;
+            Repository = repository ?? string.Empty;
+            RepositorySourceLocation = repositorySourceLocation ?? string.Empty;
+            Tags = tags ?? Utils.EmptyStrArray;
+            Type = type;
+            UpdatedDate = updatedDate;
+            Version = version ?? new Version();
+        }
+        #endregion
+
+    }
     #endregion
 
     #region Test Hooks

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1193,13 +1193,27 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
         #region HttpRequest
 
-        public static async Task<JObject> SendRequestAsync(HttpRequestMessage message, HttpClient s_client)
+        public static async Task<JObject> SendV3RequestAsync(HttpRequestMessage message, HttpClient s_client)
         {
             try
             {
                 HttpResponseMessage response = await s_client.SendAsync(message);
                 response.EnsureSuccessStatusCode();
                 return JsonConvert.DeserializeObject<JObject>(await response.Content.ReadAsStringAsync());
+            }
+            catch (HttpRequestException e)
+            {
+                throw new HttpRequestException("Error occured while trying to retrieve response: " + e.Message);
+            }
+        }
+
+        public static async Task<string> SendV2RequestAsync(HttpRequestMessage message, HttpClient s_client)
+        {
+            try
+            {
+                HttpResponseMessage response = await s_client.SendAsync(message);
+                response.EnsureSuccessStatusCode();
+                return response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             }
             catch (HttpRequestException e)
             {

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -165,9 +165,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// - Include prerelease: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
         /// Implementation Note: Need to filter further for latest version (prerelease or non-prerelease dependening on user preference)
         /// </summary>
-        public string FindName(string packageName, PSRepositoryInfo repository, out string errRecord) {
+        /// // TODO:  change repository from string to PSRepositoryInfo
+        public string FindName(string packageName, string repository, out string errRecord) {
             // Make sure to include quotations around the package name
-            var requestUrlV2 = $"{repository.Uri}/FindPackagesById()?id='{packageName}'";
+            var requestUrlV2 = $"{repository}/FindPackagesById()?id='{packageName}'";
 
             return HttpRequestCall(requestUrlV2, out errRecord);  
         }
@@ -284,7 +285,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUrlV2);
                     
                     // We can have this return a Task, or the response (json string)
-                    var response = Utils.SendRequestAsync(request, s_client).GetAwaiter().GetResult();
+                    var response = Utils.SendV2RequestAsync(request, s_client).GetAwaiter().GetResult();
 
                     // Do we want to check if response is 200?
                     // response will be json metadata object that will get returned


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
