### PR TITLE
Add bugfix for parsing nuspec tags for local repos

### DIFF
--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -538,7 +538,9 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     }
 
                     pkgMetadata.Add(_fileTypeKey, Utils.MetadataFileType.Nuspec);
-                    pkgTags.AddRange(pkgMetadata["tags"] as string[]);
+                    string nuspecTags = pkgMetadata["tags"] as string;
+                    string[] nuspecTagsArray = nuspecTags.Split(new char[]{' '});
+                    pkgTags.AddRange(nuspecTagsArray);
                 }
                 else
                 {

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -21,6 +21,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         Get-NewPSResourceRepositoryFile
         Register-LocalRepos
 
+        $localRepoUriAddress = Join-Path -Path $TestDrive -ChildPath "testdir"
         $tagsEscaped = @("'Test'", "'Tag2'", "'$cmdName'", "'$dscName'")
         $prereleaseLabel = "alpha001"
 
@@ -37,11 +38,20 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         Get-RevertPSResourceRepositoryFile
     }
 
-    It "find resource given specific Name, Version null" {
+    It "find resource given specific Name, Version null (module)" {
         # FindName()
         $res = Find-PSResource -Name $testModuleName -Repository $localRepo
         $res.Name | Should -Be $testModuleName
         $res.Version | Should -Be "5.0.0"
+    }
+
+    It "find resource given Name, Version null (package containing nuspec only)" {
+        # FindName()
+        $pkgName = "test_nonpsresource"
+        Save-PSResource -Name $pkgName -Repository "NuGetGallery" -Path $localRepoUriAddress -AsNupkg
+        $res = Find-PSResource -Name $pkgName -Repository $localRepo
+        $res.Name | Should -Be $pkgName
+        $res.Repository | Should -Be $localRepo
     }
 
     It "should not find resource given nonexistant Name" {

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -48,10 +48,12 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
     It "find resource given Name, Version null (package containing nuspec only)" {
         # FindName()
         $pkgName = "test_nonpsresource"
+        $requiredTag = "Tag1"
         Save-PSResource -Name $pkgName -Repository "NuGetGallery" -Path $localRepoUriAddress -AsNupkg
         $res = Find-PSResource -Name $pkgName -Repository $localRepo
         $res.Name | Should -Be $pkgName
         $res.Repository | Should -Be $localRepo
+        $res.Tags | Should -Contain $requiredTag
     }
 
     It "should not find resource given nonexistant Name" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The tags property is a string, not string[] in the .nuspec file. For non-powershell resources when we default to parsing the .nuspec we should parse tags out as string. Otherwise it fails with an error.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
