### PR TITLE
Add 'Get-PSResource' alias to 'Get-InstalledPSResource'

### DIFF
--- a/src/Microsoft.PowerShell.PSResourceGet.psd1
+++ b/src/Microsoft.PowerShell.PSResourceGet.psd1
@@ -33,7 +33,7 @@
         'Update-PSResource')
 
     VariablesToExport = 'PSGetPath'
-    AliasesToExport = @()
+    AliasesToExport = @('Get-PSResource')
     PrivateData = @{
         PSData = @{
             Prerelease = 'beta22'

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -14,6 +14,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
     /// Returns a single resource or multiple resource.
     /// </summary>
     [Cmdlet(VerbsCommon.Get, "InstalledPSResource")]
+    [Alias("Get-PSResource")]
     [OutputType(typeof(PSResourceInfo))]
     public sealed class GetInstalledPSResourceCommand : PSCmdlet
     {

--- a/test/GetInstalledPSResource/GetInstalledPSResource.Tests.ps1
+++ b/test/GetInstalledPSResource/GetInstalledPSResource.Tests.ps1
@@ -135,10 +135,8 @@ $testCases =
         $res.Prerelease | Should -Be "alpha"
     }
 
-    It "Get resource using alias 'Get-PSResource'" {
-        $pkg = Get-PSResource -Name $testModuleName
-        $pkg.Name | Should -Contain $testModuleName
-        $pkg.Type | Should -Contain "Module"
+    It "Get definition for alias 'Get-PSResource'" {
+        (Get-Alias Get-PSResource).Definition | Should -BeExactly 'Get-InstalledPSResource'
     }
 
      # Windows only

--- a/test/GetInstalledPSResource/GetInstalledPSResource.Tests.ps1
+++ b/test/GetInstalledPSResource/GetInstalledPSResource.Tests.ps1
@@ -135,6 +135,12 @@ $testCases =
         $res.Prerelease | Should -Be "alpha"
     }
 
+    It "Get resource using alias 'Get-PSResource'" {
+        $pkg = Get-PSResource -Name $testModuleName
+        $pkg.Name | Should -Contain $testModuleName
+        $pkg.Type | Should -Contain "Module"
+    }
+
      # Windows only
      It "Get resource under CurrentUser scope - Windows only" -Skip:(!(Get-IsWindows)) {
         $pkg = Get-InstalledPSResource -Name $testModuleName -Scope CurrentUser


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Add `Get-PSResource` as an alias to `Get-InstalledPSResource` cmdlet.

## PR Context
Resolves #1158 
Resolves #1072 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
