### PR TITLE
Fix bug with version parsing in Publish-PSResource

### DIFF
--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -543,7 +543,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     {
                         if (psData.ContainsKey("prerelease") && psData["prerelease"] is string preReleaseVersion)
                         {
-                            version = string.Format(@"{0}-{1}", version, preReleaseVersion);
+                            if (!string.IsNullOrEmpty(preReleaseVersion))
+                            {
+                                version = string.Format(@"{0}-{1}", version, preReleaseVersion);
+                            }
                         }
 
                         if (psData.ContainsKey("licenseuri") && psData["licenseuri"] is string licenseUri)

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -396,7 +396,9 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $moduleName = "Pester"
         $moduleVersion = "5.5.0"
         Save-PSResource -Name $moduleName -Path $tmpRepoPath -Version $moduleVersion -Repository PSGallery -TrustRepository
-        $moduleManifestPath = Join-Path -Path $tmpRepoPath -ChildPath $moduleName -AdditionalChildPath $moduleVersion, "Pester.psd1"
+        $modulePath = Join-Path -Path $tmpRepoPath -ChildPath $moduleName 
+        $moduleVersionPath = Join-Path -Path $modulePath -ChildPath $moduleVersion
+        $moduleManifestPath = Join-path -Path $moduleVersionPath -ChildPath "$moduleName.psd1"
         Publish-PSResource -Path $moduleManifestPath -Repository $testRepository2
         $expectedPath = Join-Path -Path $script:repositoryPath2 -ChildPath "$moduleName.$moduleVersion.nupkg"
         (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -392,6 +392,16 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         (Get-ChildItem $script:destinationPath).FullName | Should -Be $expectedPath
     }
 
+    It "Publish a module with -Path -Repository and -DestinationPath" {
+        $moduleName = "Pester"
+        $moduleVersion = "5.5.0"
+        Save-PSResource -Name $moduleName -Path $tmpRepoPath -Version $moduleVersion -Repository PSGallery -TrustRepository
+        $moduleManifestPath = Join-Path -Path $tmpRepoPath -ChildPath $moduleName -AdditionalChildPath $moduleVersion, "Pester.psd1"
+        Publish-PSResource -Path $moduleManifestPath -Repository $testRepository2
+        $expectedPath = Join-Path -Path $script:repositoryPath2 -ChildPath "$moduleName.$moduleVersion.nupkg"
+        (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath
+    }
+
     It "Publish a module and clean up properly when file in module is readonly" {
         $version = "1.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fix bug with parsing version from module manifest for `Publish-PSResource`.

## PR Context
Resolves #1102 
Resolves #883 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
