### PR TITLE
Change Publish-PSResource to preserve file structure

### DIFF
--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -399,19 +399,23 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         // Copy files over to temp folder
                         foreach (string fileNamePath in System.IO.Directory.GetFiles(rootModuleDir, "*", System.IO.SearchOption.AllDirectories))
                         {
-                            FileInfo fileInfo = new FileInfo(fileNamePath);
+                            // if file is hidden, do not copy it over
+                            System.IO.FileAttributes attributes = File.GetAttributes(fileNamePath);
+                            if ((attributes & FileAttributes.Hidden) == FileAttributes.Hidden) {
+                                continue;
+                            }
 
-                            var newFilePath = System.IO.Path.Combine(outputDir, fileInfo.Name);
+                            var fileName = fileNamePath.Substring(fileNamePath.Length).Trim(_PathSeparators);
+                            var newFilePath = System.IO.Path.Combine(outputDir, fileName);
                             // The user may have a .nuspec defined in the module directory
                             // If that's the case, we will not use that file and use the .nuspec that is generated via PSGet
                             // The .nuspec that is already in in the output directory is the one that was generated via the CreateNuspec method
+
                             if (!File.Exists(newFilePath))
                             {
                                 System.IO.File.Copy(fileNamePath, newFilePath);
                             }
                         }
-
-
                     }
                     catch (Exception e)
                     {

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -392,23 +392,15 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         // Create subdirectory structure in temp folder
                         foreach (string dir in System.IO.Directory.GetDirectories(rootModuleDir, "*", System.IO.SearchOption.AllDirectories))
                         {
-                            DirectoryInfo dirInfo = new DirectoryInfo(dir);
-                            System.IO.Directory.CreateDirectory(System.IO.Path.Combine(outputDir, dirInfo.Name));
+                            var dirName = dir.Substring(rootModuleDir.Length).Trim(_PathSeparators);
+                            System.IO.Directory.CreateDirectory(System.IO.Path.Combine(outputDir, dirName));
                         }
 
                         // Copy files over to temp folder
                         foreach (string fileNamePath in System.IO.Directory.GetFiles(rootModuleDir, "*", System.IO.SearchOption.AllDirectories))
                         {
-                            // if file is hidden, do not copy it over
-                            //System.IO.FileAttributes attributes = File.GetAttributes(fileNamePath);
-                            //if ((attributes & FileAttributes.Hidden) == FileAttributes.Hidden) {
-                            //    continue;
-                            //}
-
-                            //var fileName = fileNamePath.Substring(fileNamePath.Length).Trim(_PathSeparators);
-                            //var newFilePath = System.IO.Path.Combine(outputDir, fileName);
-                            FileInfo fileInfo = new FileInfo(fileNamePath);
-                            var newFilePath = System.IO.Path.Combine(outputDir, fileInfo.Name);
+                            var fileName = fileNamePath.Substring(rootModuleDir.Length).Trim(_PathSeparators);
+                            var newFilePath = System.IO.Path.Combine(outputDir, fileName);
                             // The user may have a .nuspec defined in the module directory
                             // If that's the case, we will not use that file and use the .nuspec that is generated via PSGet
                             // The .nuspec that is already in in the output directory is the one that was generated via the CreateNuspec method

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -400,13 +400,15 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         foreach (string fileNamePath in System.IO.Directory.GetFiles(rootModuleDir, "*", System.IO.SearchOption.AllDirectories))
                         {
                             // if file is hidden, do not copy it over
-                            System.IO.FileAttributes attributes = File.GetAttributes(fileNamePath);
-                            if ((attributes & FileAttributes.Hidden) == FileAttributes.Hidden) {
-                                continue;
-                            }
+                            //System.IO.FileAttributes attributes = File.GetAttributes(fileNamePath);
+                            //if ((attributes & FileAttributes.Hidden) == FileAttributes.Hidden) {
+                            //    continue;
+                            //}
 
-                            var fileName = fileNamePath.Substring(fileNamePath.Length).Trim(_PathSeparators);
-                            var newFilePath = System.IO.Path.Combine(outputDir, fileName);
+                            //var fileName = fileNamePath.Substring(fileNamePath.Length).Trim(_PathSeparators);
+                            //var newFilePath = System.IO.Path.Combine(outputDir, fileName);
+                            FileInfo fileInfo = new FileInfo(fileNamePath);
+                            var newFilePath = System.IO.Path.Combine(outputDir, fileInfo.Name);
                             // The user may have a .nuspec defined in the module directory
                             // If that's the case, we will not use that file and use the .nuspec that is generated via PSGet
                             // The .nuspec that is already in in the output directory is the one that was generated via the CreateNuspec method

--- a/test/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResource.Tests.ps1
@@ -178,16 +178,15 @@ Describe "Test Publish-PSResource" {
     It "Publish a module and preserve file structure" {
         $version = "1.0.0"
         $testFile = Join-Path -Path "TestSubDirectory" -ChildPath "TestSubDirFile.ps1"
-        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module" -RequiredModules @{ModuleName = "$script:DependencyModuleName"; ModuleVersion = "$dependencyVersion" }
-        New-Item -Path (Join-Path -Path $script:PublishModuleBase -ChildPath $testFile) -ItemType "file" -Force  
-        
+        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
+        New-Item -Path (Join-Path -Path $script:PublishModuleBase -ChildPath $testFile) -Force
+
         Publish-PSResource -Path $script:PublishModuleBase
 
         $zipPath = Join-Path -Path $script:repositoryPath -ChildPath "$script:PublishModuleName.$version.nupkg"
         $unzippedPath = Join-Path -Path $TestDrive -ChildPath "tmpPathForPreservingFileStructure\$script:PublishModuleName"
         New-Item $unzippedPath -Itemtype directory -Force
-
-        Expand-Archive -Path $zipPath -DestinationPath $unzippedPkgPath
+        Expand-Archive -Path $zipPath -DestinationPath $unzippedPath
 
         Test-Path -Path (Join-Path -Path $unzippedPath -ChildPath $testFile) | Should -Be $True
     }

--- a/test/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResource.Tests.ps1
@@ -182,9 +182,12 @@ Describe "Test Publish-PSResource" {
         New-Item -Path (Join-Path -Path $script:PublishModuleBase -ChildPath $testFile) -Force
 
         Publish-PSResource -Path $script:PublishModuleBase
-
-        $zipPath = Join-Path -Path $script:repositoryPath -ChildPath "$script:PublishModuleName.$version.nupkg"
-        $unzippedPath = Join-Path -Path $TestDrive -ChildPath "tmpPathForPreservingFileStructure\$script:PublishModuleName"
+        
+        # Must change .nupkg to .zip so that Expand-Archive can work on Windows PowerShell
+        $nupkgPath = Join-Path -Path $script:repositoryPath -ChildPath "$script:PublishModuleName.$version.nupkg"
+        $zipPath = Join-Path -Path $script:repositoryPath -ChildPath "$script:PublishModuleName.$version.zip"
+        Rename-Item -Path $nupkgPath -NewName $zipPath 
+        $unzippedPath = Join-Path -Path $TestDrive -ChildPath "$script:PublishModuleName"
         New-Item $unzippedPath -Itemtype directory -Force
         Expand-Archive -Path $zipPath -DestinationPath $unzippedPath
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR updates `PS-Resource` to preserve file structure by keeping the full name of the file path to be copied over before publishing. 

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Addresses issue #837 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
