### PR TITLE
Add tests for find and install using REST calls

### DIFF
--- a/test/HttpFindPSResource.Tests.ps1
+++ b/test/HttpFindPSResource.Tests.ps1
@@ -1,0 +1,381 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
+
+Describe 'Test HTTP Find-PSResource for Module' {
+
+    BeforeAll{
+        $PSGalleryName = Get-PSGalleryName
+        $NuGetGalleryName = Get-NuGetGalleryName
+        $testModuleName = "test_module"
+        $testScriptName = "test_script"
+        $commandName = "Get-TargetResource"
+        $dscResourceName = "SystemLocale"
+        $parentModuleName = "SystemLocaleDsc"
+        Get-NewPSResourceRepositoryFile
+        Register-PSGallery
+    }
+
+    AfterAll {
+        Get-RevertPSResourceRepositoryFile
+    }
+
+    It "find Specific Module Resource by Name" {
+        $specItem = Find-PSResource -Name $testModuleName
+        $specItem.Name | Should -Be $testModuleName
+    }
+
+    It "should not find resource given nonexistant name" {
+        $res = Find-PSResource -Name NonExistantModule
+        $res | Should -BeNullOrEmpty
+    }
+
+    It "should not find any resources given names with invalid wildcard characters" {
+        Find-PSResource -Name "Invalid?PkgName", "Invalid[PkgName" -ErrorVariable err -ErrorAction SilentlyContinue
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "ErrorFilteringNamesForUnsupportedWildcards,Microsoft.PowerShell.PowerShellGet.Cmdlets.FindPSResource" 
+    }
+
+    It "find resources when Name contains * from V2 endpoint repository (PowerShellGallery))" {
+        $foundScript = $False
+        $res = Find-PSResource -Name "AzureS*" -Repository $PSGalleryName
+        $res.Count | Should -BeGreaterThan 1
+        # should find Module and Script resources
+        foreach ($item in $res)
+        {
+            if ($item.Type -eq "Script")
+            {
+                $foundScript = $true
+            }
+        }
+
+        $foundScript | Should -BeTrue
+    }
+
+    # TODO: get working with local repo
+    # It "should find all resources given Name that equals wildcard, '*'" {
+    #     $repoName = "psgettestlocal"
+    #     Get-ModuleResourcePublishedToLocalRepoTestDrive "TestLocalModule1" $repoName
+    #     Get-ModuleResourcePublishedToLocalRepoTestDrive "TestLocalModule2" $repoName
+    #     Get-ModuleResourcePublishedToLocalRepoTestDrive "TestLocalModule3" $repoName
+
+    #     $foundResources = Find-PSResource -Name "TestLocalModule1","TestLocalModule2","TestLocalModule3" -Repository $repoName
+    #     # TODO: wildcard search is not supported with local repositories, from NuGet protocol API side- ask about this.
+    #     # $foundResources = Find-PSResource -Name "*" -Repository $repoName 
+    #     $foundResources.Count | Should -Not -Be 0
+
+    #     # Should find Module and Script resources but no prerelease resources
+    #     $foundResources | where-object Name -eq "TestLocalModule1" | Should -Not -BeNullOrEmpty -Because "TestLocalModule1 should exist in local repo"
+    #     $foundResources | where-object Name -eq "test_script" | Should -Not -BeNullOrEmpty -Because "TestLocalScript1 should exist in local repo"
+    #     $foundResources | where-object IsPrerelease -eq $true | Should -BeNullOrEmpty -Because "No prerelease resources should be returned"
+    # }
+
+    # # TODO: get working with local repo
+    # It "should find all resources (including prerelease) given Name that equals wildcard, '*' and Prerelease parameter" {
+    #     Get-ModuleResourcePublishedToLocalRepoTestDrive "TestLocalModule1" $repoName
+    #     Get-ModuleResourcePublishedToLocalRepoTestDrive "TestLocalModule2" $repoName
+    #     Get-ModuleResourcePublishedToLocalRepoTestDrive "TestLocalModule3" $repoName
+    #     $foundResources = Find-PSResource -Name "*" -Prerelease -Repository $repoName
+
+    #     # Should find Module and Script resources inlcuding prerelease resources
+    #     $foundResources | where-object Name -eq "test_module" | Should -Not -BeNullOrEmpty -Because "test_module should exist in local repo"
+    #     $foundResources | where-object Name -eq "test_script" | Should -Not -BeNullOrEmpty -Because "test_script should exist in local repo"
+    #     $foundResources | where-object IsPrerelease -eq $true | Should -Not -BeNullOrEmpty -Because "Prerelease resources should be returned"
+    # }
+
+    It "find resource given Name from V3 endpoint repository (NuGetGallery)" {
+        $res = Find-PSResource -Name "Serilog" -Repository $NuGetGalleryName
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be "Serilog"
+        $res.Repository | Should -Be $NuGetGalleryName
+    }
+
+    It "find resources when Name contains wildcard * from V3 endpoint repository" {
+        $res = Find-PSResource -Name "Serilog*" -Repository $NuGetGalleryName
+        $res.Count | Should -BeGreaterThan 1
+    }
+
+    $testCases2 = @{Version="[5.0.0.0]";           ExpectedVersions=@("5.0.0.0");                                  Reason="validate version, exact match"},
+                  @{Version="5.0.0.0";             ExpectedVersions=@("5.0.0.0");                                  Reason="validate version, exact match without bracket syntax"},
+                  @{Version="[1.0.0.0, 5.0.0.0]";  ExpectedVersions=@("1.0.0.0", "3.0.0.0", "5.0.0.0");            Reason="validate version, exact range inclusive"},
+                  @{Version="(1.0.0.0, 5.0.0.0)";  ExpectedVersions=@("3.0.0.0");                                  Reason="validate version, exact range exclusive"},
+                  @{Version="(1.0.0.0,)";          ExpectedVersions=@("3.0.0.0", "5.0.0.0");                       Reason="validate version, minimum version exclusive"},
+                  @{Version="[1.0.0.0,)";          ExpectedVersions=@("1.0.0.0", "3.0.0.0", "5.0.0.0");            Reason="validate version, minimum version inclusive"},
+                  @{Version="(,3.0.0.0)";          ExpectedVersions=@("1.0.0.0");                                  Reason="validate version, maximum version exclusive"},
+                  @{Version="(,3.0.0.0]";          ExpectedVersions=@("1.0.0.0", "3.0.0.0");                       Reason="validate version, maximum version inclusive"},
+                  @{Version="[1.0.0.0, 5.0.0.0)";  ExpectedVersions=@("1.0.0.0", "3.0.0.0");                       Reason="validate version, mixed inclusive minimum and exclusive maximum version"}
+                  @{Version="(1.0.0.0, 5.0.0.0]";  ExpectedVersions=@("3.0.0.0", "5.0.0.0");                       Reason="validate version, mixed exclusive minimum and inclusive maximum version"}
+
+    It "find resource when given Name to <Reason> <Version>" -TestCases $testCases2{
+        param($Version, $ExpectedVersions)
+        $res = Find-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName
+        foreach ($item in $res) {
+            $item.Name | Should -Be $testModuleName
+            $ExpectedVersions | Should -Contain $item.Version
+        }
+    }
+
+    It "not find resource with incorrectly formatted version such as <Description>" -TestCases @(
+        @{Version='(1.0.0.0)';       Description="exclusive version (2.5.0.0)"},
+        @{Version='[1-0-0-0]';       Description="version formatted with invalid delimiter"}
+    ) {
+        param($Version, $Description)
+
+        $res = Find-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName 2>$null
+        $res | Should -BeNullOrEmpty
+    }
+
+    $testCases = @{Version='[1.*.0.0]';       Description="version with wilcard in middle"},
+                 @{Version='[*.0.0.0]';       Description="version with wilcard at start"},
+                 @{Version='[1.0.*.0]';       Description="version with wildcard at third digit"}
+                 @{Version='[1.0.0.*';        Description="version with wildcard at end"},
+                 @{Version='[1..0.0]';        Description="version with missing digit in middle"},
+                 @{Version='[1.0.0.]';        Description="version with missing digit at end"},
+                 @{Version='[1.0.0.0.0]';     Description="version with more than 4 digits"}
+
+    It "not find resource and throw exception with incorrectly formatted version such as <Description>" -TestCases $testCases {
+        param($Version, $Description)
+
+        Find-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "IncorrectVersionFormat,Microsoft.PowerShell.PowerShellGet.Cmdlets.FindPSResource"
+    }
+
+    It "find all versions of resource when given Name, Version not null --> '*'" {
+        $res = Find-PSResource -Name $testModuleName -Version "*" -Repository $PSGalleryName
+        $res | ForEach-Object {
+            $_.Name | Should -Be $testModuleName
+        }
+        $res.Count | Should -BeGreaterOrEqual 1
+    }
+
+    It "find resources when given Name with wildcard, Version not null --> '*'" {
+        $res = Find-PSResource -Name "TestModuleWithDependency*" -Version "*" -Repository $PSGalleryName
+        $moduleA = $res | Where-Object {$_.Name -eq "TestModuleWithDependencyA"}
+        $moduleA.Count | Should -BeGreaterOrEqual 3
+        $moduleB = $res | Where-Object {$_.Name -eq "TestModuleWithDependencyB"}
+        $moduleB.Count | Should -BeGreaterOrEqual 2
+        $moduleC = $res | Where-Object {$_.Name -eq "TestModuleWithDependencyC"}
+        $moduleC.Count | Should -BeGreaterOrEqual 3
+        $moduleD = $res | Where-Object {$_.Name -eq "TestModuleWithDependencyD"}
+        $moduleD.Count | Should -BeGreaterOrEqual 2
+        $moduleE = $res | Where-Object {$_.Name -eq "TestModuleWithDependencyE"}
+        $moduleE.Count | Should -BeGreaterOrEqual 1        
+        $moduleF = $res | Where-Object {$_.Name -eq "TestModuleWithDependencyF"}
+        $moduleF.Count | Should -BeGreaterOrEqual 1
+    }
+
+    It "find resources when given Name with wildcard, Version range" {
+        $res = Find-PSResource -Name "TestModuleWithDependency*" -Version "[1.0.0.0, 5.0.0.0]" -Repository $PSGalleryName
+        foreach ($pkg in $res) {
+            $pkg.Name | Should -Match "TestModuleWithDependency*"
+            [System.Version]$pkg.Version -ge [System.Version]"1.0.0.0" -or [System.Version]$pkg.Version -le [System.Version]"5.0.0.0" | Should -Be $true
+        }
+    }
+
+    It "find resource when given Name, Version param null" {
+        $res = Find-PSResource -Name $testModuleName -Repository $PSGalleryName
+        $res.Name | Should -Be $testModuleName
+        $res.Version | Should -Be "5.0.0.0"
+    }
+
+    It "find resource with latest (including prerelease) version given Prerelease parameter" {
+        # test_module resource's latest version is a prerelease version, before that it has a non-prerelease version
+        $res = Find-PSResource -Name $testModuleName -Repository $PSGalleryName
+        $res.Version | Should -Be "5.0.0.0"
+
+        $resPrerelease = Find-PSResource -Name $testModuleName -Prerelease -Repository $PSGalleryName
+        $resPrerelease.Version | Should -Be "5.2.5.0"
+        $resPrerelease.Prerelease | Should -Be "alpha001"
+    }
+
+    It "find resources, including Prerelease version resources, when given Prerelease parameter" {
+        $resWithoutPrerelease = Find-PSResource -Name $testModuleName -Version "*" -Repository $PSGalleryName
+        $resWithPrerelease = Find-PSResource -Name $testModuleName -Version "*" -Repository $PSGalleryName
+        $resWithPrerelease.Count | Should -BeGreaterOrEqual $resWithoutPrerelease.Count
+    }
+
+    It "find resource and its dependency resources with IncludeDependencies parameter" {
+        $resWithoutDependencies = Find-PSResource -Name "TestModuleWithDependencyE" -Repository $PSGalleryName
+        $resWithoutDependencies.Count | Should -Be 1
+        $resWithoutDependencies.Name | Should -Be "TestModuleWithDependencyE"
+
+        # TestModuleWithDependencyE has the following dependencies:
+        # TestModuleWithDependencyC <= 1.0.0.0
+        #    TestModuleWithDependencyB >= 1.0.0.0
+        #    TestModuleWithDependencyD <= 1.0.0.0
+
+        $resWithDependencies = Find-PSResource -Name "TestModuleWithDependencyE" -IncludeDependencies -Repository $PSGalleryName
+        $resWithDependencies.Count | Should -BeGreaterThan $resWithoutDependencies.Count
+
+        $foundParentPkgE = $false
+        $foundDepB = $false
+        $foundDepBCorrectVersion = $false
+        $foundDepC = $false
+        $foundDepCCorrectVersion = $false
+        $foundDepD = $false
+        $foundDepDCorrectVersion = $false
+        foreach ($pkg in $resWithDependencies)
+        {
+            if ($pkg.Name -eq "TestModuleWithDependencyE")
+            {
+                $foundParentPkgE = $true
+            }
+            elseif ($pkg.Name -eq "TestModuleWithDependencyC")
+            {
+                $foundDepC = $true
+                $foundDepCCorrectVersion = [System.Version]$pkg.Version -le [System.Version]"1.0.0.0"
+            }
+            elseif ($pkg.Name -eq "TestModuleWithDependencyB")
+            {
+                $foundDepB = $true
+                $foundDepBCorrectVersion = [System.Version]$pkg.Version -ge [System.Version]"3.0.0.0"
+            }
+            elseif ($pkg.Name -eq "TestModuleWithDependencyD")
+            {
+                $foundDepD = $true
+                $foundDepDCorrectVersion = [System.Version]$pkg.Version -le [System.Version]"1.0.0.0"
+            }
+        }
+
+        $foundParentPkgE | Should -Be $true
+        $foundDepC | Should -Be $true
+        $foundDepCCorrectVersion | Should -Be $true
+        $foundDepB | Should -Be $true
+        $foundDepBCorrectVersion | Should -Be $true
+        $foundDepD | Should -Be $true
+        $foundDepDCorrectVersion | Should -Be $true
+    }
+
+    It "find resource of Type script or module from PSGallery, when no Type parameter provided" {
+        $resScript = Find-PSResource -Name $testScriptName -Repository $PSGalleryName
+        $resScript.Name | Should -Be $testScriptName
+        $resScriptType = Out-String -InputObject $resScript.Type
+        $resScriptType.Replace(",", " ").Split() | Should -Contain "Script"
+
+        $resModule = Find-PSResource -Name $testModuleName -Repository $PSGalleryName
+        $resModule.Name | Should -Be $testModuleName
+        $resModuleType = Out-String -InputObject $resModule.Type
+        $resModuleType.Replace(",", " ").Split() | Should -Contain "Module"
+    }
+
+    It "find resource of Type Script from PSGallery, when Type Script specified" {
+        $resScript = Find-PSResource -Name $testScriptName -Repository $PSGalleryName -Type "Script"
+        $resScript.Name | Should -Be $testScriptName
+        $resScript.Repository | Should -Be "PSGalleryScripts"
+        $resScriptType = Out-String -InputObject $resScript.Type
+        $resScriptType.Replace(",", " ").Split() | Should -Contain "Script"
+    }
+
+    It "find resource of Type Command from PSGallery, when Type Command specified" {
+        $resources = Find-PSResource -Name "AzureS*" -Repository $PSGalleryName -Type "Command"
+        foreach ($item in $resources) {
+            $resType = Out-String -InputObject $item.Type
+            $resType.Replace(",", " ").Split() | Should -Contain "Command"
+        }
+    }
+
+    It "find all resources of Type Module when Type parameter set is used" -Skip {
+        $foundScript = $False
+        $res = Find-PSResource -Name "test*" -Type Module -Repository $PSGalleryName
+        $res.Count | Should -BeGreaterThan 1
+        foreach ($item in $res) {
+            if ($item.Type -eq "Script")
+            {
+                $foundScript = $True
+            }
+        }
+
+        $foundScript | Should -Be $False
+    }
+
+    It "find resources given Tag parameter" {
+        $resWithEitherExpectedTag = @("NetworkingDsc", "DSCR_FileContent", "SS.PowerShell")
+        $res = Find-PSResource -Name "NetworkingDsc", "HPCMSL", "DSCR_FileContent", "SS.PowerShell", "PowerShellGet" -Tag "Dsc", "json" -Repository $PSGalleryName
+        foreach ($item in $res) {
+            $resWithEitherExpectedTag | Should -Contain $item.Name
+        }
+    }
+
+    It "find all resources with specified tag given Tag property" {
+        $foundTestModule = $False
+        $foundTestScript = $False
+        $tagToFind = "Tag2"
+        $res = Find-PSResource -Tag $tagToFind -Repository $PSGalleryName
+        foreach ($item in $res) {
+            $item.Tags -contains $tagToFind | Should -Be $True
+
+            if ($item.Name -eq $testModuleName)
+            {
+                $foundTestModule = $True
+            }
+
+            if ($item.Name -eq $testScriptName)
+            {
+                $foundTestScript = $True
+            }
+        }
+
+        $foundTestModule | Should -Be $True
+        $foundTestScript | Should -Be $True
+    }
+
+    It "find resource in local repository given Repository parameter" {
+        $publishModuleName = "TestFindModule"
+        $repoName = "psgettestlocal"
+        Get-ModuleResourcePublishedToLocalRepoTestDrive $publishModuleName $repoName
+
+        $res = Find-PSResource -Name $publishModuleName -Repository $repoName
+        $res | Should -Not -BeNullOrEmpty
+        $res.Name | Should -Be $publishModuleName
+        $res.Repository | Should -Be $repoName
+    }
+
+    It "find Resource given repository parameter, where resource exists in multiple local repos" {
+        $moduleName = "test_local_mod"
+        $repoHigherPriorityRanking = "psgettestlocal"
+        $repoLowerPriorityRanking = "psgettestlocal2"
+
+        Get-ModuleResourcePublishedToLocalRepoTestDrive $moduleName $repoHigherPriorityRanking
+        Get-ModuleResourcePublishedToLocalRepoTestDrive $moduleName $repoLowerPriorityRanking
+
+        $res = Find-PSResource -Name $moduleName
+        $res.Repository | Should -Be $repoHigherPriorityRanking
+
+        $resNonDefault = Find-PSResource -Name $moduleName -Repository $repoLowerPriorityRanking
+        $resNonDefault.Repository | Should -Be $repoLowerPriorityRanking
+    }
+
+    # # Skip test for now because it takes too run (132.24 sec)
+    # It "find resource given CommandName (CommandNameParameterSet)" -Skip {
+    #     $res = Find-PSResource -CommandName $commandName -Repository $PSGalleryName
+    #     foreach ($item in $res) {
+    #         $item.Name | Should -Be $commandName
+    #         $item.ParentResource.Includes.Command | Should -Contain $commandName
+    #     }
+    # }
+
+    It "find resource given CommandName and ModuleName (CommandNameParameterSet)" {
+        $res = Find-PSResource -CommandName $commandName -ModuleName $parentModuleName -Repository $PSGalleryName
+        $res.Name | Should -Be $commandName
+        $res.ParentResource.Name | Should -Be $parentModuleName
+        $res.ParentResource.Includes.Command | Should -Contain $commandName
+    }
+
+    # Skip test for now because it takes too long to run (> 60 sec)
+    # It "find resource given DSCResourceName (DSCResourceNameParameterSet)" -Skip {
+    #     $res = Find-PSResource -DscResourceName $dscResourceName -Repository $PSGalleryName
+    #     foreach ($item in $res) {
+    #         $item.Name | Should -Be $dscResourceName
+    #         $item.ParentResource.Includes.DscResource | Should -Contain $dscResourceName
+    #     }
+    # }
+
+    It "find resource given DscResourceName and ModuleName (DSCResourceNameParameterSet)" {
+        $res = Find-PSResource -DscResourceName $dscResourceName -ModuleName $parentModuleName -Repository $PSGalleryName
+        $res.Name | Should -Be $dscResourceName
+        $res.ParentResource.Name | Should -Be $parentModuleName
+        $res.ParentResource.Includes.DscResource | Should -Contain $dscResourceName
+    }
+}

--- a/test/HttpInstallPSResource.Tests.ps1
+++ b/test/HttpInstallPSResource.Tests.ps1
@@ -1,0 +1,562 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+$ProgressPreference = "SilentlyContinue"
+Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
+
+Describe 'Test Http Install-PSResource for Module' {
+
+    BeforeAll {
+        $PSGalleryName = Get-PSGalleryName
+        $PSGalleryUri = Get-PSGalleryLocation
+        $NuGetGalleryName = Get-NuGetGalleryName
+        $testModuleName = "test_module"
+        $testModuleName2 = "TestModule99"
+        $testScriptName = "test_script"
+        $PackageManagement = "PackageManagement"
+        $RequiredResourceJSONFileName = "TestRequiredResourceFile.json"
+        $RequiredResourcePSD1FileName = "TestRequiredResourceFile.psd1"
+        Get-NewPSResourceRepositoryFile
+        Register-PSGallery
+    }
+
+    AfterEach {
+        Uninstall-PSResource "test_module", "test_module2", "test_script", "TestModule99", "testModuleWithlicense", "TestFindModule","ClobberTestModule1", "ClobberTestModule2", "PackageManagement" -SkipDependencyCheck -ErrorAction SilentlyContinue
+    }
+
+    AfterAll {
+        Get-RevertPSResourceRepositoryFile
+    }
+
+    $testCases = @{Name="*";                          ErrorId="NameContainsWildcard"},
+                 @{Name="Test_Module*";               ErrorId="NameContainsWildcard"},
+                 @{Name="Test?Module","Test[Module";  ErrorId="ErrorFilteringNamesForUnsupportedWildcards"}
+
+    It "Should not install resource with wildcard in name" -TestCases $testCases {
+        param($Name, $ErrorId)
+        Install-PSResource -Name $Name -ErrorVariable err -ErrorAction SilentlyContinue
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "$ErrorId,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
+    }
+
+    It "Install specific module resource by name" {
+        Install-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "5.0.0.0"
+    }
+
+    It "Install specific script resource by name" {
+        Install-PSResource -Name $testScriptName -Repository $PSGalleryName -TrustRepository
+        $pkg = Get-PSResource $testScriptName
+        $pkg.Name | Should -Be $testScriptName
+        $pkg.Version | Should -Be "3.5.0.0"
+    }
+
+    It "Install multiple resources by name" {
+        $pkgNames = @($testModuleName,$testModuleName2)
+        Install-PSResource -Name $pkgNames -Repository $PSGalleryName -TrustRepository  
+        $pkg = Get-PSResource $pkgNames
+        $pkg.Name | Should -Be $pkgNames
+    }
+
+    It "Should not install resource given nonexistant name" {
+        Install-PSResource -Name "NonExistantModule" -Repository $PSGalleryName -TrustRepository -ErrorVariable err -ErrorAction SilentlyContinue
+        $pkg = Get-PSResource "NonExistantModule"
+        $pkg.Name | Should -BeNullOrEmpty
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "ResourceNotFoundError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource" 
+    }
+
+    # Do some version testing, but Find-PSResource should be doing thorough testing
+    It "Should install resource given name and exact version" {
+        Install-PSResource -Name $testModuleName -Version "1.0.0" -Repository $PSGalleryName -TrustRepository
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "1.0.0.0"
+    }
+
+    It "Should install resource given name and exact version with bracket syntax" {
+        Install-PSResource -Name $testModuleName -Version "[1.0.0]" -Repository $PSGalleryName -TrustRepository  
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "1.0.0.0"
+    }
+
+    It "Should install resource given name and exact range inclusive [1.0.0, 5.0.0]" {
+        Install-PSResource -Name $testModuleName -Version "[1.0.0, 5.0.0]" -Repository $PSGalleryName -TrustRepository  
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "5.0.0.0"
+    }
+
+    It "Should install resource given name and exact range exclusive (1.0.0, 5.0.0)" {
+        Install-PSResource -Name $testModuleName -Version "(1.0.0, 5.0.0)" -Repository $PSGalleryName -TrustRepository  
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "3.0.0.0"
+    }
+
+    # TODO: Update this test and others like it that use try/catch blocks instead of Should -Throw
+    It "Should not install resource with incorrectly formatted version such as exclusive version (1.0.0.0)" {
+        $Version = "(1.0.0.0)"
+        try {
+            Install-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
+        }
+        catch
+        {}
+        $Error[0].FullyQualifiedErrorId | Should -be "IncorrectVersionFormat,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
+
+        $res = Get-PSResource $testModuleName
+        $res | Should -BeNullOrEmpty
+    }
+
+    It "Should not install resource with incorrectly formatted version such as version formatted with invalid delimiter [1-0-0-0]" {
+        $Version="[1-0-0-0]"
+        try {
+            Install-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -TrustRepository -ErrorAction SilentlyContinue
+        }
+        catch
+        {}
+        $Error[0].FullyQualifiedErrorId | Should -be "ResourceNotFoundError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
+
+        $res = Get-PSResource $testModuleName
+        $res | Should -BeNullOrEmpty
+    }
+
+    It "Install resource when given Name, Version '*', should install the latest version" {
+        Install-PSResource -Name $testModuleName -Version "*" -Repository $PSGalleryName -TrustRepository
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "5.0.0.0"
+    }
+
+    It "Install resource with latest (including prerelease) version given Prerelease parameter" {
+        Install-PSResource -Name $testModuleName -Prerelease -Repository $PSGalleryName -TrustRepository 
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "5.2.5"
+        $pkg.Prerelease | Should -Be "alpha001"
+    }
+
+    It "Install a module with a dependency" {
+        Uninstall-PSResource -Name "TestModuleWithDependency*" -Version "*" -SkipDependencyCheck
+        Install-PSResource -Name "TestModuleWithDependencyC" -Version "1.0.0.0" -Repository $PSGalleryName -TrustRepository 
+
+        $pkg = Get-PSResource "TestModuleWithDependencyC"
+        $pkg.Name | Should -Be "TestModuleWithDependencyC"
+        $pkg.Version | Should -Be "1.0.0.0"
+
+        $pkg = Get-PSResource "TestModuleWithDependencyB"
+        $pkg.Name | Should -Be "TestModuleWithDependencyB"
+        $pkg.Version | Should -Be "3.0.0.0"
+
+        $pkg = Get-PSResource "TestModuleWithDependencyD"
+        $pkg.Name | Should -Be "TestModuleWithDependencyD"
+        $pkg.Version | Should -Be "1.0.0.0"
+    }
+
+    It "Install a module with a dependency and skip installing the dependency" {
+        Uninstall-PSResource -Name "TestModuleWithDependency*" -Version "*" -SkipDependencyCheck
+        Install-PSResource -Name "TestModuleWithDependencyC" -Version "1.0.0.0" -SkipDependencyCheck -Repository $PSGalleryName -TrustRepository
+        $pkg = Get-PSResource "TestModuleWithDependencyC"
+        $pkg.Name | Should -Be "TestModuleWithDependencyC"
+        $pkg.Version | Should -Be "1.0.0.0"
+
+        $pkg = Get-PSResource "TestModuleWithDependencyB", "TestModuleWithDependencyD"
+        $pkg | Should -BeNullOrEmpty
+    }
+
+    It "Install resource via InputObject by piping from Find-PSresource" {
+        Find-PSResource -Name $testModuleName -Repository $PSGalleryName | Install-PSResource -TrustRepository 
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName 
+        $pkg.Version | Should -Be "5.0.0.0"
+    }
+
+    It "Install resource under specified in PSModulePath" {
+        Install-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName 
+        ($env:PSModulePath).Contains($pkg.InstalledLocation)
+    }
+
+    It "Install resource with companyname, copyright and repository source location and validate" {
+        Install-PSResource -Name $testModuleName -Version "5.2.5-alpha001" -Repository PSGallery -TrustRepository
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Version | Should -Be "5.2.5"
+        $pkg.Prerelease | Should -Be "alpha001"
+
+        $pkg.CompanyName | Should -Be "Anam"
+        $pkg.Copyright | Should -Be "(c) Anam Navied. All rights reserved."
+        $pkg.RepositorySourceLocation | Should -Be $PSGalleryUri
+    }
+
+
+    It "Install script with companyname, copyright, and repository source location and validate" {
+        Install-PSResource -Name "Install-VSCode" -Version "1.4.2" -Repository $PSGalleryName -TrustRepository
+
+        $res = Get-PSResource "Install-VSCode" -Version "1.4.2"
+        $res.Name | Should -Be "Install-VSCode"
+        $res.Version | Should -Be "1.4.2.0"
+        $res.CompanyName | Should -Be "Microsoft Corporation"
+        $res.Copyright | Should -Be "(c) Microsoft Corporation"
+        $res.RepositorySourceLocation | Should -Be $PSGalleryUri
+    }
+
+    # Windows only
+    It "Install resource under CurrentUser scope - Windows only" -Skip:(!(Get-IsWindows)) {
+        Install-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository -Scope CurrentUser
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.InstalledLocation.ToString().Contains("Documents") | Should -Be $true
+    }
+
+    # Windows only
+    It "Install resource under AllUsers scope - Windows only" -Skip:(!((Get-IsWindows) -and (Test-IsAdmin))) {
+        Install-PSResource -Name "testmodule99" -Repository $PSGalleryName -TrustRepository -Scope AllUsers -Verbose
+        $pkg = Get-Module "testmodule99" -ListAvailable
+        $pkg.Name | Should -Be "testmodule99"
+        $pkg.Path.ToString().Contains("Program Files")
+    }
+
+    # Windows only
+    It "Install resource under no specified scope - Windows only" -Skip:(!(Get-IsWindows)) {
+        Install-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository 
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.InstalledLocation.ToString().Contains("Documents") | Should -Be $true
+    }
+
+    # Unix only
+    # Expected path should be similar to: '/home/janelane/.local/share/powershell/Modules'
+    It "Install resource under CurrentUser scope - Unix only" -Skip:(Get-IsWindows) {
+        Install-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository -Scope CurrentUser
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.InstalledLocation.ToString().Contains("$env:HOME/.local") | Should -Be $true
+    }
+
+    # Unix only
+    # Expected path should be similar to: '/home/janelane/.local/share/powershell/Modules'
+    It "Install resource under no specified scope - Unix only" -Skip:(Get-IsWindows) {
+        Install-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.InstalledLocation.ToString().Contains("$env:HOME/.local") | Should -Be $true
+    }
+
+    It "Should not install resource that is already installed" {
+        Install-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        Install-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository -WarningVariable WarningVar -warningaction SilentlyContinue
+        $WarningVar | Should -Not -BeNullOrEmpty
+    }
+
+    It "Reinstall resource that is already installed with -Reinstall parameter" {
+        Install-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "5.0.0.0"
+        Install-PSResource -Name $testModuleName -Repository $PSGalleryName -Reinstall -TrustRepository
+        $pkg = Get-PSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "5.0.0.0"
+    }
+
+    It "Restore resource after reinstall fails" {
+        Install-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository
+        $pkg = Get-Module $testModuleName -ListAvailable
+        $pkg.Name | Should -Contain $testModuleName
+        $pkg.Version | Should -Contain "5.0.0.0"
+
+        $resourcePath = Split-Path -Path $pkg.Path -Parent
+        $resourceFiles = Get-ChildItem -Path $resourcePath -Recurse
+
+        # Lock resource file to prevent reinstall from succeeding.
+        $fs = [System.IO.File]::Open($resourceFiles[0].FullName, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
+        try
+        {
+            # Reinstall of resource should fail with one of its files locked.
+            Install-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository -Reinstall -ErrorVariable ev -ErrorAction Silent
+            $ev.FullyQualifiedErrorId | Should -BeExactly 'InstallPackageFailed,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource'
+        }
+        finally
+        {
+            $fs.Close()
+        }
+
+        # Verify that resource module has been restored.
+        (Get-ChildItem -Path $resourcePath -Recurse).Count | Should -BeExactly $resourceFiles.Count
+    }
+
+    # It "Install resource that requires accept license with -AcceptLicense flag" {
+    #     Install-PSResource -Name "testModuleWithlicense" -Repository $TestGalleryName -AcceptLicense
+    #     $pkg = Get-PSResource "testModuleWithlicense"
+    #     $pkg.Name | Should -Be "testModuleWithlicense" 
+    #     $pkg.Version | Should -Be "0.0.3.0"
+    # }
+
+
+    It "Install resource with cmdlet names from a module already installed (should clobber)" {
+        Install-PSResource -Name "CLobberTestModule1" -Repository $PSGalleryName -TrustRepository
+        $pkg = Get-PSResource "ClobberTestModule1"
+        $pkg.Name | Should -Be "ClobberTestModule1" 
+        $pkg.Version | Should -Be "0.0.1.0"
+
+        Install-PSResource -Name "ClobberTestModule2" -Repository $PSGalleryName -TrustRepository
+        $pkg = Get-PSResource "ClobberTestModule2"
+        $pkg.Name | Should -Be "ClobberTestModule2" 
+        $pkg.Version | Should -Be "0.0.1.0"
+    }
+
+    It "Install resource from local repository given Repository parameter" {
+        $publishModuleName = "TestFindModule"
+        $repoName = "psgettestlocal"
+        Get-ModuleResourcePublishedToLocalRepoTestDrive $publishModuleName $repoName
+        Set-PSResourceRepository "psgettestlocal" -Trusted:$true
+
+        Install-PSResource -Name $publishModuleName -Repository $repoName
+        $pkg = Get-PSResource $publishModuleName
+        $pkg | Should -Not -BeNullOrEmpty
+        $pkg.Name | Should -Be $publishModuleName
+    }
+
+    It "Install module using -WhatIf, should not install the module" {
+        Install-PSResource -Name $testModuleName -WhatIf
+    
+        $res = Get-PSResource $testModuleName
+        $res | Should -BeNullOrEmpty
+    }
+
+    It "Validates that a module with module-name script files (like Pester) installs under Modules path" {
+
+        Install-PSResource -Name "testModuleWithScript" -Repository $PSGalleryName -TrustRepository
+    
+        $res = Get-PSResource "testModuleWithScript"
+        $res.InstalledLocation.ToString().Contains("Modules") | Should -Be $true
+    }
+
+    It "Install module using -NoClobber, should throw clobber error and not install the module" {
+        Install-PSResource -Name "ClobberTestModule1" -Repository $PSGalleryName -TrustRepository
+    
+        $res = Get-PSResource "ClobberTestModule1"
+        $res.Name | Should -Be "ClobberTestModule1"
+
+        Install-PSResource -Name "ClobberTestModule2" -Repository $PSGalleryName -TrustRepository -NoClobber -ErrorAction SilentlyContinue
+        $Error[0].FullyQualifiedErrorId | Should -be "CommandAlreadyExists,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
+    }
+
+    It "Install PSResourceInfo object piped in" {
+        Find-PSResource -Name $testModuleName -Version "1.0.0.0" -Repository $PSGalleryName | Install-PSResource -TrustRepository
+        $res = Get-PSResource -Name $testModuleName
+        $res.Name | Should -Be $testModuleName
+        $res.Version | Should -Be "1.0.0.0"
+    }
+
+    It "Install module using -PassThru" {
+        $res = Install-PSResource -Name $testModuleName -Repository $PSGalleryName -PassThru -TrustRepository
+        $res.Name | Should -Contain $testModuleName
+    }
+
+    It "Install modules using -RequiredResource with hashtable" {
+        $rrHash = @{
+            test_module = @{
+               version = "[1.0.0,5.0.0)"
+               repository = $PSGalleryName
+             }
+          
+             test_module2 = @{
+               version = "[1.0.0,3.0.0)"
+               repository = $PSGalleryName
+               prerelease = "true"
+             }
+          
+             TestModule99 = @{}
+          }
+
+          Install-PSResource -RequiredResource $rrHash -TrustRepository
+    
+          $res1 = Get-PSResource $testModuleName
+          $res1.Name | Should -Be $testModuleName
+          $res1.Version | Should -Be "3.0.0.0"
+
+          $res2 = Get-PSResource "test_module2" -Version "2.5.0-beta"
+          $res2.Name | Should -Be "test_module2"
+          $res2.Version | Should -Be "2.5.0"
+          $res2.Prerelease | Should -Be "beta"
+
+          $res3 = Get-PSResource $testModuleName2
+          $res3.Name | Should -Be $testModuleName2
+          $res3.Version | Should -Be "0.0.93.0"
+    }
+
+    It "Install modules using -RequiredResource with JSON string" {
+        $rrJSON = "{
+           'test_module': {
+             'version': '[1.0.0,5.0.0)',
+             'repository': 'PSGallery'
+           },
+           'test_module2': {
+             'version': '[1.0.0,3.0.0)',
+             'repository': 'PSGallery',
+             'prerelease': 'true'
+           },
+           'TestModule99': {
+             'repository': 'PSGallery'
+           }
+         }"
+
+          Install-PSResource -RequiredResource $rrJSON -TrustRepository
+    
+          $res1 = Get-PSResource $testModuleName
+          $res1.Name | Should -Be $testModuleName
+          $res1.Version | Should -Be "3.0.0.0"
+
+          $res2 = Get-PSResource "test_module2" -Version "2.5.0-beta"
+          $res2.Name | Should -Be "test_module2"
+          $res2.Version | Should -Be "2.5.0"
+          $res2.Prerelease | Should -Be "beta"
+
+          $res3 = Get-PSResource $testModuleName2
+          $res3.Name | Should -Be $testModuleName2
+          $res3.Version | Should -Be "0.0.93.0"
+    }
+
+    It "Install modules using -RequiredResourceFile with PSD1 file" {
+        $rrFilePSD1 = Join-Path -Path $psscriptroot -ChildPath $RequiredResourcePSD1FileName
+
+        Install-PSResource -RequiredResourceFile $rrFilePSD1 -TrustRepository
+
+        $res1 = Get-PSResource $testModuleName
+        $res1.Name | Should -Be $testModuleName
+        $res1.Version | Should -Be "3.0.0.0"
+
+        $res2 = Get-PSResource "test_module2" -Version "2.5.0-beta"
+        $res2.Name | Should -Be "test_module2"
+        $res2.Version | Should -Be "2.5.0"
+        $res2.Prerelease | Should -Be "beta"
+
+        $res3 = Get-PSResource $testModuleName2
+        $res3.Name | Should -Be $testModuleName2
+        $res3.Version | Should -Be "0.0.93.0"
+    }
+
+    It "Install modules using -RequiredResourceFile with JSON file" {
+        $rrFileJSON = Join-Path -Path $psscriptroot -ChildPath $RequiredResourceJSONFileName
+
+        Install-PSResource -RequiredResourceFile $rrFileJSON -TrustRepository
+
+        $res1 = Get-PSResource $testModuleName
+        $res1.Name | Should -Be $testModuleName
+        $res1.Version | Should -Be "3.0.0.0"
+ 
+        $res2 = Get-PSResource "test_module2" -Version "2.5.0-beta"
+        $res2.Name | Should -Be "test_module2"
+        $res2.Version | Should -Be "2.5.0"
+        $res2.Prerelease | Should -Be "beta"
+ 
+        $res3 = Get-PSResource $testModuleName2
+        $res3.Name | Should -Be $testModuleName2
+        $res3.Version | Should -Be "0.0.93.0"
+    }
+
+    # Install module 1.4.3 (is authenticode signed and has catalog file)
+    # Should install successfully 
+    It "Install modules with catalog file using publisher validation" -Skip:(!(Get-IsWindows)) {
+        Install-PSResource -Name $PackageManagement -Version "1.4.3" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository
+
+        $res1 = Get-PSResource $PackageManagement -Version "1.4.3"
+        $res1.Name | Should -Be $PackageManagement
+        $res1.Version | Should -Be "1.4.3.0"
+    }
+
+    # Install module 1.4.7 (is authenticode signed and has no catalog file)
+    # Should not install successfully 
+    It "Install module with no catalog file" -Skip:(!(Get-IsWindows)) {
+        Install-PSResource -Name $PackageManagement -Version "1.4.7" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository
+
+        $res1 = Get-PSResource $PackageManagement -Version "1.4.7"
+        $res1.Name | Should -Be $PackageManagement
+        $res1.Version | Should -Be "1.4.7.0"    
+    }
+
+    # Install module that is not authenticode signed
+    # Should FAIL to install the  module
+    It "Install module that is not authenticode signed" -Skip:(!(Get-IsWindows)) {
+        { Install-PSResource -Name $testModuleName -Version "5.0.0" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository } | Should -Throw -ErrorId "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
+    }
+
+    # Install 1.4.4.1 (with incorrect catalog file)
+    # Should FAIL to install the  module
+    It "Install module with incorrect catalog file" -Skip:(!(Get-IsWindows)) {
+        { Install-PSResource -Name $PackageManagement -Version "1.4.4.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository } | Should -Throw -ErrorId "TestFileCatalogError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
+    }
+
+    # Install script that is signed
+    # Should install successfully 
+    It "Install script that is authenticode signed" -Skip:(!(Get-IsWindows)) {
+        Install-PSResource -Name "Install-VSCode" -Version "1.4.2" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository
+
+        $res1 = Get-PSResource "Install-VSCode" -Version "1.4.2"
+        $res1.Name | Should -Be "Install-VSCode"
+        $res1.Version | Should -Be "1.4.2.0"
+    }
+
+    # Install script that is not signed
+    # Should throw
+    It "Install script that is not signed" -Skip:(!(Get-IsWindows)) {
+        { Install-PSResource -Name "TestTestScript" -Version "1.3.1.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository } | Should -Throw -ErrorId "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
+    }
+}
+
+<# Temporarily commented until -Tag is implemented for this Describe block
+Describe 'Test Install-PSResource for interactive and root user scenarios' {
+
+    BeforeAll{
+        $TestGalleryName = Get-PoshTestGalleryName
+        $PSGalleryName = Get-PSGalleryName
+        $NuGetGalleryName = Get-NuGetGalleryName
+        Get-NewPSResourceRepositoryFile
+        Register-LocalRepos
+    }
+
+    AfterEach {
+        Uninstall-PSResource "TestModule", "testModuleWithlicense" -SkipDependencyCheck -ErrorAction SilentlyContinue
+    }
+
+    AfterAll {
+        Get-RevertPSResourceRepositoryFile
+    }
+
+    # Unix only manual test
+    # Expected path should be similar to: '/usr/local/share/powershell/Modules'
+    It "Install resource under AllUsers scope - Unix only" -Skip:(Get-IsWindows) {
+        Install-PSResource -Name "TestModule" -Repository $TestGalleryName -Scope AllUsers
+        $pkg = Get-Module "TestModule" -ListAvailable
+        $pkg.Name | Should -Be "TestModule" 
+        $pkg.Path.Contains("/usr/") | Should -Be $true
+    }
+
+    # This needs to be manually tested due to prompt
+    It "Install resource that requires accept license without -AcceptLicense flag" {
+        Install-PSResource -Name "testModuleWithlicense" -Repository $TestGalleryName
+        $pkg = Get-PSResource "testModuleWithlicense"
+        $pkg.Name | Should -Be "testModuleWithlicense" 
+        $pkg.Version | Should -Be "0.0.1.0"
+    }
+
+    # This needs to be manually tested due to prompt
+    It "Install resource should prompt 'trust repository' if repository is not trusted" {
+        Set-PSResourceRepository PoshTestGallery -Trusted:$false
+
+        Install-PSResource -Name "TestModule" -Repository $TestGalleryName -confirm:$false
+        
+        $pkg = Get-Module "TestModule" -ListAvailable
+        $pkg.Name | Should -Be "TestModule" 
+
+        Set-PSResourceRepository PoshTestGallery -Trusted
+    }
+}
+#>

--- a/test/PSGetTestUtils.psm1
+++ b/test/PSGetTestUtils.psm1
@@ -256,6 +256,18 @@ function Register-LocalRepos {
     Write-Verbose("registered psgettestlocal, psgettestlocal2")
 }
 
+function Register-PSGallery {
+    $PSGalleryRepoParams = @{
+        Name = $script:PSGalleryName
+        Uri = $script:PSGalleryLocation
+        Priority = 1
+        Trusted = $false
+    }
+    Register-PSResourceRepository @PSGalleryRepoParams
+
+    Write-Verbose("registered PSGallery")
+}
+
 function Unregister-LocalRepos {
     if(Get-PSResourceRepository -Name "psgettestlocal"){
         Unregister-PSResourceRepository -Name "psgettestlocal"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Adding tests for find and install interface work.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
