### PR TITLE
Remove PSModulePath reference when searching paths

### DIFF
--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -721,21 +721,13 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
                out string programFilesPath);
 
             List<string> resourcePaths = new List<string>();
-
-            // Path search order is PSModulePath paths first, then default paths.
-            if (scope is null)
-            {
-                string psModulePath = Environment.GetEnvironmentVariable("PSModulePath");
-                resourcePaths.AddRange(psModulePath.Split(Path.PathSeparator).ToList());
-            }
-
             if (scope is null || scope.Value is ScopeType.CurrentUser)
             {
                 resourcePaths.Add(Path.Combine(myDocumentsPath, "Modules"));
                 resourcePaths.Add(Path.Combine(myDocumentsPath, "Scripts"));
             }
 
-            if (scope is null || scope.Value is ScopeType.AllUsers)
+            if (scope.Value is ScopeType.AllUsers)
             {
                 resourcePaths.Add(Path.Combine(programFilesPath, "Modules"));
                 resourcePaths.Add(Path.Combine(programFilesPath, "Scripts"));


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR removes all references to `PSModulePath` so that the only module/script paths PSGet searches through are those that are hardcoded for `CurrentUser` and `AllUsers`.  Note that post-GA we will work on searching paths specified in `PSModulePath`, however we currently don't have a clear plan for how we want to handle `PSModulePath` . To mitigate breaking changes, we'll start with this PR as a conservative measure. 

`CurrentUser` scope is now the default scope.

## PR Context
Resolves #1049 
Resolves #881 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
