### PR TITLE
Improve performance for Uninstall-PSResource by caching

### DIFF
--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -363,7 +363,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 _dependentModules = _pwsh.AddCommand("Microsoft.PowerShell.Core\\Get-Module").AddParameter("ListAvailable").Invoke<PSModuleInfo>();
             }
 
-            // Structure of LINQ call:
             // Results is a collection of PSModuleInfo objects that contain a property listing module dependencies, "RequiredModules".
             // RequiredModules is collection of PSModuleInfo objects that need to be iterated through to see if any of them are the pkg we're trying to uninstall
             // If we anything from the final call gets returned, there is a dependency on this pkg.

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -410,7 +410,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return true;
             }
 
-
             return false;
         }
 

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -168,7 +168,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         protected override void EndProcessing()
         {
-            _dependentModules?.Clear();
             _pwsh?.Dispose();
         }
 

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -168,16 +168,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         protected override void EndProcessing()
         {
-            if (_dependentModules is not null)
-            {
-                _dependentModules.Clear();
-                _dependentModules = null;
-            }
-
-            if (_pwsh is not null)
-            {
-                _pwsh.Dispose();
-            }
+            _dependentModules?.Clear();
+            _pwsh?.Dispose();
         }
 
         #endregion
@@ -363,23 +355,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // TODO:  implement a dependencies database for querying dependency info
             // cannot uninstall a module if another module is dependent on it
 
-            if (_pwsh is null)
-            {
-                _pwsh = System.Management.Automation.PowerShell.Create();
-            }
+            _pwsh ??= System.Management.Automation.PowerShell.Create();
 
             // Check all modules for dependencies
-            if (_dependentModules == null || _dependentModules.Count == 0)
+            if (_dependentModules is null || _dependentModules.Count == 0)
             {
-                _dependentModules = _pwsh.AddCommand("Get-Module").AddParameter("ListAvailable").Invoke<PSModuleInfo>();
+                _dependentModules = _pwsh.AddCommand("Microsoft.PowerShell.Core\\Get-Module").AddParameter("ListAvailable").Invoke<PSModuleInfo>();
             }
 
             // Structure of LINQ call:
             // Results is a collection of PSModuleInfo objects that contain a property listing module dependencies, "RequiredModules".
             // RequiredModules is collection of PSModuleInfo objects that need to be iterated through to see if any of them are the pkg we're trying to uninstall
             // If we anything from the final call gets returned, there is a dependency on this pkg.
-
-            //IEnumerable<PSObject> pkgsWithRequiredModules = new List<PSObject>();
 
             HashSet<string> uniquePackageNames = new();
 

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -363,7 +363,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 _dependentModules = _pwsh.AddCommand("Microsoft.PowerShell.Core\\Get-Module").AddParameter("ListAvailable").Invoke<PSModuleInfo>();
             }
 
-            // Results is a collection of PSModuleInfo objects that contain a property listing module dependencies, "RequiredModules".
+            // _dependentModules is a collection of PSModuleInfo objects that contain a property listing module dependencies, "RequiredModules".
+
             // RequiredModules is collection of PSModuleInfo objects that need to be iterated through to see if any of them are the pkg we're trying to uninstall
             // If we anything from the final call gets returned, there is a dependency on this pkg.
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Cache the output of Get-Module -ListAvailable for every invocation of the cmdlet.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
