### PR TITLE
Enhanced CredentialInfo handling, direct support for SecretManagement SecretInfo type

### DIFF
--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -89,7 +89,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// Specifies vault and secret names as PSCredentialInfo for the repository.
         /// </summary>
         [Parameter(ParameterSetName = NameParameterSet)]
-        [PSCredentialInfoTransform()]
         public PSCredentialInfo CredentialInfo { get; set; }
 
         /// <summary>

--- a/src/code/SetPSResourceRepository.cs
+++ b/src/code/SetPSResourceRepository.cs
@@ -86,7 +86,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// Specifies vault and secret names as PSCredentialInfo for the repository.
         /// </summary>
         [Parameter(ParameterSetName = NameParameterSet)]
-        [PSCredentialInfoTransform()]
         public PSCredentialInfo CredentialInfo { get; set; }
 
         /// <summary>


### PR DESCRIPTION
# PR Summary

Upgrade to the handling of the CredentialInfo parameters, removing the ArgumentTransformation attribute as not useful, integrating functionality into the base class and adding support for SecretInfo object from Microsoft.PowerShell.SecretManagement.

## PR Context

It allows direct integration between SecretManagement and PowerShellGet and makes it easier for devs to integrate their own tooling.

## Details

+ Removed the ArgumentTransformationAttribute from the CredentialInfo parameters as a non-helpful antipattern, disabling native PowerShell Type-Coercion.
+ Integrated functionality natively into PSCredentialInfo, to avoid loss of functionality.
+ Added fallback to `Name` property when `SecretName` is empty, as that is what `Get-SecretInfo` from `Microsoft.PowerShell.SecretManagement` returns.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
