### PR TITLE
Allow CredentialInfo parameter to accept a hashtable 

### DIFF
--- a/src/code/PSCredentialInfo.cs
+++ b/src/code/PSCredentialInfo.cs
@@ -119,35 +119,6 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         internal static readonly string CredentialAttribute = nameof(Credential);
 
         #endregion
-
-        /* #region Methods
-        
-        public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
-        {
-            if (inputData is Hashtable)
-            {
-                var ht = inputData as Hashtable;
-
-                if (ht.ContainsKey(VaultNameAttribute) && ht.ContainsKey(SecretNameAttribute))
-                {
-                    return new PSCredentialInfo(ht[VaultNameAttribute] as string, ht[SecretNameAttribute] as string);
-                }
-                else
-                {
-                    throw new ArgumentTransformationMetadataException();
-                }
-            }
-            else if (inputData is PSCredentialInfo)
-            {
-                return inputData;
-            }
-            else
-            {
-                throw new ArgumentTransformationMetadataException();
-            }
-        }
-
-        #endregion */
     }
 
     class PSCredentialInfoTransformAttribute : ArgumentTransformationAttribute {
@@ -169,7 +140,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                     throw new ArgumentTransformationMetadataException();
                 }
             }
-            else if (inputData is PSCredentialInfo)
+            else if (inputData is PSObject)
             {
                 return inputData;
             }

--- a/src/code/PSCredentialInfo.cs
+++ b/src/code/PSCredentialInfo.cs
@@ -12,7 +12,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
     /// <summary>
     /// This class contains information for a repository's authentication credential.
     /// </summary>
-    public sealed class PSCredentialInfo: ArgumentTransformationAttribute
+    public sealed class PSCredentialInfo
     {
         #region Constructor
 
@@ -120,7 +120,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 
         #endregion
 
-        #region Methods
+        /* #region Methods
         
         public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
         {
@@ -131,6 +131,38 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 if (ht.ContainsKey(VaultNameAttribute) && ht.ContainsKey(SecretNameAttribute))
                 {
                     return new PSCredentialInfo(ht[VaultNameAttribute] as string, ht[SecretNameAttribute] as string);
+                }
+                else
+                {
+                    throw new ArgumentTransformationMetadataException();
+                }
+            }
+            else if (inputData is PSCredentialInfo)
+            {
+                return inputData;
+            }
+            else
+            {
+                throw new ArgumentTransformationMetadataException();
+            }
+        }
+
+        #endregion */
+    }
+
+    class PSCredentialInfoTransformAttribute : ArgumentTransformationAttribute {
+
+        #region Methods
+        
+        public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
+        {
+            if (inputData is Hashtable)
+            {
+                var ht = inputData as Hashtable;
+
+                if (ht.ContainsKey("VaultName") && ht.ContainsKey("SecretName"))
+                {
+                    return new PSCredentialInfo(ht["VaultName"] as string, ht["SecretName"] as string);
                 }
                 else
                 {

--- a/src/code/PSCredentialInfo.cs
+++ b/src/code/PSCredentialInfo.cs
@@ -5,13 +5,14 @@ using System;
 using System.Management.Automation;
 using System.Net;
 using System.Security;
+using System.Collections;
 
 namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 {
     /// <summary>
     /// This class contains information for a repository's authentication credential.
     /// </summary>
-    public sealed class PSCredentialInfo
+    public sealed class PSCredentialInfo: ArgumentTransformationAttribute
     {
         #region Constructor
 
@@ -116,6 +117,35 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
         internal static readonly string VaultNameAttribute = nameof(VaultName);
         internal static readonly string SecretNameAttribute = nameof(SecretName);
         internal static readonly string CredentialAttribute = nameof(Credential);
+
+        #endregion
+
+        #region Methods
+        
+        public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
+        {
+            if (inputData is Hashtable)
+            {
+                var ht = inputData as Hashtable;
+
+                if (ht.ContainsKey(VaultNameAttribute) && ht.ContainsKey(SecretNameAttribute))
+                {
+                    return new PSCredentialInfo(ht[VaultNameAttribute] as string, ht[SecretNameAttribute] as string);
+                }
+                else
+                {
+                    throw new ArgumentTransformationMetadataException();
+                }
+            }
+            else if (inputData is PSCredentialInfo)
+            {
+                return inputData;
+            }
+            else
+            {
+                throw new ArgumentTransformationMetadataException();
+            }
+        }
 
         #endregion
     }

--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -89,6 +89,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// Specifies vault and secret names as PSCredentialInfo for the repository.
         /// </summary>
         [Parameter(ParameterSetName = NameParameterSet)]
+        [PSCredentialInfoTransform()]
         public PSCredentialInfo CredentialInfo { get; set; }
 
         /// <summary>

--- a/src/code/SetPSResourceRepository.cs
+++ b/src/code/SetPSResourceRepository.cs
@@ -86,6 +86,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// Specifies vault and secret names as PSCredentialInfo for the repository.
         /// </summary>
         [Parameter(ParameterSetName = NameParameterSet)]
+        [PSCredentialInfoTransform()]
         public PSCredentialInfo CredentialInfo { get; set; }
 
         /// <summary>

--- a/test/RegisterPSResourceRepository.Tests.ps1
+++ b/test/RegisterPSResourceRepository.Tests.ps1
@@ -380,4 +380,15 @@ Describe "Test Register-PSResourceRepository" {
         $res = Get-PSResourceRepository -Name $TestRepoName1 -ErrorAction Ignore
         $res | Should -BeNullOrEmpty
     }
+
+    It "should register a repository with a hashtable passed in as CredentialInfo" {
+        $hashtable = @{VaultName = "testvault"; SecretName = $randomSecret}
+
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -Trusted -Priority 20 -CredentialInfo $hashtable 
+
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res.CredentialInfo.VaultName | Should -Be "testvault"
+        $res.CredentialInfo.SecretName | Should -Be $randomSecret
+        $res.CredentialInfo.Credential | Should -BeNullOrEmpty
+    }
 }

--- a/test/SetPSResourceRepository.Tests.ps1
+++ b/test/SetPSResourceRepository.Tests.ps1
@@ -302,4 +302,19 @@ Describe "Test Set-PSResourceRepository" {
         $res = Get-PSResourceRepository -Name $TestRepoName1 -ErrorAction Ignore
         $res.CredentialInfo | Should -BeNullOrEmpty
     }
+
+    It "set repository with a hashtable passed in as CredentialInfo" {
+        $hashtable = @{VaultName = "testvault"; SecretName = $randomSecret}
+
+        $newRandomSecret = [System.IO.Path]::GetRandomFileName()
+        $newHashtable = @{VaultName = "testvault"; SecretName = $newRandomSecret}
+
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -Trusted -Priority 20 -CredentialInfo $hashtable 
+        Set-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -Trusted -Priority 20 -CredentialInfo $newHashtable 
+
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+        $res.CredentialInfo.VaultName | Should -Be "testvault"
+        $res.CredentialInfo.SecretName | Should -Be $newRandomSecret
+        $res.CredentialInfo.Credential | Should -BeNullOrEmpty
+    }
 }

--- a/test/perf/benchmarks/BenchmarksV2RemoteRepo.cs
+++ b/test/perf/benchmarks/BenchmarksV2RemoteRepo.cs
@@ -27,7 +27,7 @@ namespace Benchmarks
             pwsh.Invoke();
         }
 		
-        [GloblaCleanup]
+        [GlobalCleanup]
         public void IterationCleanup()
         {
             pwsh.Dispose();


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
This PR adds `ArgumentTransformAttribute` to `PSCredentialInfo` so users don't need to create a `PSCredentialInfo` object but instead pass a hashtable to the `CredentialInfo` parameter in `Set-PSResourceRepository` and `Register-PSResourceRepository` cmdlets 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Resolves #679 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
