### PR TITLE
Fix prerelease install name bug for v3

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -554,7 +554,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
                         foreach (PSResourceResult searchResult in _httpFindPSResource.FindAll(repository, _prerelease, _type))
                         {
-                            if (!String.IsNullOrEmpty(searchResult.errorMsg))
+                            if (String.IsNullOrEmpty(searchResult.errorMsg))
                             {
                                 PSResourceInfo foundPkg = searchResult.returnedObject;
                                 parentPkgs.Add(foundPkg);
@@ -573,7 +573,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         {
                             foreach (PSResourceResult searchResult in _httpFindPSResource.FindNameGlobbing(pkgName, repository, _prerelease, _type))
                             {
-                                if (!String.IsNullOrEmpty(searchResult.errorMsg))
+                                if (String.IsNullOrEmpty(searchResult.errorMsg))
                                 {
                                     PSResourceInfo foundPkg = searchResult.returnedObject;
                                     parentPkgs.Add(foundPkg);
@@ -592,7 +592,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         // if they attempt this combination
                         foreach (PSResourceResult searchResult in _httpFindPSResource.FindVersion(pkgName, nugetVersion.ToNormalizedString(), repository, _type))
                         {
-                            if (!String.IsNullOrEmpty(searchResult.errorMsg))
+                            if (String.IsNullOrEmpty(searchResult.errorMsg))
                             {
                                 PSResourceInfo foundPkg = searchResult.returnedObject;
                                 parentPkgs.Add(foundPkg);
@@ -616,7 +616,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         // If no version is specified, just retrieve the latest version
                         foreach (PSResourceResult searchResult in _httpFindPSResource.FindName(pkgName, repository, _prerelease, _type))
                         {
-                            if (!String.IsNullOrEmpty(searchResult.errorMsg))
+                            if (String.IsNullOrEmpty(searchResult.errorMsg))
                             {
                                 PSResourceInfo foundPkg = searchResult.returnedObject;
                                 parentPkgs.Add(foundPkg);
@@ -661,7 +661,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         // TODO: deal with errRecord and making FindVesionGlobbing yield single packages instead of returning an array.
                         foreach (PSResourceResult searchResult in _httpFindPSResource.FindVersionGlobbing(pkgName, versionRange, repository, _prerelease, _type, getOnlyLatest: false))
                         {
-                            if (!String.IsNullOrEmpty(searchResult.errorMsg))
+                            if (String.IsNullOrEmpty(searchResult.errorMsg))
                             {
                                 PSResourceInfo foundPkg = searchResult.returnedObject;
                                 parentPkgs.Add(foundPkg);
@@ -1003,7 +1003,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             foreach (PSResourceResult searchResult in _httpFindPSResource.FindTags(_tag, repository, _prerelease, type))
             {
-                if (!String.IsNullOrEmpty(searchResult.errorMsg))
+                if (String.IsNullOrEmpty(searchResult.errorMsg))
                 {
                     PSResourceInfo foundPkg = searchResult.returnedObject;
                     yield return foundPkg;
@@ -1017,8 +1017,17 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         private IEnumerable<PSCommandResourceInfo> HttpFindCmdOrDsc(PSRepositoryInfo repository, bool isSearchingForCommands)
         {
-            yield return _httpFindPSResource.FindCommandOrDscResource(_tag, repository, _prerelease, isSearchingForCommands).First();
-            // TODO:  write out error
+            foreach (PSResourceResult searchResult in _httpFindPSResource.FindCommandOrDscResource(_tag, repository, _prerelease, isSearchingForCommands))
+            {
+                if (String.IsNullOrEmpty(searchResult.errorMsg))
+                {
+                    yield return searchResult.returnedCmdObject;
+                }
+                else
+                {
+                    _cmdletPassedIn.WriteError(new ErrorRecord(new PSInvalidOperationException(searchResult.errorMsg), "FindCommandOrDscResourceFail", ErrorCategory.NotSpecified, null));
+                }
+            }
         }
 
         private IEnumerable<PSResourceInfo> HttpFindDependencyPackages(PSResourceInfo currentPkg, PSRepositoryInfo repository)

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -400,18 +400,16 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                         // FindVersionGlobbing, pick latest, InstallVersion
                         foreach (string pkgName in pkgNamesToInstall)
                         {
-                            IEnumerable<PSResourceInfo> pkgsSatisfyingRange = _httpFindPSResource.FindVersionGlobbing(pkgName, versionRange, repository, _prerelease, ResourceType.None, getOnlyLatest: true);
+                            PSResourceResult searchResult = _httpFindPSResource.FindVersionGlobbing(pkgName, versionRange, repository, _prerelease, ResourceType.None, getOnlyLatest: true).First();
                             
-                            PSResourceInfo pkgToInstall;
-                            if (pkgsSatisfyingRange != null)
+                            if (!String.IsNullOrEmpty(searchResult.errorMsg))
                             {
-                                pkgToInstall = pkgsSatisfyingRange.First();
-                            }
-                            else
-                            {
-                                // TODO: add error message saying nothing was found for this name,version range
+                                _cmdletPassedIn.WriteError(new ErrorRecord(new PSInvalidOperationException(searchResult.errorMsg), "FindVersionGlobbingForInstallFailed", ErrorCategory.NotSpecified, null));
                                 continue;
                             }
+
+                            PSResourceInfo pkgToInstall = searchResult.returnedObject;
+                            
 
                             pkgToInstall.AdditionalMetadata.TryGetValue("NormalizedVersion", out string pkgVersion);
                             pkgToInstall.RepositorySourceLocation = repository.Uri.ToString();
@@ -421,12 +419,21 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                             if (repository.ApiVersion == PSRepositoryInfo.APIVersion.v2)
                             {
                                 responseContent = _v2ServerApiCalls.InstallVersion(pkgName, pkgVersion, repository, out string errorRecord);
+                                if (!String.IsNullOrEmpty(errorRecord))
+                                {
+                                    _cmdletPassedIn.WriteError(new ErrorRecord(new PSInvalidOperationException(errorRecord), "InstallVersionFailed", ErrorCategory.NotSpecified, null));
+                                    continue;
+                                }
                             }
                             else if (repository.ApiVersion == PSRepositoryInfo.APIVersion.v3)
                             {
                                 responseContent = _v3ServerApiCalls.InstallVersion(pkgName, pkgVersion, repository, out string errorRecord);
+                                if (!String.IsNullOrEmpty(errorRecord))
+                                {
+                                    _cmdletPassedIn.WriteError(new ErrorRecord(new PSInvalidOperationException(errorRecord), "InstallVersionFailed", ErrorCategory.NotSpecified, null));
+                                    continue;
+                                }
                             }
-                            // TODO: add error handling
 
                             bool installedSuccessfully = TryMoveInstallContent(responseContent, tempInstallPath, pkgName, pkgVersion, scope, pkgToInstall);
 
@@ -444,30 +451,43 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     foreach (string pkgName in pkgNamesToInstall)
                     {
                         string nugetVersionString = nugetVersion.ToNormalizedString(); // 3.0.17-beta
-                        // TODO: remove FindVersion and directly call install API. Add method to work with HTTPContent returned from Install to parse into PSResourceInfo
+
                         
-                         IEnumerable<PSResourceInfo> pkgToInstall = _httpFindPSResource.FindVersion(pkgName, nugetVersionString, repository, ResourceType.None);
-                        // pkgToInstall.RepositorySourceLocation = repository.Uri.ToString();
+                        PSResourceResult searchResult = _httpFindPSResource.FindVersion(pkgName, nugetVersionString, repository, ResourceType.None).First();
+                        if (!String.IsNullOrEmpty(searchResult.errorMsg))
+                        {
+                            _cmdletPassedIn.WriteError(new ErrorRecord(new PSInvalidOperationException(searchResult.errorMsg), "FindVersionForInstallFailed", ErrorCategory.NotSpecified, null));
+                            continue;
+                        }
+
+                        PSResourceInfo pkgToInstall = searchResult.returnedObject;
+                        pkgToInstall.RepositorySourceLocation = repository.Uri.ToString();
 
                         // download the module
                         HttpContent responseContent = null;
                         if (repository.ApiVersion == PSRepositoryInfo.APIVersion.v2)
                         {
                             responseContent = _v2ServerApiCalls.InstallVersion(pkgName, nugetVersionString, repository, out string errorRecord);
+                            if (!String.IsNullOrEmpty(errorRecord))
+                            {
+                                _cmdletPassedIn.WriteError(new ErrorRecord(new PSInvalidOperationException(errorRecord), "InstallVersionFailed", ErrorCategory.NotSpecified, null));
+                                continue;
+                            }
                         }
                         else if (repository.ApiVersion == PSRepositoryInfo.APIVersion.v3) {
                             responseContent = _v3ServerApiCalls.InstallVersion(pkgName, nugetVersionString, repository, out string errorRecord);
-
+                            if (!String.IsNullOrEmpty(errorRecord))
+                            {
+                                _cmdletPassedIn.WriteError(new ErrorRecord(new PSInvalidOperationException(errorRecord), "InstallVersionFailed", ErrorCategory.NotSpecified, null));
+                                continue;
+                            }
                         }
-                        // TODO: add error handling
 
-
-
-                        bool installedSuccessfully = TryMoveInstallContent(responseContent, tempInstallPath, pkgName, nugetVersionString, scope, pkgToInstall.First());
+                        bool installedSuccessfully = TryMoveInstallContent(responseContent, tempInstallPath, pkgName, nugetVersionString, scope, pkgToInstall);
 
                         if (installedSuccessfully)
                         {
-                            pkgsSuccessfullyInstalled.Add(pkgToInstall.First());
+                            pkgsSuccessfullyInstalled.Add(pkgToInstall);
                         }
                     }
                 }
@@ -477,28 +497,56 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 // InstallName
                 foreach (string pkgName in pkgNamesToInstall)
                 {
-                    PSResourceInfo pkgToInstall = _httpFindPSResource.FindName(pkgName, repository, _prerelease, ResourceType.None).First();
-                    //pkgToInstall.RepositorySourceLocation = repository.Uri.ToString();
+                    PSResourceResult searchResult = _httpFindPSResource.FindName(pkgName, repository, _prerelease, ResourceType.None).First();
+
+                    if (!String.IsNullOrEmpty(searchResult.errorMsg))
+                    {
+                        _cmdletPassedIn.WriteError(new ErrorRecord(new PSInvalidOperationException(searchResult.errorMsg), "FindVersionForInstallFailed", ErrorCategory.NotSpecified, null));
+                        continue;
+                    }
+
+                    PSResourceInfo pkgToInstall = searchResult.returnedObject;
+
+                    pkgToInstall.RepositorySourceLocation = repository.Uri.ToString();
+                    pkgToInstall.AdditionalMetadata.TryGetValue("NormalizedVersion", out string pkgVersion);
 
                     // pkgToInstall.Dependencies -> Dependency[] (string, VersionRange)
                     // helper method that takes Dependency[], checks with GetHelper which are already installed, construct dependency tree
                     // install those only which are needed
-
-                    pkgToInstall.AdditionalMetadata.TryGetValue("NormalizedVersion", out string pkgVersion);
 
                     // download the module
                     HttpContent responseContent = null;
                     if (repository.ApiVersion == PSRepositoryInfo.APIVersion.v2)
                     {
                         responseContent = _v2ServerApiCalls.InstallName(pkgName, _prerelease, repository, out string errorRecord);
+                        if (!String.IsNullOrEmpty(errorRecord))
+                        {
+                            _cmdletPassedIn.WriteError(new ErrorRecord(new PSInvalidOperationException(errorRecord), "InstallNameFailed", ErrorCategory.NotSpecified, null));
+                            continue;
+                        }
                     }
                     else if (repository.ApiVersion == PSRepositoryInfo.APIVersion.v3)
                     {
-                        responseContent = _v3ServerApiCalls.InstallName(pkgName, _prerelease, repository, out string errorRecord);
-
+                        if (_prerelease)
+                        {
+                            responseContent = _v3ServerApiCalls.InstallVersion(pkgName, pkgVersion, repository, out string errorRecord);
+                            if (!String.IsNullOrEmpty(errorRecord))
+                            {
+                                _cmdletPassedIn.WriteError(new ErrorRecord(new PSInvalidOperationException(errorRecord), "InstallVersionFailed", ErrorCategory.NotSpecified, null));
+                                continue;
+                            }
+                        }
+                        else
+                        {
+                            responseContent = _v3ServerApiCalls.InstallName(pkgName, _prerelease, repository, out string errorRecord);
+                            if (!String.IsNullOrEmpty(errorRecord))
+                            {
+                                _cmdletPassedIn.WriteError(new ErrorRecord(new PSInvalidOperationException(errorRecord), "InstallVersionFailed", ErrorCategory.NotSpecified, null));
+                                continue;
+                            }
+                        }
                     }
 
-                    // TODO: add error handling
                     bool installedSuccessfully = TryMoveInstallContent(responseContent, tempInstallPath, pkgName, pkgVersion, scope, pkgToInstall);
 
                     if (installedSuccessfully)

--- a/src/code/PSResourceResult.cs
+++ b/src/code/PSResourceResult.cs
@@ -4,7 +4,6 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 {
     public sealed class PSResourceResult
     {
-
         internal PSResourceInfo returnedObject { get; }
         internal PSCommandResourceInfo returnedCmdObject { get; }
         internal string errorMsg { get; }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
