### PR TITLE
Alias 'Tag' alias to New-PSScriptFile, Update-PSScriptFileInfo, and Update-ModuleManifest

### DIFF
--- a/src/code/NewPSScriptFile.cs
+++ b/src/code/NewPSScriptFile.cs
@@ -99,6 +99,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// The tags associated with the script.
         /// </summary>
         [Parameter]
+        [Alias("Tag")]
         [ValidateNotNullOrEmpty()]
         public string[] Tags { get; set; }
 

--- a/src/code/UpdateModuleManifest.cs
+++ b/src/code/UpdateModuleManifest.cs
@@ -198,6 +198,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// Specifies an array of tags.
         /// </summary>
         [Parameter]
+        [Alias("Tag")]
         public string[] Tags { get; set; }
 
         /// <summary>

--- a/src/code/UpdatePSScriptFileInfo.cs
+++ b/src/code/UpdatePSScriptFileInfo.cs
@@ -134,6 +134,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// The tags associated with the script.
         /// </summary>
         [Parameter]
+        [Alias("Tag")]
         [ValidateNotNullOrEmpty()]
         public string[] Tags { get; set; }
 

--- a/test/PSScriptFileInfoTests/NewPSScriptFile.Tests.ps1
+++ b/test/PSScriptFileInfoTests/NewPSScriptFile.Tests.ps1
@@ -151,6 +151,20 @@ Describe "Test New-PSScriptFile" -tags 'CI' {
         $results.Contains(".TAGS $tag1 $tag2") | Should -BeTrue
     }
 
+    It "Create new .ps1 given Tag parameter" {
+        $description = "Test Description"
+        $tag1 = "tag1"
+        $tag2 = "tag2"
+
+        New-PSScriptFile -Path $script:testScriptFilePath -Tag $tag1, $tag2 -Description $description 
+
+        Test-Path -Path $script:testScriptFilePath | Should -BeTrue
+        $results = Get-Content -Path $script:testScriptFilePath -Raw
+        $results.Contains($tag1) | Should -BeTrue
+        $results.Contains($tag2) | Should -BeTrue
+        $results.Contains(".TAGS $tag1 $tag2") | Should -BeTrue
+    }
+
     It "Create new .ps1 given ProjectUri parameter" {
         $description = "Test Description"
         $projectUri = "https://www.testprojecturi.com/"

--- a/test/PSScriptFileInfoTests/UpdatePSScriptFileInfo.Tests.ps1
+++ b/test/PSScriptFileInfoTests/UpdatePSScriptFileInfo.Tests.ps1
@@ -290,6 +290,19 @@ Describe "Test Update-PSScriptFileInfo" -tags 'CI' {
         $results.Contains(".TAGS $tag1 $tag2") | Should -BeTrue
     }
 
+    It "update script file Tag property" {
+        $tag1 = "tag1"
+        $tag2 = "tag2"
+        Update-PSScriptFileInfo -Path $script:testScriptFilePath -Tag $tag1, $tag2
+        Test-PSScriptFile $script:testScriptFilePath | Should -Be $true
+
+        Test-Path -Path $script:testScriptFilePath | Should -BeTrue
+        $results = Get-Content -Path $script:testScriptFilePath -Raw
+        $results.Contains($tag1) | Should -BeTrue
+        $results.Contains($tag2) | Should -BeTrue
+        $results.Contains(".TAGS $tag1 $tag2") | Should -BeTrue
+    }
+
     It "throw error when attempting to update a signed script without -RemoveSignature parameter" {
         # Note: user should sign the script again once it's been updated
 

--- a/test/UpdateModuleManifest/UpdateModuleManifest.Tests.ps1
+++ b/test/UpdateModuleManifest/UpdateModuleManifest.Tests.ps1
@@ -118,6 +118,17 @@ Describe 'Test Update-ModuleManifest' {
         $results.PrivateData.PSData.Tags | Should -Be @($Tag1, $Tag2) 
     }
 
+    It "Update module manifest given Tag parameter" {
+        $Description = "Test Description"
+        $Tag1 = "tag1"
+        $Tag2 = "tag2"
+        New-ModuleManifest -Path $script:testManifestPath -Description $Description
+        Update-ModuleManifest -Path $script:testManifestPath -Tag $Tag1, $Tag2
+
+        $results = Test-ModuleManifest -Path $script:testManifestPath
+        $results.PrivateData.PSData.Tags | Should -Be @($Tag1, $Tag2) 
+    }
+
     It "Update module manifest given ProjectUri parameter" {
         $Description = "Test Description"
         $ProjectUri = "https://www.testprojecturi.com/"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Add `-Tag` alias for the `-Tags` parameter in `New-PSScriptFile`, `Update-PSScriptFileInfo`, and `Update-ModuleManifest`

## PR Context

Resolves #1079 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
