### PR TITLE
Bug fix for PSCredentialInfo constructor

### DIFF
--- a/src/code/PSCredentialInfo.cs
+++ b/src/code/PSCredentialInfo.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.PowerShellGet.UtilClasses
 			else
 				SecretName = hashtable["Name"] as string;
 
-			if (hashtable.ContainsKey("Credential") && hashtable["PSCredential"] is PSCredential psCred)
+			if (hashtable.ContainsKey("Credential") && hashtable["Credential"] is PSCredential psCred)
 			{
 				Credential = psCred;
 			}

--- a/test/PSCredentialInfo.Tests.ps1
+++ b/test/PSCredentialInfo.Tests.ps1
@@ -41,6 +41,17 @@ Describe "Create PSCredentialInfo with VaultName, SecretName, and Credential" -t
         $credentialInfo.VaultName | Should -Be "testvault"
         $credentialInfo.SecretName | Should -Be $randomSecret
     }
+
+    It "Creates PSCredentialInfo successfully from hashtable" {
+        $randomSecret = [System.IO.Path]::GetRandomFileName()
+        $randomPassword = [System.IO.Path]::GetRandomFileName()
+        $credential = New-Object System.Management.Automation.PSCredential ("username", (ConvertTo-SecureString $randomPassword -AsPlainText -Force))
+        $hash = @{ "VaultName" = "testvault" ; "SecretName" = $randomSecret ; "Credential" = $credential }
+        $credentialInfo = New-Object Microsoft.PowerShell.PowerShellGet.UtilClasses.PSCredentialInfo ($hash)
+        
+        $credentialInfo.VaultName | Should -Be "testvault"
+        $credentialInfo.SecretName | Should -Be $randomSecret
+    }
 }
 
 Describe "Create PSCredentialInfo from a PSObject" -tags 'CI' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Small bug fix for one of the constructors of the PSCredentialInfo object.  It attempts to convert the key "PSCredential" into a PSCredential object, however the expected key is actually "Credential", not "PSCredential".

## PR Context
Resolves #1127 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
