### PR TITLE
Add Import-PSGetRepository

### DIFF
--- a/src/Microsoft.PowerShell.PSResourceGet.psd1
+++ b/src/Microsoft.PowerShell.PSResourceGet.psd1
@@ -2,19 +2,20 @@
 # Licensed under the MIT License.
 
 @{
-    RootModule        = './Microsoft.PowerShell.PSResourceGet.dll'
-    ModuleVersion     = '0.5.22'
-    CompatiblePSEditions = @('Core', 'Desktop')
-    GUID              = 'e4e0bda1-0703-44a5-b70d-8fe704cd0643'
-    Author            = 'Microsoft Corporation'
-    CompanyName       = 'Microsoft Corporation'
-    Copyright         = '(c) Microsoft Corporation. All rights reserved.'
-    Description       = 'PowerShell module with commands for discovering, installing, updating and publishing the PowerShell artifacts like Modules, Scripts, and DSC Resources.'
-    PowerShellVersion = '5.1'
+    RootModule             = './Microsoft.PowerShell.PSResourceGet.dll'
+    NestedModules          = @('./Microsoft.PowerShell.PSResourceGet.psm1')
+    ModuleVersion          = '0.5.23'
+    CompatiblePSEditions   = @('Core', 'Desktop')
+    GUID                   = 'e4e0bda1-0703-44a5-b70d-8fe704cd0643'
+    Author                 = 'Microsoft Corporation'
+    CompanyName            = 'Microsoft Corporation'
+    Copyright              = '(c) Microsoft Corporation. All rights reserved.'
+    Description            = 'PowerShell module with commands for discovering, installing, updating and publishing the PowerShell artifacts like Modules, Scripts, and DSC Resources.'
+    PowerShellVersion      = '5.1'
     DotNetFrameworkVersion = '2.0'
-    CLRVersion = '4.0.0'
-    FormatsToProcess  = 'PSGet.Format.ps1xml'
-    CmdletsToExport = @(
+    CLRVersion             = '4.0.0'
+    FormatsToProcess       = 'PSGet.Format.ps1xml'
+    CmdletsToExport        = @(
         'Find-PSResource',
         'Get-InstalledPSResource',
         'Get-PSResourceRepository',
@@ -30,22 +31,29 @@
         'Uninstall-PSResource',
         'Unregister-PSResourceRepository',
         'Update-PSModuleManifest',
-        'Update-PSResource')
+        'Update-PSResource'
+    )
+    FunctionsToExport      = @(
+        'Import-PSGetRepository'
+    )
 
-    VariablesToExport = 'PSGetPath'
-    AliasesToExport = @()
-    PrivateData = @{
+    VariablesToExport      = 'PSGetPath'
+    AliasesToExport        = @()
+    PrivateData            = @{
         PSData = @{
-            Prerelease = 'beta22'
-            Tags = @('PackageManagement',
+            Prerelease   = 'beta23'
+            Tags         = @('PackageManagement',
                 'PSEdition_Desktop',
                 'PSEdition_Core',
                 'Linux',
                 'Mac',
                 'Windows')
-            ProjectUri = 'https://go.microsoft.com/fwlink/?LinkId=828955'
-            LicenseUri = 'https://go.microsoft.com/fwlink/?LinkId=829061'
+            ProjectUri   = 'https://go.microsoft.com/fwlink/?LinkId=828955'
+            LicenseUri   = 'https://go.microsoft.com/fwlink/?LinkId=829061'
             ReleaseNotes = @'
+## 0.5.22-beta23
+- Add Import-PSGetRepository
+
 ## 0.5.22-beta22
 
 ### Breaking Changes
@@ -72,12 +80,12 @@
 - Bug fix for Install-PSResource -NoClobber parameter (#1121)
 - Save-PSResource now searches through all repos when no repo is specified (#1125)
 - Caching for improved performance in Uninstall-PSResource (#1175)
-- Bug fix for parsing package tags from local repository (#1119) 
+- Bug fix for parsing package tags from local repository (#1119)
 
 See change log (CHANGELOG.md) at https://github.com/PowerShell/PSResourceGet
 '@
         }
     }
 
-    HelpInfoUri       = 'https://go.microsoft.com/fwlink/?linkid=2238183'
+    HelpInfoUri            = 'https://go.microsoft.com/fwlink/?linkid=2238183'
 }

--- a/src/Microsoft.PowerShell.PSResourceGet.psm1
+++ b/src/Microsoft.PowerShell.PSResourceGet.psm1
@@ -1,0 +1,57 @@
+﻿<#
+    .SYNOPSIS
+    Finds the repositories registered with PowerShellGet and registers them for PSResourceGet.
+#>
+function Import-PSGetRepository {
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    param(
+        # Use the -Force switch to overwrite existing repositories.
+        [switch]$Force
+    )
+    if ($IsWindows) {
+        $PSGetAppLocalPath = Microsoft.PowerShell.Management\Join-Path -Path $env:LOCALAPPDATA -ChildPath 'Microsoft\Windows\PowerShell\PowerShellGet\'
+    }
+    else {
+        $PSGetAppLocalPath = Microsoft.PowerShell.Management\Join-Path -Path ([System.Management.Automation.Platform]::SelectProductNameForDirectory('CACHE')) -ChildPath 'PowerShellGet'
+    }
+    $PSRepositoriesFilePath = Microsoft.PowerShell.Management\Join-Path -Path $PSGetAppLocalPath -ChildPath "PSRepositories.xml"
+    $PSGetRepositories = Microsoft.PowerShell.Utility\Import-Clixml $PSRepositoriesFilePath -ea SilentlyContinue
+
+    Microsoft.PowerShell.Utility\Write-Verbose ('Found {0} registered PowerShellGet repositories.' -f $PSGetRepositories.Count)
+
+    if ($PSGetRepositories.Count) {
+        $repos = $PSGetRepositories.Values |
+            Microsoft.PowerShell.Core\Where-Object {$_.PackageManagementProvider -eq 'NuGet'-and $_.Name -ne 'PSGallery'} |
+            Microsoft.PowerShell.Utility\Select-Object Name, Trusted, SourceLocation
+
+        Microsoft.PowerShell.Utility\Write-Verbose ('Selected {0} NuGet repositories.' -f $repos.Count)
+
+        if ($repos.Count) {
+            $repos | Microsoft.PowerShell.Core\ForEach-Object {
+                try {
+                    $message = 'Registering {0} at {1} -Trusted:${2} -Force:${3}.' -f $_.Name,
+                        $_.SourceLocation, $_.Trusted, $Force
+                    if ($PSCmdlet.ShouldProcess($message, $_.Name, 'Register-PSResourceRepository')) {
+                        $registerPSResourceRepositorySplat = @{
+                            Name = $_.Name
+                            Uri = $_.SourceLocation
+                            Trusted = $_.Trusted
+                            PassThru = $true
+                            Force = $Force
+                        }
+                        Register-PSResourceRepository @registerPSResourceRepositorySplat
+                    }
+                }
+                catch [System.Management.Automation.PSInvalidOperationException] {
+                    if ($_.Exception.Message -match 'already exists') {
+                        Microsoft.PowerShell.Utility\Write-Warning $_.Exception.Message
+                        Microsoft.PowerShell.Utility\Write-Warning 'Use the -Force switch to overwrite existing repositories.'
+                    }
+                    else {
+                        throw $_.Exception
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# PR Summary

This PR adds the `Import-PSGetRepository` function in a PSM1 file. This function provides a simple way for users to import their existing v2 PSRepositories into PSResourceRepositories.

## PR Context

The `Import-PSGetRepository` function performs the following tasks
- Loads the `PSRepositories.xml` created by PowerShellGet v2 (and older)
- Selects the NuGet repositories that have been registered (excluding PSGallery)
  - Non-NuGet repositories are not supported by PSResourceGet
- Attempts to register each selected repository as a PSResourceRepository

Features include:
- `SupportsShouldProcess` so you can use `-WhatIf`
- Has verbose output
- Includes `-Force` to overwrite existing repositories

The function is included as a **NestedModule** in a PSM1 file.

Work that is out-of-scope for this PR but still needs to be done
- [ ] Build integration and signing
- [ ] End-user docs
- [ ] Pester tests

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: TBD
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
