### PR TITLE
Resolve bug with Find-PSResource -Type Module not returning modules

### DIFF
--- a/src/code/V2ResponseUtil.cs
+++ b/src/code/V2ResponseUtil.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 if (elemList.Length == 0)
                 {
                     // this indicates we got a non-empty, XML response (as noticed for V2 server) but it's not a response that's meaningful (contains 'properties')
-                    string errorMsg = $"Response didn't contain properties element";
+                    string errorMsg = $"Package does not exist on the server.";
                     yield return new PSResourceResult(returnedObject: null, errorMsg: errorMsg, isTerminatingError: false);
                 }
 

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -248,8 +248,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             // This should return the latest stable version or the latest prerelease version (respectively)
             // https://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'&$filter=IsLatestVersion and substringof('PSModule', Tags) eq true
-            string typeFilterPart = type == ResourceType.Script ? $" and substringof('PS{type.ToString()}', Tags) eq true " : string.Empty;
-            var requestUrlV2 = $"{repository.Uri}/FindPackagesById()?id='{packageName}'&$filter={prerelease}{typeFilterPart}&{select}";
+            // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
+            string idFilterPart = $" and Id eq '{packageName}'";
+            string typeFilterPart = GetTypeFilterForRequest(type);
+            var requestUrlV2 = $"{repository.Uri}/FindPackagesById()?id='{packageName}'&$filter={prerelease}{idFilterPart}{typeFilterPart}&{select}";
 
             return HttpRequestCall(requestUrlV2, out edi);  
         }
@@ -267,15 +269,16 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             // This should return the latest stable version or the latest prerelease version (respectively)
             // https://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'&$filter=IsLatestVersion and substringof('PSModule', Tags) eq true
-            string typeFilterPart = type == ResourceType.Script ? $" and substringof('PS{type.ToString()}', Tags) eq true " : string.Empty;
-
+            // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
+            string idFilterPart = $" and Id eq '{packageName}'";
+            string typeFilterPart = GetTypeFilterForRequest(type);
             string tagFilterPart = String.Empty;
             foreach (string tag in tags)
             {
                 tagFilterPart += $" and substringof('{tag}', Tags) eq true";
             }
 
-            var requestUrlV2 = $"{repository.Uri}/FindPackagesById()?id='{packageName}'&$filter={prerelease}{typeFilterPart}{tagFilterPart}&{select}";
+            var requestUrlV2 = $"{repository.Uri}/FindPackagesById()?id='{packageName}'&$filter={prerelease}{idFilterPart}{typeFilterPart}{tagFilterPart}&{select}";
 
             return HttpRequestCall(requestUrlV2, out edi);  
         }
@@ -426,8 +429,10 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             // https://www.powershellgallery.com/api/v2/FindPackagesById()?id='blah'&includePrerelease=false&$filter= NormalizedVersion eq '1.1.0' and substringof('PSModule', Tags) eq true 
             // Quotations around package name and version do not matter, same metadata gets returned.
-            string typeFilterPart = type == ResourceType.Script ? $" and substringof('PS{type.ToString()}', Tags) eq true " : string.Empty;
-            var requestUrlV2 = $"{repository.Uri}/FindPackagesById()?id='{packageName}'&$filter= NormalizedVersion eq '{version}'{typeFilterPart}&{select}";
+            // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
+            string idFilterPart = $" and Id eq '{packageName}'";
+            string typeFilterPart = GetTypeFilterForRequest(type);
+            var requestUrlV2 = $"{repository.Uri}/FindPackagesById()?id='{packageName}'&$filter= NormalizedVersion eq '{version}'{idFilterPart}{typeFilterPart}&{select}";
             
             return HttpRequestCall(requestUrlV2, out edi);  
         }
@@ -440,14 +445,16 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// </summary>
         public override string FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ExceptionDispatchInfo edi)
         {
-            string typeFilterPart = type == ResourceType.Script ? $" and substringof('PS{type.ToString()}', Tags) eq true " : string.Empty;
+            // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
+            string idFilterPart = $" and Id eq '{packageName}'";
+            string typeFilterPart = GetTypeFilterForRequest(type);
             string tagFilterPart = String.Empty;
             foreach (string tag in tags)
             {
                 tagFilterPart += $" and substringof('{tag}', Tags) eq true";
             }
 
-            var requestUrlV2 = $"{repository.Uri}/FindPackagesById()?id='{packageName}'&$filter= NormalizedVersion eq '{version}'{typeFilterPart}{tagFilterPart}&{select}";
+            var requestUrlV2 = $"{repository.Uri}/FindPackagesById()?id='{packageName}'&$filter= NormalizedVersion eq '{version}'{idFilterPart}{typeFilterPart}{tagFilterPart}&{select}";
             
             return HttpRequestCall(requestUrlV2, out edi);
         }
@@ -651,7 +658,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 return string.Empty;
             }
 
-            string typeFilterPart = type == ResourceType.Script ? $" and substringof('PS{type.ToString()}', Tags) eq true " : string.Empty;
+            string typeFilterPart = GetTypeFilterForRequest(type);
             var requestUrlV2 = $"{repository.Uri}/Search()?$filter={nameFilter}{typeFilterPart} and {prerelease}&{select}{extraParam}";
             
             return HttpRequestCall(requestUrlV2, out edi);  
@@ -714,7 +721,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 tagFilterPart += $" and substringof('{tag}', Tags) eq true";
             }
             
-            string typeFilterPart = type == ResourceType.Script ? $" and substringof('PS{type.ToString()}', Tags) eq true " : string.Empty;
+            string typeFilterPart = GetTypeFilterForRequest(type);
             var requestUrlV2 = $"{repository.Uri}/Search()?$filter={nameFilter}{tagFilterPart}{typeFilterPart} and {prerelease}&{select}{extraParam}";
             
             return HttpRequestCall(requestUrlV2, out edi);  
@@ -782,9 +789,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             string filterQuery = "&$filter=";
             filterQuery += includePrerelease ? string.Empty : "IsPrerelease eq false";
-
-            string joiningOperator = filterQuery.EndsWith("=") ? String.Empty : " and " ;
-            filterQuery += type == ResourceType.Script ? $"{joiningOperator}substringof('PS{type.ToString()}', Tags) eq true" : String.Empty;
+            
+            string andOperator = " and ";
+            string joiningOperator = filterQuery.EndsWith("=") ? String.Empty : andOperator;
+            // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
+            string idFilterPart = $"{joiningOperator}Id eq '{packageName}'";
+            filterQuery += idFilterPart;
+            filterQuery += type == ResourceType.Script ? $"{andOperator}substringof('PS{type.ToString()}', Tags) eq true" : String.Empty;
 
             if (!String.IsNullOrEmpty(versionFilterParts))
             {
@@ -792,8 +803,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 // Single case where version is "*" (or "[,]") and includePrerelease is true, then we do not want to add "$filter" to the requestUrl.
         
                 // Note: could be null/empty if Version was "*" -> [,]
-                joiningOperator = filterQuery.EndsWith("=") ? String.Empty : " and " ;
-                filterQuery +=  $"{joiningOperator}{versionFilterParts}";
+                filterQuery +=  $"{andOperator}{versionFilterParts}";
             }
 
             string topParam = getOnlyLatest ? "$top=1" : "$top=100"; // only need 1 package if interested in latest
@@ -803,6 +813,20 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             var requestUrlV2 = $"{repository.Uri}/FindPackagesById()?id='{packageName}'&$orderby=NormalizedVersion desc&{paginationParam}&{select}{filterQuery}";
 
             return HttpRequestCall(requestUrlV2, out edi);  
+        }
+
+        private string GetTypeFilterForRequest(ResourceType type) {
+            string typeFilterPart = string.Empty;
+            if (type == ResourceType.Script)
+            {
+                typeFilterPart += $" and substringof('PS{type.ToString()}', Tags) eq true ";
+            }
+            else if (type == ResourceType.Module)
+            {
+                typeFilterPart += $" and substringof('PS{ResourceType.Script.ToString()}', Tags) eq false ";
+            }
+
+            return typeFilterPart;
         }
 
         /// <summary>

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -248,7 +248,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             // This should return the latest stable version or the latest prerelease version (respectively)
             // https://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'&$filter=IsLatestVersion and substringof('PSModule', Tags) eq true
-            string typeFilterPart = type == ResourceType.None ? $" and Id eq '{packageName}'" :  $" and substringof('PS{type.ToString()}', Tags) eq true";
+            string typeFilterPart = type == ResourceType.Script ? $" and substringof('PS{type.ToString()}', Tags) eq true " : string.Empty;
             var requestUrlV2 = $"{repository.Uri}/FindPackagesById()?id='{packageName}'&$filter={prerelease}{typeFilterPart}&{select}";
 
             return HttpRequestCall(requestUrlV2, out edi);  
@@ -267,7 +267,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             // This should return the latest stable version or the latest prerelease version (respectively)
             // https://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'&$filter=IsLatestVersion and substringof('PSModule', Tags) eq true
-            string typeFilterPart = type == ResourceType.None ? $" and Id eq '{packageName}'" :  $" and substringof('PS{type.ToString()}', Tags) eq true";
+            string typeFilterPart = type == ResourceType.Script ? $" and substringof('PS{type.ToString()}', Tags) eq true " : string.Empty;
 
             string tagFilterPart = String.Empty;
             foreach (string tag in tags)
@@ -424,9 +424,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// </summary>
         public override string FindVersion(string packageName, string version, ResourceType type, out ExceptionDispatchInfo edi) 
         {
-            // https://www.powershellgallery.com/api/v2//FindPackagesById()?id='blah'&includePrerelease=false&$filter= NormalizedVersion eq '1.1.0' and substringof('PSModule', Tags) eq true 
+            // https://www.powershellgallery.com/api/v2/FindPackagesById()?id='blah'&includePrerelease=false&$filter= NormalizedVersion eq '1.1.0' and substringof('PSModule', Tags) eq true 
             // Quotations around package name and version do not matter, same metadata gets returned.
-            string typeFilterPart = type == ResourceType.None ? String.Empty :  $" and substringof('PS{type.ToString()}', Tags) eq true";
+            string typeFilterPart = type == ResourceType.Script ? $" and substringof('PS{type.ToString()}', Tags) eq true " : string.Empty;
             var requestUrlV2 = $"{repository.Uri}/FindPackagesById()?id='{packageName}'&$filter= NormalizedVersion eq '{version}'{typeFilterPart}&{select}";
             
             return HttpRequestCall(requestUrlV2, out edi);  
@@ -440,8 +440,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// </summary>
         public override string FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ExceptionDispatchInfo edi)
         {
-            string typeFilterPart = type == ResourceType.None ? String.Empty :  $" and substringof('PS{type.ToString()}', Tags) eq true";
-
+            string typeFilterPart = type == ResourceType.Script ? $" and substringof('PS{type.ToString()}', Tags) eq true " : string.Empty;
             string tagFilterPart = String.Empty;
             foreach (string tag in tags)
             {
@@ -652,8 +651,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 return string.Empty;
             }
 
-            string typeFilterPart = type == ResourceType.None ? String.Empty :  $" and substringof('PS{type.ToString()}', Tags) eq true";
-            
+            string typeFilterPart = type == ResourceType.Script ? $" and substringof('PS{type.ToString()}', Tags) eq true " : string.Empty;
             var requestUrlV2 = $"{repository.Uri}/Search()?$filter={nameFilter}{typeFilterPart} and {prerelease}&{select}{extraParam}";
             
             return HttpRequestCall(requestUrlV2, out edi);  
@@ -716,7 +714,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 tagFilterPart += $" and substringof('{tag}', Tags) eq true";
             }
             
-            string typeFilterPart = type == ResourceType.None ? String.Empty :  $" and substringof('PS{type.ToString()}', Tags) eq true";
+            string typeFilterPart = type == ResourceType.Script ? $" and substringof('PS{type.ToString()}', Tags) eq true " : string.Empty;
             var requestUrlV2 = $"{repository.Uri}/Search()?$filter={nameFilter}{tagFilterPart}{typeFilterPart} and {prerelease}&{select}{extraParam}";
             
             return HttpRequestCall(requestUrlV2, out edi);  
@@ -784,10 +782,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
 
             string filterQuery = "&$filter=";
             filterQuery += includePrerelease ? string.Empty : "IsPrerelease eq false";
-            //filterQuery +=  type == ResourceType.None ? String.Empty : $" and substringof('PS{type.ToString()}', Tags) eq true";
 
             string joiningOperator = filterQuery.EndsWith("=") ? String.Empty : " and " ;
-            filterQuery += type == ResourceType.None ? String.Empty : $"{joiningOperator}substringof('PS{type.ToString()}', Tags) eq true";
+            filterQuery += type == ResourceType.Script ? $"{joiningOperator}substringof('PS{type.ToString()}', Tags) eq true" : String.Empty;
 
             if (!String.IsNullOrEmpty(versionFilterParts))
             {

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -354,4 +354,11 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
             $item.ParentResource.Includes.DscResource | Should -Contain $dscResourceName
         }
     }
+    <## NOTE:  THIS TEST SHOULD BE RUN MANUALLY BEFORE EACH RELEASE ##
+    It "find resource given CommandName" {
+        $res = Find-PSResource -Name "MicrosoftPowerBIMgmt" -Repository $PSGalleryName -Type Module
+
+        $res.Name | Should -Be "MicrosoftPowerBIMgmt"
+    }
+    #>
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Resolve bug when running `Find-PSResource` with `-Type` parameter.  See issue below for more details.

## PR Context

Resolves #1044 #1026 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
