### PR TITLE
Change ExceptionDispatchInfo objects to ErrorRecords - Error updates pt 1

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -228,10 +228,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 _cmdletPassedIn.WriteVerbose(string.Format("Searching in repository {0}", repositoriesToSearch[i].Name));
 
-                FindResults responses = currentServer.FindCommandOrDscResource(tag, _prerelease, isSearchingForCommands, out ExceptionDispatchInfo edi);
-                if (edi != null)
+                FindResults responses = currentServer.FindCommandOrDscResource(tag, _prerelease, isSearchingForCommands, out ErrorRecord errRecord);
+                if (errRecord != null)
                 {
-                    _cmdletPassedIn.WriteError(new ErrorRecord(edi.SourceException, "FindCommandOrDSCResourceFail", ErrorCategory.InvalidOperation, this));
+                    _cmdletPassedIn.WriteError(errRecord);
                     continue;
                 }
 
@@ -339,11 +339,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         this));
                 }
 
-                FindResults responses = currentServer.FindTags(_tag, _prerelease, type, out ExceptionDispatchInfo edi);
+                FindResults responses = currentServer.FindTags(_tag, _prerelease, type, out ErrorRecord errRecord);
 
-                if (edi != null)
+                if (errRecord != null)
                 {
-                    _cmdletPassedIn.WriteError(new ErrorRecord(edi.SourceException, "FindTagFail", ErrorCategory.InvalidOperation, this));
+                    _cmdletPassedIn.WriteError(errRecord);
                     continue;
                 }
 
@@ -367,7 +367,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         private IEnumerable<PSResourceInfo> SearchByNames(ServerApiCall currentServer, ResponseUtil currentResponseUtil, PSRepositoryInfo repository)
         {
-            ExceptionDispatchInfo edi = null;
+            ErrorRecord errRecord = null;
             List<PSResourceInfo> parentPkgs = new List<PSResourceInfo>();
             HashSet<string> pkgsFound = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -378,10 +378,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (pkgName.Trim().Equals("*"))
                     {
                         // Example: Find-PSResource -Name "*"
-                        FindResults responses = currentServer.FindAll(_prerelease, _type, out edi);
-                        if (edi != null)
+                        FindResults responses = currentServer.FindAll(_prerelease, _type, out errRecord);
+                        if (errRecord != null)
                         {
-                            _cmdletPassedIn.WriteError(new ErrorRecord(edi.SourceException, "FindAllFail", ErrorCategory.InvalidOperation, this));
+                            _cmdletPassedIn.WriteError(errRecord);
                             continue;
                         }
 
@@ -409,18 +409,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         FindResults responses = null;
                         if (_tag.Length == 0)
                         {
-                            responses = currentServer.FindNameGlobbing(pkgName, _prerelease, _type, out edi);
+                            responses = currentServer.FindNameGlobbing(pkgName, _prerelease, _type, out errRecord);
                         }
                         else
                         {
-                            responses = currentServer.FindNameGlobbingWithTag(pkgName, _tag, _prerelease, _type, out edi);
+                            responses = currentServer.FindNameGlobbingWithTag(pkgName, _tag, _prerelease, _type, out errRecord);
                             string tagsAsString = String.Join(", ", _tag);
                             tagMsg = $" and Tags {tagsAsString}";
                         }
 
-                        if (edi != null)
+                        if (errRecord != null)
                         {
-                            _cmdletPassedIn.WriteError(new ErrorRecord(edi.SourceException, "FindNameGlobbingFail", ErrorCategory.InvalidOperation, this));
+                            _cmdletPassedIn.WriteError(errRecord);
                             continue;
                         }
 
@@ -448,18 +448,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         FindResults responses = null;
                         if (_tag.Length == 0)
                         {
-                            responses = currentServer.FindName(pkgName, _prerelease, _type, out edi);
+                            responses = currentServer.FindName(pkgName, _prerelease, _type, out errRecord);
                         }
                         else
                         {
-                            responses = currentServer.FindNameWithTag(pkgName, _tag, _prerelease, _type, out edi);
+                            responses = currentServer.FindNameWithTag(pkgName, _tag, _prerelease, _type, out errRecord);
                             string tagsAsString = String.Join(", ", _tag);
                             tagMsg = $" and Tags {tagsAsString}";
                         }
 
-                        if (edi != null)
+                        if (errRecord != null)
                         {
-                            _cmdletPassedIn.WriteError(new ErrorRecord(edi.SourceException, "FindNameFail", ErrorCategory.InvalidOperation, this));
+                            _cmdletPassedIn.WriteError(errRecord);
                             continue;
                         }
 
@@ -498,18 +498,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         string tagMsg = String.Empty;
                         if (_tag.Length == 0)
                         {
-                            responses = currentServer.FindVersion(pkgName, _nugetVersion.ToNormalizedString(), _type, out edi);
+                            responses = currentServer.FindVersion(pkgName, _nugetVersion.ToNormalizedString(), _type, out errRecord);
                         }
                         else
                         {
-                            responses = currentServer.FindVersionWithTag(pkgName, _nugetVersion.ToNormalizedString(), _tag, _type, out edi);
+                            responses = currentServer.FindVersionWithTag(pkgName, _nugetVersion.ToNormalizedString(), _tag, _type, out errRecord);
                             string tagsAsString = String.Join(", ", _tag);
                             tagMsg = $" and Tags {tagsAsString}";
                         }
 
-                        if (edi != null)
+                        if (errRecord != null)
                         {
-                            _cmdletPassedIn.WriteError(new ErrorRecord(edi.SourceException, "FindVersionFail", ErrorCategory.InvalidOperation, this));
+                            _cmdletPassedIn.WriteError(errRecord);
                             continue;
                         }
 
@@ -545,7 +545,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         FindResults responses = null;
                         if (_tag.Length == 0)
                         {
-                            responses = currentServer.FindVersionGlobbing(pkgName, _versionRange, _prerelease, _type, getOnlyLatest: false, out edi);
+                            responses = currentServer.FindVersionGlobbing(pkgName, _versionRange, _prerelease, _type, getOnlyLatest: false, out errRecord);
                         }
                         else
                         {
@@ -556,9 +556,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             continue;
                         }
 
-                        if (edi != null)
+                        if (errRecord != null)
                         {
-                            _cmdletPassedIn.WriteError(new ErrorRecord(edi.SourceException, "FindVersionGlobbingFail", ErrorCategory.InvalidOperation, this));
+                            _cmdletPassedIn.WriteError(errRecord);
                             continue;
                         }
 
@@ -635,10 +635,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                     if (dep.VersionRange == VersionRange.All)
                     {
-                        FindResults responses = currentServer.FindName(dep.Name, _prerelease, _type, out ExceptionDispatchInfo edi);
-                        if (edi != null)
+                        FindResults responses = currentServer.FindName(dep.Name, _prerelease, _type, out ErrorRecord errRecord);
+                        if (errRecord != null)
                         {
-                            _cmdletPassedIn.WriteError(new ErrorRecord(edi.SourceException, "HttpFindDepPackagesFindNameFail", ErrorCategory.InvalidOperation, this));
+                            _cmdletPassedIn.WriteError(errRecord);
                             yield return null;
                             continue;
                         }
@@ -665,10 +665,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     }
                     else
                     {
-                        FindResults responses = currentServer.FindVersionGlobbing(dep.Name, dep.VersionRange, _prerelease, ResourceType.None, getOnlyLatest: true, out ExceptionDispatchInfo edi);
-                        if (edi != null)
+                        FindResults responses = currentServer.FindVersionGlobbing(dep.Name, dep.VersionRange, _prerelease, ResourceType.None, getOnlyLatest: true, out ErrorRecord errRecord);
+                        if (errRecord != null)
                         {
-                            _cmdletPassedIn.WriteError(new ErrorRecord(edi.SourceException, "HttpFindDepPackagesFindVersionGlobbingFail", ErrorCategory.InvalidOperation, this));
+                            _cmdletPassedIn.WriteError(errRecord);
                             yield return null;
                             continue;
                         }

--- a/src/code/IServerAPICalls.cs
+++ b/src/code/IServerAPICalls.cs
@@ -4,6 +4,7 @@
 using Microsoft.PowerShell.PSResourceGet.UtilClasses;
 using NuGet.Versioning;
 using System.IO;
+using System.Management.Automation;
 using System.Runtime.ExceptionServices;
 
 public interface IServerAPICalls
@@ -13,27 +14,27 @@ public interface IServerAPICalls
     /// Find method which allows for searching for all packages from a repository and returns latest version for each.
     /// Examples: Search -Repository PSGallery
     /// </summary>
-    FindResults FindAll(bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi);
+    FindResults FindAll(bool includePrerelease, ResourceType type, out ErrorRecord errRecord);
 
     /// <summary>
     /// Find method which allows for searching for packages with tag from a repository and returns latest version for each.
     /// Examples: Search -Tag "JSON" -Repository PSGallery
     /// </summary>
-    FindResults FindTags(string[] tags, bool includePrerelease, ResourceType _type, out ExceptionDispatchInfo edi);
+    FindResults FindTags(string[] tags, bool includePrerelease, ResourceType _type, out ErrorRecord errRecord);
   
     /// <summary>
     /// Find method which allows for searching for single name and returns latest version.
     /// Name: no wildcard support
     /// Examples: Search "PowerShellGet"
     /// </summary>
-    FindResults FindName(string packageName, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi);
+    FindResults FindName(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord);
 
     /// <summary>
     /// Find method which allows for searching for single name and returns latest version.
     /// Name: no wildcard support
     /// Examples: Search "PowerShellGet" -Tag "Provider"
     /// </summary>
-    FindResults FindNameWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi);
+    FindResults FindNameWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord);
 
     /// <summary>
     /// Find method which allows for searching for single name with version range.
@@ -42,7 +43,7 @@ public interface IServerAPICalls
     /// Examples: Search "PowerShellGet" "[3.0.0.0, 5.0.0.0]"
     ///           Search "PowerShellGet" "3.*"
     /// </summary>
-    FindResults FindNameGlobbing(string packageName, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi);
+    FindResults FindNameGlobbing(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord);
 
     /// <summary>
     /// Find method which allows for searching for single name and tag with version range.
@@ -51,7 +52,7 @@ public interface IServerAPICalls
     /// Examples: Search "PowerShellGet" "[3.0.0.0, 5.0.0.0]"
     ///           Search "PowerShellGet" "3.*"
     /// </summary>
-    FindResults FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi);
+    FindResults FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord);
 
     /// <summary>
     /// Find method which allows for searching for single name with specific version.
@@ -59,7 +60,7 @@ public interface IServerAPICalls
     /// Version: no wildcard support
     /// Examples: Search "PowerShellGet" "2.2.5"
     /// </summary>
-    FindResults FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ExceptionDispatchInfo edi);
+    FindResults FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ErrorRecord errRecord);
 
     // <summary>
     /// Find method which allows for searching for single name with specific version.
@@ -67,7 +68,7 @@ public interface IServerAPICalls
     /// Version: no wildcard support
     /// Examples: Search "PowerShellGet" "2.2.5"
     /// </summary>
-    FindResults FindVersion(string packageName, string version, ResourceType type, out ExceptionDispatchInfo edi);
+    FindResults FindVersion(string packageName, string version, ResourceType type, out ErrorRecord errRecord);
 
     // <summary>
     /// Find method which allows for searching for single name and tag with specific version.
@@ -75,14 +76,14 @@ public interface IServerAPICalls
     /// Version: no wildcard support
     /// Examples: Search "PowerShellGet" "2.2.5" -Tag "Provider"
     /// </summary>
-    FindResults FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ExceptionDispatchInfo edi);
+    FindResults FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ErrorRecord errRecord);
 
     /// <summary>
     /// Installs specific package.
     /// Name: no wildcard support.
     /// Examples: Install "PowerShellGet"
     /// </summary>
-    Stream InstallName(string packageName, bool includePrerelease, out ExceptionDispatchInfo edi);
+    Stream InstallName(string packageName, bool includePrerelease, out ErrorRecord errRecord);
 
     /// <summary>
     /// Installs package with specific name and version.
@@ -91,7 +92,7 @@ public interface IServerAPICalls
     /// Examples: Install "PowerShellGet" -Version "3.0.0.0"
     ///           Install "PowerShellGet" -Version "3.0.0-beta16"
     /// </summary>    
-    Stream InstallVersion(string packageName, string version, out ExceptionDispatchInfo edi);
+    Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord);
 
     #endregion
 }

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -43,9 +43,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// API call: 
         /// - No prerelease: http://www.powershellgallery.com/api/v2/Search()?$filter=IsLatestVersion
         /// </summary>
-        public override FindResults FindAll(bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindAll(bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
-            return FindTagsHelper(tags: Utils.EmptyStrArray, includePrerelease, out edi);
+            return FindTagsHelper(tags: Utils.EmptyStrArray, includePrerelease, out errRecord);
         }
 
         /// <summary>
@@ -54,18 +54,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// API call: 
         /// - Include prerelease: http://www.powershellgallery.com/api/v2/Search()?$filter=IsAbsoluteLatestVersion&searchTerm=tag:JSON&includePrerelease=true
         /// </summary>
-        public override FindResults FindTags(string[] tags, bool includePrerelease, ResourceType _type, out ExceptionDispatchInfo edi)
+        public override FindResults FindTags(string[] tags, bool includePrerelease, ResourceType _type, out ErrorRecord errRecord)
         {
-            return FindTagsHelper(tags, includePrerelease, out edi);
+            return FindTagsHelper(tags, includePrerelease, out errRecord);
         }
 
         /// <summary>
         /// Find method which allows for searching for all packages that have specified Command or DSCResource name.
         /// </summary>
-        public override FindResults FindCommandOrDscResource(string[] tags, bool includePrerelease, bool isSearchingForCommands, out ExceptionDispatchInfo edi)
+        public override FindResults FindCommandOrDscResource(string[] tags, bool includePrerelease, bool isSearchingForCommands, out ErrorRecord errRecord)
         {
             string[] cmdsOrDSCs = GetCmdsOrDSCTags(tags: tags, isSearchingForCommands: isSearchingForCommands);
-            return FindTagsHelper(cmdsOrDSCs, includePrerelease, out edi);
+            return FindTagsHelper(cmdsOrDSCs, includePrerelease, out errRecord);
         }
 
         /// <summary>
@@ -77,9 +77,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// - Include prerelease: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
         /// Implementation Note: Need to filter further for latest version (prerelease or non-prerelease dependening on user preference)
         /// </summary>
-        public override FindResults FindName(string packageName, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindName(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
-            return FindNameHelper(packageName, Utils.EmptyStrArray, includePrerelease, type, out edi);
+            return FindNameHelper(packageName, Utils.EmptyStrArray, includePrerelease, type, out errRecord);
         }
 
         /// <summary>
@@ -88,9 +88,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Search "PowerShellGet" -Tag "Provider"
         /// Implementation Note: Need to filter further for latest version (prerelease or non-prerelease dependening on user preference)
         /// </summary>
-        public override FindResults FindNameWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindNameWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
-            return FindNameHelper(packageName, tags, includePrerelease, type, out edi);
+            return FindNameHelper(packageName, tags, includePrerelease, type, out errRecord);
         }
 
         /// <summary>
@@ -101,9 +101,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// - No prerelease: http://www.powershellgallery.com/api/v2/Search()?$filter=IsLatestVersion&searchTerm='az*'
         /// Implementation Note: filter additionally and verify ONLY package name was a match.
         /// </summary>
-        public override FindResults FindNameGlobbing(string packageName, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindNameGlobbing(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
-            return FindNameGlobbingHelper(packageName, Utils.EmptyStrArray, includePrerelease, type, out edi);
+            return FindNameGlobbingHelper(packageName, Utils.EmptyStrArray, includePrerelease, type, out errRecord);
         }
 
         /// <summary>
@@ -112,9 +112,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Search "PowerShell*" -Tag "Provider"
         /// Implementation Note: filter additionally and verify ONLY package name was a match.
         /// </summary>
-        public override FindResults FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
-            return FindNameGlobbingHelper(packageName, tags, includePrerelease, type, out edi);
+            return FindNameGlobbingHelper(packageName, tags, includePrerelease, type, out errRecord);
         }
 
         /// <summary>
@@ -126,13 +126,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// API Call: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
         /// Implementation note: Returns all versions, including prerelease ones. Later (in the API client side) we'll do filtering on the versions to satisfy what user provided.
         /// </summary>
-        public override FindResults FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ExceptionDispatchInfo edi)
+        public override FindResults FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ErrorRecord errRecord)
         {
             FindResults findResponse = new FindResults();
-            edi = null;
+            errRecord = null;
             string actualPkgName = packageName;
 
-            Hashtable pkgVersionsFound = GetMatchingFilesGivenSpecificName(packageName: packageName, includePrerelease: includePrerelease, versionRange: versionRange, actualName: out actualPkgName, edi: out edi);
+            Hashtable pkgVersionsFound = GetMatchingFilesGivenSpecificName(packageName: packageName, includePrerelease: includePrerelease, versionRange: versionRange, actualName: out actualPkgName, errRecord: out errRecord);
 
             List<NuGetVersion> pkgVersionsList = pkgVersionsFound.Keys.Cast<NuGetVersion>().ToList();
             pkgVersionsList.Sort();
@@ -144,8 +144,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 string packagePath = (string) pkgVersionsFound[satisfyingVersion];
 
-                Hashtable pkgMetadata = GetMetadataFromNupkg(packageName: actualPkgName, packagePath: packagePath, requiredTags: Utils.EmptyStrArray, edi: out edi);
-                if (edi != null || pkgMetadata.Count == 0)
+                Hashtable pkgMetadata = GetMetadataFromNupkg(packageName: actualPkgName, packagePath: packagePath, requiredTags: Utils.EmptyStrArray, errRecord: out errRecord);
+                if (errRecord != null || pkgMetadata.Count == 0)
                 {
                     continue;
                 }
@@ -165,9 +165,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Search "PowerShellGet" "2.2.5"
         /// API call: http://www.powershellgallery.com/api/v2/Packages(Id='PowerShellGet', Version='2.2.5')
         /// </summary>
-        public override FindResults FindVersion(string packageName, string version, ResourceType type, out ExceptionDispatchInfo edi) 
+        public override FindResults FindVersion(string packageName, string version, ResourceType type, out ErrorRecord errRecord) 
         {
-            return FindVersionHelper(packageName, version, Utils.EmptyStrArray, type, out edi);
+            return FindVersionHelper(packageName, version, Utils.EmptyStrArray, type, out errRecord);
         }
 
         /// <summary>
@@ -176,9 +176,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Version: no wildcard support
         /// Examples: Search "PowerShellGet" "2.2.5" -Tag "Provider"
         /// </summary>
-        public override FindResults FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ErrorRecord errRecord)
         {
-            return FindVersionHelper(packageName, version, tags, type, out edi);
+            return FindVersionHelper(packageName, version, tags, type, out errRecord);
         }
 
         /**  INSTALL APIS **/
@@ -190,10 +190,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Implementation Note:   if not prerelease: https://www.powershellgallery.com/api/v2/package/powershellget (Returns latest stable)
         ///                        if prerelease, call into InstallVersion instead. 
         /// </summary>
-        public override Stream InstallName(string packageName, bool includePrerelease, out ExceptionDispatchInfo edi)
+        public override Stream InstallName(string packageName, bool includePrerelease, out ErrorRecord errRecord)
         {
             FileStream fs = null;
-            edi = null;
+            errRecord = null;
             WildcardPattern pkgNamePattern = new WildcardPattern($"{packageName}.*", WildcardOptions.IgnoreCase);
             NuGetVersion latestVersion = new NuGetVersion("0.0.0.0");
             String latestVersionPath = String.Empty;
@@ -220,7 +220,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (String.IsNullOrEmpty(latestVersionPath))
             {
-                edi = ExceptionDispatchInfo.Capture(new LocalResourceEmpty($"Package for name {packageName} was not present in repository"));
+                errRecord = new ErrorRecord(new LocalResourceEmpty($"'{packageName}' is not present in repository"), "InstallNameFailure", ErrorCategory.ResourceUnavailable, this);
             }
             else
             {
@@ -228,7 +228,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 if (fs == null)
                 {
-                    edi = ExceptionDispatchInfo.Capture(new LocalResourceEmpty("The contents of the package file for specified resource was empty or invalid"));
+                    errRecord = new ErrorRecord(new LocalResourceEmpty("The contents of the package file for specified resource was empty or invalid"), "InstallNameFailure", ErrorCategory.ResourceUnavailable, this);
                 }
             }
 
@@ -243,9 +243,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         ///           Install "PowerShellGet" -Version "3.0.0-beta16"
         /// API Call: https://www.powershellgallery.com/api/v2/package/Id/version (version can be prerelease)
         /// </summary>    
-        public override Stream InstallVersion(string packageName, string version, out ExceptionDispatchInfo edi)
+        public override Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord)
         {
-            edi = null;
+            errRecord = null;
             FileStream fs = null;
 
             // if 4 digits and last is 0, create 3 digit equiv string
@@ -260,7 +260,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string packagePath = Path.Combine(Repository.Uri.AbsolutePath, packageFullName);
             if (!File.Exists(packagePath))
             {
-                edi = ExceptionDispatchInfo.Capture(new LocalResourceNotFoundException($"Package with specified criteria: Name {packageName} and version {version} does not exist in this repository"));
+                errRecord = new ErrorRecord(new LocalResourceNotFoundException($"'{packageName}' version '{version}' does not exist in this repository"), "InstallVersionFailure", ErrorCategory.ResourceUnavailable, this);
                 return fs;
             }
 
@@ -268,7 +268,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (fs == null)
             {
-                edi = ExceptionDispatchInfo.Capture(new LocalResourceEmpty("The contents of the package file for specified resource was empty or invalid"));
+                errRecord = new ErrorRecord(new LocalResourceEmpty("The contents of the package file for specified resource was empty or invalid"), "InstallVersionFailure", ErrorCategory.ResourceUnavailable, this);
             }
 
             return fs;
@@ -281,10 +281,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method called by FindName() and FindNameWithTag()
         /// </summary>
-        private FindResults FindNameHelper(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        private FindResults FindNameHelper(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             FindResults findResponse = new FindResults();
-            edi = null;
+            errRecord = null;
 
             WildcardPattern pkgNamePattern = new WildcardPattern($"{packageName}.*", WildcardOptions.IgnoreCase);
             NuGetVersion latestVersion = new NuGetVersion("0.0.0.0");
@@ -297,8 +297,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 if (!String.IsNullOrEmpty(packageFullName) && pkgNamePattern.IsMatch(packageFullName))
                 {
-                    NuGetVersion nugetVersion = GetInfoFromFileName(packageFullName: packageFullName, packageName: packageName, actualName: out actualPkgName, out edi);
-                    if (edi != null)
+                    NuGetVersion nugetVersion = GetInfoFromFileName(packageFullName: packageFullName, packageName: packageName, actualName: out actualPkgName, out errRecord);
+                    if (errRecord != null)
                     {
                         return findResponse;
                     }
@@ -317,12 +317,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (String.IsNullOrEmpty(latestVersionPath))
             {
                 // means no package was found with this name
-                edi = ExceptionDispatchInfo.Capture(new LocalResourceNotFoundException($"Package with name {packageName} could not be found in this repository."));
+                errRecord = new ErrorRecord(new LocalResourceNotFoundException($"Package with name {packageName} could not be found in this repository."), "FindNameFailure", ErrorCategory.ResourceUnavailable, this);
                 return findResponse;
             }
 
-            Hashtable pkgMetadata = GetMetadataFromNupkg(packageName: actualPkgName, packagePath: latestVersionPath, requiredTags: tags, edi: out edi);
-            if (edi != null)
+            Hashtable pkgMetadata = GetMetadataFromNupkg(packageName: actualPkgName, packagePath: latestVersionPath, requiredTags: tags, errRecord: out errRecord);
+            if (errRecord != null)
             {
                 return findResponse;
             }
@@ -330,7 +330,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // this condition will be true, for FindNameWithTags() when package satisfying that criteria is not met
             if (pkgMetadata.Count == 0)
             {
-                edi = ExceptionDispatchInfo.Capture(new SpecifiedTagsNotFoundException($"Package with name {packageName}, and tags {String.Join(", ", tags)} could not be found."));
+                errRecord = new ErrorRecord(new SpecifiedTagsNotFoundException($"'{packageName}' with tags {String.Join(", ", tags)} could not be found."), "FindNameFailure", ErrorCategory.ResourceUnavailable, this);
             }
 
             findResponse = new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: new Hashtable[]{pkgMetadata}, responseType: _localServerFindResponseType);
@@ -340,11 +340,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method called by FindNameGlobbing() and FindNameGlobbingWithTag()
         /// </summary>
-        private FindResults FindNameGlobbingHelper(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        private FindResults FindNameGlobbingHelper(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             FindResults findResponse = new FindResults();
             List<Hashtable> pkgsFound = new List<Hashtable>();
-            edi = null;
+            errRecord = null;
 
             Hashtable pkgVersionsFound = GetMatchingFilesGivenNamePattern(packageNameWithWildcard: packageName, includePrerelease: includePrerelease);
 
@@ -354,8 +354,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 Hashtable pkgInfo = pkgVersionsFound[pkgFound] as Hashtable;
                 string pkgPath = pkgInfo["path"] as string;
 
-                Hashtable pkgMetadata = GetMetadataFromNupkg(packageName: pkgFound, packagePath: pkgPath, requiredTags: tags, edi: out edi);
-                if (edi != null || pkgMetadata.Count == 0)
+                Hashtable pkgMetadata = GetMetadataFromNupkg(packageName: pkgFound, packagePath: pkgPath, requiredTags: tags, errRecord: out errRecord);
+                if (errRecord != null || pkgMetadata.Count == 0)
                 {
                     continue;
                 }
@@ -371,14 +371,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method called by FindVersion() and FindVersionWithTag()
         /// </summary>
-        private FindResults FindVersionHelper(string packageName, string version, string[] tags, ResourceType type, out ExceptionDispatchInfo edi)
+        private FindResults FindVersionHelper(string packageName, string version, string[] tags, ResourceType type, out ErrorRecord errRecord)
         {
             FindResults findResponse = new FindResults();
-            edi = null;
+            errRecord = null;
 
             if (!NuGetVersion.TryParse(version, out NuGetVersion requiredVersion))
             {
-                edi = ExceptionDispatchInfo.Capture(new InvalidOperationException($"Version {version} could not be parsed into a valid NuGetVersion"));
+                errRecord = new ErrorRecord(new InvalidOperationException($"Version {version} could not be parsed into a valid NuGetVersion"), "FindVersionFailure", ErrorCategory.InvalidData, this);
                 return findResponse;
             }
 
@@ -390,8 +390,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 string packageFullName = Path.GetFileName(path);
                 if (!String.IsNullOrEmpty(packageFullName) && pkgNamePattern.IsMatch(packageFullName))
                 {
-                    NuGetVersion nugetVersion = GetInfoFromFileName(packageFullName: packageFullName, packageName: packageName, actualName: out actualPkgName, out edi);
-                    if (edi != null)
+                    NuGetVersion nugetVersion = GetInfoFromFileName(packageFullName: packageFullName, packageName: packageName, actualName: out actualPkgName, out errRecord);
+                    if (errRecord != null)
                     {
                         return findResponse;
                     }
@@ -408,12 +408,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (String.IsNullOrEmpty(pkgPath))
             {
                 // means no package was found with this name, version (and possibly tags).
-                edi = ExceptionDispatchInfo.Capture(new LocalResourceNotFoundException($"Package with Name {packageName}, Version {version} and Tags {String.Join(", ", tags)} could not be found in this repository."));
+                errRecord = new ErrorRecord(new LocalResourceNotFoundException($"Package with Name {packageName}, Version {version} and Tags {String.Join(", ", tags)} could not be found in this repository."), "FindVersionFailure", ErrorCategory.ResourceUnavailable, this);
                 return findResponse;
             }
 
-            Hashtable pkgMetadata = GetMetadataFromNupkg(packageName: actualPkgName, packagePath: pkgPath, requiredTags: tags, edi: out edi);
-            if (edi != null)
+            Hashtable pkgMetadata = GetMetadataFromNupkg(packageName: actualPkgName, packagePath: pkgPath, requiredTags: tags, errRecord: out errRecord);
+            if (errRecord != null)
             {
                 return findResponse;
             }
@@ -421,7 +421,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // this condition will be true, for FindVersionWithTags() when package satisfying that criteria is not met
             if (pkgMetadata.Count == 0)
             {
-                edi = ExceptionDispatchInfo.Capture(new SpecifiedTagsNotFoundException($"Package with name {packageName}, and tags {String.Join(", ", tags)} could not be found."));
+                errRecord = new ErrorRecord(new SpecifiedTagsNotFoundException($"Package with name {packageName}, and tags {String.Join(", ", tags)} could not be found."), "FindVersionFailure", ErrorCategory.InvalidResult, this);
             }
 
             findResponse = new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: new Hashtable[]{pkgMetadata}, responseType: _localServerFindResponseType);
@@ -431,11 +431,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method called by FindTags(), FindAll(), and FindCommandOrDSCResource()
         /// </summary>
-        private FindResults FindTagsHelper(string[] tags, bool includePrerelease, out ExceptionDispatchInfo edi)
+        private FindResults FindTagsHelper(string[] tags, bool includePrerelease, out ErrorRecord errRecord)
         {
             FindResults findResponse = new FindResults();
             List<Hashtable> pkgsFound = new List<Hashtable>();
-            edi = null;
+            errRecord = null;
 
             Hashtable pkgVersionsFound = GetMatchingFilesGivenNamePattern(packageNameWithWildcard: String.Empty, includePrerelease: includePrerelease);
 
@@ -446,8 +446,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 NuGetVersion pkgVersion = pkgInfo["version"] as NuGetVersion;
                 string pkgPath = pkgInfo["path"] as string;
 
-                Hashtable pkgMetadata = GetMetadataFromNupkg(packageName: pkgFound, packagePath: pkgPath, requiredTags: tags, edi: out edi);
-                if (edi != null || pkgMetadata.Count == 0)
+                Hashtable pkgMetadata = GetMetadataFromNupkg(packageName: pkgFound, packagePath: pkgPath, requiredTags: tags, errRecord: out errRecord);
+                if (errRecord != null || pkgMetadata.Count == 0)
                 {
                     return findResponse;
                 }
@@ -464,10 +464,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Extract metadata from .nupkg package file.
         /// This is called only for packages that are ascertained to be a match for our search criteria.
         /// </summary>
-        private Hashtable GetMetadataFromNupkg(string packageName, string packagePath, string[] requiredTags, out ExceptionDispatchInfo edi)
+        private Hashtable GetMetadataFromNupkg(string packageName, string packagePath, string[] requiredTags, out ErrorRecord errRecord)
         {
             Hashtable pkgMetadata = new Hashtable(StringComparer.OrdinalIgnoreCase);
-            edi = null;
+            errRecord = null;
 
             // create temp directory where we will copy .nupkg to, extract contents, etc.
             var tempDiscoveryPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -499,7 +499,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     if (!Utils.TryReadManifestFile(psd1FilePath, out pkgMetadata, out Exception readManifestError))
                     {
-                        edi = ExceptionDispatchInfo.Capture(readManifestError);
+                        errRecord = new ErrorRecord(readManifestError, "GetMetadataFromNupkgFailure", ErrorCategory.ParserError, this);
                         return pkgMetadata;
                     }
 
@@ -519,7 +519,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     if (!PSScriptFileInfo.TryTestPSScriptFileInfo(ps1FilePath, out PSScriptFileInfo parsedScript, out ErrorRecord[] errors, out string[] verboseMsgs))
                     {
-                        edi = ExceptionDispatchInfo.Capture(new InvalidDataException($"PSScriptFile could not be read properly")); // TODO: how to handle multiple? maybe just write a error of our own
+                        errRecord = new ErrorRecord(new InvalidDataException($"PSScriptFile could not be read properly"), "GetMetadataFromNupkgFailure", ErrorCategory.ParserError, this);
                         return pkgMetadata;
                     }
 
@@ -531,8 +531,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
                 else if (File.Exists(nuspecFilePath))
                 {
-                    pkgMetadata = GetHashtableForNuspec(nuspecFilePath, out edi);
-                    if (edi != null)
+                    pkgMetadata = GetHashtableForNuspec(nuspecFilePath, out errRecord);
+                    if (errRecord != null)
                     {
                         return pkgMetadata;
                     }
@@ -544,7 +544,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
                 else
                 {
-                    edi = ExceptionDispatchInfo.Capture(new InvalidDataException($".nupkg package must contain either .psd1, .ps1, or .nuspec file and none were found"));
+                    errRecord = new ErrorRecord(new InvalidDataException($".nupkg package must contain either .psd1, .ps1, or .nuspec file and none were found"), "GetMetadataFromNupkgFailure", ErrorCategory.InvalidData, this);
                     return pkgMetadata;
                 }
 
@@ -558,7 +558,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             catch (Exception e)
             {
-               edi = ExceptionDispatchInfo.Capture(new InvalidOperationException($"Temporary folder for installation could not be created or set due to: {e.Message}"));
+               errRecord = new ErrorRecord(new InvalidOperationException($"Temporary folder for installation could not be created or set due to: {e.Message}"), "GetMetadataFromNupkgFailure", ErrorCategory.InvalidOperation, this);
             }
             finally
             {
@@ -576,13 +576,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// hashtable with those that matches the exact name and prerelease requirements provided.
         /// This helper method is called for FindVersionGlobbing()
         /// </summary>
-        private Hashtable GetMatchingFilesGivenSpecificName(string packageName, bool includePrerelease, VersionRange versionRange, out string actualName, out ExceptionDispatchInfo edi)
+        private Hashtable GetMatchingFilesGivenSpecificName(string packageName, bool includePrerelease, VersionRange versionRange, out string actualName, out ErrorRecord errRecord)
         {
             actualName = packageName;
             // used for FindVersionGlobbing where we know exact non-wildcard name of the package
             WildcardPattern pkgNamePattern = new WildcardPattern($"{packageName}.*", WildcardOptions.IgnoreCase);
             Hashtable pkgVersionsFound = new Hashtable(StringComparer.OrdinalIgnoreCase);
-            edi = null;
+            errRecord = null;
 
             foreach (string path in Directory.GetFiles(Repository.Uri.AbsolutePath))
             {
@@ -590,8 +590,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 if (!String.IsNullOrEmpty(packageFullName) && pkgNamePattern.IsMatch(packageFullName))
                 {
-                    NuGetVersion nugetVersion = GetInfoFromFileName(packageFullName: packageFullName, packageName: packageName, out actualName, edi: out edi);
-                    if (edi != null)
+                    NuGetVersion nugetVersion = GetInfoFromFileName(packageFullName: packageFullName, packageName: packageName, out actualName, errRecord: out errRecord);
+                    if (errRecord != null)
                     {
                         continue;
                     }
@@ -676,10 +676,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Takes .nupkg package file name (i.e like mypackage.1.0.0.nupkg) and parses out version from it.
         /// </summary>
-        private NuGetVersion GetInfoFromFileName(string packageFullName, string packageName, out string actualName, out ExceptionDispatchInfo edi)
+        private NuGetVersion GetInfoFromFileName(string packageFullName, string packageName, out string actualName, out ErrorRecord errRecord)
         {
             // packageFullName will look like package.1.0.0.nupkg
-            edi = null;
+            errRecord = null;
 
             string[] packageWithoutName = packageFullName.ToLower().Split(new string[]{ $"{packageName.ToLower()}." }, StringSplitOptions.RemoveEmptyEntries);
             string packageVersionAndExtension = packageWithoutName[0];
@@ -689,7 +689,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string version = packageVersionAndExtension.Substring(0, extensionDot);
             if (!NuGetVersion.TryParse(version, out NuGetVersion nugetVersion))
             {
-                edi = ExceptionDispatchInfo.Capture(new ArgumentException($"Could not parse version {version} from file {packageFullName}"));
+                errRecord = new ErrorRecord(new ArgumentException($"Could not parse version {version} from file {packageFullName}"), "GetInfoFromFileNameFilaure", ErrorCategory.ParserError, this);
                 return null;
             }
 
@@ -699,15 +699,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Method that loads file content into XMLDocument. Used when reading .nuspec file.
         /// </summary>
-        private XmlDocument LoadXmlDocument(string filePath, out ExceptionDispatchInfo edi)
+        private XmlDocument LoadXmlDocument(string filePath, out ErrorRecord errRecord)
         {
-            edi = null;
+            errRecord = null;
             XmlDocument doc = new XmlDocument();
             doc.PreserveWhitespace = true;
             try { doc.Load(filePath); }
             catch (Exception e)
             {
-                edi = ExceptionDispatchInfo.Capture(new InvalidOperationException(e.Message));
+                errRecord = new ErrorRecord(e, "LoadXmlDocumentFailure", ErrorCategory.ReadError, this);
             }
 
             return doc;
@@ -735,12 +735,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Method that reads .nuspec file and parses out metadata information into Hashtable.
         /// </summary>
-        private Hashtable GetHashtableForNuspec(string filePath, out ExceptionDispatchInfo edi)
+        private Hashtable GetHashtableForNuspec(string filePath, out ErrorRecord errRecord)
         {
             Hashtable nuspecHashtable = new Hashtable(StringComparer.InvariantCultureIgnoreCase);
 
-            XmlDocument nuspecXmlDocument = LoadXmlDocument(filePath, out edi);
-            if (edi != null)
+            XmlDocument nuspecXmlDocument = LoadXmlDocument(filePath, out errRecord);
+            if (errRecord != null)
             {
                 return nuspecHashtable;
             }
@@ -767,7 +767,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             catch (Exception e)
             {
-                edi = ExceptionDispatchInfo.Capture(new InvalidOperationException(e.Message));
+                errRecord = new ErrorRecord(e, "GetHashtableForNuspecFailure", ErrorCategory.ReadError, this);
             }
 
             return nuspecHashtable;        

--- a/src/code/PSGetException.cs
+++ b/src/code/PSGetException.cs
@@ -7,8 +7,8 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 {
     public class V3ResourceNotFoundException : Exception
     {
-        public V3ResourceNotFoundException(string message)
-            : base (message)
+        public V3ResourceNotFoundException(string message, Exception innerException = null)
+            : base (message, innerException)
         {
         }
     }

--- a/src/code/ServerApiCall.cs
+++ b/src/code/ServerApiCall.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using NuGet.Versioning;
 using System.Net;
 using System.Runtime.ExceptionServices;
+using System.Management.Automation;
 
 namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 {
@@ -40,46 +41,46 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Find method which allows for searching for all packages from a repository and returns latest version for each.
         /// </summary>
-        public abstract FindResults FindAll(bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi);
+        public abstract FindResults FindAll(bool includePrerelease, ResourceType type, out ErrorRecord errRecord);
 
         /// <summary>
         /// Find method which allows for searching for packages with tag from a repository and returns latest version for each.
         /// Examples: Search -Tag "JSON" -Repository PSGallery
         /// </summary>
-        public abstract FindResults FindTags(string[] tags, bool includePrerelease, ResourceType _type, out ExceptionDispatchInfo edi);
+        public abstract FindResults FindTags(string[] tags, bool includePrerelease, ResourceType _type, out ErrorRecord errRecord);
 
         /// <summary>
         /// Find method which allows for searching for all packages that have specified Command or DSCResource name.
         /// </summary>
-        public abstract FindResults FindCommandOrDscResource(string[] tags, bool includePrerelease, bool isSearchingForCommands, out ExceptionDispatchInfo edi);
+        public abstract FindResults FindCommandOrDscResource(string[] tags, bool includePrerelease, bool isSearchingForCommands, out ErrorRecord errRecord);
 
         /// <summary>
         /// Find method which allows for searching for package by single name and returns latest version.
         /// Name: no wildcard support
         /// Examples: Search "PowerShellGet"
         /// </summary>
-        public abstract FindResults FindName(string packageName, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi);
+        public abstract FindResults FindName(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord);
 
         /// <summary>
         /// Find method which allows for searching for package by single name and tag and returns latest version.
         /// Name: no wildcard support
         /// Examples: Search "PowerShellGet" -Tag "provider"
         /// </summary>
-        public abstract FindResults FindNameWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi);
+        public abstract FindResults FindNameWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord);
 
         /// <summary>
         /// Find method which allows for searching for single name with wildcards and returns latest version.
         /// Name: supports wildcards
         /// Examples: Search "PowerShell*"
         /// </summary>
-        public abstract FindResults FindNameGlobbing(string packageName, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi);
+        public abstract FindResults FindNameGlobbing(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord);
 
         /// <summary>
         /// Find method which allows for searching for single name with wildcards and tag and returns latest version.
         /// Name: supports wildcards
         /// Examples: Search "PowerShell*"
         /// </summary>
-        public abstract FindResults FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi);
+        public abstract FindResults FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord);
         /// <summary>
         /// Find method which allows for searching for single name with version range.
         /// Name: no wildcard support
@@ -87,7 +88,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Search "PowerShellGet" "[3.0.0.0, 5.0.0.0]"
         ///           Search "PowerShellGet" "3.*"
         /// </summary>
-        public abstract FindResults FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ExceptionDispatchInfo edi);
+        public abstract FindResults FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ErrorRecord errRecord);
 
         /// <summary>
         /// Find method which allows for searching for single name with specific version.
@@ -95,7 +96,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Version: no wildcard support
         /// Examples: Search "PowerShellGet" "2.2.5"
         /// </summary>
-        public abstract FindResults FindVersion(string packageName, string version, ResourceType type, out ExceptionDispatchInfo edi);
+        public abstract FindResults FindVersion(string packageName, string version, ResourceType type, out ErrorRecord errRecord);
 
         /// <summary>
         /// Find method which allows for searching for single name with specific version.
@@ -103,7 +104,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Version: no wildcard support
         /// Examples: Search "PowerShellGet" "2.2.5" -Tag "Provider"
         /// </summary>
-        public abstract FindResults FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ExceptionDispatchInfo edi);
+        public abstract FindResults FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ErrorRecord errRecord);
 
         /**  INSTALL APIS **/
 
@@ -115,7 +116,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         ///                        if prerelease, the calling method should first call IFindPSResource.FindName(), 
         ///                             then find the exact version to install, then call into install version
         /// </summary>
-        public abstract Stream InstallName(string packageName, bool includePrerelease, out ExceptionDispatchInfo edi);
+        public abstract Stream InstallName(string packageName, bool includePrerelease, out ErrorRecord errRecord);
 
 
         /// <summary>
@@ -125,7 +126,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Install "PowerShellGet" -Version "3.0.0.0"
         ///           Install "PowerShellGet" -Version "3.0.0-beta16"
         /// </summary>    
-        public abstract Stream InstallVersion(string packageName, string version, out ExceptionDispatchInfo edi);
+        public abstract Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord);
 
         #endregion
     

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -161,10 +161,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             _findHelper = new FindHelper(
                 cancellationToken: _cancellationTokenSource.Token, 
-                cmdletPassedIn: this,
+                cmdletPasserrRecordn: this,
                 networkCredential: networkCred);
 
-             _installHelper = new InstallHelper(cmdletPassedIn: this, networkCredential: networkCred);
+             _installHelper = new InstallHelper(cmdletPasserrRecordn: this, networkCredential: networkCred);
         }
 
         protected override void ProcessRecord()
@@ -289,7 +289,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             // Get all installed packages selected for updating.
-            GetHelper getHelper = new GetHelper(cmdletPassedIn: this);
+            GetHelper getHelper = new GetHelper(cmdletPasserrRecordn: this);
             var installedPackages = new Dictionary<string, PSResourceInfo>(StringComparer.InvariantCultureIgnoreCase);
 
             // selectPrereleaseOnly is false because even if Prerelease is true we want to include both stable and prerelease, not select prerelease only.

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -161,10 +161,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             _findHelper = new FindHelper(
                 cancellationToken: _cancellationTokenSource.Token, 
-                cmdletPasserrRecordn: this,
+                cmdletPassedIn: this,
                 networkCredential: networkCred);
 
-             _installHelper = new InstallHelper(cmdletPasserrRecordn: this, networkCredential: networkCred);
+             _installHelper = new InstallHelper(cmdletPassedIn: this, networkCredential: networkCred);
         }
 
         protected override void ProcessRecord()
@@ -289,7 +289,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             // Get all installed packages selected for updating.
-            GetHelper getHelper = new GetHelper(cmdletPasserrRecordn: this);
+            GetHelper getHelper = new GetHelper(cmdletPassedIn: this);
             var installedPackages = new Dictionary<string, PSResourceInfo>(StringComparer.InvariantCultureIgnoreCase);
 
             // selectPrereleaseOnly is false because even if Prerelease is true we want to include both stable and prerelease, not select prerelease only.

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using System.Net;
 using System.Runtime.ExceptionServices;
+using System.Management.Automation;
 
 namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 {
@@ -61,21 +62,21 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// API call: 
         /// - No prerelease: http://www.powershellgallery.com/api/v2/Search()?$filter=IsLatestVersion
         /// </summary>
-        public override FindResults FindAll(bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi) {
-            edi = null;
+        public override FindResults FindAll(bool includePrerelease, ResourceType type, out ErrorRecord errRecord) {
+            errRecord = null;
             List<string> responses = new List<string>();
 
             if (type == ResourceType.Script || type == ResourceType.None)
             {
                 int scriptSkip = 0;
-                string initialScriptResponse = FindAllFromTypeEndPoint(includePrerelease, isSearchingModule: false, scriptSkip, out edi);
-                if (edi != null)
+                string initialScriptResponse = FindAllFromTypeEndPoint(includePrerelease, isSearchingModule: false, scriptSkip, out errRecord);
+                if (errRecord != null)
                 {
                     return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
                 responses.Add(initialScriptResponse);
-                int initalScriptCount = GetCountFromResponse(initialScriptResponse, out edi);
-                if (edi != null)
+                int initalScriptCount = GetCountFromResponse(initialScriptResponse, out errRecord);
+                if (errRecord != null)
                 {
                     return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
@@ -84,8 +85,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 while (count > 0)
                 {
                     scriptSkip += 6000;
-                    var tmpResponse = FindAllFromTypeEndPoint(includePrerelease, isSearchingModule: false, scriptSkip, out edi);
-                    if (edi != null)
+                    var tmpResponse = FindAllFromTypeEndPoint(includePrerelease, isSearchingModule: false, scriptSkip, out errRecord);
+                    if (errRecord != null)
                     {
                         return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                     }
@@ -96,14 +97,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (type != ResourceType.Script)
             {
                 int moduleSkip = 0;
-                string initialModuleResponse = FindAllFromTypeEndPoint(includePrerelease, isSearchingModule: true, moduleSkip, out edi);
-                if (edi != null)
+                string initialModuleResponse = FindAllFromTypeEndPoint(includePrerelease, isSearchingModule: true, moduleSkip, out errRecord);
+                if (errRecord != null)
                 {
                     return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
                 responses.Add(initialModuleResponse);
-                int initalModuleCount = GetCountFromResponse(initialModuleResponse, out edi);
-                if (edi != null)
+                int initalModuleCount = GetCountFromResponse(initialModuleResponse, out errRecord);
+                if (errRecord != null)
                 {
                     return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
@@ -113,8 +114,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 while (count > 0)
                 {
                     moduleSkip += 6000;
-                    var tmpResponse = FindAllFromTypeEndPoint(includePrerelease, isSearchingModule: true, moduleSkip, out edi);
-                    if (edi != null)
+                    var tmpResponse = FindAllFromTypeEndPoint(includePrerelease, isSearchingModule: true, moduleSkip, out errRecord);
+                    if (errRecord != null)
                     {
                         return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                     }
@@ -132,22 +133,22 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// API call: 
         /// - Include prerelease: http://www.powershellgallery.com/api/v2/Search()?$filter=IsAbsoluteLatestVersion&searchTerm=tag:JSON&includePrerelease=true
         /// </summary>
-        public override FindResults FindTags(string[] tags, bool includePrerelease, ResourceType _type, out ExceptionDispatchInfo edi)
+        public override FindResults FindTags(string[] tags, bool includePrerelease, ResourceType _type, out ErrorRecord errRecord)
         {
-            edi = null;
+            errRecord = null;
             List<string> responses = new List<string>();
 
             if (_type == ResourceType.Script || _type == ResourceType.None)
             {
                 int scriptSkip = 0;
-                string initialScriptResponse = FindTagFromEndpoint(tags, includePrerelease, isSearchingModule: false, scriptSkip, out edi);
-                if (edi != null)
+                string initialScriptResponse = FindTagFromEndpoint(tags, includePrerelease, isSearchingModule: false, scriptSkip, out errRecord);
+                if (errRecord != null)
                 {
                     return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
                 responses.Add(initialScriptResponse);
-                int initalScriptCount = GetCountFromResponse(initialScriptResponse, out edi);
-                if (edi != null)
+                int initalScriptCount = GetCountFromResponse(initialScriptResponse, out errRecord);
+                if (errRecord != null)
                 {
                     return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
@@ -157,8 +158,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     // skip 100
                     scriptSkip += 100;
-                    var tmpResponse = FindTagFromEndpoint(tags, includePrerelease, isSearchingModule: false,  scriptSkip, out edi);
-                    if (edi != null)
+                    var tmpResponse = FindTagFromEndpoint(tags, includePrerelease, isSearchingModule: false,  scriptSkip, out errRecord);
+                    if (errRecord != null)
                     {
                         return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                     }
@@ -169,14 +170,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (_type != ResourceType.Script)
             {
                 int moduleSkip = 0;
-                string initialModuleResponse = FindTagFromEndpoint(tags, includePrerelease, isSearchingModule: true, moduleSkip, out edi);
-                if (edi != null)
+                string initialModuleResponse = FindTagFromEndpoint(tags, includePrerelease, isSearchingModule: true, moduleSkip, out errRecord);
+                if (errRecord != null)
                 {
                     return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
                 responses.Add(initialModuleResponse);
-                int initalModuleCount = GetCountFromResponse(initialModuleResponse, out edi);
-                if (edi != null)
+                int initalModuleCount = GetCountFromResponse(initialModuleResponse, out errRecord);
+                if (errRecord != null)
                 {
                     return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
@@ -185,8 +186,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 while (count > 0)
                 {
                     moduleSkip += 100;
-                    var tmpResponse = FindTagFromEndpoint(tags, includePrerelease, isSearchingModule: true, moduleSkip, out edi);
-                    if (edi != null)
+                    var tmpResponse = FindTagFromEndpoint(tags, includePrerelease, isSearchingModule: true, moduleSkip, out errRecord);
+                    if (errRecord != null)
                     {
                         return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                     }
@@ -201,19 +202,19 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Find method which allows for searching for all packages that have specified Command or DSCResource name.
         /// </summary>
-        public override FindResults FindCommandOrDscResource(string[] tags, bool includePrerelease, bool isSearchingForCommands, out ExceptionDispatchInfo edi)
+        public override FindResults FindCommandOrDscResource(string[] tags, bool includePrerelease, bool isSearchingForCommands, out ErrorRecord errRecord)
         {
             List<string> responses = new List<string>();
             int skip = 0;
 
-            string initialResponse = FindCommandOrDscResource(tags, includePrerelease, isSearchingForCommands, skip, out edi);
-            if (edi != null)
+            string initialResponse = FindCommandOrDscResource(tags, includePrerelease, isSearchingForCommands, skip, out errRecord);
+            if (errRecord != null)
             {
                 return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
             responses.Add(initialResponse);
-            int initialCount = GetCountFromResponse(initialResponse, out edi);
-            if (edi != null)
+            int initialCount = GetCountFromResponse(initialResponse, out errRecord);
+            if (errRecord != null)
             {
                 return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
@@ -222,8 +223,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             while (count > 0)
             {
                 skip += 100;
-                var tmpResponse = FindCommandOrDscResource(tags, includePrerelease, isSearchingForCommands, skip, out edi);
-                if (edi != null)
+                var tmpResponse = FindCommandOrDscResource(tags, includePrerelease, isSearchingForCommands, skip, out errRecord);
+                if (errRecord != null)
                 {
                     return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
@@ -243,7 +244,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// - Include prerelease: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
         /// Implementation Note: Need to filter further for latest version (prerelease or non-prerelease dependening on user preference)
         /// </summary>
-        public override FindResults FindName(string packageName, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindName(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             // Make sure to include quotations around the package name
             var prerelease = includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion";
@@ -255,7 +256,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string typeFilterPart = GetTypeFilterForRequest(type);
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter={prerelease}{idFilterPart}{typeFilterPart}";
 
-            string response = HttpRequestCall(requestUrlV2, out edi);  
+            string response = HttpRequestCall(requestUrlV2, out errRecord);  
             return new FindResults(stringResponse: new string[]{ response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
         }
 
@@ -265,7 +266,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Search "PowerShellGet" -Tag "Provider"
         /// Implementation Note: Need to filter further for latest version (prerelease or non-prerelease dependening on user preference)
         /// </summary>
-        public override FindResults FindNameWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindNameWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             // Make sure to include quotations around the package name
             var prerelease = includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion";
@@ -283,7 +284,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter={prerelease}{idFilterPart}{typeFilterPart}{tagFilterPart}";
 
-            string response = HttpRequestCall(requestUrlV2, out edi);
+            string response = HttpRequestCall(requestUrlV2, out errRecord);
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
         }
 
@@ -295,13 +296,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// - No prerelease: http://www.powershellgallery.com/api/v2/Search()?$filter=IsLatestVersion&searchTerm='az*'
         /// Implementation Note: filter additionally and verify ONLY package name was a match.
         /// </summary>
-        public override FindResults FindNameGlobbing(string packageName, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindNameGlobbing(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             List<string> responses = new List<string>();
             int skip = 0;
 
-            var initialResponse = FindNameGlobbing(packageName, type, includePrerelease, skip, out edi);
-            if (edi != null)
+            var initialResponse = FindNameGlobbing(packageName, type, includePrerelease, skip, out errRecord);
+            if (errRecord != null)
             {
                 return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
@@ -309,8 +310,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             responses.Add(initialResponse);
 
             // check count (regex)  425 ==> count/100  ~~>  4 calls 
-            int initalCount = GetCountFromResponse(initialResponse, out edi);  // count = 4
-            if (edi != null)
+            int initalCount = GetCountFromResponse(initialResponse, out errRecord);  // count = 4
+            if (errRecord != null)
             {
                 return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
@@ -320,8 +321,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 // skip 100
                 skip += 100;
-                var tmpResponse = FindNameGlobbing(packageName, type, includePrerelease, skip, out edi);
-                if (edi != null)
+                var tmpResponse = FindNameGlobbing(packageName, type, includePrerelease, skip, out errRecord);
+                if (errRecord != null)
                 {
                     return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
@@ -338,13 +339,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Search "PowerShell*" -Tag "Provider"
         /// Implementation Note: filter additionally and verify ONLY package name was a match.
         /// </summary>
-        public override FindResults FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             List<string> responses = new List<string>();
             int skip = 0;
 
-            var initialResponse = FindNameGlobbingWithTag(packageName, tags, type, includePrerelease, skip, out edi);
-            if (edi != null)
+            var initialResponse = FindNameGlobbingWithTag(packageName, tags, type, includePrerelease, skip, out errRecord);
+            if (errRecord != null)
             {
                 return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
@@ -352,8 +353,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             responses.Add(initialResponse);
 
             // check count (regex)  425 ==> count/100  ~~>  4 calls 
-            int initalCount = GetCountFromResponse(initialResponse, out edi);  // count = 4
-            if (edi != null)
+            int initalCount = GetCountFromResponse(initialResponse, out errRecord);  // count = 4
+            if (errRecord != null)
             {
                 return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
@@ -363,8 +364,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 // skip 100
                 skip += 100;
-                var tmpResponse = FindNameGlobbingWithTag(packageName, tags, type, includePrerelease, skip, out edi);
-                if (edi != null)
+                var tmpResponse = FindNameGlobbingWithTag(packageName, tags, type, includePrerelease, skip, out errRecord);
+                if (errRecord != null)
                 {
                     return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
@@ -384,13 +385,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// API Call: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
         /// Implementation note: Returns all versions, including prerelease ones. Later (in the API client side) we'll do filtering on the versions to satisfy what user provided.
         /// </summary>
-        public override FindResults FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ExceptionDispatchInfo edi)
+        public override FindResults FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ErrorRecord errRecord)
         {
             List<string> responses = new List<string>();
             int skip = 0;
 
-            var initialResponse = FindVersionGlobbing(packageName, versionRange, includePrerelease, type, skip, getOnlyLatest, out edi);
-            if (edi != null)
+            var initialResponse = FindVersionGlobbing(packageName, versionRange, includePrerelease, type, skip, getOnlyLatest, out errRecord);
+            if (errRecord != null)
             {
                 return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
@@ -398,8 +399,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (!getOnlyLatest)
             {
-                int initalCount = GetCountFromResponse(initialResponse, out edi);
-                if (edi != null)
+                int initalCount = GetCountFromResponse(initialResponse, out errRecord);
+                if (errRecord != null)
                 {
                     return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
@@ -409,8 +410,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     // skip 100
                     skip += 100;
-                    var tmpResponse = FindVersionGlobbing(packageName, versionRange, includePrerelease, type, skip, getOnlyLatest, out edi);
-                    if (edi != null)
+                    var tmpResponse = FindVersionGlobbing(packageName, versionRange, includePrerelease, type, skip, getOnlyLatest, out errRecord);
+                    if (errRecord != null)
                     {
                         return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                     }
@@ -429,7 +430,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Search "PowerShellGet" "2.2.5"
         /// API call: http://www.powershellgallery.com/api/v2/Packages(Id='PowerShellGet', Version='2.2.5')
         /// </summary>
-        public override FindResults FindVersion(string packageName, string version, ResourceType type, out ExceptionDispatchInfo edi) 
+        public override FindResults FindVersion(string packageName, string version, ResourceType type, out ErrorRecord errRecord) 
         {
             // https://www.powershellgallery.com/api/v2/FindPackagesById()?id='blah'&includePrerelease=false&$filter= NormalizedVersion eq '1.1.0' and substringof('PSModule', Tags) eq true 
             // Quotations around package name and version do not matter, same metadata gets returned.
@@ -438,7 +439,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string typeFilterPart = GetTypeFilterForRequest(type);
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter= NormalizedVersion eq '{version}'{idFilterPart}{typeFilterPart}";
             
-            string response = HttpRequestCall(requestUrlV2, out edi);  
+            string response = HttpRequestCall(requestUrlV2, out errRecord);  
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
         }
 
@@ -448,7 +449,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Version: no wildcard support
         /// Examples: Search "PowerShellGet" "2.2.5" -Tag "Provider"
         /// </summary>
-        public override FindResults FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ErrorRecord errRecord)
         {
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
             string idFilterPart = $" and Id eq '{packageName}'";
@@ -461,7 +462,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter= NormalizedVersion eq '{version}'{idFilterPart}{typeFilterPart}{tagFilterPart}";
             
-            string response = HttpRequestCall(requestUrlV2, out edi);
+            string response = HttpRequestCall(requestUrlV2, out errRecord);
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
         }
 
@@ -474,11 +475,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Implementation Note:   if not prerelease: https://www.powershellgallery.com/api/v2/package/powershellget (Returns latest stable)
         ///                        if prerelease, call into InstallVersion instead. 
         /// </summary>
-        public override Stream InstallName(string packageName, bool includePrerelease, out ExceptionDispatchInfo edi)
+        public override Stream InstallName(string packageName, bool includePrerelease, out ErrorRecord errRecord)
         {
             var requestUrlV2 = $"{Repository.Uri}/package/{packageName}";
 
-            var response = HttpRequestCallForContent(requestUrlV2, out edi);
+            var response = HttpRequestCallForContent(requestUrlV2, out errRecord);
             var responseStream = response.ReadAsStreamAsync().Result;
             return responseStream;
         }
@@ -491,11 +492,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         ///           Install "PowerShellGet" -Version "3.0.0-beta16"
         /// API Call: https://www.powershellgallery.com/api/v2/package/Id/version (version can be prerelease)
         /// </summary>    
-        public override Stream InstallVersion(string packageName, string version, out ExceptionDispatchInfo edi)
+        public override Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord)
         {
             var requestUrlV2 = $"{Repository.Uri}/package/{packageName}/{version}";
 
-            var response = HttpRequestCallForContent(requestUrlV2, out edi);
+            var response = HttpRequestCallForContent(requestUrlV2, out errRecord);
             var responseStream = response.ReadAsStreamAsync().Result;
             return responseStream;
         }
@@ -503,9 +504,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method that makes the HTTP request for the V2 server protocol url passed in for find APIs.
         /// </summary>
-        private string HttpRequestCall(string requestUrlV2, out ExceptionDispatchInfo edi)
+        private string HttpRequestCall(string requestUrlV2, out ErrorRecord errRecord)
         {
-            edi = null;
+            errRecord = null;
             string response = string.Empty;
 
             try
@@ -516,15 +517,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             catch (HttpRequestException e)
             {
-                edi = ExceptionDispatchInfo.Capture(e);
+                errRecord = new ErrorRecord(e, "HttpRequestFallFailure", ErrorCategory.ConnectionError, this);
             }
             catch (ArgumentNullException e)
             {
-                edi = ExceptionDispatchInfo.Capture(e);
+                errRecord = new ErrorRecord(e, "HttpRequestFallFailure", ErrorCategory.ConnectionError, this);
             }
             catch (InvalidOperationException e)
             {
-                edi = ExceptionDispatchInfo.Capture(e);
+                errRecord = new ErrorRecord(e, "HttpRequestFallFailure", ErrorCategory.ConnectionError, this);
             }
 
             return response;
@@ -533,9 +534,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method that makes the HTTP request for the V2 server protocol url passed in for install APIs.
         /// </summary>
-        private HttpContent HttpRequestCallForContent(string requestUrlV2, out ExceptionDispatchInfo edi) 
+        private HttpContent HttpRequestCallForContent(string requestUrlV2, out ErrorRecord errRecord) 
         {
-            edi = null;
+            errRecord = null;
             HttpContent content = null;
 
             try
@@ -546,15 +547,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             catch (HttpRequestException e)
             {
-                edi = ExceptionDispatchInfo.Capture(e);
+                errRecord = new ErrorRecord(e, "HttpRequestFailure", ErrorCategory.ConnectionError , this);
             }
             catch (ArgumentNullException e)
             {
-                edi = ExceptionDispatchInfo.Capture(e);
+                errRecord = new ErrorRecord(e, "HttpRequestFailure", ErrorCategory.InvalidData, this);
             }
             catch (InvalidOperationException e)
             {
-                edi = ExceptionDispatchInfo.Capture(e);
+                errRecord = new ErrorRecord(e, "HttpRequestFailure", ErrorCategory.InvalidOperation, this);
             }
 
             return content;
@@ -567,7 +568,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method for string[] FindAll(string, PSRepositoryInfo, bool, bool, ResourceType, out string)
         /// </summary>
-        private string FindAllFromTypeEndPoint(bool includePrerelease, bool isSearchingModule, int skip, out ExceptionDispatchInfo edi)
+        private string FindAllFromTypeEndPoint(bool includePrerelease, bool isSearchingModule, int skip, out ErrorRecord errRecord)
         {
             string typeEndpoint = isSearchingModule ? String.Empty : "/items/psscript";
             string paginationParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=6000";
@@ -575,13 +576,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             var requestUrlV2 = $"{Repository.Uri}{typeEndpoint}/Search()?$filter={prereleaseFilter}{paginationParam}";
 
-            return HttpRequestCall(requestUrlV2, out edi);
+            return HttpRequestCall(requestUrlV2, out errRecord);
         }
 
         /// <summary>
         /// Helper method for string[] FindTag(string, PSRepositoryInfo, bool, bool, ResourceType, out string)
         /// </summary>
-        private string FindTagFromEndpoint(string[] tags, bool includePrerelease, bool isSearchingModule, int skip, out ExceptionDispatchInfo edi)
+        private string FindTagFromEndpoint(string[] tags, bool includePrerelease, bool isSearchingModule, int skip, out ErrorRecord errRecord)
         {
             // scenarios with type + tags:
             // type: None -> search both endpoints
@@ -602,13 +603,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             var requestUrlV2 = $"{Repository.Uri}{typeEndpoint}/Search()?{prereleaseFilter}{typeFilterPart}{tagFilterPart}{paginationParam}";
 
-            return HttpRequestCall(requestUrlV2: requestUrlV2, out edi);  
+            return HttpRequestCall(requestUrlV2: requestUrlV2, out errRecord);  
         }
 
         /// <summary>
         /// Helper method for string[] FindCommandOrDSCResource(string, PSRepositoryInfo, bool, bool, ResourceType, out string)
         /// </summary>
-        private string FindCommandOrDscResource(string[] tags, bool includePrerelease, bool isSearchingForCommands, int skip, out ExceptionDispatchInfo edi)
+        private string FindCommandOrDscResource(string[] tags, bool includePrerelease, bool isSearchingForCommands, int skip, out ErrorRecord errRecord)
         {
             // can only find from Modules endpoint
             string paginationParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=6000";
@@ -627,13 +628,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             var requestUrlV2 = $"{Repository.Uri}/Search()?{prereleaseFilter}&searchTerm='{tagSearchTermPart}'{paginationParam}";
-            return HttpRequestCall(requestUrlV2, out edi);
+            return HttpRequestCall(requestUrlV2, out errRecord);
         }
 
         /// <summary>
         /// Helper method for string[] FindNameGlobbing()
         /// </summary>
-        private string FindNameGlobbing(string packageName, ResourceType type, bool includePrerelease, int skip, out ExceptionDispatchInfo edi)
+        private string FindNameGlobbing(string packageName, ResourceType type, bool includePrerelease, int skip, out ErrorRecord errRecord)
         {
             // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and startswith(Id, 'PowerShell') and IsLatestVersion (stable)
             // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and IsAbsoluteLatestVersion&includePrerelease=true
@@ -646,7 +647,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (names.Length == 0)
             {
-                edi = ExceptionDispatchInfo.Capture(new ArgumentException("-Name '*' for V2 server protocol repositories is not supported"));
+                errRecord = new ErrorRecord(new ArgumentException("-Name '*' for V2 server protocol repositories is not supported"), "FindNameGlobbingFailure", ErrorCategory.InvalidArgument, this); 
+
                 return string.Empty;
             }
             if (names.Length == 1)
@@ -677,20 +679,20 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             else 
             {
-                edi = ExceptionDispatchInfo.Capture(new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."));
+                errRecord = new ErrorRecord(new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."), "FindNameGlobbingFailure", ErrorCategory.InvalidArgument, this);
                 return string.Empty;
             }
 
             string typeFilterPart = GetTypeFilterForRequest(type);
             var requestUrlV2 = $"{Repository.Uri}/Search()?$filter={nameFilter}{typeFilterPart} and {prerelease}{extraParam}";
             
-            return HttpRequestCall(requestUrlV2, out edi);  
+            return HttpRequestCall(requestUrlV2, out errRecord);  
         }
 
         /// <summary>
         /// Helper method for string[] FindNameGlobbingWithTag()
         /// </summary>
-        private string FindNameGlobbingWithTag(string packageName, string[] tags, ResourceType type, bool includePrerelease, int skip, out ExceptionDispatchInfo edi)
+        private string FindNameGlobbingWithTag(string packageName, string[] tags, ResourceType type, bool includePrerelease, int skip, out ErrorRecord errRecord)
         {
             // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and startswith(Id, 'PowerShell') and IsLatestVersion (stable)
             // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and IsAbsoluteLatestVersion&includePrerelease=true
@@ -703,7 +705,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (names.Length == 0)
             {
-                edi = ExceptionDispatchInfo.Capture(new ArgumentException("-Name '*' for V2 server protocol repositories is not supported"));
+                errRecord = new ErrorRecord(new ArgumentException("-Name '*' for V2 server protocol repositories is not supported"), "FindNameGlobbingFailure", ErrorCategory.InvalidArgument, this);
+
                 return string.Empty;
             }
             if (names.Length == 1)
@@ -734,7 +737,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             else 
             {
-                edi = ExceptionDispatchInfo.Capture(new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."));
+                errRecord = new ErrorRecord(new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."), "FindNameGlobbing", ErrorCategory.InvalidArgument, this);
+
                 return string.Empty;
             }
 
@@ -747,13 +751,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string typeFilterPart = GetTypeFilterForRequest(type);
             var requestUrlV2 = $"{Repository.Uri}/Search()?$filter={nameFilter}{tagFilterPart}{typeFilterPart} and {prerelease}{extraParam}";
             
-            return HttpRequestCall(requestUrlV2, out edi);  
+            return HttpRequestCall(requestUrlV2, out errRecord);  
         }
 
         /// <summary>
         /// Helper method for string[] FindVersionGlobbing()
         /// </summary>
-        private string FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, int skip, bool getOnlyLatest, out ExceptionDispatchInfo edi)
+        private string FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, int skip, bool getOnlyLatest, out ErrorRecord errRecord)
         {
             //https://www.powershellgallery.com/api/v2//FindPackagesById()?id='blah'&includePrerelease=false&$filter= NormalizedVersion gt '1.0.0' and NormalizedVersion lt '2.2.5' and substringof('PSModule', Tags) eq true 
             //https://www.powershellgallery.com/api/v2//FindPackagesById()?id='PowerShellGet'&includePrerelease=false&$filter= NormalizedVersion gt '1.1.1' and NormalizedVersion lt '2.2.5'
@@ -835,7 +839,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             filterQuery = filterQuery.EndsWith("=") ? string.Empty : filterQuery;
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$orderby=NormalizedVersion desc&{paginationParam}{filterQuery}";
 
-            return HttpRequestCall(requestUrlV2, out edi);  
+            return HttpRequestCall(requestUrlV2, out errRecord);  
         }
 
         private string GetTypeFilterForRequest(ResourceType type) {
@@ -856,9 +860,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Helper method that makes gets 'count' property from http response string.
         /// The count property is used to determine the number of total results found (for pagination).
         /// </summary>
-        public int GetCountFromResponse(string httpResponse, out ExceptionDispatchInfo edi)
+        public int GetCountFromResponse(string httpResponse, out ErrorRecord errRecord)
         {
-            edi = null;
+            errRecord = null;
             int count = 0;
 
             //Create the XmlDocument.
@@ -870,9 +874,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             catch (XmlException e)
             {
-                edi = ExceptionDispatchInfo.Capture(e);
+                errRecord = new ErrorRecord(e, "GetCountFromResponse", ErrorCategory.InvalidData, this);
             }
-            if (edi != null)
+            if (errRecord != null)
             {
                 return count;
             }

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -13,6 +13,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using System.Collections;
 using System.Runtime.ExceptionServices;
+using System.Management.Automation;
 
 namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 {
@@ -67,10 +68,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Find method which allows for searching for all packages from a repository and returns latest version for each.
         /// Not supported for V3 repository.
         /// </summary>
-        public override FindResults FindAll(bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindAll(bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             string errMsg = $"Find all is not supported for the V3 repository {Repository.Name}";
-            edi = ExceptionDispatchInfo.Capture(new InvalidOperationException(errMsg));
+            errRecord = new ErrorRecord(new InvalidOperationException(errMsg), "FindAllFailure", ErrorCategory.InvalidOperation, this);
 
             return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
         }
@@ -79,16 +80,16 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Find method which allows for searching for packages with tag(s) from a repository and returns latest version for each.
         /// This is supported only for the NuGet repository special case, not other V3 repositories.
         /// </summary>
-        public override FindResults FindTags(string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindTags(string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             if (_isNuGetRepo || _isJFrogRepo)
             {
-                return FindTagsFromNuGetRepo(tags, includePrerelease, out edi);
+                return FindTagsFromNuGetRepo(tags, includePrerelease, out errRecord);
             }
             else
             {
                 string errMsg = $"Find by Tags is not supported for the V3 repository {Repository.Name}";
-                edi = ExceptionDispatchInfo.Capture(new InvalidOperationException(errMsg));
+                errRecord = new ErrorRecord(new InvalidOperationException(errMsg), "FindTagsFailure", ErrorCategory.InvalidOperation, this);
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
         }
@@ -97,10 +98,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Find method which allows for searching for packages with specified Command or DSCResource name.
         /// Not supported for V3 repository.
         /// </summary>
-        public override FindResults FindCommandOrDscResource(string[] tags, bool includePrerelease, bool isSearchingForCommands, out ExceptionDispatchInfo edi)
+        public override FindResults FindCommandOrDscResource(string[] tags, bool includePrerelease, bool isSearchingForCommands, out ErrorRecord errRecord)
         {
             string errMsg = $"Find by CommandName or DSCResource is not supported for the V3 server repository {Repository.Name}";
-            edi = ExceptionDispatchInfo.Capture(new InvalidOperationException(errMsg));
+            errRecord = new ErrorRecord(new InvalidOperationException(errMsg), "FindCommandOrDscResourceFailure", ErrorCategory.InvalidOperation, this);
 
             return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
         }
@@ -111,9 +112,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Search "Newtonsoft.Json"
         /// We use the latest RegistrationBaseUrl version resource we can find and check if contains an entry with the package name.
         /// </summary>
-        public override FindResults FindName(string packageName, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindName(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
-            return FindNameHelper(packageName, tags: Utils.EmptyStrArray, includePrerelease, type, out edi);
+            return FindNameHelper(packageName, tags: Utils.EmptyStrArray, includePrerelease, type, out errRecord);
         }
 
         /// <summary>
@@ -122,25 +123,25 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Search "Newtonsoft.Json" -Tag "json"
         /// We use the latest RegistrationBaseUrl version resource we can find and check if contains an entry with the package name.
         /// </summary>
-        public override FindResults FindNameWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindNameWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
-            return FindNameHelper(packageName, tags, includePrerelease, type, out edi);
+            return FindNameHelper(packageName, tags, includePrerelease, type, out errRecord);
         }
 
         /// <summary>
         /// Find method which allows for searching for single name with wildcards and returns latest version.
         /// This is supported only for the NuGet repository special case, not other V3 repositories.
         /// </summary>
-        public override FindResults FindNameGlobbing(string packageName, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindNameGlobbing(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo)
             {
-                return FindNameGlobbingFromNuGetRepo(packageName, tags: Utils.EmptyStrArray, includePrerelease, out edi);
+                return FindNameGlobbingFromNuGetRepo(packageName, tags: Utils.EmptyStrArray, includePrerelease, out errRecord);
             }
             else
             {
                 string errMsg = $"Find with Name containing wildcards is not supported for the V3 server repository {Repository.Name}";
-                edi = ExceptionDispatchInfo.Capture(new InvalidOperationException(errMsg));
+                errRecord = new ErrorRecord(new InvalidOperationException(errMsg), "FindNameGlobbingFailure", ErrorCategory.InvalidOperation, this);
 
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
@@ -150,16 +151,16 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Find method which allows for searching for single name with wildcards and tag and returns latest version.
         /// This is supported only for the NuGet repository special case, not other V3 repositories.
         /// </summary>
-        public override FindResults FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo)
             {
-                return FindNameGlobbingFromNuGetRepo(packageName, tags, includePrerelease, out edi);
+                return FindNameGlobbingFromNuGetRepo(packageName, tags, includePrerelease, out errRecord);
             }
             else
             {
                 string errMsg = $"Find with Name containing wildcards is not supported for the V3 server repository {Repository.Name}";
-                edi = ExceptionDispatchInfo.Capture(new InvalidOperationException(errMsg));
+                errRecord = new ErrorRecord(new InvalidOperationException(errMsg), "FindNameGlobbingWithTagFailure", ErrorCategory.InvalidOperation, this);
 
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
@@ -173,10 +174,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         ///           Search "NuGet.Server.Core" "3.*"
         /// We use the latest RegistrationBaseUrl version resource we can find and check if contains an entry with the package name, then get all versions and match to satisfying versions.
         /// </summary>
-        public override FindResults FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ExceptionDispatchInfo edi)
+        public override FindResults FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ErrorRecord errRecord)
         {
-            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out edi);
-            if (edi != null)
+            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord);
+            if (errRecord != null)
             {
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
@@ -191,7 +192,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         JsonElement rootDom = pkgVersionEntry.RootElement;
                         if (!rootDom.TryGetProperty(versionName, out JsonElement pkgVersionElement))
                         {
-                            edi = ExceptionDispatchInfo.Capture(new InvalidOrEmptyResponse($"Response does not contain '{versionName}' element."));
+                            errRecord = new ErrorRecord(new InvalidOrEmptyResponse($"Response does not contain '{versionName}' element."), "FindVersionGlobbingFailure", ErrorCategory.InvalidData, this);
                             return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
                         }
 
@@ -206,7 +207,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
                 catch (Exception e)
                 {
-                    edi = ExceptionDispatchInfo.Capture(e);
+                    errRecord = new ErrorRecord(e, "FindVersionGlobbingFailure", ErrorCategory.InvalidResult, this);
                     return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
                 }
             }
@@ -221,9 +222,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Search "NuGet.Server.Core" "3.0.0-beta"
         /// We use the latest RegistrationBaseUrl version resource we can find and check if contains an entry with the package name, then match to the specified version.
         /// </summary>
-        public override FindResults FindVersion(string packageName, string version, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindVersion(string packageName, string version, ResourceType type, out ErrorRecord errRecord)
         {
-            return FindVersionHelper(packageName, version, tags: Utils.EmptyStrArray, type, out edi);
+            return FindVersionHelper(packageName, version, tags: Utils.EmptyStrArray, type, out errRecord);
         }
 
         /// <summary>
@@ -233,9 +234,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Search "NuGet.Server.Core" "3.0.0-beta" -Tag "core"
         /// We use the latest RegistrationBaseUrl version resource we can find and check if contains an entry with the package name, then match to the specified version.
         /// </summary>     
-        public override FindResults FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ExceptionDispatchInfo edi)
+        public override FindResults FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ErrorRecord errRecord)
         {
-            return FindVersionHelper(packageName, version, tags: tags, type, out edi);
+            return FindVersionHelper(packageName, version, tags: tags, type, out errRecord);
         }
 
         /**  INSTALL APIS **/
@@ -245,9 +246,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Name: no wildcard support.
         /// Examples: Install "Newtonsoft.json"
         /// </summary>
-        public override Stream InstallName(string packageName, bool includePrerelease, out ExceptionDispatchInfo edi)
+        public override Stream InstallName(string packageName, bool includePrerelease, out ErrorRecord errRecord)
         {
-            return InstallHelper(packageName, version: null, out edi);
+            return InstallHelper(packageName, version: null, out errRecord);
         }
 
         /// <summary>
@@ -257,15 +258,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Install "Newtonsoft.json" -Version "1.0.0.0"
         ///           Install "Newtonsoft.json" -Version "2.5.0-beta"
         /// </summary>    
-        public override Stream InstallVersion(string packageName, string version, out ExceptionDispatchInfo edi)
+        public override Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord)
         {
             if (!NuGetVersion.TryParse(version, out NuGetVersion requiredVersion))
             {
-                edi = ExceptionDispatchInfo.Capture(new ArgumentException($"Version {version} to be installed is not a valid NuGet version."));
+                errRecord = new ErrorRecord(new ArgumentException($"Version {version} to be installed is not a valid NuGet version."), "InstallVersionFailure", ErrorCategory.InvalidArgument, this);
                 return null;
             }
 
-            return InstallHelper(packageName, requiredVersion, out edi);
+            return InstallHelper(packageName, requiredVersion, out errRecord);
         }
 
         #endregion
@@ -275,14 +276,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method called by FindNameGlobbing() and FindNameGlobbingWithTag() for special case where repository is NuGet.org repository.
         /// </summary>
-        private FindResults FindNameGlobbingFromNuGetRepo(string packageName, string[] tags, bool includePrerelease, out ExceptionDispatchInfo edi)
+        private FindResults FindNameGlobbingFromNuGetRepo(string packageName, string[] tags, bool includePrerelease, out ErrorRecord errRecord)
         {
             var names = packageName.Split(new char[] { '*' }, StringSplitOptions.RemoveEmptyEntries);
             string querySearchTerm;
 
             if (names.Length == 0)
             {
-                edi = ExceptionDispatchInfo.Capture(new ArgumentException("-Name '*' for V3 server protocol repositories is not supported"));
+                errRecord = new ErrorRecord(new ArgumentException("-Name '*' for V3 server protocol repositories is not supported"), "FindNameGlobbingFromNuGetRepoFailure", ErrorCategory.InvalidArgument, this);
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
             if (names.Length == 1)
@@ -299,12 +300,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // pow*get*
                 // *pow*get
 
-                edi = ExceptionDispatchInfo.Capture(new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."));
+                errRecord = new ErrorRecord(new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."), "FindNameGlobbingFromNuGetRepoFailure", ErrorCategory.InvalidArgument, this);
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
 
-            var matchingPkgEntries = GetVersionedPackageEntriesFromSearchQueryResource(querySearchTerm, includePrerelease, out edi);
-            if (edi != null)
+            var matchingPkgEntries = GetVersionedPackageEntriesFromSearchQueryResource(querySearchTerm, includePrerelease, out errRecord);
+            if (errRecord != null)
             {
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
@@ -321,14 +322,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (!pkgEntry.TryGetProperty(idName, out JsonElement idItem))
                     {
                         string errMsg = $"FindNameGlobbing(): Name element could not be found in response.";
-                        edi = ExceptionDispatchInfo.Capture(new JsonParsingException(errMsg));
+                        errRecord = new ErrorRecord(new JsonParsingException(errMsg), "GetEntriesFromSearchQueryResourceFailure", ErrorCategory.InvalidResult, this);
                         return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
                     }
 
                     if (!pkgEntry.TryGetProperty(tagsName, out JsonElement tagsItem))
                     {
                         string errMsg = $"FindNameGlobbing(): Tags element could not be found in response.";
-                        edi = ExceptionDispatchInfo.Capture(new JsonParsingException(errMsg));
+                        errRecord = new ErrorRecord(new JsonParsingException(errMsg), "GetEntriesFromSearchQueryResourceFailure", ErrorCategory.InvalidResult, this);
                         return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
                     }
 
@@ -339,7 +340,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         (packageName.EndsWith("*") && id.StartsWith(querySearchTerm, StringComparison.OrdinalIgnoreCase)) ||
                         (packageName.StartsWith("*") && id.EndsWith(querySearchTerm, StringComparison.OrdinalIgnoreCase)))
                     {
-                        bool isTagMatch = IsRequiredTagSatisfied(tagsItem, tags, out edi);
+                        bool isTagMatch = IsRequiredTagSatisfied(tagsItem, tags, out errRecord);
                         if (!isTagMatch)
                         {
                             continue;
@@ -351,8 +352,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     
                 catch (Exception e)
                 {
-                    string errMsg = $"FindNameGlobbing(): Name or Version element could not be parsed from response due to exception {e.Message}.";
-                    edi = ExceptionDispatchInfo.Capture(new JsonParsingException(errMsg));
+                    errRecord = new ErrorRecord(e, "GetEntriesFromSearchQueryResourceFailure", ErrorCategory.InvalidResult, this);
                     break;
                 }
             }
@@ -363,13 +363,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method called by FindTags() for special case where repository is NuGet.org repository.
         /// </summary>        
-        private FindResults FindTagsFromNuGetRepo(string[] tags, bool includePrerelease, out ExceptionDispatchInfo edi)
+        private FindResults FindTagsFromNuGetRepo(string[] tags, bool includePrerelease, out ErrorRecord errRecord)
         {
             string tagsQueryTerm = $"tags:{String.Join(" ", tags)}";
             // Get responses for all packages that contain the required tags
             // example query: 
-            var tagPkgEntries = GetVersionedPackageEntriesFromSearchQueryResource(tagsQueryTerm, includePrerelease, out edi);
-            if (edi != null)
+            var tagPkgEntries = GetVersionedPackageEntriesFromSearchQueryResource(tagsQueryTerm, includePrerelease, out errRecord);
+            if (errRecord != null)
             {
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
@@ -386,10 +386,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method called by FindName() and FindNameWithTag()
         /// <summary>
-        private FindResults FindNameHelper(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        private FindResults FindNameHelper(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
-            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out edi);
-            if (edi != null)
+            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord);
+            if (errRecord != null)
             {
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
@@ -405,12 +405,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         JsonElement rootDom = pkgVersionEntry.RootElement;
                         if (!rootDom.TryGetProperty(versionName, out JsonElement pkgVersionElement))
                         {
-                            edi = ExceptionDispatchInfo.Capture(new InvalidOrEmptyResponse($"Response does not contain '{versionName}' element for search with Name {packageName} in '{Repository.Name}'."));
+                            errRecord = new ErrorRecord(new InvalidOrEmptyResponse($"Response does not contain '{versionName}' element for search with Name {packageName} in '{Repository.Name}'."), "FindNameFailure", ErrorCategory.InvalidResult, this);
                             return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
                         }
                         if (!rootDom.TryGetProperty(tagsName, out JsonElement tagsItem))
                         {
-                            edi = ExceptionDispatchInfo.Capture(new InvalidOrEmptyResponse($"Response does not contain '{tagsName}' element for search with Name {packageName} in '{Repository.Name}'."));
+                            errRecord = new ErrorRecord(new InvalidOrEmptyResponse($"Response does not contain '{tagsName}' element for search with Name {packageName} in '{Repository.Name}'."), "FindNameFailure", ErrorCategory.InvalidResult, this);
                             return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
                         }
 
@@ -420,7 +420,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             {
                                 // Versions are always in descending order i.e 5.0.0, 3.0.0, 1.0.0 so grabbing the first match suffices
                                 latestVersionResponse = response;
-                                isTagMatch = IsRequiredTagSatisfied(tagsItem, tags, out edi);
+                                isTagMatch = IsRequiredTagSatisfied(tagsItem, tags, out errRecord);
                                 break;
                             }
                         }
@@ -428,25 +428,25 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
                 catch (Exception e)
                 {
-                    edi = ExceptionDispatchInfo.Capture(e);
+                    errRecord = new ErrorRecord(e, "FindNameFailure", ErrorCategory.InvalidResult, this);
                     return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
                 }
             }
 
             if (String.IsNullOrEmpty(latestVersionResponse))
             {
-                string errMsg = $"FindName(): Package with Name {packageName} was not found in repository {Repository.Name}.";
-                edi = ExceptionDispatchInfo.Capture(new SpecifiedTagsNotFoundException(errMsg));
+                string errMsg = $"Package with Name {packageName} was not found in repository {Repository.Name}.";
+                errRecord = new ErrorRecord(new SpecifiedTagsNotFoundException(errMsg), "FindNameFailure", ErrorCategory.InvalidResult, this);
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
 
             // Check and write error for tags matching requirement. If no tags were required the isTagMatch variable will be true.
             if (!isTagMatch)
             {
-                if (edi == null)
+                if (errRecord == null)
                 {
-                    string errMsg = $"FindName(): Package with Name {packageName} and Tags {String.Join(", ", tags)} was not found in repository {Repository.Name}.";
-                    edi = ExceptionDispatchInfo.Capture(new SpecifiedTagsNotFoundException(errMsg));
+                    string errMsg = $"Package with Name {packageName} and Tags {String.Join(", ", tags)} was not found in repository {Repository.Name}.";
+                    errRecord = new ErrorRecord(new SpecifiedTagsNotFoundException(errMsg), "FindNameFailure", ErrorCategory.InvalidResult, this);
                 }
 
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -458,16 +458,16 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method called by FindVersion() and FindVersionWithTag()
         /// </summary>
-        private FindResults FindVersionHelper(string packageName, string version, string[] tags, ResourceType type, out ExceptionDispatchInfo edi)
+        private FindResults FindVersionHelper(string packageName, string version, string[] tags, ResourceType type, out ErrorRecord errRecord)
         {
             if (!NuGetVersion.TryParse(version, out NuGetVersion requiredVersion))
             {
-                edi = ExceptionDispatchInfo.Capture(new ArgumentException($"Version {version} to be found is not a valid NuGet version."));
+                errRecord = new ErrorRecord(new ArgumentException($"Version {version} to be found is not a valid NuGet version."), "FindNameFailure", ErrorCategory.InvalidArgument, this);
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
 
-            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out edi);
-            if (edi != null)
+            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord);
+            if (errRecord != null)
             {
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
@@ -484,12 +484,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         JsonElement rootDom = pkgVersionEntry.RootElement;
                         if (!rootDom.TryGetProperty(versionName, out JsonElement pkgVersionElement))
                         {
-                            edi = ExceptionDispatchInfo.Capture(new InvalidOrEmptyResponse($"Response does not contain '{versionName}' element for search with Name {packageName} and Version {version} in '{Repository.Name}'."));
+                            errRecord = new ErrorRecord(new InvalidOrEmptyResponse($"Response does not contain '{versionName}' element for search with Name {packageName} and Version {version} in '{Repository.Name}'."), "FindVersionFailure", ErrorCategory.InvalidResult, this);
                             return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
                         }
                         if (!rootDom.TryGetProperty(tagsName, out JsonElement tagsItem))
                         {
-                            edi = ExceptionDispatchInfo.Capture(new InvalidOrEmptyResponse($"Response does not contain '{tagsName}' element for search with Name {packageName} and Version {version} in '{Repository.Name}'."));
+                            errRecord = new ErrorRecord(new InvalidOrEmptyResponse($"Response does not contain '{tagsName}' element for search with Name {packageName} and Version {version} in '{Repository.Name}'."), "FindVersionFailure", ErrorCategory.InvalidResult, this);
                             return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
                         }
                         if (NuGetVersion.TryParse(pkgVersionElement.ToString(), out NuGetVersion pkgVersion))
@@ -497,7 +497,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             if (pkgVersion == requiredVersion)
                             {
                                 latestVersionResponse = response;
-                                isTagMatch = IsRequiredTagSatisfied(tagsItem, tags, out edi);
+                                isTagMatch = IsRequiredTagSatisfied(tagsItem, tags, out errRecord);
                                 break;
                             }
                         }
@@ -505,23 +505,23 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
                 catch (Exception e)
                 {
-                    edi = ExceptionDispatchInfo.Capture(e);
+                    errRecord = new ErrorRecord(e, "FindVersionFailure", ErrorCategory.InvalidResult, this);
                     return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
                 }
             }
 
             if (String.IsNullOrEmpty(latestVersionResponse))
             {
-                edi = ExceptionDispatchInfo.Capture(new InvalidOrEmptyResponse($"FindVersion(): Package with Name {packageName}, Version {version} was not found in repository {Repository.Name}"));
+                errRecord = new ErrorRecord(new InvalidOrEmptyResponse($"Package with Name {packageName}, Version {version} was not found in repository {Repository.Name}"), "FindVersionFailure", ErrorCategory.InvalidResult, this);
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
 
             if (!isTagMatch)
             {
-                if (edi == null)
+                if (errRecord == null)
                 {
                     string errMsg = $"FindVersion(): Package with Name {packageName}, Version {version} and Tags {String.Join(", ", tags)} was not found in repository {Repository.Name}.";
-                    edi = ExceptionDispatchInfo.Capture(new SpecifiedTagsNotFoundException(errMsg));
+                    errRecord = new ErrorRecord(new SpecifiedTagsNotFoundException(errMsg), "FindVersionFailure", ErrorCategory.InvalidResult, this);
                 }
 
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -534,7 +534,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Helper method that is called by InstallName() and InstallVersion()
         /// For InstallName() we want latest version installed (so version parameter passed in will be null), for InstallVersion() we want specified, non-null version installed.
         /// </summary>
-        private Stream InstallHelper(string packageName, NuGetVersion version, out ExceptionDispatchInfo edi)
+        private Stream InstallHelper(string packageName, NuGetVersion version, out ErrorRecord errRecord)
         {
             Stream pkgStream = null;
             bool getLatestVersion = true;
@@ -543,8 +543,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 getLatestVersion = false;
             }
 
-            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, packageContentProperty, isSearch: false, out edi);
-            if (edi != null)
+            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, packageContentProperty, isSearch: false, out errRecord);
+            if (errRecord != null)
             {
                 return pkgStream;
             }
@@ -552,7 +552,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (versionedResponses.Length == 0)
             {
                 string errorMsg = $"Package with Name {packageName} and Version {version} could not be found in repository {Repository.Name}";
-                edi = ExceptionDispatchInfo.Capture(new Exception(errorMsg));
+                errRecord = new ErrorRecord(new Exception(errorMsg), "InstallFailure", ErrorCategory.InvalidResult, this);
                 return null;
             }
 
@@ -579,12 +579,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (String.IsNullOrEmpty(pkgContentUrl))
             {
                 string errorMsg = $"Package with Name {packageName} and Version {version} could not be found in repository {Repository.Name}";
-                edi = ExceptionDispatchInfo.Capture(new Exception(errorMsg));
+                errRecord = new ErrorRecord(new Exception(errorMsg), "InstallFailure", ErrorCategory.InvalidResult, this);
                 return null;
             }
 
-            var content = HttpRequestCallForContent(pkgContentUrl, out edi);
-            if (edi != null)
+            var content = HttpRequestCallForContent(pkgContentUrl, out errRecord);
+            if (errRecord != null)
             {
                 return null;
             }
@@ -598,23 +598,23 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// i.e when the package Name being searched for does not contain wildcard
         /// This is called by FindNameHelper(), FindVersionHelper(), FindVersionGlobbing(), InstallHelper()
         /// </summary>
-        private string[] GetVersionedPackageEntriesFromRegistrationsResource(string packageName, string propertyName, bool isSearch, out ExceptionDispatchInfo edi)
+        private string[] GetVersionedPackageEntriesFromRegistrationsResource(string packageName, string propertyName, bool isSearch, out ErrorRecord errRecord)
         {
             string[] responses = Utils.EmptyStrArray;
-            Dictionary<string, string> resources = GetResourcesFromServiceIndex(out edi);
-            if (edi != null)
+            Dictionary<string, string> resources = GetResourcesFromServiceIndex(out errRecord);
+            if (errRecord != null)
             {
                 return responses;
             }
 
-            string registrationsBaseUrl = FindRegistrationsBaseUrl(resources, out edi);
-            if (edi != null)
+            string registrationsBaseUrl = FindRegistrationsBaseUrl(resources, out errRecord);
+            if (errRecord != null)
             {
                 return responses;
             }
 
-            responses = GetVersionedResponsesFromRegistrationsResource(registrationsBaseUrl, packageName, propertyName, isSearch, out edi);
-            if (edi != null)
+            responses = GetVersionedResponsesFromRegistrationsResource(registrationsBaseUrl, packageName, propertyName, isSearch, out errRecord);
+            if (errRecord != null)
             {
                 return Utils.EmptyStrArray;
             }
@@ -627,17 +627,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// i.e when the package Name being searched for contains wildcards or a Tag query search is performed
         /// This is called by FindNameGlobbingFromNuGetRepo() and FindTagsFromNuGetRepo()
         /// </summary>
-        private List<JsonElement> GetVersionedPackageEntriesFromSearchQueryResource(string queryTerm, bool includePrerelease, out ExceptionDispatchInfo edi)
+        private List<JsonElement> GetVersionedPackageEntriesFromSearchQueryResource(string queryTerm, bool includePrerelease, out ErrorRecord errRecord)
         {
             List<JsonElement> pkgEntries = new();
-            Dictionary<string, string> resources = GetResourcesFromServiceIndex(out edi);
-            if (edi != null)
+            Dictionary<string, string> resources = GetResourcesFromServiceIndex(out errRecord);
+            if (errRecord != null)
             {
                 return pkgEntries;
             }
 
-            string searchQueryServiceUrl = FindSearchQueryService(resources, out edi);
-            if (edi != null)
+            string searchQueryServiceUrl = FindSearchQueryService(resources, out errRecord);
+            if (errRecord != null)
             {
                 return pkgEntries;
             }
@@ -647,7 +647,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string query = $"{searchQueryServiceUrl}?q={queryTerm}&prerelease={includePrerelease}&semVerLevel=2.0.0&skip={skip}&take=100";
 
             // Get responses for all packages that contain the required tags
-            pkgEntries.AddRange(GetJsonElementArr(query, dataName, out int initialCount, out edi).ToList());
+            pkgEntries.AddRange(GetJsonElementArr(query, dataName, out int initialCount, out errRecord).ToList());
 
             // check count (ie "totalHits") 425 ==> count/100  ~~> 5 calls 
             int count = initialCount / 100;
@@ -655,7 +655,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             while (count > 0)
             {
                 skip += 100;
-                pkgEntries.AddRange(GetJsonElementArr(query, dataName, out int unneededCount, out edi).ToList());
+                pkgEntries.AddRange(GetJsonElementArr(query, dataName, out int unneededCount, out errRecord).ToList());
                 count--;
             }
 
@@ -666,11 +666,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Finds all resources present in the repository's service index.
         /// For example: https://api.nuget.org/v3/index.json
         /// </summary>
-        private Dictionary<string, string> GetResourcesFromServiceIndex(out ExceptionDispatchInfo edi)
+        private Dictionary<string, string> GetResourcesFromServiceIndex(out ErrorRecord errRecord)
         {
             Dictionary<string, string> resources = new Dictionary<string, string>();
-            JsonElement[] resourcesArray = GetJsonElementArr($"{Repository.Uri}", resourcesName, out int totalHits, out edi);
-            if (edi != null)
+            JsonElement[] resourcesArray = GetJsonElementArr($"{Repository.Uri}", resourcesName, out int totalHits, out errRecord);
+            if (errRecord != null)
             {
                 return resources;
             }
@@ -681,13 +681,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     if (!resource.TryGetProperty("@type", out JsonElement typeElement))
                     {
-                        edi = ExceptionDispatchInfo.Capture(new JsonParsingException($"@type element not found for resource in service index for repository {Repository.Name}"));
+                        errRecord = new ErrorRecord(new JsonParsingException($"@type element not found for resource in service index for repository {Repository.Name}"), "GetResourcesFromServiceIndexFailure", ErrorCategory.InvalidResult, this);
                         return new Dictionary<string, string>();
                     }
 
                     if (!resource.TryGetProperty("@id", out JsonElement idElement))
                     {
-                        edi = ExceptionDispatchInfo.Capture(new JsonParsingException($"@id element not found for resource in service index for repository {Repository.Name}"));
+                        errRecord = new ErrorRecord(new JsonParsingException($"@id element not found for resource in service index for repository {Repository.Name}"), "GetResourcesFromServiceIndexFailure", ErrorCategory.InvalidResult, this);
                         return new Dictionary<string, string>();
                     }
 
@@ -699,8 +699,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
                 catch (Exception e)
                 {
+                    // TODO:  how to keep repo name in error message?
                     string errMsg = $"Exception parsing service index JSON for respository {Repository.Name} with error: {e.Message}";
-                    edi = ExceptionDispatchInfo.Capture(new JsonParsingException(errMsg));
+                    errRecord = new ErrorRecord(e, "GetResourcesFromServiceIndexFailure", ErrorCategory.InvalidResult, this);
                     return new Dictionary<string, string>();
                 }
             }
@@ -712,9 +713,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Gets the resource of type "RegistrationBaseUrl" from the repository's resources.
         /// A repository can have multiple resources of type "RegistrationsBaseUrl" so it finds the best match according to the guideline comment in the method.
         /// </summary>
-        private string FindRegistrationsBaseUrl(Dictionary<string, string> resources, out ExceptionDispatchInfo edi)
+        private string FindRegistrationsBaseUrl(Dictionary<string, string> resources, out ErrorRecord errRecord)
         {
-            edi = null;
+            errRecord = null;
             string registrationsBaseUrl = String.Empty;
 
             /**
@@ -748,7 +749,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             else
             {
-                edi = ExceptionDispatchInfo.Capture(new V3ResourceNotFoundException($"RegistrationBaseUrl resource could not be found for Repository '{Repository.Name}'"));
+                errRecord = new ErrorRecord(new V3ResourceNotFoundException($"RegistrationBaseUrl resource could not be found for Repository '{Repository.Name}'"), "FindRegistrationsBaseUrlFailure", ErrorCategory.InvalidResult, this);
             }
 
             return registrationsBaseUrl;
@@ -758,9 +759,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Gets the resource of type "SearchQueryService" from the repository's resources.
         /// A repository can have multiple resources of type "SearchQueryService" so it finds the best match according to the guideline comment in the method.
         /// </summary>
-        private string FindSearchQueryService(Dictionary<string, string> resources, out ExceptionDispatchInfo edi)
+        private string FindSearchQueryService(Dictionary<string, string> resources, out ErrorRecord errRecord)
         {
-            edi = null;
+            errRecord = null;
             string searchQueryServiceUrl = String.Empty;
 
             if (resources.ContainsKey("SearchQueryService/3.5.0"))
@@ -781,7 +782,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             else
             {
-                edi = ExceptionDispatchInfo.Capture(new V3ResourceNotFoundException($"SearchQueryService resource could not be found for Repository '{Repository.Name}'"));
+                errRecord = new ErrorRecord(new V3ResourceNotFoundException($"SearchQueryService resource could not be found for Repository '{Repository.Name}'"), "FindSearchQueryServiceFailure", ErrorCategory.InvalidResult, this);
             }
 
             return searchQueryServiceUrl;
@@ -791,18 +792,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// For JFrog repository, the metadata is located under "@id" > inner "items" element
         /// This is different than other V3 repositories response's metadata location.
         /// </summary>
-        private JsonElement GetMetadataElementForJFrogRepo(JsonElement itemsElement, string packageName, out ExceptionDispatchInfo edi)
+        private JsonElement GetMetadataElementForJFrogRepo(JsonElement itemsElement, string packageName, out ErrorRecord errRecord)
         {
             JsonElement metadataElement;
             if (!itemsElement.TryGetProperty(idLinkName, out metadataElement))
             {
-                edi = ExceptionDispatchInfo.Capture(new ArgumentException($"Response does not contain '{idLinkName}' element for package with Name {packageName}, from JFrog repository {Repository.Name}"));
+                errRecord = new ErrorRecord(new ArgumentException($"'{idLinkName}' element from package '{packageName}' could not be found in JFrog repository '{Repository.Name}'"), "GetElementForJFrogRepoFailure", ErrorCategory.InvalidResult, this);
                 return metadataElement;
             }
 
             string metadataUri = metadataElement.ToString();
-            string response = HttpRequestCall(metadataUri, out edi);
-            if (edi != null)
+            string response = HttpRequestCall(metadataUri, out errRecord);
+            if (errRecord != null)
             {
                 return metadataElement;
             }
@@ -814,7 +815,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     JsonElement rootDom = metadataEntries.RootElement;
                     if (!rootDom.TryGetProperty(itemsName, out JsonElement innerItemsElement))
                     {
-                        edi = ExceptionDispatchInfo.Capture(new ArgumentException($"Response does not contain inner '{itemsName}' element for package with Name {packageName}, from JFrog repository {Repository.Name}"));
+                        errRecord = new ErrorRecord(new ArgumentException($"'{itemsName}' element from package '{packageName}' could not be found in JFrog repository '{Repository.Name}'"), "GetElementForJFrogRepoFailure", ErrorCategory.InvalidResult, this);
                         return metadataElement;
                     }
 
@@ -824,7 +825,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             catch (Exception e)
             {
-                edi = ExceptionDispatchInfo.Capture(e);
+                errRecord = new ErrorRecord(e, "FindSearchQueryServiceFailure", ErrorCategory.InvalidResult, this);
             }
 
             return metadataElement;
@@ -838,14 +839,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         ///     The "packageContent" property is used for download, and the value is a URI for the .nupkg file.
         /// </param>
         /// <summary>
-        private string[] GetVersionedResponsesFromRegistrationsResource(string registrationsBaseUrl, string packageName, string property, bool isSearch, out ExceptionDispatchInfo edi)
+        private string[] GetVersionedResponsesFromRegistrationsResource(string registrationsBaseUrl, string packageName, string property, bool isSearch, out ErrorRecord errRecord)
         {
             List<string> versionedResponses = new List<string>();
             string[] versionedResponseArr;
             var requestPkgMapping = registrationsBaseUrl.EndsWith("/") ? $"{registrationsBaseUrl}{packageName.ToLower()}/index.json" : $"{registrationsBaseUrl}/{packageName.ToLower()}/index.json";
 
-            string pkgMappingResponse = HttpRequestCall(requestPkgMapping, out edi);
-            if (edi != null)
+            string pkgMappingResponse = HttpRequestCall(requestPkgMapping, out errRecord);
+            if (errRecord != null)
             {
                 return Utils.EmptyStrArray;
             }
@@ -859,7 +860,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     JsonElement rootDom = pkgVersionEntry.RootElement;
                     if (!rootDom.TryGetProperty(itemsName, out JsonElement itemsElement) || itemsElement.GetArrayLength() == 0)
                     {
-                        edi = ExceptionDispatchInfo.Capture(new ArgumentException($"Response does not contain '{itemsName}' element, for package with Name {packageName}."));
+                        errRecord = new ErrorRecord(new ArgumentException($"Response does not contain '{itemsName}' element for package '{packageName}' from Repository '{Repository.Name}'."), " ", ErrorCategory.InvalidResult, this);
                         return Utils.EmptyStrArray;
                     }
 
@@ -870,11 +871,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     {
                         if (_isJFrogRepo)
                         {
-                            innerItemsElement = GetMetadataElementForJFrogRepo(firstItem, packageName, out edi);
+                            innerItemsElement = GetMetadataElementForJFrogRepo(firstItem, packageName, out errRecord);
                         }
                         else
                         {
-                            edi = ExceptionDispatchInfo.Capture(new ArgumentException($"Response does not contain '{itemsName}' element, for package with Name {packageName}."));
+                            errRecord = new ErrorRecord(new ArgumentException($"Response does not contain '{itemsName}' element for package '{packageName}' from Repository '{Repository.Name}'."), "GetResponsesFromRegistrationsResourceFailure", ErrorCategory.InvalidResult, this);
                             return Utils.EmptyStrArray;
                         }
                     }
@@ -885,7 +886,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     // The "count" property represents how many versions are present for that package, (i.e how many elements are in the inner "items" array)
                     if (!firstItem.TryGetProperty(countName, out JsonElement countElement) || !countElement.TryGetInt32(out int count))
                     {
-                        edi = ExceptionDispatchInfo.Capture(new ArgumentException($"Response does not contain inner '{countName}' element or it is not a valid integer, for package with Name {packageName}."));
+                        errRecord = new ErrorRecord(new ArgumentException($"Response does not contain inner '{countName}' element for package '{packageName}' from repository '{Repository.Name}'."), "GetResponsesFromRegistrationsResourceFailure", ErrorCategory.InvalidResult, this);
                         return Utils.EmptyStrArray;
                     }
 
@@ -896,20 +897,20 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                     if (!firstItem.TryGetProperty("upper", out JsonElement upperVersionElement))
                     {
-                        edi = ExceptionDispatchInfo.Capture(new ArgumentException($"Response does not contain inner 'upper' element, for package with Name {packageName}."));
+                        errRecord = new ErrorRecord(new ArgumentException($"Response does not contain inner 'upper' element, for package with name {packageName} from repository '{Repository.Name}'."), "GetResponsesFromRegistrationsResourceFailure", ErrorCategory.InvalidResult, this);
                         return Utils.EmptyStrArray;
                     }
 
                     // Get the specific entry for each package version
-                    foreach (JsonElement versionedItem in innerItemsElement.EnumerateArray())
+                    foreach (JsonElement versionerrRecordtem in innerItemsElement.EnumerateArray())
                     {
                         // For search:
                         // The "catalogEntry" property in the specific package version entry contains package metadata
                         // For download:
                         // The "packageContent" property in the specific package version entry has the .nupkg URI for each version of the package.
-                        if (!versionedItem.TryGetProperty(property, out JsonElement metadataElement))
+                        if (!versionerrRecordtem.TryGetProperty(property, out JsonElement metadataElement))
                         {
-                            edi = ExceptionDispatchInfo.Capture(new ArgumentException($"Response does not contain inner '{property}' element, for package with Name {packageName}."));
+                            errRecord = new ErrorRecord(new ArgumentException($"Response does not contain inner '{property}' element for package '{packageName}' from repository '{Repository.Name}'."), "GetResponsesFromRegistrationsResourceFailure", ErrorCategory.InvalidResult, this);
                             continue;
                         }
                         
@@ -930,14 +931,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     versionedResponseArr = versionedResponses.ToArray();
                     if (isSearch)
                     {
-                        if (!IsLatestVersionFirstForSearch(versionedResponseArr, upperVersion, out edi))
+                        if (!IsLatestVersionFirstForSearch(versionedResponseArr, upperVersion, out errRecord))
                         {
                             Array.Reverse(versionedResponseArr);
                         }
                     }
                     else
                     {
-                        if (!IsLatestVersionFirstForInstall(versionedResponseArr, upperVersion, out edi))
+                        if (!IsLatestVersionFirstForInstall(versionedResponseArr, upperVersion, out errRecord))
                         {
                             Array.Reverse(versionedResponseArr);
                         }
@@ -946,7 +947,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             catch (Exception e)
             {
-                edi = ExceptionDispatchInfo.Capture(e);
+                errRecord = new ErrorRecord(e, "GetResponsesFromRegistrationsResourceFailure", ErrorCategory.InvalidResult, this);
                 return Utils.EmptyStrArray;
             }
 
@@ -957,9 +958,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Returns true if the metadata entries are arranged in descending order with respect to the package's version.
         /// ADO feeds usually return version entries in descending order, but Nuget.org repository returns them in ascending order.
         /// </summary>
-        private bool IsLatestVersionFirstForSearch(string[] versionedResponses, string upperVersion, out ExceptionDispatchInfo edi)
+        private bool IsLatestVersionFirstForSearch(string[] versionedResponses, string upperVersion, out ErrorRecord errRecord)
         {
-            edi = null;
+            errRecord = null;
             bool latestVersionFirst = true;
 
             // We don't need to perform this check if no responses, or single response
@@ -976,7 +977,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     JsonElement firstResponseDom = firstResponseJson.RootElement;
                     if (!firstResponseDom.TryGetProperty(versionName, out JsonElement firstVersionElement))
                     {
-                        edi = ExceptionDispatchInfo.Capture(new JsonParsingException($"Response did not contain '{versionName}' element"));
+                        errRecord = new ErrorRecord(new JsonParsingException($"Response did not contain '{versionName}' element"), "LatestVersionFirstSearchFailure", ErrorCategory.InvalidResult, this);
                         return latestVersionFirst;
                     }
 
@@ -992,7 +993,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             catch (Exception e)
             {
-                edi = ExceptionDispatchInfo.Capture(e);
+                errRecord = new ErrorRecord(e, "LatestVersionFirstSearchFailure", ErrorCategory.InvalidResult, this);
                 return true;
             }
         
@@ -1003,9 +1004,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Returns true if the nupkg URI entries for each package version are arranged in descending order with respect to the package's version.
         /// ADO feeds usually return version entries in descending order, but Nuget.org repository returns them in ascending order.
         /// </summary>
-        private bool IsLatestVersionFirstForInstall(string[] versionedResponses, string upperVersion, out ExceptionDispatchInfo edi)
+        private bool IsLatestVersionFirstForInstall(string[] versionedResponses, string upperVersion, out ErrorRecord errRecord)
         {
-            edi = null;
+            errRecord = null;
             bool latestVersionFirst = true;
 
             // We don't need to perform this check if no responses, or single response
@@ -1027,9 +1028,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method that determines if specified tags are present in package's tags.
         /// </summary>
-        private bool IsRequiredTagSatisfied(JsonElement tagsElement, string[] tags, out ExceptionDispatchInfo edi)
+        private bool IsRequiredTagSatisfied(JsonElement tagsElement, string[] tags, out ErrorRecord errRecord)
         {
-            edi = null;
+            errRecord = null;
             string[] pkgTags = Utils.EmptyStrArray;
 
             // Get the package's tags from the tags JsonElement
@@ -1054,8 +1055,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             catch (Exception e)
             {
-                string errMsg = $"DetermineTagsPresent(): Exception parsing 'Tags' element found in JSON from respository {Repository.Name} with error: {e.Message}";
-                edi = ExceptionDispatchInfo.Capture(new JsonParsingException(errMsg));
+                errRecord = new ErrorRecord(e, "GetResponsesFromRegistrationsResourceFailure", ErrorCategory.InvalidResult, this);
                 return false;
             }
 
@@ -1076,15 +1076,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method that parses response for given property and returns result for that property as a JsonElement array.
         /// </summary>
-        private JsonElement[] GetJsonElementArr(string request, string propertyName, out int totalHits, out ExceptionDispatchInfo edi)
+        private JsonElement[] GetJsonElementArr(string request, string propertyName, out int totalHits, out ErrorRecord errRecord)
         {
             List<JsonElement> responseEntries = new List<JsonElement>();
             JsonElement[] entries = new JsonElement[0];
             totalHits = 0;
             try
             { 
-                string response = HttpRequestCall(request, out edi);
-                if (edi != null)
+                string response = HttpRequestCall(request, out errRecord);
+                if (errRecord != null)
                 {
                     return new JsonElement[]{};
                 }
@@ -1109,8 +1109,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             catch (Exception e)
             {
-                string errMsg = $"Exception parsing JSON for respository {Repository.Uri} with error: {e.Message}";
-                edi = ExceptionDispatchInfo.Capture(new JsonParsingException(errMsg));
+                errRecord = new ErrorRecord(e, "GetResponsesFromRegistrationsResourceFailure", ErrorCategory.InvalidResult, this);
             }
 
             return entries;
@@ -1119,9 +1118,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method that makes the HTTP request for the V3 server protocol url passed in for find APIs.
         /// </summary>
-        private string HttpRequestCall(string requestUrlV3, out ExceptionDispatchInfo edi)
+        private string HttpRequestCall(string requestUrlV3, out ErrorRecord errRecord)
         {
-            edi = null;
+            errRecord = null;
             string response = string.Empty;
 
             try
@@ -1132,19 +1131,19 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             catch (HttpRequestException e)
             {
-                edi = ExceptionDispatchInfo.Capture(e);
+                errRecord = new ErrorRecord(e, "HttpRequestCallFailure", ErrorCategory.InvalidResult, this);
             }
             catch (ArgumentNullException e)
             {
-                edi = ExceptionDispatchInfo.Capture(e);
+                errRecord = new ErrorRecord(e, "HttpRequestCallFailure", ErrorCategory.InvalidResult, this);
             }
             catch (InvalidOperationException e)
             {
-                edi = ExceptionDispatchInfo.Capture(e);
+                errRecord = new ErrorRecord(e, "HttpRequestCallFailure", ErrorCategory.InvalidResult, this);
             }
             catch (Exception e)
             {
-                edi = ExceptionDispatchInfo.Capture(e);
+                errRecord = new ErrorRecord(e, "HttpRequestCallFailure", ErrorCategory.InvalidResult, this);
             }
 
             return response;
@@ -1153,9 +1152,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method that makes the HTTP request for the V3 server protocol url passed in for install APIs.
         /// </summary>
-        private HttpContent HttpRequestCallForContent(string requestUrlV3, out ExceptionDispatchInfo edi)
+        private HttpContent HttpRequestCallForContent(string requestUrlV3, out ErrorRecord errRecord)
         {
-            edi = null;
+            errRecord = null;
             HttpContent content = null;
 
             try
@@ -1164,17 +1163,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 content = SendV3RequestForContentAsync(request, _sessionClient).GetAwaiter().GetResult();
             }
-            catch (HttpRequestException e)
+            catch (Exception e)
             {
-                edi = ExceptionDispatchInfo.Capture(e);
-            }
-            catch (ArgumentNullException e)
-            {
-                edi = ExceptionDispatchInfo.Capture(e);
-            }
-            catch (InvalidOperationException e)
-            {
-                edi = ExceptionDispatchInfo.Capture(e);
+                errRecord = new ErrorRecord(e, "HttpRequestCallForContentFailure", ErrorCategory.InvalidResult, this);
             }
 
             return content;

--- a/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "HttpRequestFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 
@@ -40,7 +40,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $wildcardName -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameGlobbingFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameGlobbingFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 
@@ -109,7 +109,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name and Tag property (multiple tags)" {
@@ -127,7 +127,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTags -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resources when given Name with wildcard and Tag proprties" {
@@ -137,7 +137,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $nameWithWildcard -Tag $requiredTag -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameGlobbingFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameGlobbingWithTagFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name, Version and Tag property (single tag)" {
@@ -155,7 +155,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name, Version and Tag property (multiple tags)" {
@@ -175,7 +175,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTags -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resources given Tag property" {
@@ -184,7 +184,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Tag $tagToFind -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindTagFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindTagsFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resource given CommandName" {
@@ -192,7 +192,8 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -CommandName "command" -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindCommandOrDSCResourceFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        write-Host $($err[0].FullyQualifiedErrorId)
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindCommandOrDscResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resource given DscResourceName" {
@@ -200,7 +201,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -DscResourceName "dscResource" -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindCommandOrDSCResourceFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindCommandOrDscResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find all resources given Name '*'" {
@@ -208,6 +209,6 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name "*" -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindAllFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindAllFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 }

--- a/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "HttpRequestFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "HttpRequestCallFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 

--- a/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
@@ -35,7 +35,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource(s) given wildcard Name" {
@@ -221,7 +221,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Tag $tagToFind -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindTagFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindTagsFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resource given CommandName" {

--- a/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
@@ -35,7 +35,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource(s) given wildcard Name" {
@@ -115,7 +115,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name and Tag property (multiple tags)" {
@@ -133,7 +133,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTags -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find all resources that satisfy Name pattern and have specified Tag (single tag)" {
@@ -192,7 +192,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name, Version and Tag property (multiple tags)" {
@@ -212,7 +212,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTags -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resources given Tag property" {
@@ -221,7 +221,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Tag $tagToFind -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindTagFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindTagFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resource given CommandName" {
@@ -229,7 +229,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -CommandName "command" -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindCommandOrDSCResourceFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindCommandOrDscResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resource given DscResourceName" {
@@ -237,7 +237,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -DscResourceName "dscResource" -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindCommandOrDSCResourceFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindCommandOrDscResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find all resources given Name '*'" {
@@ -245,6 +245,6 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name "*" -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindAllFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindAllFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 }

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -58,7 +58,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $localRepo -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 
@@ -131,7 +131,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $localRepo -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 
@@ -195,7 +195,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $localRepo -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 

--- a/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 

--- a/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
@@ -124,7 +124,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name and Tag property (multiple tags)" {
@@ -142,7 +142,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTags -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find all resources that satisfy Name pattern and have specified Tag (single tag)" {
@@ -201,7 +201,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name, Version and Tag property (multiple tags)" {
@@ -221,7 +221,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTags -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     # It "find all resources with specified tag given Tag property" {
@@ -252,28 +252,28 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -CommandName "command" -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindCommandOrDSCResourceFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindCommandOrDscResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resource given DscResourceName" {
         $res = Find-PSResource -DscResourceName "dscResource" -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindCommandOrDSCResourceFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindCommandOrDscResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find all resources given Name '*'" {
         $res = Find-PSResource -Name "*" -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindAllFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindAllFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find an unlisted module" {
         $res = Find-PSResource -Name "PMTestDependency1" -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
     
     # "carb*" is intentionally chosen as a sequence that will trigger pagination (ie more than 100 results),

--- a/test/InstallPSResourceTests/InstallPSResourceADOServer.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceADOServer.Tests.ps1
@@ -64,7 +64,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
         $pkg = Get-InstalledPSResource "NonExistantModule"
         $pkg | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "HttpRequestCallFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
     }
 
     # Do some version testing, but Find-PSResource should be doing thorough testing

--- a/test/InstallPSResourceTests/InstallPSResourceGithubPackages.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceGithubPackages.Tests.ps1
@@ -67,7 +67,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
         $pkg = Get-InstalledPSResource "NonExistantModule"
         $pkg | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
     }
 
     # Do some version testing, but Find-PSResource should be doing thorough testing

--- a/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
@@ -68,7 +68,7 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
         $res = Install-PSResource -Name "NonExistantModule" -Repository $localRepo -TrustRepository -PassThru -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
     }
 
     It "Should install resource given name and exact version with bracket syntax" {

--- a/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
@@ -496,7 +496,7 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
     It "Install module that is not authenticode signed" -Skip:(!(Get-IsWindows)) {
         Install-PSResource -Name $testModuleName -Version "5.0.0" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "GetAuthenticodeSignatureError,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
     }
 
     # # Install 1.4.4.1 (with incorrect catalog file)
@@ -523,7 +523,7 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
         $err.Count | Should -HaveCount 1
         write-Host $err
         write-Host $err[0]
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "GetAuthenticodeSignatureError,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
     }
 }
 

--- a/test/InstallPSResourceTests/InstallPSResourceV3Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV3Server.Tests.ps1
@@ -70,7 +70,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
         $pkg = Get-InstalledPSResource "NonExistantModule"
         $pkg.Name | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
     }
 
     # Do some version testing, but Find-PSResource should be doing thorough testing

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -226,7 +226,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $dependencyVersion = "2.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module" -RequiredModules @(@{ModuleName = 'PackageManagement'; ModuleVersion = '1.4.4' })
 
-        {Publish-PSResource -Path $script:PublishModuleBase -ErrorAction Stop} | Should -Throw -ErrorId "FindVersionFail,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
+        {Publish-PSResource -Path $script:PublishModuleBase -ErrorAction Stop} | Should -Throw -ErrorId "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
     }
 
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
There's a series of error handling related changes that are needed in PSResourceGet.  This is the first piece of that, which changes every instance of `ExceptionDispatchInfo` to `ErrorRecord` in order to capture and add better error messaging to later display to the user.  

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
