### PR TITLE
Filter out unlisted packages from v3 endpoints

### DIFF
--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -852,7 +852,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         {
                             if (bool.TryParse(listedElement.ToString(), out bool listed) && !listed)
                             {
-                                continue;
+                                return Utils.EmptyStrArray;
                             }
                         }
 

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -847,6 +847,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             return Utils.EmptyStrArray;
                         }
                         
+                        // If metadata has a "listed" property, but it's set to false, skip this package version
+                        if (metadataElement.TryGetProperty("listed", out JsonElement listedElement))
+                        {
+                            if (bool.TryParse(listedElement.ToString(), out bool listed) && !listed)
+                            {
+                                continue;
+                            }
+                        }
+                        
                         versionedResponses.Add(metadataElement.ToString());
                     }
 

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -847,6 +847,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             return Utils.EmptyStrArray;
                         }
                         
+                        /*
                         // If metadata has a "listed" property, but it's set to false, skip this package version
                         if (metadataElement.TryGetProperty("listed", out JsonElement listedElement))
                         {
@@ -855,6 +856,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                 continue;
                             }
                         }
+                        */
                         
                         versionedResponses.Add(metadataElement.ToString());
                     }

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -847,7 +847,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             return Utils.EmptyStrArray;
                         }
                         
-                        /*
                         // If metadata has a "listed" property, but it's set to false, skip this package version
                         if (metadataElement.TryGetProperty("listed", out JsonElement listedElement))
                         {
@@ -856,8 +855,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                 continue;
                             }
                         }
-                        */
-                        
+
                         versionedResponses.Add(metadataElement.ToString());
                     }
 

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -844,15 +844,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         if (!versionedItem.TryGetProperty(property, out JsonElement metadataElement))
                         {
                             edi = ExceptionDispatchInfo.Capture(new ArgumentException($"Response does not contain inner '{property}' element, for package with Name {packageName}."));
-                            return Utils.EmptyStrArray;
+                            continue;
                         }
                         
                         // If metadata has a "listed" property, but it's set to false, skip this package version
-                        if (metadataElement.TryGetProperty("listed", out JsonElement listedElement))
+                        if (property.Equals("catalogEntry") && metadataElement.TryGetProperty("listed", out JsonElement listedElement))
                         {
                             if (bool.TryParse(listedElement.ToString(), out bool listed) && !listed)
                             {
-                                return Utils.EmptyStrArray;
+                                continue;
                             }
                         }
 

--- a/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
@@ -268,4 +268,11 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $err.Count | Should -BeGreaterThan 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "FindAllFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
+
+    It "should not find an unlisted module" {
+        $res = Find-PSResource -Name "PMTestDependency1" -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -BeNullOrEmpty
+        $err.Count | Should -BeGreaterThan 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

A continuation of PR https://github.com/PowerShell/PSResourceGet/pull/1161, this PR skips returning all packages marked as unlisted.

## PR Context

Resolves https://github.com/PowerShell/PSResourceGet/issues/1162

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
