### PR TITLE
Add paging to V3 server queries

### DIFF
--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -624,29 +624,43 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private JsonElement[] GetVersionedPackageEntriesFromSearchQueryResource(string queryTerm, bool includePrerelease, out ExceptionDispatchInfo edi)
         {
-            JsonElement[] pkgEntries = new JsonElement[]{};
+            List<JsonElement> pkgEntries = new List<JsonElement>();
+
             Dictionary<string, string> resources = GetResourcesFromServiceIndex(out edi);
             if (edi != null)
             {
-                return pkgEntries;
+                return pkgEntries.ToArray();
             }
 
             string searchQueryServiceUrl = FindSearchQueryService(resources, out edi);
             if (edi != null)
             {
-                return pkgEntries;
+                return pkgEntries.ToArray();
             }
 
-            string query = $"{searchQueryServiceUrl}?q={queryTerm}&prerelease={includePrerelease}&semVerLevel=2.0.0";
+            // Get initial response 
+            int skip = 0;
+            string query = $"{searchQueryServiceUrl}?q={queryTerm}&prerelease={includePrerelease}&semVerLevel=2.0.0&skip={skip}&take=100";
 
             // Get responses for all packages that contain the required tags
-            pkgEntries = GetJsonElementArr(query, dataName, out edi);
+            pkgEntries.AddRange(GetJsonElementArr(query, dataName, out int initialCount, out edi).ToList());
+
+            // check count (ie "totalHits") 425 ==> count/100  ~~> 5 calls 
+            int count = initialCount / 100;
+            // if more than 100 count, loop and add response to list
+            while (count > 0)
+            {
+                skip += 100;
+                pkgEntries.AddRange(GetJsonElementArr(query, dataName, out int unneededCount, out edi).ToList());
+                count--;
+            }
+
             if (edi != null)
             {
                 return new JsonElement[]{};
             }
 
-            return pkgEntries;
+            return pkgEntries.ToArray();
         }
 
         /// <summary>
@@ -656,7 +670,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private Dictionary<string, string> GetResourcesFromServiceIndex(out ExceptionDispatchInfo edi)
         {
             Dictionary<string, string> resources = new Dictionary<string, string>();
-            JsonElement[] resourcesArray = GetJsonElementArr($"{Repository.Uri}", resourcesName, out edi);
+            JsonElement[] resourcesArray = GetJsonElementArr($"{Repository.Uri}", resourcesName, out int totalHits, out edi);
             if (edi != null)
             {
                 return resources;
@@ -1001,10 +1015,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method that parses response for given property and returns result for that property as a JsonElement array.
         /// </summary>
-        private JsonElement[] GetJsonElementArr(string request, string propertyName, out ExceptionDispatchInfo edi)
+        private JsonElement[] GetJsonElementArr(string request, string propertyName, out int totalHits, out ExceptionDispatchInfo edi)
         {
             List<JsonElement> responseEntries = new List<JsonElement>();
             JsonElement[] entries = new JsonElement[0];
+            totalHits = 0;
             try
             { 
                 string response = HttpRequestCall(request, out edi);
@@ -1019,6 +1034,16 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     foreach (JsonElement entry in entryElement.EnumerateArray())
                     {
                         responseEntries.Add(entry.Clone());
+                    }
+
+                    if (!pkgsDom.RootElement.TryGetProperty("totalHits", out JsonElement totalHitsElement))
+                    {
+                        totalHits = 0;
+                    }
+                    if (!int.TryParse(totalHitsElement.ToString(), out totalHits))
+                    {
+                        string errMsg = $"GetCountFromResponse(): Error parsing totalHits.";
+                        edi = ExceptionDispatchInfo.Capture(new JsonParsingException(errMsg));
                     }
 
                     entries = responseEntries.ToArray();

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -1036,14 +1036,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         responseEntries.Add(entry.Clone());
                     }
 
-                    if (!pkgsDom.RootElement.TryGetProperty("totalHits", out JsonElement totalHitsElement))
+                    totalHits = 0;
+                    if (pkgsDom.RootElement.TryGetProperty("totalHits", out JsonElement totalHitsElement))
                     {
-                        totalHits = 0;
-                    }
-                    if (!int.TryParse(totalHitsElement.ToString(), out totalHits))
-                    {
-                        string errMsg = $"GetCountFromResponse(): Error parsing totalHits.";
-                        edi = ExceptionDispatchInfo.Capture(new JsonParsingException(errMsg));
+                        int.TryParse(totalHitsElement.ToString(), out totalHits);
                     }
 
                     entries = responseEntries.ToArray();

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -298,7 +298,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
 
-            JsonElement[] matchingPkgEntries = GetVersionedPackageEntriesFromSearchQueryResource(querySearchTerm, includePrerelease, out edi);
+            var matchingPkgEntries = GetVersionedPackageEntriesFromSearchQueryResource(querySearchTerm, includePrerelease, out edi);
             if (edi != null)
             {
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -363,7 +363,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string tagsQueryTerm = $"tags:{String.Join(" ", tags)}";
             // Get responses for all packages that contain the required tags
             // example query: 
-            JsonElement[] tagPkgEntries = GetVersionedPackageEntriesFromSearchQueryResource(tagsQueryTerm, includePrerelease, out edi);
+            var tagPkgEntries = GetVersionedPackageEntriesFromSearchQueryResource(tagsQueryTerm, includePrerelease, out edi);
             if (edi != null)
             {
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -622,20 +622,19 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// i.e when the package Name being searched for contains wildcards or a Tag query search is performed
         /// This is called by FindNameGlobbingFromNuGetRepo() and FindTagsFromNuGetRepo()
         /// </summary>
-        private JsonElement[] GetVersionedPackageEntriesFromSearchQueryResource(string queryTerm, bool includePrerelease, out ExceptionDispatchInfo edi)
+        private List<JsonElement> GetVersionedPackageEntriesFromSearchQueryResource(string queryTerm, bool includePrerelease, out ExceptionDispatchInfo edi)
         {
-            List<JsonElement> pkgEntries = new List<JsonElement>();
-
+            List<JsonElement> pkgEntries = new();
             Dictionary<string, string> resources = GetResourcesFromServiceIndex(out edi);
             if (edi != null)
             {
-                return pkgEntries.ToArray();
+                return pkgEntries;
             }
 
             string searchQueryServiceUrl = FindSearchQueryService(resources, out edi);
             if (edi != null)
             {
-                return pkgEntries.ToArray();
+                return pkgEntries;
             }
 
             // Get initial response 
@@ -655,12 +654,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 count--;
             }
 
-            if (edi != null)
-            {
-                return new JsonElement[]{};
-            }
-
-            return pkgEntries.ToArray();
+            return pkgEntries;
         }
 
         /// <summary>

--- a/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
@@ -268,4 +268,12 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $err.Count | Should -BeGreaterThan 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "FindAllFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
+
+    # This test is time consuming, so marked as pending for now, should always be manually tested.
+    It "Should find more than 100 Az* packages" -Pending {
+        # Tests pagination
+        $res = Find-PSResource -Name "Az*" -Repository $NuGetGalleryName
+        $res | Should -Not -BeNullOrEmpty
+        $res.Count | Should -BeGreaterThan 100
+    }
 }

--- a/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
@@ -269,11 +269,13 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $err[0].FullyQualifiedErrorId | Should -BeExactly "FindAllFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
-    # This test is time consuming, so marked as pending for now, should always be manually tested.
-    It "Should find more than 100 Az* packages" -Pending {
+    # "carb*" is intentionally chosen as a sequence that will trigger pagination (ie more than 100 results),
+    # but is not too time consuming.
+    # There are currently between 300-350 packages that should be returned
+    It "Should find more than 100 packages that contain 'carb*' in the name" {
         # Tests pagination
-        $res = Find-PSResource -Name "Az*" -Repository $NuGetGalleryName
+        $res = Find-PSResource -Name "carb*" -Repository $NuGetGalleryName
         $res | Should -Not -BeNullOrEmpty
-        $res.Count | Should -BeGreaterThan 100
+        $res.Count | Should -BeGreaterThan 300
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Add pagination to find queries for v3 repositories.
Specifically, this PR adds skip and take parameters to the server query being made to ensure we get more responses if more exist.

## PR Context

Resolves #1020 
## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
