### PR TITLE
Remove Proxy parameters in Register-PSResourceRepository

### DIFF
--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -92,19 +92,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         public PSCredentialInfo CredentialInfo { get; set; }
 
         /// <summary>
-        /// Specifies a proxy server for the request, rather than a direct connection to the internet resource.
-        /// </summary>
-        [Parameter]
-        [ValidateNotNullOrEmpty]
-        public Uri Proxy { get; set; }
-
-        /// <summary>
-        /// Specifies a user account that has permission to use the proxy server that is specified by the Proxy parameter.
-        /// </summary>
-        [Parameter]
-        public PSCredential ProxyCredential { get; set; }
-
-        /// <summary>
         /// When specified, displays the succcessfully registered repository and its information.
         /// </summary>
         [Parameter]
@@ -122,15 +109,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         protected override void BeginProcessing()
         {
-            if (Proxy != null || ProxyCredential != null)
-            {
-                ThrowTerminatingError(new ErrorRecord(
-                    new PSNotImplementedException("Proxy and ProxyCredential are not yet implemented. Please rerun cmdlet with other parameters."),
-                    "ParametersNotImplementedYet",
-                    ErrorCategory.NotImplemented,
-                    this));
-            }
-
             RepositorySettings.CheckRepositoryStore();
         }
         protected override void ProcessRecord()


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Remove the `-Proxy` and `-ProxyCredential` parameters in `Register-PSResourceRepository` since they don't actually do anything and there is no proxy support yet.

Note:  in hindsight we probably don't need Proxy support for `Register-PSResourceRepository` since we are not making a network call in this cmdlet (v2 did ping the repository being registered so needed proxy information in order to make that call).

## PR Context

Resolves #752 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
