### PR TITLE
Fix -NoClobber bug in Install-PSResource

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -755,7 +755,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 pathsToSearch: _pathsToSearch,
                 selectPrereleaseOnly: false);
             // User parsed metadata hash.
-            List<string> listOfCmdlets = new List<string>();
+            HashSet<string> listOfCmdlets = new HashSet<string>();
             foreach (var cmdletName in parsedMetadataHashtable["CmdletsToExport"] as object[])
             {
                 listOfCmdlets.Add(cmdletName as string);
@@ -775,7 +775,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 if (pkg.Includes.Cmdlet != null && pkg.Includes.Cmdlet.Any())
                 {
                     duplicateCmdlets = listOfCmdlets.Where(cmdlet => pkg.Includes.Cmdlet.Contains(cmdlet)).ToList();
-
                 }
 
                 if (pkg.Includes.Command != null && pkg.Includes.Command.Any())
@@ -785,7 +784,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                 if (duplicateCmdlets.Any() || duplicateCmds.Any())
                 {
-
                     duplicateCmdlets.AddRange(duplicateCmds);
 
                     var errMessage = string.Format(

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -755,14 +755,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 pathsToSearch: _pathsToSearch,
                 selectPrereleaseOnly: false);
             // User parsed metadata hash.
-            HashSet<string> listOfCmdlets = new HashSet<string>();
+            HashSet<string> cmdletsToInstall = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var cmdletName in parsedMetadataHashtable["CmdletsToExport"] as object[])
             {
-                listOfCmdlets.Add(cmdletName as string);
+                cmdletsToInstall.Add(cmdletName as string);
             }
 
             // Exit early if there's no cmdlets in the package to be installed.
-            if (listOfCmdlets.Count == 0) 
+            if (cmdletsToInstall.Count == 0) 
             {
                 return foundClobber;
             }
@@ -774,12 +774,23 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 // See if any of the cmdlets or commands in the pkg we're trying to install exist within a package that's already installed.
                 if (pkg.Includes.Cmdlet != null && pkg.Includes.Cmdlet.Any())
                 {
-                    duplicateCmdlets = listOfCmdlets.Where(cmdlet => pkg.Includes.Cmdlet.Contains(cmdlet)).ToList();
+                    foreach (string cmdlet in pkg.Includes.Cmdlet) 
+                    {
+                        if (cmdletsToInstall.Contains(cmdlet)) { 
+                            duplicateCmdlets.Add(cmdlet);
+                        }   
+                    }
                 }
 
                 if (pkg.Includes.Command != null && pkg.Includes.Command.Any())
                 {
-                    duplicateCmds = listOfCmdlets.Where(commands => pkg.Includes.Command.Contains(commands, StringComparer.InvariantCultureIgnoreCase)).ToList();
+                    foreach (string command in pkg.Includes.Command)
+                    {
+                        if (cmdletsToInstall.Contains(command))
+                        {
+                            duplicateCmdlets.Add(command);
+                        }
+                    }
                 }
 
                 if (duplicateCmdlets.Any() || duplicateCmds.Any())

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -566,7 +566,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         }
 
                         // If NoClobber is specified, ensure command clobbering does not happen
-                        if (_noClobber && !DetectClobber(pkg.Name, parsedMetadataHashtable))
+                        if (_noClobber && DetectClobber(pkg.Name, parsedMetadataHashtable))
                         {
                             continue;
                         }
@@ -754,19 +754,24 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 versionRange: VersionRange.All,
                 pathsToSearch: _pathsToSearch,
                 selectPrereleaseOnly: false);
-            // user parsed metadata hash
+            // User parsed metadata hash.
             List<string> listOfCmdlets = new List<string>();
             foreach (var cmdletName in parsedMetadataHashtable["CmdletsToExport"] as object[])
             {
                 listOfCmdlets.Add(cmdletName as string);
+            }
 
+            // Exit early if there's no cmdlets in the package to be installed.
+            if (listOfCmdlets.Count == 0) 
+            {
+                return foundClobber;
             }
 
             foreach (var pkg in pkgsAlreadyInstalled)
             {
                 List<string> duplicateCmdlets = new List<string>();
                 List<string> duplicateCmds = new List<string>();
-                // See if any of the cmdlets or commands in the pkg we're trying to install exist within a package that's already installed
+                // See if any of the cmdlets or commands in the pkg we're trying to install exist within a package that's already installed.
                 if (pkg.Includes.Cmdlet != null && pkg.Includes.Cmdlet.Any())
                 {
                     duplicateCmdlets = listOfCmdlets.Where(cmdlet => pkg.Includes.Cmdlet.Contains(cmdlet)).ToList();

--- a/test/InstallPSResource.Tests.ps1
+++ b/test/InstallPSResource.Tests.ps1
@@ -509,6 +509,14 @@ Describe 'Test Install-PSResource for Module' {
     It "Install script that is not signed" -Skip:(!(Get-IsWindows)) {
         { Install-PSResource -Name "TestTestScript" -Version "1.3.1.1" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository } | Should -Throw -ErrorId "GetAuthenticodeSignatureError,Microsoft.PowerShell.PowerShellGet.Cmdlets.InstallPSResource"
     }
+
+    It "Install module with -NoClobber parameter" -Skip:(!(Get-IsWindows)) {
+        Install-PSResource -Name $TestModuleName -Version "5.0.0" -Repository $PSGalleryName -NoClobber -Reinstall -TrustRepository
+
+        $res = Get-PSResource $TestModuleName
+        $res.Name | Should -Be $TestModuleName
+        $res.Version | Should -Be "5.0.0.0"    
+    }
 }
 
 <# Temporarily commented until -Tag is implemented for this Describe block


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
`-NoClobber` parameter for `Install-PSResource` was not working properly.  I made a small bug fix there and added an early out if the package to be installed does not have any cmdlets (ie there's no potential for clobbering).

## PR Context

Resolves #676 

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
