### PR TITLE
fix verbose message for untrusted repos gaining trust

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -164,7 +164,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             var findHelper = new FindHelper(_cancellationToken, _cmdletPassedIn);
             List<PSResourceInfo> allPkgsInstalled = new List<PSResourceInfo>();
-            bool sourceTrusted = true;
+            bool sourceTrusted = false;
 
             foreach (var repo in listOfRepositories)
             {
@@ -200,7 +200,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     // OR the user issues trust interactively via console.
                     if (repo.Trusted == false && !trustRepository && !_force)
                     {
-                        _cmdletPassedIn.WriteVerbose("Checking if untrusted repository should be used");
+                        _cmdletPassedIn.WriteVerbose(string.Format("Checking if untrusted repository '{0}' should be used", repoName));
 
                         if (!(yesToAll || noToAll))
                         {
@@ -208,14 +208,16 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                             var message = string.Format(CultureInfo.InvariantCulture, MsgInstallUntrustedPackage, repoName);
                             sourceTrusted = _cmdletPassedIn.ShouldContinue(message, MsgRepositoryNotTrusted, true, ref yesToAll, ref noToAll);
                         }
-                    }
 
-                    if (!sourceTrusted && !yesToAll)
-                    {
-                        continue;
+                        if (sourceTrusted || yesToAll)
+                        {
+                            _cmdletPassedIn.WriteVerbose(string.Format("Untrusted repository '{0}' accepted as trusted source.", repoName));
+                        }
+                        else
+                        {
+                            continue;
+                        }
                     }
-
-                    _cmdletPassedIn.WriteVerbose("Untrusted repository accepted as trusted source.");
                 }
 
                 // Select the first package from each name group, which is guaranteed to be the latest version.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Currently when installing from a repository, whether trusted on untrusted, a verbose message is written indicating that an untrusted repository became trusted. This PR makes that verbose message only be output when the repository was actually untrusted.

## PR Context

Resolves #730 fully.

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
