### PR TITLE
Add SkipModuleManifestValidate parameter to Publish-PSResource cmdlet

### DIFF
--- a/.ci/ci_release.yml
+++ b/.ci/ci_release.yml
@@ -297,7 +297,7 @@ stages:
           BuildDropPath: $(signOutPath)
           Build_Repository_Uri: 'https://github.com/powershell/powershellget'
           PackageName: 'PowerShellGet'
-          PackageVersion: '3.0.18'
+          PackageVersion: '3.0.19'
 
     - pwsh: |
         $modulePath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath 'TempModules'

--- a/src/PowerShellGet.psd1
+++ b/src/PowerShellGet.psd1
@@ -3,7 +3,7 @@
 
 @{
     RootModule        = './netstandard2.0/PowerShellGet.dll'
-    ModuleVersion     = '3.0.18'
+    ModuleVersion     = '3.0.19'
     GUID              = '1d73a601-4a6c-43c5-ba3f-619b18bbb404'
     Author            = 'Microsoft Corporation'
     CompanyName       = 'Microsoft Corporation'
@@ -35,7 +35,7 @@
     AliasesToExport = @('inmo', 'fimo', 'upmo', 'pumo')
     PrivateData = @{
         PSData = @{
-            Prerelease = 'beta18'
+            Prerelease = 'beta19'
             Tags = @('PackageManagement',
                 'PSEdition_Desktop',
                 'PSEdition_Core',

--- a/src/code/PowerShellGet.csproj
+++ b/src/code/PowerShellGet.csproj
@@ -5,9 +5,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PowerShellGet</RootNamespace>
     <AssemblyName>PowerShellGet</AssemblyName>
-    <AssemblyVersion>3.0.18.0</AssemblyVersion>
-    <FileVersion>3.0.18</FileVersion>
-    <InformationalVersion>3.0.18</InformationalVersion>
+    <AssemblyVersion>3.0.19.0</AssemblyVersion>
+    <FileVersion>3.0.19</FileVersion>
+    <InformationalVersion>3.0.19</InformationalVersion>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -74,8 +74,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// Bypasses the default check that all dependencies are present.
         /// </summary>
         [Parameter]
-        [ValidateNotNullOrEmpty]
         public SwitchParameter SkipDependenciesCheck { get; set; }
+
+        /// <summary>
+        /// Bypasses validating a resource module manifest before publishing.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter SkipModuleManifestValidate { get; set; }
 
         /// <summary>
         /// Specifies a proxy server for the request, rather than a direct connection to the internet resource.
@@ -275,7 +280,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 }
 
                 // Validate that the module manifest has correct data
-                if (! Utils.ValidateModuleManifest(pathToModuleManifestToPublish, out string errorMsg))
+                if (! SkipModuleManifestValidate &&
+                    ! Utils.ValidateModuleManifest(pathToModuleManifestToPublish, out string errorMsg))
                 {
                     ThrowTerminatingError(new ErrorRecord(
                         new PSInvalidOperationException(errorMsg),

--- a/test/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResource.Tests.ps1
@@ -3,6 +3,42 @@
 
 Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
 
+function CreateTestModule
+{
+    param (
+        [string] $Path = "$TestDrive",
+        [string] $ModuleName = 'TestModule'
+    )
+
+    $modulePath = Join-Path -Path $Path -ChildPath $ModuleName
+    $moduleMan = Join-Path $modulePath -ChildPath ($ModuleName + '.psd1')
+    $moduleSrc = Join-Path $modulePath -ChildPath ($ModuleName + '.psm1')
+
+    if ( Test-Path -Path $modulePath) {
+        Remove-Item -Path $modulePath -Recurse -Force
+    }
+
+    $null = New-Item -Path $modulePath -ItemType Directory -Force
+
+    @'
+    @{{
+        RootModule        = "{0}.psm1"
+        ModuleVersion     = '1.0.0'
+        Author            = 'None'
+        Description       = 'None'
+        GUID              = '0c2829fc-b165-4d72-9038-ae3a71a755c1'
+        FunctionsToExport = @('Test1')
+        RequiredModules   = @('NonExistentModule')
+    }}
+'@ -f $ModuleName | Out-File -Path $moduleMan
+
+    @'
+    function Test1 {
+        Write-Output 'Hello from Test1'
+    }
+'@ | Out-File -Path $moduleSrc
+}
+
 Describe "Test Publish-PSResource" {
     BeforeAll {
         Get-NewPSResourceRepositoryFile
@@ -56,6 +92,9 @@ Describe "Test Publish-PSResource" {
 
         # Path to specifically to that invalid test scripts folder
         $script:testScriptsFolderPath = Join-Path $testFilesFolderPath -ChildPath "testScripts"
+
+        # Create test module with missing required module
+        CreateTestModule -Path $TestDrive -ModuleName 'ModuleWithMissingRequiredModule'
     }
     AfterAll {
        Get-RevertPSResourceRepositoryFile
@@ -70,6 +109,20 @@ Describe "Test Publish-PSResource" {
 
         $pkgsToDelete = Join-Path -Path $script:PublishModuleBase  -ChildPath "*"
         Remove-Item $pkgsToDelete -Recurse -ErrorAction SilentlyContinue
+    }
+
+    It "Publish module with required module not installed on the local machine using -SkipModuleManifestValidate" {
+        # Skip the module manifest validation test, which fails from the missing manifest required module.
+        $testModulePath = Join-Path -Path $TestDrive -ChildPath ModuleWithMissingRequiredModule
+        Publish-PSResource -Path $testModulePath -Repository $testRepository2 -Confirm:$false -SkipDependenciesCheck -SkipModuleManifestValidate
+
+        $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath 'ModuleWithMissingRequiredModule.1.0.0.nupkg'
+        $publishedModuleFound = Test-Path -Path $expectedPath
+        $publishedModuleFound | Should -BeTrue
+
+        if ($publishedModuleFound) {
+            Remove-Item $expectedPath -Force -ErrorAction SilentlyContinue
+        }
     }
 
     It "Publish a module with -Path to the highest priority repo" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR addresses issue #891 by adding a `-SkipModuleManifestValidate` parameter so user can optionally bypass this step during a publish operation.  This PR also updates module version to next beta version.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: 
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed]()
        - [x] Issue filed:  #899
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
