### PR TITLE
Remove references to en-us directory

### DIFF
--- a/.ci/ci_auto.yml
+++ b/.ci/ci_auto.yml
@@ -155,8 +155,6 @@ stages:
           $null = New-Item -Path $signOutPath -ItemType Directory
         }
 
-        # en-US
-        Copy-Item -Path (Join-Path -Path $srcPath -ChildPath "en-US") -Dest $signOutPath -Recurse
         # Copy Notice.txt
         Copy-Item -Path (Join-Path -Path $srcPath -ChildPath "Notice.txt") -Dest $signOutPath
         # Copy LICENSE

--- a/.ci/ci_release.yml
+++ b/.ci/ci_release.yml
@@ -167,8 +167,6 @@ stages:
           $null = New-Item -Path $signOutPath -ItemType Directory
         }
 
-        # en-US
-        Copy-Item -Path (Join-Path -Path $srcPath -ChildPath "en-US") -Dest $signOutPath -Recurse
         # Copy Notice.txt
         Copy-Item -Path (Join-Path -Path $srcPath -ChildPath "Notice.txt") -Dest $signOutPath
         # Copy LICENSE


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
AutoBuild CI pipeline is broken due to error:
`Copy-Item : Cannot find path 'D:\a\_work\1\s\out\PSResourceGet\en-US' because it does not exist.`

Since we no longer have an `en-US` directory, I've removed the lines that copy the directory contents in both the AutoBuild and Release yamls.

## PR Context
CI Autobuild is broken in Azure DevOps.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
