### PR TITLE
Add error handling to Get-InstalledPSResource and Find-PSResource

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -417,6 +417,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         // Example: Find-PSResource -Name "Az*" -Tag "Storage"
                         string tagMsg = String.Empty;
                         FindResults responses = null;
+                        string tagsAsString = string.Empty;
                         if (_tag.Length == 0)
                         {
                             responses = currentServer.FindNameGlobbing(pkgName, _prerelease, _type, out errRecord);
@@ -424,7 +425,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         else
                         {
                             responses = currentServer.FindNameGlobbingWithTag(pkgName, _tag, _prerelease, _type, out errRecord);
-                            string tagsAsString = String.Join(", ", _tag);
+                            tagsAsString = String.Join(", ", _tag);
                             tagMsg = $" and Tags {tagsAsString}";
                         }
 
@@ -439,8 +440,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                             {
                                 // write warning?
+                                string message = _tag.Length == 0 ? $"Package '{pkgName}' could not be found." : $"Package '{pkgName}' with tags '{tagsAsString}' could not be found.";
+
                                 _cmdletPassedIn.WriteError(new ErrorRecord(
-                                            new PackageNotFoundException($"Package '{pkgName}' with tags '{tagMsg}' could not be found", currentResult.exception), 
+                                            new PackageNotFoundException(message, currentResult.exception), 
                                             "FindNameGlobbingConvertToPSResourceFailure", 
                                             ErrorCategory.InvalidResult, 
                                             this));
@@ -460,6 +463,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         // Example: Find-PSResource -Name "Az" -Tag "Storage"
                         string tagMsg = String.Empty;
                         FindResults responses = null;
+                        string tagsAsString = string.Empty;
                         if (_tag.Length == 0)
                         {
                             responses = currentServer.FindName(pkgName, _prerelease, _type, out errRecord);
@@ -467,7 +471,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         else
                         {
                             responses = currentServer.FindNameWithTag(pkgName, _tag, _prerelease, _type, out errRecord);
-                            string tagsAsString = String.Join(", ", _tag);
+                            tagsAsString = String.Join(", ", _tag);
                             tagMsg = $" and Tags {tagsAsString}";
                         }
 
@@ -481,8 +485,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         
                         if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                         {
+                            string message = _tag.Length == 0 ? $"Package '{pkgName}' could not be found." : $"Package '{pkgName}' with tags '{tagsAsString}' could not be found.";
+
                             _cmdletPassedIn.WriteError(new ErrorRecord(
-                                        new PackageNotFoundException($"Package '{pkgName}' with tags '{tagMsg}' could not be found", currentResult.exception), 
+                                        new PackageNotFoundException(message, currentResult.exception), 
                                         "FindNameConvertToPSResourceFailure", 
                                         ErrorCategory.InvalidResult, 
                                         this));

--- a/src/code/GetHelper.cs
+++ b/src/code/GetHelper.cs
@@ -8,8 +8,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation;
 
-using Dbg = System.Diagnostics.Debug;
-
 namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 {
     /// <summary>
@@ -133,8 +131,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         // Filter by user provided version
         public IEnumerable<String> FilterPkgPathsByVersion(VersionRange versionRange, List<string> dirsToSearch, bool selectPrereleaseOnly)
         {
-            Dbg.Assert(versionRange != null, "Version Range cannot be null");
-
             // if no version is specified, just get the latest version
             foreach (string pkgPath in dirsToSearch)
             {

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -5,6 +5,7 @@ using Microsoft.PowerShell.PSResourceGet.UtilClasses;
 using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Management.Automation;
 
 namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
@@ -138,13 +139,55 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             // SelectPrereleaseOnly is false because we want both stable and prerelease versions all the time..
             GetHelper getHelper = new GetHelper(this);
+            List<string> pkgsFound = new List<string>();
             foreach (PSResourceInfo pkg in getHelper.GetPackagesFromPath(
                 name: namesToSearch,
                 versionRange: _versionRange,
                 pathsToSearch: _pathsToSearch,
                 selectPrereleaseOnly: false))
             {
+                pkgsFound.Add(pkg.Name);
                 WriteObject(pkg);
+            }
+
+            List<string> pkgsNotFound = new List<string>();
+            foreach (string name in namesToSearch)
+            {
+                if (!pkgsFound.Contains(name, StringComparer.OrdinalIgnoreCase)) 
+                {
+                    if (name.Contains('*'))
+                    {
+                        WildcardPattern nameWildCardPattern = new WildcardPattern(name, WildcardOptions.IgnoreCase);
+
+                        bool foundWildcardMatch = false;
+                        foreach (string pkgFound in pkgsFound)
+                        {
+                            if (nameWildCardPattern.IsMatch(pkgFound))
+                            {
+                                foundWildcardMatch = true;
+                                break;
+                            }
+                        }
+
+                        if (!foundWildcardMatch)
+                        {
+                            pkgsNotFound.Add(name);
+                        }
+                    }
+                    else
+                    {
+                        pkgsNotFound.Add(name);
+                    }
+                }
+            }
+
+            if (pkgsNotFound.Count > 0)
+            {
+                WriteError(new ErrorRecord(
+                    new PackageNotFoundException($"No match was found for package '{string.Join(", ", pkgsNotFound)}'."),
+                    "InstalledPackageNotFound",
+                    ErrorCategory.ObjectNotFound,
+                    this));
             }
         }
 

--- a/test/GetInstalledPSResource/GetInstalledPSResource.Tests.ps1
+++ b/test/GetInstalledPSResource/GetInstalledPSResource.Tests.ps1
@@ -117,7 +117,7 @@ $testCases =
 
     It "Get prerelease version module when version with correct prerelease label is specified" {
         Install-PSResource -Name $testModuleName -Version "5.2.5-alpha001" -Repository $PSGalleryName -TrustRepository
-        $res = Get-InstalledPSResource -Name $testModuleName -Version "5.2.5"
+        $res = Get-InstalledPSResource -Name $testModuleName -Version "5.2.5" -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $res = Get-InstalledPSResource -Name $testModuleName -Version "5.2.5-alpha001"
         $res.Name | Should -Be $testModuleName
@@ -127,12 +127,17 @@ $testCases =
 
     It "Get prerelease version script when version with correct prerelease label is specified" {
         Install-PSResource -Name $testScriptName -Version "3.0.0-alpha" -Repository $PSGalleryName -TrustRepository
-        $res = Get-InstalledPSResource -Name $testScriptName -Version "3.0.0"
+        $res = Get-InstalledPSResource -Name $testScriptName -Version "3.0.0" -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $res = Get-InstalledPSResource -Name $testScriptName -Version "3.0.0-alpha"
         $res.Name | Should -Be $testScriptName
         $res.Version | Should -Be "3.0.0"
         $res.Prerelease | Should -Be "alpha"
+    }
+
+    It "Throw package not found error when searching for module that does not exist" {
+        Get-InstalledPSResource -Name "DoesNotExist" -ErrorVariable err -ErrorAction SilentlyContinue
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstalledPackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.GetInstalledPSResourceCommand"
     }
 
      # Windows only


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Add better error messaging to `Find-PSResource` when resource is not found.  
Add error handling to `Get-InstalledPSResource`.

## PR Context
Resolves #699 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
