### PR TITLE
Narrow signing file search

### DIFF
--- a/.ci/ci_auto.yml
+++ b/.ci/ci_auto.yml
@@ -142,11 +142,10 @@ stages:
         certificateId: "CP-460906"
         shouldSign: $(ShouldSign)
         pattern: |
-          **\*.dll
+          out\CreatedFiles\**\*.dll
           **\*.psd1
           **\*.psm1
           **\*.ps1xml
-          **\*.mof
         useMinimatch: true
 
     - pwsh: |
@@ -202,7 +201,7 @@ stages:
         certificateId: "CP-231522"
         shouldSign: $(ShouldSign)
         pattern: |
-          **\*.dll
+          out\ThirdParty\**\*.dll
         useMinimatch: true
 
     - pwsh: |

--- a/.ci/ci_release.yml
+++ b/.ci/ci_release.yml
@@ -131,11 +131,10 @@ stages:
         signOutputPath: $(signOutPath)
         certificateId: "CP-230012"
         pattern: |
-          **\*.dll
+          out\CreatedFiles\**\*.dll
           **\*.psd1
           **\*.psm1
           **\*.ps1xml
-          **\*.mof
         useMinimatch: true
 
     - pwsh: |
@@ -191,7 +190,7 @@ stages:
         signOutputPath: $(signOutPath)
         certificateId: "CP-231522"
         pattern: |
-          **\*.dll
+          out\ThirdParty\**\*.dll
         useMinimatch: true
 
     - pwsh: |


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Only affects release pipelines.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
