### PR TITLE
Update Uninstall tests to run faster for WindowsPS in CI

### DIFF
--- a/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
@@ -252,7 +252,7 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
     It "Do not Uninstall module that is a dependency for another module" {
         $null = Install-PSResource "test_module" -Repository $PSGalleryName -TrustRepository -WarningAction SilentlyContinue
 
-        Uninstall-PSResource -Name "RequiredModule1" -ErrorVariable ev -ErrorAction SilentlyContinue -SkipDependencyCheck
+        Uninstall-PSResource -Name "RequiredModule1" -ErrorVariable ev -ErrorAction SilentlyContinue
 
         $pkg = Get-InstalledPSResource "RequiredModule1"
         $pkg | Should -Not -Be $null
@@ -263,7 +263,7 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
     It "Uninstall module that is a dependency for another module using -SkipDependencyCheck" {
         $null = Install-PSResource $testModuleName -Repository $PSGalleryName -TrustRepository -WarningAction SilentlyContinue
 
-        Uninstall-PSResource -Name "RequiredModule1" -SkipDependencyCheck -SkipDependencyCheck
+        Uninstall-PSResource -Name "RequiredModule1" -SkipDependencyCheck
 
         $pkg = Get-InstalledPSResource "RequiredModule1"
         $pkg | Should -BeNullOrEmpty


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Add `-SkipDependencyCheck` to `Uninstall-PSResource` tests to expedite test runs.  There are still a test to validate dependency check.

## PR Context
CI tests for Windows PowerShell was taking too long.  This was due to the fact that each time `Uninstall-PSResource` is called, a check is done on each module being uninstalled to ensure there are no modules dependent on that package.  This check (CheckIfDependency) runs Get-Module -ListAvailable to find all dependencies, which is much slower on Windows Powershell than on Powershell 7.

Resolves #1081 

In the future we should add cached information of a dependency graph to make look up faster (see #1174)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
