### PR TITLE
fix version range bug for Update-PSResource

### DIFF
--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -364,6 +364,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     continue;
                 }
 
+                string repoNuGetVersionString = Utils.GetNormalizedVersionString(repositoryPackage.Version.ToString(), repositoryPackage.Prerelease);
+                // If the current package is out of range, install it with the correct version.
+                if (!NuGetVersion.TryParse(repoNuGetVersionString, out NuGetVersion repoVersion))
+                {
+                    WriteWarning($"Cannot parse nuget version for repository package '{repositoryPackage.Name}'. Cannot update package.");
+                    continue;
+                }
+
                 // If the current package is out of range, install it with the correct version.
                 if (!NuGetVersion.TryParse(installedPackage.Version.ToString(), out NuGetVersion installedVersion))
                 {
@@ -371,8 +379,13 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     continue;
                 }
 
-                if (((versionRange == null || versionRange == VersionRange.All) && repositoryPackage.Version > installedPackage.Version) ||
-                    (versionRange != null && !versionRange.Satisfies(installedVersion)))
+                // cases in which to update:
+                // versionRange: null/*,        , repoVersion : 2.0.0-beta, installedVersion: 1.5.0
+                // versionRange: [1.8.0, 2.1.0] , repoVersion: 2.0.0, installedVersion: 1.6.0 
+                // versionRange: [, 2.1.0]      , repoVersion: 2.0.0, installedVersion: 1.5.0 (installedVersion satisfies requirement, but there's later version)
+                if (((versionRange == null || versionRange == VersionRange.All) && repoVersion > installedVersion) ||
+                    (versionRange != null && !versionRange.Satisfies(installedVersion)) ||
+                    versionRange != null && repoVersion > installedVersion && versionRange.Satisfies(repoVersion))
                 {
                     namesToUpdate.Add(repositoryPackage.Name);
                 }

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -384,7 +384,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 // versionRange: [1.8.0, 2.1.0] , repoVersion: 2.0.0, installedVersion: 1.6.0 
                 // versionRange: [, 2.1.0]      , repoVersion: 2.0.0, installedVersion: 1.5.0 (installedVersion satisfies requirement, but there's later version)
                 if (((versionRange == null || versionRange == VersionRange.All) && repoVersion > installedVersion) ||
-                    (versionRange != null && !versionRange.Satisfies(installedVersion)) ||
                     versionRange != null && repoVersion > installedVersion && versionRange.Satisfies(repoVersion))
                 {
                     namesToUpdate.Add(repositoryPackage.Name);

--- a/test/UpdatePSResourceTests/UpdatePSResourceV2Tests.ps1
+++ b/test/UpdatePSResourceTests/UpdatePSResourceV2Tests.ps1
@@ -89,29 +89,25 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
         $isPkgUpdated | Should -BeTrue
     }
 
-    $testCases2 = @{Version="[3.0.0.0]";           ExpectedVersions=@("1.0.0.0", "3.0.0.0"); Reason="validate version, exact match"},
-                  @{Version="3.0.0.0";             ExpectedVersions=@("1.0.0.0", "3.0.0.0"); Reason="validate version, exact match without bracket syntax"},
-                  @{Version="[3.0.0.0, 5.0.0.0]";  ExpectedVersions=@("1.0.0.0", "3.0.0.0", "5.0.0.0"); Reason="validate version, exact range inclusive"},
-                  @{Version="(3.0.0.0, 6.0.0.0)";  ExpectedVersions=@("1.0.0.0", "3.0.0.0", "5.0.0.0"); Reason="validate version, exact range exclusive"},
-                  @{Version="(3.0.0.0,)";          ExpectedVersions=@("1.0.0.0", "5.0.0.0"); Reason="validate version, minimum version exclusive"},
-                  @{Version="[3.0.0.0,)";          ExpectedVersions=@("1.0.0.0", "3.0.0.0", "5.0.0.0"); Reason="validate version, minimum version inclusive"},
-                  @{Version="(,5.0.0.0)";          ExpectedVersions=@("1.0.0.0", "3.0.0.0"); Reason="validate version, maximum version exclusive"},
-                  @{Version="(,5.0.0.0]";          ExpectedVersions=@("1.0.0.0", "3.0.0.0", "5.0.0.0"); Reason="validate version, maximum version inclusive"},
-                  @{Version="[1.0.0.0, 5.0.0.0)";  ExpectedVersions=@("1.0.0.0", "3.0.0.0"); Reason="validate version, mixed inclusive minimum and exclusive maximum version"}
-                  @{Version="(1.0.0.0, 3.0.0.0]";  ExpectedVersions=@("1.0.0.0", "3.0.0.0"); Reason="validate version, mixed exclusive minimum and inclusive maximum version"}
+    $testCases2 = @{Version="[3.0.0.0]";           UpdatedVersion="3.0.0.0"; Reason="validate version, exact match"},
+                  @{Version="3.0.0.0";             UpdatedVersion="3.0.0.0"; Reason="validate version, exact match without bracket syntax"},
+                  @{Version="[3.0.0.0, 5.0.0.0]";  UpdatedVersion="5.0.0.0"; Reason="validate version, exact range inclusive"},
+                  @{Version="(3.0.0.0, 6.0.0.0)";  UpdatedVersion="5.0.0.0"; Reason="validate version, exact range exclusive"},
+                  @{Version="(3.0.0.0,)";          UpdatedVersion="5.0.0.0"; Reason="validate version, minimum version exclusive"},
+                  @{Version="[3.0.0.0,)";          UpdatedVersion="5.0.0.0"; Reason="validate version, minimum version inclusive"},
+                  @{Version="(,5.0.0.0)";          UpdatedVersion="3.0.0.0"; Reason="validate version, maximum version exclusive"},
+                  @{Version="(,5.0.0.0]";          UpdatedVersion="5.0.0.0"; Reason="validate version, maximum version inclusive"},
+                  @{Version="[1.0.0.0, 5.0.0.0)";  UpdatedVersion="3.0.0.0"; Reason="validate version, mixed inclusive minimum and exclusive maximum version"}
+                  @{Version="(1.0.0.0, 3.0.0.0]";  UpdatedVersion="3.0.0.0"; Reason="validate version, mixed exclusive minimum and inclusive maximum version"}
 
     It "Update resource when given Name to <Reason> <Version>" -TestCases $testCases2{
-        param($Version, $ExpectedVersions)
+        param($Version, $UpdatedVersion)
 
         Install-PSResource -Name $testModuleName -Version "1.0.0.0" -Repository $PSGalleryName -TrustRepository
-        Update-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -TrustRepository
+        $res = Update-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -TrustRepository -PassThru -SkipDependencyCheck
 
-        $res = Get-PSResource -Name $testModuleName
-
-        foreach ($item in $res) {
-            $item.Name | Should -Be $testModuleName
-            $ExpectedVersions | Should -Contain $item.Version
-        }
+        $res.Name | Should -Be $testModuleName
+        $res.Version | Should -Be $UpdatedVersion
     }
 
     $testCases = @(

--- a/test/UpdatePSResourceTests/UpdatePSResourceV3Tests.ps1
+++ b/test/UpdatePSResourceTests/UpdatePSResourceV3Tests.ps1
@@ -53,29 +53,25 @@ Describe 'Test HTTP Update-PSResource for V3 Server Protocol' -tags 'CI' {
         $isPkgUpdated | Should -BeTrue
     }
 
-    $testCases2 = @{Version="[3.0.0]";           ExpectedVersions=@("1.0.0", "3.0.0"); Reason="validate version, exact match"},
-                  @{Version="3.0.0";             ExpectedVersions=@("1.0.0", "3.0.0"); Reason="validate version, exact match without bracket syntax"},
-                  @{Version="[3.0.0, 5.0.0]";  ExpectedVersions=@("1.0.0", "3.0.0", "5.0.0"); Reason="validate version, exact range inclusive"},
-                  @{Version="(3.0.0, 6.0.0)";  ExpectedVersions=@("1.0.0", "3.0.0", "5.0.0"); Reason="validate version, exact range exclusive"},
-                  @{Version="(3.0.0,)";          ExpectedVersions=@("1.0.0", "5.0.0"); Reason="validate version, minimum version exclusive"},
-                  @{Version="[3.0.0,)";          ExpectedVersions=@("1.0.0", "3.0.0", "5.0.0"); Reason="validate version, minimum version inclusive"},
-                  @{Version="(,5.0.0)";          ExpectedVersions=@("1.0.0", "3.0.0"); Reason="validate version, maximum version exclusive"},
-                  @{Version="(,5.0.0]";          ExpectedVersions=@("1.0.0", "3.0.0", "5.0.0"); Reason="validate version, maximum version inclusive"},
-                  @{Version="[1.0.0, 5.0.0)";  ExpectedVersions=@("1.0.0", "3.0.0"); Reason="validate version, mixed inclusive minimum and exclusive maximum version"}
-                  @{Version="(1.0.0, 3.0.0]";  ExpectedVersions=@("1.0.0", "3.0.0"); Reason="validate version, mixed exclusive minimum and inclusive maximum version"}
+    $testCases2 = @{Version="[3.0.0.0]";           UpdatedVersion="3.0.0"; Reason="validate version, exact match"},
+                  @{Version="3.0.0.0";             UpdatedVersion="3.0.0"; Reason="validate version, exact match without bracket syntax"},
+                  @{Version="[3.0.0.0, 5.0.0.0]";  UpdatedVersion="5.0.0"; Reason="validate version, exact range inclusive"},
+                  @{Version="(3.0.0.0, 6.0.0.0)";  UpdatedVersion="5.0.0"; Reason="validate version, exact range exclusive"},
+                  @{Version="(3.0.0.0,)";          UpdatedVersion="5.0.0"; Reason="validate version, minimum version exclusive"},
+                  @{Version="[3.0.0.0,)";          UpdatedVersion="5.0.0"; Reason="validate version, minimum version inclusive"},
+                  @{Version="(,5.0.0.0)";          UpdatedVersion="3.0.0"; Reason="validate version, maximum version exclusive"},
+                  @{Version="(,5.0.0.0]";          UpdatedVersion="5.0.0"; Reason="validate version, maximum version inclusive"},
+                  @{Version="[1.0.0.0, 5.0.0.0)";  UpdatedVersion="3.0.0"; Reason="validate version, mixed inclusive minimum and exclusive maximum version"}
+                  @{Version="(1.0.0.0, 3.0.0.0]";  UpdatedVersion="3.0.0"; Reason="validate version, mixed exclusive minimum and inclusive maximum version"}
 
     It "Update resource when given Name to <Reason> <Version>" -TestCases $testCases2{
-        param($Version, $ExpectedVersions)
+        param($Version, $UpdatedVersion)
 
         Install-PSResource -Name $testModuleName -Version "1.0.0.0" -Repository $NuGetGalleryName -TrustRepository
-        Update-PSResource -Name $testModuleName -Version $Version -Repository $NuGetGalleryName -TrustRepository
+        $res = Update-PSResource -Name $testModuleName -Version $Version -Repository $NuGetGalleryName -TrustRepository -PassThru -SkipDependencyCheck
 
-        $res = Get-PSResource -Name $testModuleName
-
-        foreach ($item in $res) {
-            $item.Name | Should -Be $testModuleName
-            $ExpectedVersions | Should -Contain $item.Version
-        }
+        $res.Name | Should -Be $testModuleName
+        $res.Version | Should -Be $UpdatedVersion
     }
 
     $testCases = @(


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Resolves #943 #696

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
