### PR TITLE
Add check to see if results are empty in tests

### DIFF
--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -201,6 +201,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
 
     It "find resource given CommandName" {
         $res = Find-PSResource -CommandName $commandName -Repository $localRepo
+        $res | Should -Not -BeNullOrEmpty
         foreach ($item in $res) {
             $item.Names | Should -Be $commandName
             $item.ParentResource.Includes.Command | Should -Contain $commandName
@@ -209,6 +210,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
 
     It "find resource given DscResourceName" {
         $res = Find-PSResource -DscResourceName $dscResourceName -Repository $localRepo
+        $res | Should -Not -BeNullOrEmpty
         foreach ($item in $res) {
             $item.Names | Should -Be $dscResourceName    
             $item.ParentResource.Includes.DscResource | Should -Contain $dscResourceName

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -70,6 +70,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         # FindVersionGlobbing()
         param($Version, $ExpectedVersions)
         $res = Find-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName
+        $res | Should -Not -BeNullOrEmpty
         foreach ($item in $res) {
             $item.Name | Should -Be $testModuleName
             $ExpectedVersions | Should -Contain $item.Version

--- a/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
@@ -60,6 +60,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         # FindVersionGlobbing()
         param($Version, $ExpectedVersions)
         $res = Find-PSResource -Name $testModuleName -Version $Version -Repository $NuGetGalleryName
+        $res | Should -Not -BeNullOrEmpty
         foreach ($item in $res) {
             $item.Name | Should -Be $testModuleName
             $ExpectedVersions | Should -Contain $item.Version

--- a/test/UpdatePSResourceTests/UpdatePSResourceV2Tests.ps1
+++ b/test/UpdatePSResourceTests/UpdatePSResourceV2Tests.ps1
@@ -31,7 +31,7 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
 
         Update-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository
         $res = Get-InstalledPSResource -Name $testModuleName
-
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -50,7 +50,7 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
 
         Update-PSResource -Name "test_mod*" -Repository $PSGalleryName -TrustRepository
         $res = Get-InstalledPSResource -Name "test_mod*" -Version "5.0.0.0"
-
+        $res | Should -Not -BeNullOrEmpty
         $inputHashtable = @{test_module = "1.0.0.0"; test_module2 = "1.0.0.0"}
         $isTest_ModuleUpdated = $false
         $isTest_Module2Updated = $false
@@ -78,6 +78,7 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
 
         Update-PSResource -Name $testModuleName -Version "5.0.0.0" -Repository $PSGalleryName -TrustRepository
         $res = Get-InstalledPSResource -Name $testModuleName
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -122,6 +123,7 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
         Update-PSResource -Name $testModuleName -Version $Version -Repository $PSGalleryName -TrustRepository 2>$null
 
         $res = Get-InstalledPSResource -Name $testModuleName
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -139,6 +141,7 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
 
         Update-PSResource -Name $testModuleName -Version "3.*" -Repository $PSGalleryName -TrustRepository
         $res = Get-InstalledPSResource -Name $testModuleName
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -155,7 +158,7 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
         Install-PSResource -Name $testModuleName -Version "1.0.0.0" -Repository $PSGalleryName -TrustRepository
         Update-PSResource -Name $testModuleName -Prerelease -Repository $PSGalleryName -TrustRepository
         $res = Get-InstalledPSResource -Name $testModuleName
-
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -178,7 +181,7 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
         Update-PSResource -Name $testModuleName -Version "3.0.0.0" -Repository $PSGalleryName -TrustRepository -Scope CurrentUser
 
         $res = Get-InstalledPSResource -Name $testModuleName
-
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -210,7 +213,7 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
         Update-PSResource -Name $testModuleName -Version "3.0.0.0" -Repository $PSGalleryName -TrustRepository -verbose
 
         $res = Get-InstalledPSResource -Name $testModuleName
-
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -234,7 +237,7 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
         Update-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository -Scope CurrentUser
 
         $res = Get-InstalledPSResource -Name $testModuleName
-
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -258,7 +261,7 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
         Update-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository -Scope AllUsers
 
         $res = Get-InstalledPSResource -Name $testModuleName
-
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -282,7 +285,7 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
         Update-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository
 
         $res = Get-InstalledPSResource -Name $testModuleName
-
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -318,7 +321,7 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
         Update-PSResource -Name $testModuleName -WhatIf -Repository $PSGalleryName -TrustRepository
 
         $res = Get-InstalledPSResource -Name $testModuleName
-
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {

--- a/test/UpdatePSResourceTests/UpdatePSResourceV3Tests.ps1
+++ b/test/UpdatePSResourceTests/UpdatePSResourceV3Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Test HTTP Update-PSResource for V3 Server Protocol' -tags 'CI' {
 
         Update-PSResource -Name $testModuleName -Repository $NuGetGalleryName -TrustRepository
         $res = Get-InstalledPSResource -Name $testModuleName
-
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -42,6 +42,7 @@ Describe 'Test HTTP Update-PSResource for V3 Server Protocol' -tags 'CI' {
 
         Update-PSResource -Name $testModuleName -Version "5.0.0.0" -Repository $NuGetGalleryName -TrustRepository
         $res = Get-InstalledPSResource -Name $testModuleName
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -86,6 +87,7 @@ Describe 'Test HTTP Update-PSResource for V3 Server Protocol' -tags 'CI' {
         Update-PSResource -Name $testModuleName -Version $Version -Repository $NuGetGalleryName -TrustRepository 2>$null
 
         $res = Get-InstalledPSResource -Name $testModuleName
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -102,7 +104,7 @@ Describe 'Test HTTP Update-PSResource for V3 Server Protocol' -tags 'CI' {
         Install-PSResource -Name $testModuleName -Version "1.0.0.0" -Repository $NuGetGalleryName -TrustRepository
         Update-PSResource -Name $testModuleName -Prerelease -Repository $NuGetGalleryName -TrustRepository
         $res = Get-InstalledPSResource -Name $testModuleName
-
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -125,7 +127,7 @@ Describe 'Test HTTP Update-PSResource for V3 Server Protocol' -tags 'CI' {
         Update-PSResource -Name $testModuleName -Version "3.0.0.0" -Repository $NuGetGalleryName -TrustRepository -Scope CurrentUser
 
         $res = Get-InstalledPSResource -Name $testModuleName
-
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -157,7 +159,7 @@ Describe 'Test HTTP Update-PSResource for V3 Server Protocol' -tags 'CI' {
         Update-PSResource -Name $testModuleName -Version "3.0.0.0" -Repository $NuGetGalleryName -TrustRepository -verbose
 
         $res = Get-InstalledPSResource -Name $testModuleName
-
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -181,7 +183,7 @@ Describe 'Test HTTP Update-PSResource for V3 Server Protocol' -tags 'CI' {
         Update-PSResource -Name $testModuleName -Repository $NuGetGalleryName -TrustRepository -Scope CurrentUser
 
         $res = Get-InstalledPSResource -Name $testModuleName
-
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -205,7 +207,7 @@ Describe 'Test HTTP Update-PSResource for V3 Server Protocol' -tags 'CI' {
         Update-PSResource -Name $testModuleName -Repository $NuGetGalleryName -TrustRepository -Scope AllUsers
 
         $res = Get-InstalledPSResource -Name $testModuleName
-
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -229,7 +231,7 @@ Describe 'Test HTTP Update-PSResource for V3 Server Protocol' -tags 'CI' {
         Update-PSResource -Name $testModuleName -Repository $NuGetGalleryName -TrustRepository
 
         $res = Get-InstalledPSResource -Name $testModuleName
-
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {
@@ -265,7 +267,7 @@ Describe 'Test HTTP Update-PSResource for V3 Server Protocol' -tags 'CI' {
         Update-PSResource -Name $testModuleName -WhatIf -Repository $NuGetGalleryName -TrustRepository
 
         $res = Get-InstalledPSResource -Name $testModuleName
-
+        $res | Should -Not -BeNullOrEmpty
         $isPkgUpdated = $false
         foreach ($pkg in $res)
         {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Some tests are incorrectly passing because they do not entire the for loop that validates results.  This PR simply adds a check to see if results are empty before validating.

## PR Context

Resolves #1122 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
