### PR TITLE
Bug fix for Get-InstalledPSResource returning type of scripts as module

### DIFF
--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -392,7 +392,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     repositorySourceLocation: GetStringProperty(nameof(PSResourceInfo.RepositorySourceLocation), psObjectInfo),
                     tags: Utils.GetStringArray(GetProperty<ArrayList>(nameof(PSResourceInfo.Tags), psObjectInfo)),
                     type: Enum.TryParse(
-                            GetProperty<string>(nameof(PSResourceInfo.Type), psObjectInfo) ?? nameof(ResourceType.Module),
+                            GetProperty<object>(nameof(PSResourceInfo.Type), psObjectInfo).ToString() ?? nameof(ResourceType.Module),
                                 out ResourceType currentReadType)
                                     ? currentReadType : ResourceType.Module,
                     updatedDate: GetProperty<DateTime>(nameof(PSResourceInfo.UpdatedDate), psObjectInfo),

--- a/test/GetInstalledPSResource/GetInstalledPSResource.Tests.ps1
+++ b/test/GetInstalledPSResource/GetInstalledPSResource.Tests.ps1
@@ -34,13 +34,13 @@ Describe 'Test Get-InstalledPSResource for Module' -tags 'CI' {
     It "Get specific module resource by name" {
         $pkg = Get-InstalledPSResource -Name $testModuleName
         $pkg.Name | Should -Contain $testModuleName
-        $pkg.Type | Should -Be "Module"
+        $pkg.Type | Should -Contain "Module"
     }
 
     It "Get specific script resource by name" {
         $pkg = Get-InstalledPSResource -Name $testScriptName
         $pkg.Name | Should -Be $testScriptName
-        $pkg.Type | Should -Be "Script"
+        $pkg.Type | Should -Contain "Script"
     }
 
     It "Get resource when given Name to <Reason> <Version>" -TestCases @(

--- a/test/GetInstalledPSResource/GetInstalledPSResource.Tests.ps1
+++ b/test/GetInstalledPSResource/GetInstalledPSResource.Tests.ps1
@@ -34,11 +34,13 @@ Describe 'Test Get-InstalledPSResource for Module' -tags 'CI' {
     It "Get specific module resource by name" {
         $pkg = Get-InstalledPSResource -Name $testModuleName
         $pkg.Name | Should -Contain $testModuleName
+        $pkg.Type | Should -Be "Module"
     }
 
     It "Get specific script resource by name" {
         $pkg = Get-InstalledPSResource -Name $testScriptName
         $pkg.Name | Should -Be $testScriptName
+        $pkg.Type | Should -Be "Script"
     }
 
     It "Get resource when given Name to <Reason> <Version>" -TestCases @(


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
`Get-InstalledPSResource` shows the resource type of all scripts to be 'module'.  This is due to a bug with parsing the property from the InstalledScriptInfos xml.  

## PR Context
Resolves #1187 

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
