### PR TITLE
Update -WhatIf message in Uninstall-PSResoure

### DIFF
--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -189,13 +189,6 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                 currentUninstalledDirCount++;
                 pkgName = Utils.GetInstalledPackageName(pkgPath);
 
-                if (!ShouldProcess(string.Format("Uninstall resource '{0}' from the machine.", pkgName)))
-                {
-                    WriteVerbose("ShouldProcess is set to false.");
-                    successfullyUninstalled = true;
-                    continue;
-                }
-
                 // show uninstall progress info
                 int activityId = 0;
                 string activity = string.Format("Uninstalling {0}...", pkgName);
@@ -249,6 +242,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
             }
 
             DirectoryInfo dir = new DirectoryInfo(pkgPath);
+            Uri uri = new Uri(dir.FullName);
+            string version = uri.Segments.Last();
+            if (!ShouldProcess(string.Format("Uninstall resource '{0}', version '{1}', from path '{2}'", pkgName, version, dir.FullName)))
+            {
+                WriteVerbose("ShouldProcess is set to false.");
+                return true;
+            }
+
             dir.Attributes &= ~FileAttributes.ReadOnly;
 
             try
@@ -292,6 +293,12 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         {
             errRecord = null;
             var successfullyUninstalledPkg = false;
+
+            if (!ShouldProcess(string.Format("Uninstall resource '{0}' from path '{1}'", pkgName, pkgPath)))
+            {
+                WriteVerbose("ShouldProcess is set to false.");
+                return true;
+            }
 
             // delete the appropriate file
             try

--- a/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
@@ -234,9 +234,19 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
     }
 
     It "Uninstall module using -WhatIf, should not uninstall the module" {
+        Start-Transcript .\testUninstallWhatIf.txt
         Uninstall-PSResource -Name $testModuleName -WhatIf
+        Stop-Transcript
+
         $pkg = Get-InstalledPSResource $testModuleName -Version "5.0.0.0"
         $pkg.Version | Should -Be "5.0.0.0"
+
+        $match = Get-Content .\testUninstallWhatIf.txt | 
+            select-string -pattern "What if: Performing the operation ""Uninstall-PSResource"" on target ""Uninstall resource 'test_module2', version '5.0.0.0', from path '" -SimpleMatch
+
+        $match -ne $null
+
+        RemoveItem -path .\testUninstallWhatIf.txt
     }
 
     It "Do not Uninstall module that is a dependency for another module" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Update message for `-WhatIf` parameter to include version of the module being uninstalled and path for both the module and script being uninstalled. 

Displaying the version of the script would require either modification of what gets returned in GetHelper or re-parsing the script info file to find the script version. If there's a request to add this information in the future we can look into ways to more elegantly handle this scenario.
 
## PR Context

Resolves #673 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
