### PR TITLE
Update error handling in Uninstall-PSResource

### DIFF
--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -242,7 +242,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (errRecord == null)
                     {
                         string message = Version == null || Version.Trim().Equals("*") ?
-                            string.Format("Cannot not find resource '{0}' because it does not exist.", pkgName) :
+                            string.Format("Cannot uninstall resource '{0}' because it does not exist.", pkgName) :
+
                             string.Format("Cannot not find verison '{0}' of resource '{1}' because it does not exist.", Version, pkgName);
 
                         errRecords.Add(new ErrorRecord(

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -424,7 +424,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 errorRecord = new ErrorRecord(
                     new PSInvalidOperationException(
-                        $"Cannot uninstall '{pkgName}'. The following package(s) take a dependency on this package: '{strUniquePkgNames}'. If you would still like to uninstall, rerun the command with -SkipDependencyCheck."),
+                        $"Cannot uninstall '{pkgName}'. This package depends on the following package(s): '{strUniquePkgNames}'. If you would still like to uninstall, re-run the command with -SkipDependencyCheck."),
+
                     "UninstallPSResourcePackageIsaDependency",
                     ErrorCategory.InvalidOperation,
                     null);

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -187,7 +187,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 string message = Version == null || Version.Trim().Equals("*") ?
                     string.Format("Cannot uninstall resource '{0}' because it does not exist", String.Join(", ", Name)) :
 
-                    string.Format("Cannot find verison '{0}' of resource '{1}' because it does not exist", Version, String.Join(", ", Name));
+                    string.Format("Cannot uninstall verison '{0}' of resource '{1}' because it does not exist", Version, String.Join(", ", Name));
+
 
                 errRecords.Add(new ErrorRecord(
                     new PackageNotFoundException(message),

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -185,7 +185,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (totalDirs == 0) {
                 string message = Version == null || Version.Trim().Equals("*") ?
-                    string.Format("Cannot find resource '{0}' because it does not exist", String.Join(", ", Name)) :
+                    string.Format("Cannot uninstall resource '{0}' because it does not exist", String.Join(", ", Name)) :
+
                     string.Format("Cannot find verison '{0}' of resource '{1}' because it does not exist", Version, String.Join(", ", Name));
 
                 errRecords.Add(new ErrorRecord(

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -244,7 +244,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         string message = Version == null || Version.Trim().Equals("*") ?
                             string.Format("Cannot uninstall resource '{0}' because it does not exist.", pkgName) :
 
-                            string.Format("Cannot not find verison '{0}' of resource '{1}' because it does not exist.", Version, pkgName);
+                            string.Format("Cannot uninstall version '{0}' of resource '{1}' because it does not exist.", Version, pkgName);
+
 
                         errRecords.Add(new ErrorRecord(
                             new PSInvalidOperationException(message),

--- a/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
@@ -257,7 +257,7 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
         $pkg = Get-InstalledPSResource "RequiredModule1"
         $pkg | Should -Not -Be $null
 
-        $ev.FullyQualifiedErrorId | Should -BeExactly 'UninstallPSResourcePackageIsaDependency,Microsoft.PowerShell.PSResourceGet.Cmdlets.UninstallPSResource', 'UninstallResourceError,Microsoft.PowerShell.PSResourceGet.Cmdlets.UninstallPSResource'
+        $ev.FullyQualifiedErrorId | Should -BeExactly 'UninstallPSResourcePackageIsaDependency,Microsoft.PowerShell.PSResourceGet.Cmdlets.UninstallPSResource'
     }
 
     It "Uninstall module that is a dependency for another module using -SkipDependencyCheck" {
@@ -296,7 +296,7 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
 
     It "Uninstall module that is not installed should throw error" {
         Uninstall-PSResource -Name "NonInstalledModule" -ErrorVariable ev -ErrorAction SilentlyContinue -SkipDependencyCheck
-        $ev.FullyQualifiedErrorId | Should -BeExactly 'UninstallResourceError,Microsoft.PowerShell.PSResourceGet.Cmdlets.UninstallPSResource'
+        $ev.FullyQualifiedErrorId | Should -BeExactly 'ResourceNotInstalled,Microsoft.PowerShell.PSResourceGet.Cmdlets.UninstallPSResource'
     }
 
     # Windows only


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Update error handling in `Uninstall-PSResource` including better error messaging and syntax that is consistent with other PSResourceGet cmdlets.

## PR Context
Resolves #942, 
Resolves #598 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
