### PR TITLE
Add progress info for Install-PSResource and Uninstall-PSResource

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -358,11 +358,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     if (!_quiet)
                     {
                         int activityId = 0;
-                        int percentComplete = ((currentInstalledPkgCount * 100) / totalPkgs);
                         string activity = string.Format("Installing {0}...", pkg.Name);
                         string statusDescription = string.Format("{0}/{1} package installing...", currentInstalledPkgCount, totalPkgs);
-                        ProgressRecord pr = new ProgressRecord(activityId, activity, statusDescription);
-                        _cmdletPassedIn.WriteProgress(pr);
+                        _cmdletPassedIn.WriteProgress(new ProgressRecord(activityId, activity, statusDescription));
                     }
 
                     // Create PackageIdentity in order to download

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -360,9 +360,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         int activityId = 0;
                         int percentComplete = ((currentInstalledPkgCount * 100) / totalPkgs);
                         string activity = string.Format("Installing {0}...", pkg.Name);
-                        string statusDescription = string.Format("{0}% Complete", percentComplete);
-                        _cmdletPassedIn.WriteProgress(
-                            new ProgressRecord(activityId, activity, statusDescription));
+                        string statusDescription = string.Format("{0}/{1} package installing...", currentInstalledPkgCount, totalPkgs);
+                        ProgressRecord pr = new ProgressRecord(activityId, activity, statusDescription);
+                        _cmdletPassedIn.WriteProgress(pr);
                     }
 
                     // Create PackageIdentity in order to download

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -196,7 +196,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 int activityId = 0;
                 int percentComplete = ((currentUninstalledDirCount * 100) / totalDirs);
                 string activity = string.Format("Uninstalling {0}...", pkgName);
-                string statusDescription = string.Format("{0}/{1} directories uninstalled", currentUninstalledDirCount, totalDirs);
+                string statusDescription = string.Format("{0}/{1} directory uninstalling...", currentUninstalledDirCount, totalDirs);
                 ProgressRecord pr = new ProgressRecord(activityId, activity, statusDescription);
                 pr.PercentComplete = percentComplete;
                 this.WriteProgress(pr);

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -194,12 +194,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                 // show uninstall progress info
                 int activityId = 0;
-                int percentComplete = ((currentUninstalledDirCount * 100) / totalDirs);
                 string activity = string.Format("Uninstalling {0}...", pkgName);
                 string statusDescription = string.Format("{0}/{1} directory uninstalling...", currentUninstalledDirCount, totalDirs);
-                ProgressRecord pr = new ProgressRecord(activityId, activity, statusDescription);
-                pr.PercentComplete = percentComplete;
-                this.WriteProgress(pr);
+                this.WriteProgress(new ProgressRecord(activityId, activity, statusDescription));
 
                 ErrorRecord errRecord = null;
                 if (pkgPath.EndsWith(PSScriptFileExt))

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -167,6 +167,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             GetHelper getHelper = new GetHelper(this);
             List<string>  dirsToDelete = getHelper.FilterPkgPathsByName(Name, _pathsToSearch);
+			int totalDirs = dirsToDelete.Count;
 
             // Checking if module or script
             // a module path will look like:
@@ -177,8 +178,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             // note that the xml file is located in ./Scripts/InstalledScriptInfos, eg: ./Scripts/InstalledScriptInfos/TestScript_InstalledScriptInfo.xml
 
             string pkgName;
+
+			// Counter for tracking current dir out of total 
+			int currentUninstalledDirCount = 0;
             foreach (string pkgPath in getHelper.FilterPkgPathsByVersion(_versionRange, dirsToDelete, selectPrereleaseOnly: Prerelease))
             {
+				currentUninstalledDirCount++;
                 pkgName = Utils.GetInstalledPackageName(pkgPath);
 
                 if (!ShouldProcess(string.Format("Uninstall resource '{0}' from the machine.", pkgName)))
@@ -186,6 +191,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     WriteVerbose("ShouldProcess is set to false.");
                     continue;
                 }
+
+				// show uninstall progress info
+                int activityId = 0;
+				int percentComplete = ((currentUninstalledDirCount * 100) / totalDirs);
+				string activity = string.Format("Uninstalling {0}...", pkgName);
+				string statusDescription = string.Format("{0}% Complete", percentComplete);
+                this.WriteProgress(
+						new ProgressRecord(activityId, activity, statusDescription));
 
                 ErrorRecord errRecord = null;
                 if (pkgPath.EndsWith(PSScriptFileExt))

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -167,7 +167,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             GetHelper getHelper = new GetHelper(this);
             List<string>  dirsToDelete = getHelper.FilterPkgPathsByName(Name, _pathsToSearch);
-			int totalDirs = dirsToDelete.Count;
+            int totalDirs = dirsToDelete.Count;
 
             // Checking if module or script
             // a module path will look like:
@@ -179,11 +179,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             string pkgName;
 
-			// Counter for tracking current dir out of total 
-			int currentUninstalledDirCount = 0;
+            // Counter for tracking current dir out of total 
+            int currentUninstalledDirCount = 0;
             foreach (string pkgPath in getHelper.FilterPkgPathsByVersion(_versionRange, dirsToDelete, selectPrereleaseOnly: Prerelease))
             {
-				currentUninstalledDirCount++;
+                currentUninstalledDirCount++;
                 pkgName = Utils.GetInstalledPackageName(pkgPath);
 
                 if (!ShouldProcess(string.Format("Uninstall resource '{0}' from the machine.", pkgName)))
@@ -192,13 +192,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     continue;
                 }
 
-				// show uninstall progress info
+                // show uninstall progress info
                 int activityId = 0;
-				int percentComplete = ((currentUninstalledDirCount * 100) / totalDirs);
-				string activity = string.Format("Uninstalling {0}...", pkgName);
-				string statusDescription = string.Format("{0}% Complete", percentComplete);
-                this.WriteProgress(
-						new ProgressRecord(activityId, activity, statusDescription));
+                int percentComplete = ((currentUninstalledDirCount * 100) / totalDirs);
+                string activity = string.Format("Uninstalling {0}...", pkgName);
+                string statusDescription = string.Format("{0}/{1} directories uninstalled", currentUninstalledDirCount, totalDirs);
+                ProgressRecord pr = new ProgressRecord(activityId, activity, statusDescription);
+                pr.PercentComplete = percentComplete;
+                this.WriteProgress(pr);
 
                 ErrorRecord errRecord = null;
                 if (pkgPath.EndsWith(PSScriptFileExt))


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #597: Add progress info for Uninstall-PSResource.
Also modify progress info of Install-PSResource to use the "PercentComplete" attribute of the "WriteProgress" module.
Tests not written but interactive tests conducted. 

## PR Context

To fix #597. Help users to visually see uninstall progress, especially useful when uninstalling large resources that take a while to complete. 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
