### PR TITLE
add base class for ServerApi

### DIFF
--- a/src/code/ServerApiCall.cs
+++ b/src/code/ServerApiCall.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.PowerShell.PowerShellGet.UtilClasses;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using NuGet.Versioning;
+
+namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
+{
+    internal abstract class ServerApiCall : IServerAPICalls
+    {
+        #region Members
+
+        public readonly HttpClient s_client = new HttpClient();
+        public readonly HttpFindPSResource _httpFindPSResource = new HttpFindPSResource();
+
+        public readonly string select = "$select=Id,Version,NormalizedVersion,Authors,Copyright,Dependencies,Description,IconUrl,IsPrerelease,Published,ProjectUrl,ReleaseNotes,Tags,LicenseUrl,CompanyName";
+
+        #endregion
+
+        #region Constructor
+
+        // internal ServerApiCall() {}
+
+        #endregion
+        
+        #region Methods
+        // High level design: Find-PSResource >>> IFindPSResource (loops, version checks, etc.) >>> IServerAPICalls (call to repository endpoint/url)    
+
+        /// <summary>
+        /// Find method which allows for searching for all packages from a repository and returns latest version for each.
+        /// </summary>
+        public abstract string[] FindAll(PSRepositoryInfo repository, bool includePrerelease, ResourceType type, out string errRecord);
+
+        /// <summary>
+        /// Find method which allows for searching for packages with tag from a repository and returns latest version for each.
+        /// Examples: Search -Tag "JSON" -Repository PSGallery
+        /// API call: 
+        /// - Include prerelease: http://www.powershellgallery.com/api/v2/Search()?$filter=IsAbsoluteLatestVersion&searchTerm=tag:JSON&includePrerelease=true
+        /// </summary>
+        public abstract string[] FindTag(string tag, PSRepositoryInfo repository, bool includePrerelease, ResourceType _type, out string errRecord);
+
+        public abstract string[] FindCommandOrDscResource(string tag, PSRepositoryInfo repository, bool includePrerelease, bool isSearchingForCommands, out string errRecord);
+
+        /// <summary>
+        /// Find method which allows for searching for single name and returns latest version.
+        /// Name: no wildcard support
+        /// Examples: Search "PowerShellGet"
+        /// API call: 
+        /// - No prerelease: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
+        /// - Include prerelease: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
+        /// Implementation Note: Need to filter further for latest version (prerelease or non-prerelease dependening on user preference)
+        /// </summary>
+        public abstract string FindName(string packageName, PSRepositoryInfo repository, bool includePrerelease, ResourceType type, out string errRecord);
+
+        /// <summary>
+        /// Find method which allows for searching for single name with wildcards and returns latest version.
+        /// Name: supports wildcards
+        /// Examples: Search "PowerShell*"
+        /// API call: 
+        /// - No prerelease: http://www.powershellgallery.com/api/v2/Search()?$filter=IsLatestVersion&searchTerm='az*'
+        /// Implementation Note: filter additionally and verify ONLY package name was a match.
+        /// </summary>
+        public abstract string[] FindNameGlobbing(string packageName, PSRepositoryInfo repository, bool includePrerelease, ResourceType type, out string errRecord);
+        /// <summary>
+        /// Find method which allows for searching for single name with version range.
+        /// Name: no wildcard support
+        /// Version: supports wildcards
+        /// Examples: Search "PowerShellGet" "[3.0.0.0, 5.0.0.0]"
+        ///           Search "PowerShellGet" "3.*"
+        /// API Call: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
+        /// Implementation note: Returns all versions, including prerelease ones. Later (in the API client side) we'll do filtering on the versions to satisfy what user provided.
+        /// </summary>
+        public abstract string[] FindVersionGlobbing(string packageName, VersionRange versionRange, PSRepositoryInfo repository, bool includePrerelease, ResourceType type, bool getOnlyLatest, out string errRecord);
+
+        /// <summary>
+        /// Find method which allows for searching for single name with specific version.
+        /// Name: no wildcard support
+        /// Version: no wildcard support
+        /// Examples: Search "PowerShellGet" "2.2.5"
+        /// API call: http://www.powershellgallery.com/api/v2/Packages(Id='PowerShellGet', Version='2.2.5')
+        /// </summary>
+        public abstract string FindVersion(string packageName, string version, PSRepositoryInfo repository, ResourceType type, out string errRecord);
+
+        /**  INSTALL APIS **/
+
+        /// <summary>
+        /// Installs specific package.
+        /// Name: no wildcard support.
+        /// Examples: Install "PowerShellGet"
+        /// Implementation Note:   if not prerelease: https://www.powershellgallery.com/api/v2/package/powershellget (Returns latest stable)
+        ///                        if prerelease, the calling method should first call IFindPSResource.FindName(), 
+        ///                             then find the exact version to install, then call into install version
+        /// </summary>
+        public abstract HttpContent InstallName(string packageName, bool includePrerelease, PSRepositoryInfo repository, out string errRecord);
+
+
+        /// <summary>
+        /// Installs package with specific name and version.
+        /// Name: no wildcard support.
+        /// Version: no wildcard support.
+        /// Examples: Install "PowerShellGet" -Version "3.0.0.0"
+        ///           Install "PowerShellGet" -Version "3.0.0-beta16"
+        /// API Call: https://www.powershellgallery.com/api/v2/package/Id/version (version can be prerelease)
+        /// </summary>    
+        public abstract HttpContent InstallVersion(string packageName, string version, PSRepositoryInfo repository, out string errRecord);
+
+        #endregion
+    
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
