### PR TITLE
Add support for floating versions

### DIFF
--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -219,8 +219,38 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                 return true;
             }
 
+            bool isVersionRange;
+            if (version.Contains("*"))
+            {
+                string modifiedVersion;
+                string[] versionSplit = version.Split(new string[] { "." }, StringSplitOptions.None);
+                if (versionSplit.Length == 2 && versionSplit[1].Equals("*"))
+                {
+                    // eg: 2.* should translate to the version range "[2.0,2.99999]" 
+                    modifiedVersion = $"[{versionSplit[0]}.0,{versionSplit[0]}.999999]";
+                }
+                else if (versionSplit.Length == 3 && versionSplit[2].Equals("*"))
+                {
+                    // eg: 2.1.* should translate to the version range "[2.1.0,2.1.99999]" 
+                    modifiedVersion = $"[{versionSplit[0]}.{versionSplit[1]}.0,{versionSplit[0]}.{versionSplit[1]}.999999]";
+                }
+                else if (versionSplit.Length == 4 && versionSplit[3].Equals("*"))
+                {
+                    // eg: 2.8.8.* should translate to the version range "[2.1.3.0,2.1.3.99999]" 
+                    modifiedVersion = $"[{versionSplit[0]}.{versionSplit[1]}.{versionSplit[2]}.0,{versionSplit[0]}.{versionSplit[1]}.{versionSplit[2]}.999999]";
+                }
+                else {
+                    error = "Argument for -Version parameter is not in the proper format";
+                    return false;
+                }
+                VersionRange.TryParse(modifiedVersion, out versionRange);
+                versionType = VersionType.VersionRange;
+
+                return true;
+            }
+
             bool isNugetVersion = NuGetVersion.TryParse(version, out nugetVersion);
-            bool isVersionRange = VersionRange.TryParse(version, out versionRange);
+            isVersionRange = VersionRange.TryParse(version, out versionRange);
 
             if (!isNugetVersion && !isVersionRange)
             {

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -243,6 +243,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                     error = "Argument for -Version parameter is not in the proper format";
                     return false;
                 }
+
                 VersionRange.TryParse(modifiedVersion, out versionRange);
                 versionType = VersionType.VersionRange;
 

--- a/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
@@ -107,6 +107,13 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
         $pkg.Version | Should -Be "5.0.0"
     }
 
+    It "Install resource when given Name, Version '3.*', should install the appropriate version" {
+        Install-PSResource -Name $testModuleName -Version "3.*" -Repository $localRepo -TrustRepository
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "3.0.0"
+    }
+
     It "Install resource with latest (including prerelease) version given Prerelease parameter" {
         Install-PSResource -Name $testModuleName -Prerelease -Repository $localRepo -TrustRepository 
         $pkg = Get-InstalledPSResource $testModuleName

--- a/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
@@ -79,6 +79,13 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
         $pkg.Name | Should -Be $testModuleName
         $pkg.Version | Should -Be "1.0.0.0"
     }
+    
+    It "Should install resource given name and exact version with bracket syntax" {
+        Install-PSResource -Name $testModuleName -Version "3.*" -Repository $PSGalleryName -TrustRepository  
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "3.0.0.0"
+    }
 
     It "Should install resource given name and exact version with bracket syntax" {
         Install-PSResource -Name $testModuleName -Version "[1.0.0]" -Repository $PSGalleryName -TrustRepository  

--- a/test/SavePSResourceTests/SavePSResourceLocalTests.ps1
+++ b/test/SavePSResourceTests/SavePSResourceLocalTests.ps1
@@ -62,6 +62,14 @@ Describe 'Test Save-PSResource for local repositories' -tags 'CI' {
         $pkgDirVersion = Get-ChildItem $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "1.0.0"
     }
+    
+    It "Should save resource given name and version '3.*'" {
+        Save-PSResource -Name $moduleName -Version "3.*" -Repository $localRepo -Path $SaveDir -TrustRepository
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $moduleName
+        $pkgDir | Should -Not -BeNullOrEmpty
+        $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
+        $pkgDirVersion.Name | Should -Be "3.0.0"
+    }
 
     It "Should save resource given name and exact version with bracket syntax" {
         Save-PSResource -Name $moduleName -Version "[1.0.0]" -Repository $localRepo -Path $SaveDir -TrustRepository

--- a/test/SavePSResourceTests/SavePSResourceV2Tests.ps1
+++ b/test/SavePSResourceTests/SavePSResourceV2Tests.ps1
@@ -71,6 +71,14 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
         $pkgDirVersion.Name | Should -Be "1.0.0.0"
     }
 
+    It "Should save resource given name and version '3.*'" {
+        Save-PSResource -Name $testModuleName -Version "3.*" -Repository $PSGalleryName -Path $SaveDir -TrustRepository
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir | Should -Not -BeNullOrEmpty
+        $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
+        $pkgDirVersion.Name | Should -Be "3.0.0.0"
+    }
+
     It "Should save resource given name and exact version with bracket syntax" {
         Save-PSResource -Name $testModuleName -Version "[1.0.0]" -Repository $PSGalleryName -Path $SaveDir -TrustRepository
         $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName

--- a/test/UpdatePSResourceTests/UpdatePSResourceLocalTests.ps1
+++ b/test/UpdatePSResourceTests/UpdatePSResourceLocalTests.ps1
@@ -94,6 +94,23 @@ Describe 'Test Update-PSResource for local repositories' -tags 'CI' {
         $isPkgUpdated | Should -BeTrue
     }
 
+    It "Update resource installed given Name and Version '3.*' parameters" {
+        Install-PSResource -Name $moduleName -Version "1.0.0" -Repository $localRepo -TrustRepository
+
+        Update-PSResource -Name $moduleName -Version "3.*" -Repository $localRepo -TrustRepository
+        $res = Get-InstalledPSResource -Name $moduleName
+        $isPkgUpdated = $false
+        foreach ($pkg in $res)
+        {
+            if ([System.Version]$pkg.Version -eq [System.Version]"3.0.0")
+            {
+                $isPkgUpdated = $true
+            }
+        }
+
+        $isPkgUpdated | Should -BeTrue
+    }
+
     # Windows only
     It "update resource under CurrentUser scope" -skip:(!($IsWindows -and (Test-IsAdmin))) {
         # TODO: perhaps also install TestModule with the highest version (the one above 1.2.0.0) to the AllUsers path too

--- a/test/UpdatePSResourceTests/UpdatePSResourceV2Tests.ps1
+++ b/test/UpdatePSResourceTests/UpdatePSResourceV2Tests.ps1
@@ -134,6 +134,23 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
         $isPkgUpdated | Should -Be $false
     }
 
+    It "Update resource installed given Name and Version '3.*' parameters" {
+        Install-PSResource -Name $testModuleName -Version "1.0.0" -Repository $PSGalleryName -TrustRepository
+
+        Update-PSResource -Name $testModuleName -Version "3.*" -Repository $PSGalleryName -TrustRepository
+        $res = Get-InstalledPSResource -Name $testModuleName
+        $isPkgUpdated = $false
+        foreach ($pkg in $res)
+        {
+            if ([System.Version]$pkg.Version -eq [System.Version]"3.0.0")
+            {
+                $isPkgUpdated = $true
+            }
+        }
+
+        $isPkgUpdated | Should -BeTrue
+    }
+
     It "Update resource with latest (including prerelease) version given Prerelease parameter" {
         Install-PSResource -Name $testModuleName -Version "1.0.0.0" -Repository $PSGalleryName -TrustRepository
         Update-PSResource -Name $testModuleName -Prerelease -Repository $PSGalleryName -TrustRepository


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Install-PSResource, Save-PSResource, and Update-PSResource now uses the latest version within a wildcard range (for example "2.*") instead of simply the latest version (regardless of range provided).

Note, the upper end of the version range should end in an inclusive .9999 in order to exclude prerelease packages for the next highest version.
For example:
[2.0, 3.0) will include prerelease versions of 3.0
however,
[2.0, 2.9999] will not include prerelease versions of 3.0.  

## PR Context
Resolves #867 
Resolves #684 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
