### PR TITLE
#969: Inject credentials to ISettings to pass them into PushRunner

### DIFF
--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -849,7 +849,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             var sourceProvider = new PackageSourceProvider(settings);
             if (Credential != null)
-              InjectCredentialsToSettings(settings, sourceProvider, publishLocation);
+            {
+                 InjectCredentialsToSettings(settings, sourceProvider, publishLocation);
+            }
+
 
             try
             {

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -954,7 +954,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
               new SourceItem(key, source));
           }
           else
-            key = packageSource.Name;
+          {
+              key = packageSource.Name;
+          }
+
 
           settings.AddOrUpdate(
             ConfigurationConstants.CredentialsSectionName,

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -963,7 +963,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
               key = packageSource.Name;
           }
 
-
           settings.AddOrUpdate(
             ConfigurationConstants.CredentialsSectionName,
             new CredentialsItem(

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -946,7 +946,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
           var networkCred = Credential.GetNetworkCredential();
           string key;
+          
           if (packageSource == null)
+
           {
             key = "_" + Guid.NewGuid().ToString().Replace("-", "");
             settings.AddOrUpdate(

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -969,7 +969,8 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
               key,
               networkCred.UserName,
               networkCred.Password,
-              true, ""));
+              isPasswordClearText: true,
+              String.Empty));
         }
 
     #endregion

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -936,7 +936,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
           var packageSource = sourceProvider.LoadPackageSources().FirstOrDefault(s => s.Source == source);
           if (packageSource != null)
-            if (!packageSource.IsEnabled) packageSource.IsEnabled = true;
+          {
+                if (!packageSource.IsEnabled)
+                {
+                    packageSource.IsEnabled = true;
+                }
+           }
+
 
           var networkCred = Credential.GetNetworkCredential();
           string key;

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -929,7 +929,11 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         private void InjectCredentialsToSettings(ISettings settings, IPackageSourceProvider sourceProvider, string source)
         {
-          if (Credential == null) return;
+          if (Credential == null)
+          {
+               return;
+          }
+
           var packageSource = sourceProvider.LoadPackageSources().FirstOrDefault(s => s.Source == source);
           if (packageSource != null)
             if (!packageSource.IsEnabled) packageSource.IsEnabled = true;

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -846,11 +846,16 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             var settings = NuGet.Configuration.Settings.LoadDefaultSettings(null, null, null);
             var success = false;
+
+            var sourceProvider = new PackageSourceProvider(settings);
+            if (Credential != null)
+              InjectCredentialsToSettings(settings, sourceProvider, publishLocation);
+
             try
             {
                 PushRunner.Run(
                         settings: Settings.LoadDefaultSettings(root: null, configFileName: null, machineWideSettings: null),
-                        sourceProvider: new PackageSourceProvider(settings),
+                        sourceProvider: sourceProvider,
                         packagePaths: new List<string> { fullNupkgFile },
                         source: publishLocation,
                         apiKey: ApiKey,
@@ -922,6 +927,34 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
         }
 
-        #endregion
-    }
+        private void InjectCredentialsToSettings(ISettings settings, IPackageSourceProvider sourceProvider, string source)
+        {
+          if (Credential == null) return;
+          var packageSource = sourceProvider.LoadPackageSources().FirstOrDefault(s => s.Source == source);
+          if (packageSource != null)
+            if (!packageSource.IsEnabled) packageSource.IsEnabled = true;
+
+          var networkCred = Credential.GetNetworkCredential();
+          string key;
+          if (packageSource == null)
+          {
+            key = "_" + Guid.NewGuid().ToString().Replace("-", "");
+            settings.AddOrUpdate(
+              ConfigurationConstants.PackageSources,
+              new SourceItem(key, source));
+          }
+          else
+            key = packageSource.Name;
+
+          settings.AddOrUpdate(
+            ConfigurationConstants.CredentialsSectionName,
+            new CredentialsItem(
+              key,
+              networkCred.UserName,
+              networkCred.Password,
+              true, ""));
+        }
+
+    #endregion
+  }
 }


### PR DESCRIPTION
# PR Summary
Inject credentials passed to `Publish-PSResource` into `ISettings` object in order to pass them along to the `PushRunner` that pushes the .nupkg to the feed.
Should solve #969

## PR Context
This allows publishing PS resources to an authenticated feed.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
