### PR TITLE
Interface err for VersionGlobbing

### DIFF
--- a/src/code/HttpFindPSResource.cs
+++ b/src/code/HttpFindPSResource.cs
@@ -354,7 +354,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// </summary>
         public PSResourceInfo[] FindVersionGlobbing(string packageName, VersionRange versionRange, PSRepositoryInfo repository, bool includePrerelease, ResourceType type, out string errRecord)
         {
-            var response = v2ServerAPICall.FindVersionGlobbing(packageName, versionRange, repository, includePrerelease, out errRecord);
+            var response = v2ServerAPICall.FindVersionGlobbing(packageName, versionRange, repository, includePrerelease, type, out errRecord);
             
             var elemList = ConvertResponseToXML(response);
             List<PSResourceInfo> pkgsFound = new List<PSResourceInfo>(); 
@@ -513,7 +513,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         ///           Search "PowerShellGet", "Package*", "PSReadLine" "3.*" --> do it for first, write error for second, do it for third
         ///           Search "Package*", "PSReadLin*" "3.*" --> not supported
         /// </summary>
-        public PSResourceInfo FindNamesAndVersionGlobbing(string[] packageNames, VersionRange versionRange, PSRepositoryInfo repository, bool includePrerelease, out string[] errRecords)
+        public PSResourceInfo FindNamesAndVersionGlobbing(string[] packageNames, VersionRange versionRange, PSRepositoryInfo repository, bool includePrerelease, ResourceType type, out string[] errRecords)
         {
             var response = string.Empty;
             var tmpErrRecords = new List<string>();
@@ -528,7 +528,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     }
                     else {
                         // Implementation note: Returns all versions, including prerelease ones. Later (in the API client side) we'll do filtering on the versions to satisfy what user provided.
-                        response = v2ServerAPICall.FindVersionGlobbing(pkgName, versionRange, repository, includePrerelease, out string errRecord);
+                        response = v2ServerAPICall.FindVersionGlobbing(pkgName, versionRange, repository, includePrerelease, type, out string errRecord);
                         tmpErrRecords.Add(errRecord);
                     }
                 }

--- a/src/code/HttpFindPSResource.cs
+++ b/src/code/HttpFindPSResource.cs
@@ -252,16 +252,21 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// - Include prerelease: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
         /// Implementation Note: Need to filter further for latest version (prerelease or non-prerelease dependening on user preference)
         /// </summary>
-        public PSResourceInfo FindName(string packageName, PSRepositoryInfo repository, bool includePrerelease, out string errRecord)
+        public PSResourceInfo FindName(string packageName, PSRepositoryInfo repository, bool includePrerelease, ResourceType type, out string errRecord)
         {
             errRecord = string.Empty;
 
             if (repository.ApiVersion == PSRepositoryInfo.APIVersion.v2)
             {
                 // Same API calls for both prerelease and non-prerelease
-                var response = v2ServerAPICall.FindName(packageName, repository, includePrerelease, out errRecord);
+                var response = v2ServerAPICall.FindName(packageName, repository, includePrerelease, type, out errRecord);
 
                 var elemList = ConvertResponseToXML(response);
+
+                if (elemList.Length == 0)
+                {
+                    Console.WriteLine("empty response. Error handle");
+                }
 
         
                 PSResourceInfo.TryConvertFromXml(
@@ -347,7 +352,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// API Call: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
         /// Implementation note: Returns all versions, including prerelease ones. Later (in the API client side) we'll do filtering on the versions to satisfy what user provided.
         /// </summary>
-        public PSResourceInfo[] FindVersionGlobbing(string packageName, VersionRange versionRange, PSRepositoryInfo repository, bool includePrerelease, out string errRecord)
+        public PSResourceInfo[] FindVersionGlobbing(string packageName, VersionRange versionRange, PSRepositoryInfo repository, bool includePrerelease, ResourceType type, out string errRecord)
         {
             var response = v2ServerAPICall.FindVersionGlobbing(packageName, versionRange, repository, includePrerelease, out errRecord);
             
@@ -384,16 +389,21 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// Examples: Search "PowerShellGet" "2.2.5"
         /// API call: http://www.powershellgallery.com/api/v2/Packages(Id='PowerShellGet', Version='2.2.5')
         /// </summary>
-        public PSResourceInfo FindVersion(string packageName, string version, PSRepositoryInfo repository, out string errRecord)
+        public PSResourceInfo FindVersion(string packageName, string version, PSRepositoryInfo repository, ResourceType type, out string errRecord)
         {
             errRecord = string.Empty;
 
             if (repository.ApiVersion == PSRepositoryInfo.APIVersion.v2)
             {
                 // Same API calls for both prerelease and non-prerelease
-                var response = v2ServerAPICall.FindVersion(packageName, version, repository, out errRecord);
+                var response = v2ServerAPICall.FindVersion(packageName, version, repository, type, out errRecord);
 
                 var elemList = ConvertResponseToXML(response);
+
+                if (elemList.Length == 0)
+                {
+                    Console.WriteLine("empty response. Error handle");
+                }
 
 
                 PSResourceInfo.TryConvertFromXml(

--- a/src/code/IFindPSResource.cs
+++ b/src/code/IFindPSResource.cs
@@ -55,7 +55,7 @@ public interface IFindPSResource
     /// - Include prerelease: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
     /// Implementation Note: Need to filter further for latest version (prerelease or non-prerelease dependening on user preference)
     /// </summary>
-    PSResourceInfo FindName(string packageName, PSRepositoryInfo repository, bool includePrerelease, out string errRecord);
+    PSResourceInfo FindName(string packageName, PSRepositoryInfo repository, bool includePrerelease, ResourceType type, out string errRecord);
 
     /// <summary>
     /// Find method which allows for searching for single name with wildcards and returns latest version.
@@ -77,7 +77,7 @@ public interface IFindPSResource
     /// API Call: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
     /// Implementation note: Returns all versions, including prerelease ones. Later (in the API client side) we'll do filtering on the versions to satisfy what user provided.
     /// </summary>
-    PSResourceInfo[] FindVersionGlobbing(string packageName, VersionRange versionRange, PSRepositoryInfo repository, bool includePrerelease, out string errRecord);
+    PSResourceInfo[] FindVersionGlobbing(string packageName, VersionRange versionRange, PSRepositoryInfo repository, bool includePrerelease, ResourceType type, out string errRecord);
 
     /// <summary>
     /// Find method which allows for searching for single name with specific version.
@@ -86,7 +86,7 @@ public interface IFindPSResource
     /// Examples: Search "PowerShellGet" "2.2.5"
     /// API call: http://www.powershellgallery.com/api/v2/Packages(Id='PowerShellGet', Version='2.2.5')
     /// </summary>
-    PSResourceInfo FindVersion(string packageName, string version, PSRepositoryInfo repository, out string errRecord);
+    PSResourceInfo FindVersion(string packageName, string version, PSRepositoryInfo repository, ResourceType type, out string errRecord);
     
     /// <summary>
     /// *** we will not support this scenario ***

--- a/src/code/IFindPSResource.cs
+++ b/src/code/IFindPSResource.cs
@@ -133,7 +133,7 @@ public interface IFindPSResource
     ///           Search "PowerShellGet", "Package*", "PSReadLine" "3.*" --> do it for first, write error for second, do it for third
     ///           Search "Package*", "PSReadLin*" "3.*" --> not supported
     /// </summary>
-    PSResourceInfo FindNamesAndVersionGlobbing(string[] packageNames, VersionRange versionRange, PSRepositoryInfo repository, bool includePrerelease, out string[] errRecord); 
+    PSResourceInfo FindNamesAndVersionGlobbing(string[] packageNames, VersionRange versionRange, PSRepositoryInfo repository, bool includePrerelease, ResourceType type, out string[] errRecord); 
 
     #endregion
 }

--- a/src/code/IServerAPICalls.cs
+++ b/src/code/IServerAPICalls.cs
@@ -74,7 +74,7 @@ public interface IServerAPICalls
     /// Implementation Note: Need to filter further for latest version (prerelease or non-prerelease dependening on user preference)
     /// </summary>
     /// // TODO:  change repository from string to PSRepositoryInfo
-    string FindName(string packageName, PSRepositoryInfo repository, bool includePrerelease, out string errRecord);
+    string FindName(string packageName, PSRepositoryInfo repository, bool includePrerelease, ResourceType type, out string errRecord);
 
     /// <summary>
     /// Find method which allows for searching for single name with version range.
@@ -161,7 +161,7 @@ public interface IServerAPICalls
     /// Examples: Search "PowerShellGet" "2.2.5"
     /// API call: http://www.powershellgallery.com/api/v2/Packages(Id='PowerShellGet', Version='2.2.5')
     /// </summary>
-    string FindVersion(string packageName, string version, PSRepositoryInfo repository, out string errRecord);
+    string FindVersion(string packageName, string version, PSRepositoryInfo repository, ResourceType type, out string errRecord);
     
 
     /// <summary>

--- a/src/code/IServerAPICalls.cs
+++ b/src/code/IServerAPICalls.cs
@@ -105,7 +105,7 @@ public interface IServerAPICalls
     /// Examples: Search "PowerShellGet" "2.2.5"
     /// API call: http://www.powershellgallery.com/api/v2/Packages(Id='PowerShellGet', Version='2.2.5')
     /// </summary>
-    string FindVersionGlobbing(string packageName, VersionRange versionRange, PSRepositoryInfo repository, bool includePrerelease, out string errRecord);
+    string FindVersionGlobbing(string packageName, VersionRange versionRange, PSRepositoryInfo repository, bool includePrerelease, ResourceType type, out string errRecord);
     
     /// <summary>
     /// *** we will not support this scenario ***


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
