### PR TITLE
Change resolved paths to use GetResolvedProviderPathFromPSPath

### DIFF
--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 WriteVerbose(string.Format("Provided path is: '{0}'", Path));
 
-                var resolvedPaths = SessionState.Path.GetResolvedPSPathFromPSPath(Path);
+                var resolvedPaths = GetResolvedProviderPathFromPSPath(Path, out ProviderInfo provider);
                 if (resolvedPaths.Count != 1)
                 {
                     ThrowTerminatingError(
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             this));
                 }
 
-                var resolvedPath = resolvedPaths[0].Path;
+                var resolvedPath = resolvedPaths[0];
                 WriteVerbose(string.Format("Provided resolved path is '{0}'", resolvedPath));
 
                 var versionPaths = Utils.GetSubDirectories(resolvedPath);

--- a/src/code/GetPSScriptFileInfo.cs
+++ b/src/code/GetPSScriptFileInfo.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 ThrowTerminatingError(InvalidPathError);   
             }
 
-            var resolvedPaths = SessionState.Path.GetResolvedPSPathFromPSPath(Path);
+            var resolvedPaths = GetResolvedProviderPathFromPSPath(Path, out ProviderInfo provider);
             if (resolvedPaths.Count != 1)
             {
                 var exMessage = "Error: Could not resolve provided Path argument into a single path.";
@@ -46,7 +46,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 ThrowTerminatingError(InvalidPathArgumentError);
             }
 
-            var resolvedPath = resolvedPaths[0].Path;
+            var resolvedPath = resolvedPaths[0];
             bool isValidScript = PSScriptFileInfo.TryTestPSScriptFileInfo(
                 scriptFileInfoPath: resolvedPath,
                 parsedScript: out PSScriptFileInfo psScriptFileInfo,

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -83,10 +83,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (WildcardPattern.ContainsWildcardCharacters(value)) 
                 { 
                     throw new PSArgumentException("Wildcard characters are not allowed in the temporary path."); 
-                } 
-                
+                }
+
                 // This will throw if path cannot be resolved
-                _tmpPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
+                _tmpPath = GetResolvedProviderPathFromPSPath(value, out ProviderInfo provider).First();
             }
         }
         private string _tmpPath;
@@ -164,7 +164,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 string resolvedPath = string.Empty;
                 if (!string.IsNullOrWhiteSpace(value))
                 {
-                    resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
+                    resolvedPath = GetResolvedProviderPathFromPSPath(value, out ProviderInfo provider).First();
                 }
 
                 if (!File.Exists(resolvedPath))

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -190,7 +190,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (!String.IsNullOrEmpty(DestinationPath))
             {
-                string resolvedDestinationPath = GetResolvedProviderPathFromPSPath(Path, out ProviderInfo provider).First();
+                string resolvedDestinationPath = GetResolvedProviderPathFromPSPath(DestinationPath, out ProviderInfo provider).First();
 
                 if (Directory.Exists(resolvedDestinationPath))
                 {

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -145,7 +145,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             try
             {
-                resolvedPath = SessionState.Path.GetResolvedPSPathFromPSPath(Path).First().Path;
+                resolvedPath = GetResolvedProviderPathFromPSPath(Path, out ProviderInfo provider).First();
             }
             catch (MethodInvocationException)
             {
@@ -190,7 +190,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (!String.IsNullOrEmpty(DestinationPath))
             {
-                string resolvedDestinationPath = SessionState.Path.GetResolvedPSPathFromPSPath(DestinationPath).First().Path;
+                string resolvedDestinationPath = GetResolvedProviderPathFromPSPath(Path, out ProviderInfo provider).First();
 
                 if (Directory.Exists(resolvedDestinationPath))
                 {

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -103,7 +103,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
 
                 // This will throw if path cannot be resolved
-                _path = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
+                _path = GetResolvedProviderPathFromPSPath(value, out ProviderInfo provider).First();
             }
         }
         private string _path;
@@ -127,7 +127,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
 
                 // This will throw if path cannot be resolved
-                _tmpPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
+                _tmpPath = GetResolvedProviderPathFromPSPath(value, out ProviderInfo provider).First();
             }
         }
         private string _tmpPath;

--- a/src/code/TestPSScriptFile.cs
+++ b/src/code/TestPSScriptFile.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 ThrowTerminatingError(InvalidPathError);
             }
 
-            var resolvedPaths = SessionState.Path.GetResolvedPSPathFromPSPath(Path);
+            var resolvedPaths = GetResolvedProviderPathFromPSPath(Path, out ProviderInfo provider);
             if (resolvedPaths.Count != 1)
             {
                 var exMessage = "Error: Could not resolve provided Path argument into a single path.";
@@ -48,7 +48,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 ThrowTerminatingError(InvalidPathArgumentError);
             }
 
-            var resolvedPath = resolvedPaths[0].Path;
+            var resolvedPath = resolvedPaths[0];
 
             if (!File.Exists(resolvedPath))
             {

--- a/src/code/UpdateModuleManifest.cs
+++ b/src/code/UpdateModuleManifest.cs
@@ -267,7 +267,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         protected override void EndProcessing()
         {
-             string resolvedManifestPath = SessionState.Path.GetResolvedPSPathFromPSPath(Path).First().Path;
+            string resolvedManifestPath = GetResolvedProviderPathFromPSPath(Path, out ProviderInfo provider).First();
 
             // Test the path of the module manifest to see if the file exists
             if (!File.Exists(resolvedManifestPath) || !resolvedManifestPath.EndsWith(".psd1"))

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -90,7 +90,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 } 
                 
                 // This will throw if path cannot be resolved
-                _tmpPath = SessionState.Path.GetResolvedPSPathFromPSPath(value).First().Path;
+                _tmpPath = GetResolvedProviderPathFromPSPath(value, out ProviderInfo provider).First();
             }
         }
         private string _tmpPath;

--- a/src/code/UpdatePSScriptFileInfo.cs
+++ b/src/code/UpdatePSScriptFileInfo.cs
@@ -186,7 +186,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     ThrowTerminatingError(InvalidOrNonExistantPathError);   
             }
 
-            var resolvedPaths = SessionState.Path.GetResolvedPSPathFromPSPath(Path);
+            var resolvedPaths = GetResolvedProviderPathFromPSPath(Path, out ProviderInfo provider);
             if (resolvedPaths.Count != 1)
             {
                 var exMessage = "Error: Could not resolve provided Path argument into a single path.";
@@ -195,7 +195,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 ThrowTerminatingError(InvalidPathArgumentError);
             }
 
-            string resolvedPath = resolvedPaths[0].Path;
+            string resolvedPath = resolvedPaths[0];
 
             if (!File.Exists(resolvedPath))
             {

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -396,7 +396,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             try
             {
                 // This is needed for a relative path Uri string. Does not throw error for an absolute path.
-                var filePath = cmdletPassedIn.SessionState.Path.GetResolvedPSPathFromPSPath(uriString)[0].Path;
+                var filePath = cmdletPassedIn.GetResolvedProviderPathFromPSPath(uriString, out ProviderInfo provider).First();
                 if (Uri.TryCreate(filePath, UriKind.Absolute, out uriResult))
                 {
                     return true;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR resolves special paths appropriately (ie the same way PowerShell resolves paths). Small change to modify every instance of `SessionState.Path.GetResolvedPSPathFromPSPath` to ` GetResolvedProviderPathFromPSPath`.

 
## PR Context
Resolves #947 
Resolves #1107 

## PR Checklist

- [x ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
