### PR TITLE
Change InputObject type to array for Install-PSResource, Save-PSResource, and Uninstall-PSResource

### DIFF
--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -146,7 +146,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         [Parameter(Mandatory = true, Position = 0, ValueFromPipelineByPropertyName = true, ValueFromPipeline = true, ParameterSetName = InputObjectParameterSet, HelpMessage = "PSResourceInfo object to install.")]
         [Alias("ParentResource")]
         [ValidateNotNullOrEmpty]
-        public PSResourceInfo InputObject { get; set; }
+        public PSResourceInfo[] InputObject { get; set; }
 
         /// <summary>
         /// Installs resources based on input from a .psd1 (hashtable) or .json file.
@@ -285,14 +285,16 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     break;
                     
                 case InputObjectParameterSet:
-                    string normalizedVersionString = Utils.GetNormalizedVersionString(InputObject.Version.ToString(), InputObject.Prerelease);
-                    ProcessInstallHelper(
-                        pkgNames: new string[] { InputObject.Name },
-                        pkgVersion: normalizedVersionString,
-                        pkgPrerelease: InputObject.IsPrerelease,
-                        pkgRepository: new string[]{ InputObject.Repository },
-                        pkgCredential: Credential,
-                        reqResourceParams: null);
+                    foreach (var inputObj in InputObject) {
+                        string normalizedVersionString = Utils.GetNormalizedVersionString(inputObj.Version.ToString(), inputObj.Prerelease);
+                        ProcessInstallHelper(
+                            pkgNames: new string[] { inputObj.Name },
+                            pkgVersion: normalizedVersionString,
+                            pkgPrerelease: inputObj.IsPrerelease,
+                            pkgRepository: new string[]{ inputObj.Repository },
+                            pkgCredential: Credential,
+                            reqResourceParams: null);
+                    }
                     break;
 
                 case RequiredResourceFileParameterSet:

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -150,7 +150,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         [Parameter(Mandatory = true, Position = 0, ValueFromPipelineByPropertyName = true, ValueFromPipeline = true, ParameterSetName = InputObjectParameterSet, HelpMessage = "PSResourceInfo object representing the package to save.")]
         [ValidateNotNullOrEmpty]
         [Alias("ParentResource")]
-        public PSResourceInfo InputObject { get; set; }
+        public PSResourceInfo[] InputObject { get; set; }
 
         /// <summary>
         /// Skips the check for resource dependencies, so that only found resources are saved,
@@ -200,13 +200,14 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     break;
 
                 case InputObjectParameterSet:
-                    string normalizedVersionString = Utils.GetNormalizedVersionString(InputObject.Version.ToString(), InputObject.Prerelease);
-                    ProcessSaveHelper(
-                        pkgNames: new string[] { InputObject.Name },
-                        pkgVersion: normalizedVersionString,
-                        pkgPrerelease: InputObject.IsPrerelease,
-                        pkgRepository: new string[] { InputObject.Repository });
-
+                    foreach (var inputObj in InputObject) {
+                        string normalizedVersionString = Utils.GetNormalizedVersionString(inputObj.Version.ToString(), inputObj.Prerelease);
+                        ProcessSaveHelper(
+                            pkgNames: new string[] { inputObj.Name },
+                            pkgVersion: normalizedVersionString,
+                            pkgPrerelease: inputObj.IsPrerelease,
+                            pkgRepository: new string[] { inputObj.Repository });
+                    }
                     break;
 
                 default:

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
         /// </summary>
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = InputObjectParameterSet, HelpMessage = "PSResourceInfo representing package to uninstall.")]
         [ValidateNotNullOrEmpty]
-        public PSResourceInfo InputObject { get; set; }
+        public PSResourceInfo[] InputObject { get; set; }
 
         /// <summary>
         /// Skips check to see if other resources are dependent on the resource being uninstalled.
@@ -131,28 +131,29 @@ namespace Microsoft.PowerShell.PowerShellGet.Cmdlets
                     break;
 
                 case InputObjectParameterSet:
-                    string inputObjectPrerelease = InputObject.Prerelease;
-                    string inputObjectVersion = String.IsNullOrEmpty(inputObjectPrerelease) ? InputObject.Version.ToString() : Utils.GetNormalizedVersionString(versionString: InputObject.Version.ToString(), prerelease: inputObjectPrerelease);
-                    if (!Utils.TryParseVersionOrVersionRange(
-                        version: inputObjectVersion,
-                        versionRange: out _versionRange))
-                    {
-                        var exMessage = String.Format("Version '{0}' for resource '{1}' cannot be parsed.", InputObject.Version.ToString(), InputObject.Name);
-                        var ex = new ArgumentException(exMessage);
-                        var ErrorParsingVersion = new ErrorRecord(ex, "ErrorParsingVersion", ErrorCategory.ParserError, null);
-                        WriteError(ErrorParsingVersion);
-                    }
+                    foreach (var inputObj in InputObject) {
+                        string inputObjectPrerelease = inputObj.Prerelease;
+                        string inputObjectVersion = String.IsNullOrEmpty(inputObjectPrerelease) ? inputObj.Version.ToString() : Utils.GetNormalizedVersionString(versionString: inputObj.Version.ToString(), prerelease: inputObjectPrerelease);
+                        if (!Utils.TryParseVersionOrVersionRange(
+                            version: inputObjectVersion,
+                            versionRange: out _versionRange))
+                        {
+                            var exMessage = String.Format("Version '{0}' for resource '{1}' cannot be parsed.", inputObj.Version.ToString(), inputObj.Name);
+                            var ex = new ArgumentException(exMessage);
+                            var ErrorParsingVersion = new ErrorRecord(ex, "ErrorParsingVersion", ErrorCategory.ParserError, null);
+                            WriteError(ErrorParsingVersion);
+                        }
 
-                    Name = new string[] { InputObject.Name };
-                    if (!String.IsNullOrWhiteSpace(InputObject.Name) && !UninstallPkgHelper())
-                    {
-                        // specific errors will be displayed lower in the stack
-                        var exMessage = String.Format(string.Format("Did not successfully uninstall package {0}", InputObject.Name));
-                        var ex = new ArgumentException(exMessage);
-                        var UninstallResourceError = new ErrorRecord(ex, "UninstallResourceError", ErrorCategory.InvalidOperation, null);
-                            WriteError(UninstallResourceError);
+                        Name = new string[] { inputObj.Name };
+                        if (!String.IsNullOrWhiteSpace(inputObj.Name) && !UninstallPkgHelper())
+                        {
+                            // specific errors will be displayed lower in the stack
+                            var exMessage = String.Format(string.Format("Did not successfully uninstall package {0}", inputObj.Name));
+                            var ex = new ArgumentException(exMessage);
+                            var UninstallResourceError = new ErrorRecord(ex, "UninstallResourceError", ErrorCategory.InvalidOperation, null);
+                                WriteError(UninstallResourceError);
+                        }
                     }
-                
                     break;
 
                 default:

--- a/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
@@ -129,6 +129,16 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
         $pkg.Version | Should -Be "5.0.0"
     }
 
+    It "Install resource via InputObject by piping from Find-PSResource" {
+        $modules = Find-PSResource -Name "*" -Repository $localRepo 
+        $modules.Count | Should -BeGreaterThan 1
+
+        Install-PSResource -TrustRepository -InputObject $modules
+
+        $pkg = Get-InstalledPSResource $modules.Name
+        $pkg.Count | Should -BeGreaterThan 1
+    }
+
     It "Install resource under location specified in PSModulePath" {
         Install-PSResource -Name $testModuleName -Repository $localRepo -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName

--- a/test/SavePSResourceTests/SavePSResourceLocalTests.ps1
+++ b/test/SavePSResourceTests/SavePSResourceLocalTests.ps1
@@ -142,10 +142,11 @@ Describe 'Test Save-PSResource for local repositories' -tags 'CI' {
         $modules = Find-PSResource -Name "*" -Repository $localRepo 
         $modules.Count | Should -BeGreaterThan 1
 
-        Save-PSResource -TrustRepository -InputObject $modules
-
-        $pkg = Get-InstalledPSResource $modules.Name
-        $pkg.Count | Should -BeGreaterThan 1
+        Save-PSResource -Path $SaveDir -TrustRepository -InputObject $modules
+        
+        $pkgDir = Get-ChildItem -Path $SaveDir
+        $pkgDir | Should -Not -BeNullOrEmpty
+        $pkgDir.Count | Should -BeGreaterThan 1
     }
 
     # Save module that is not authenticode signed

--- a/test/SavePSResourceTests/SavePSResourceLocalTests.ps1
+++ b/test/SavePSResourceTests/SavePSResourceLocalTests.ps1
@@ -138,6 +138,16 @@ Describe 'Test Save-PSResource for local repositories' -tags 'CI' {
         $res.Version | Should -Be "1.0.0"
     }
 
+    It "Save module via InputObject by piping from Find-PSResource" {
+        $modules = Find-PSResource -Name "*" -Repository $localRepo 
+        $modules.Count | Should -BeGreaterThan 1
+
+        Save-PSResource -TrustRepository -InputObject $modules
+
+        $pkg = Get-InstalledPSResource $modules.Name
+        $pkg.Count | Should -BeGreaterThan 1
+    }
+
     # Save module that is not authenticode signed
     # Should FAIL to save the module
     It "Save module that is not authenticode signed" -Skip:(!(Get-IsWindows)) {

--- a/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
@@ -273,6 +273,16 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
         $res | Should -BeNullOrEmpty
     }
 
+    It "Install resource via InputObject by piping from Find-PSResource" {
+        $modules = Install-PSResource -Name $testModuleName, $testScriptName -Repository $PSGalleryName 
+        $modules.Count | Should -BeGreaterThan 1
+
+        Uninstall-PSResource -TrustRepository -InputObject $modules
+
+        $pkg = Get-InstalledPSResource $modules.Name
+        $pkg.Count | Should -BeGreaterThan 1
+    }
+
     It "Uninstall module that is not installed should throw error" {
         Uninstall-PSResource -Name "NonInstalledModule" -ErrorVariable ev -ErrorAction SilentlyContinue
         $ev.FullyQualifiedErrorId | Should -BeExactly 'UninstallResourceError,Microsoft.PowerShell.PowerShellGet.Cmdlets.UninstallPSResource'

--- a/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
@@ -274,13 +274,14 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
     }
 
     It "Install resource via InputObject by piping from Find-PSResource" {
-        $modules = Install-PSResource -Name $testModuleName, $testScriptName -Repository $PSGalleryName 
-        $modules.Count | Should -BeGreaterThan 1
-
-        Uninstall-PSResource -TrustRepository -InputObject $modules
-
-        $pkg = Get-InstalledPSResource $modules.Name
+        Install-PSResource -Name $testModuleName, $testScriptName -Repository $PSGalleryName -TrustRepository
+        $pkg = Get-InstalledPSResource $testModuleName, $testScriptName
         $pkg.Count | Should -BeGreaterThan 1
+
+        Uninstall-PSResource -InputObject $pkg
+
+        $foundPkgs = Get-InstalledPSResource $pkg.Name
+        $foundPkgs.Count | Should -Be 0
     }
 
     It "Uninstall module that is not installed should throw error" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Change the type of `-InputObject` from `PSResource` to `PSResource[]` for `Install-PSResource`, `Save-PSResource`, and `Uninstall-PSResource`.

## PR Context
Resolves #1078 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
