### PR TITLE
Remove XmlSerializer and implement parser

### DIFF
--- a/src/code/HttpFindPSResource.cs
+++ b/src/code/HttpFindPSResource.cs
@@ -396,6 +396,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             {
                 nodes[i] = elemList[i]; 
             }
+
             return nodes;
         }
 

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -814,6 +814,8 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             return Utils.GetNormalizedVersionString(version, prerelease);
         }
 
+        #endregion
+
         #region Parse Metadata private static methods
 
         private static string ParseMetadataAuthor(IPackageSearchMetadata pkg)
@@ -1032,8 +1034,6 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             string[] dependencies = dependencyString.Split(new string[]{":|"}, StringSplitOptions.None);
             return new Dependency[]{};
         }
-
-        #endregion
 
         #endregion
 

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -604,11 +604,41 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             
             try
             {
-                var xNodeReader = new XmlNodeReader(entry);
-                var xmlSerializer = new XmlSerializer(typeof(PSResourceInfo));
-                psGetInfo = xmlSerializer.Deserialize(xNodeReader) as PSResourceInfo;
+                Hashtable metadata = new Hashtable();
+                var childNodes = entry.ChildNodes;
+                foreach (XmlElement child in childNodes)
+                {
+                    var key = child.LocalName;
+                    var value = child.InnerText;
+
+
+                    if (key.Equals("Version", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        metadata[key] = ParseHttpVersion(value, out string prereleaseLabel);
+                        metadata["Prerelease"] = prereleaseLabel;
+                    }
+                    else if (key.EndsWith("Url", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        metadata[key] = ParseHttpUrl(value) as Uri;
+                    }
+                    else if (key.Equals("Tags", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        metadata[key] = value.Split(new char[]{' '});
+                    }
+                    else if (key.Equals("Published", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        metadata[key] = ParseHttpDateTime(value);
+                    }
+                    else if (key.Equals("Dependencies", StringComparison.InvariantCultureIgnoreCase)) 
+                    {
+                        metadata[key] = ParseHttpDependencies(value);
+                    }
+                    else 
+                    {
+                        metadata[key] = value;
+                    }
+                }
                 
-                // Note:  still need to add some info to the psGetInfo obj, 
                 return true;
             }
             catch (Exception ex)
@@ -936,6 +966,71 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
             }
 
             return null;
+        }
+
+        private static Version ParseHttpVersion(string versionString, out string prereleaseLabel)
+        {
+            prereleaseLabel = String.Empty;
+
+            if (!String.IsNullOrEmpty(versionString))
+            {
+                string pkgVersion = versionString;
+                if (versionString.Contains("-"))
+                {
+                    // versionString: "1.2.0-alpha1"
+                    string[] versionStringParsed = versionString.Split('-');
+                    if (versionStringParsed.Length == 1)
+                    {
+                        // versionString: "1.2.0-" (unlikely, at least should not be from our PSResourceInfo.TryWrite())
+                        pkgVersion = versionStringParsed[0];
+                    }
+                    else
+                    {
+                        // versionStringParsed.Length > 1 (because string contained '-' so couldn't be 0)
+                        // versionString: "1.2.0-alpha1"
+                        pkgVersion = versionStringParsed[0];
+                        prereleaseLabel = versionStringParsed[1];
+                    }
+                }
+
+                // at this point, version is normalized (i.e either "1.2.0" (if part of prerelease) or "1.2.0.0" otherwise)
+                // parse the pkgVersion parsed out above into a System.Version object
+                if (!Version.TryParse(pkgVersion, out Version parsedVersion))
+                {
+                    prereleaseLabel = String.Empty;
+                    return null;
+                }
+                else
+                {
+                    return parsedVersion;
+                }
+            }
+
+            // version could not be parsed as string, it was written to XML file as a System.Version object
+            // V3 code briefly did so, I believe so we provide support for it
+            return new System.Version();
+        }
+
+        public static Uri ParseHttpUrl(string uriString)
+        {
+            Uri parsedUri;
+            if (!Uri.TryCreate(uriString, UriKind.Absolute, out parsedUri))
+            {
+                //return parsedUri;
+            }
+            return parsedUri;
+        }
+
+        public static DateTime? ParseHttpDateTime(string publishedString)
+        {
+            DateTime.TryParse(publishedString, out DateTime parsedDateTime);
+            return parsedDateTime;
+        }
+
+        public static Dependency[] ParseHttpDependencies(string dependencyString)
+        {
+            string[] dependencies = dependencyString.Split(new string[]{":|"}, StringSplitOptions.None);
+            return new Dependency[]{};
         }
 
         #endregion


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
