### PR TITLE
Support Nuget.Server application hosted feeds

### DIFF
--- a/doBuild.ps1
+++ b/doBuild.ps1
@@ -17,9 +17,13 @@ function DoBuild
     $BuildSrcPath = "bin/${BuildConfiguration}/${BuildFramework}/publish"
     Write-Verbose -Verbose -Message "Module build source path: '$BuildSrcPath'"
 
-    # Copy module script files
+    # Copy module .psd1 file
     Write-Verbose -Verbose "Copy-Item ${SrcPath}/${ModuleName}.psd1 to $BuildOutPath"
     Copy-Item -Path "${SrcPath}/${ModuleName}.psd1" -Dest "$BuildOutPath" -Force
+
+    # Copy module .psm1 file
+    Write-Verbose -Verbose "Copy-Item ${SrcPath}/${ModuleName}.psm1 to $BuildOutPath"
+    Copy-Item -Path "${SrcPath}/${ModuleName}.psm1" -Dest "$BuildOutPath" -Force
 
     #Copy module format ps1xml file
     Write-Verbose -Verbose -Message "Copy-Item ${SrcPath}/${FormatFileName}.ps1xml to $BuildOutPath"

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -236,6 +236,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 
                 SetNetworkCredential(currentRepository);
                 ServerApiCall currentServer = ServerFactory.GetServer(currentRepository, _networkCredential);
+                if (currentServer == null)
+                {
+                    // this indicates that PSRepositoryInfo.APIVersion = PSRepositoryInfo.APIVersion.unknown
+                    _cmdletPassedIn.WriteError(new ErrorRecord(
+                    new PSInvalidOperationException($"Repository '{currentRepository.Name}' is not a known repository type that is supported. Please file an issue for support at https://github.com/PowerShell/PSResourceGet/issues"),
+                    "RepositoryApiVersionUnknown",
+                    ErrorCategory.InvalidArgument,
+                    this));
+
+                    continue;
+                }
+
                 ResponseUtil currentResponseUtil = ResponseUtilFactory.GetResponseUtil(currentRepository);
 
                 _cmdletPassedIn.WriteVerbose(string.Format("Searching in repository {0}", repositoriesToSearch[i].Name));
@@ -344,6 +356,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 PSRepositoryInfo currentRepository = repositoriesToSearch[i];
                 SetNetworkCredential(currentRepository);
                 ServerApiCall currentServer = ServerFactory.GetServer(currentRepository, _networkCredential);
+                if (currentServer == null)
+                {
+                    // this indicates that PSRepositoryInfo.APIVersion = PSRepositoryInfo.APIVersion.unknown
+                    _cmdletPassedIn.WriteError(new ErrorRecord(
+                    new PSInvalidOperationException($"Repository '{currentRepository.Name}' is not a known repository type that is supported. Please file an issue for support at https://github.com/PowerShell/PSResourceGet/issues"),
+                    "RepositoryApiVersionUnknown",
+                    ErrorCategory.InvalidArgument,
+                    this));
+
+                    continue;
+                }
+
                 ResponseUtil currentResponseUtil = ResponseUtilFactory.GetResponseUtil(currentRepository);
 
                 if (_type != ResourceType.None && repositoriesToSearch[i].Name != "PSGallery")

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -236,6 +236,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 
                 SetNetworkCredential(currentRepository);
                 ServerApiCall currentServer = ServerFactory.GetServer(currentRepository, _networkCredential);
+                if (currentServer == null)
+                {
+                    // this indicates that PSRepositoryInfo.APIVersion = PSRepositoryInfo.APIVersion.unknown
+                    _cmdletPassedIn.WriteError(new ErrorRecord(
+                    new PSInvalidOperationException($"Repository '{currentRepository.Name}' is not a known repository type that is supported. Please file an issue for support at https://github.com/PowerShell/PSResourceGet/issues"),
+                    "RepositoryApiVersionUnknown",
+                    ErrorCategory.InvalidArgument,
+                    this));
+
+                    continue;
+                }
+
                 ResponseUtil currentResponseUtil = ResponseUtilFactory.GetResponseUtil(currentRepository);
 
                 _cmdletPassedIn.WriteVerbose(string.Format("Searching in repository {0}", repositoriesToSearch[i].Name));
@@ -340,6 +352,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 PSRepositoryInfo currentRepository = repositoriesToSearch[i];
                 SetNetworkCredential(currentRepository);
                 ServerApiCall currentServer = ServerFactory.GetServer(currentRepository, _networkCredential);
+                if (currentServer == null)
+                {
+                    // this indicates that PSRepositoryInfo.APIVersion = PSRepositoryInfo.APIVersion.unknown
+                    _cmdletPassedIn.WriteError(new ErrorRecord(
+                    new PSInvalidOperationException($"Repository '{currentRepository.Name}' is not a known repository type that is supported. Please file an issue for support at https://github.com/PowerShell/PSResourceGet/issues"),
+                    "RepositoryApiVersionUnknown",
+                    ErrorCategory.InvalidArgument,
+                    this));
+
+                    continue;
+                }
+
                 ResponseUtil currentResponseUtil = ResponseUtilFactory.GetResponseUtil(currentRepository);
 
                 if (_type != ResourceType.None && repositoriesToSearch[i].Name != "PSGallery")

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -134,6 +134,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 PSRepositoryInfo currentRepository = repositoriesToSearch[i];
                 SetNetworkCredential(currentRepository);
                 ServerApiCall currentServer = ServerFactory.GetServer(currentRepository, _networkCredential);
+                if (currentServer == null)
+                {
+                    // this indicates that PSRepositoryInfo.APIVersion = PSRepositoryInfo.APIVersion.unknown
+                    _cmdletPassedIn.WriteError(new ErrorRecord(
+                    new PSInvalidOperationException($"Repository '{currentRepository.Name}' is not a known repository type that is supported. Please file an issue for support at https://github.com/PowerShell/PSResourceGet/issues"),
+                    "RepositoryApiVersionUnknown",
+                    ErrorCategory.InvalidArgument,
+                    this));
+
+                    continue;
+                }
+
                 ResponseUtil currentResponseUtil = ResponseUtilFactory.GetResponseUtil(currentRepository);
 
                 _cmdletPassedIn.WriteVerbose(string.Format("Searching in repository {0}", repositoriesToSearch[i].Name));

--- a/src/code/NuGetServerApiCalls.cs
+++ b/src/code/NuGetServerApiCalls.cs
@@ -1,0 +1,831 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.PowerShell.PSResourceGet.UtilClasses;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using NuGet.Versioning;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Net;
+using System.Runtime.ExceptionServices;
+
+namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
+{
+    internal class NuGetServerAPICalls : ServerApiCall
+    {
+        #region Members
+
+        public override PSRepositoryInfo Repository { get; set; }
+        private HttpClient _sessionClient { get; set; }
+        private static readonly Hashtable[] emptyHashResponses = new Hashtable[]{};
+        public FindResponseType nugetServerFindResponseType = FindResponseType.ResponseString;
+
+        #endregion
+
+        #region Constructor
+
+        public NuGetServerAPICalls (PSRepositoryInfo repository, NetworkCredential networkCredential) : base (repository, networkCredential)
+        {
+            this.Repository = repository;
+            HttpClientHandler handler = new HttpClientHandler()
+            {
+                Credentials = networkCredential
+            };
+
+            _sessionClient = new HttpClient(handler);
+        }
+
+        #endregion
+
+        #region Overriden Methods 
+
+        /// <summary>
+        /// Find method which allows for searching for all packages from a repository and returns latest version for each.
+        /// Examples: Search -Repository MyNuGetServerFeed
+        /// API call: 
+        /// - No prerelease: {{repoUri}/api/v2/Search()?$filter=IsLatestVersion
+        /// </summary>
+        public override FindResults FindAll(bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi) {
+            edi = null;
+            List<string> responses = new List<string>();
+
+            int skip = 0;
+            string initialScriptResponse = FindAllFromTypeEndPoint(includePrerelease, isSearchingModule: false, skip, out edi);
+            if (edi != null)
+            {
+                return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+            }
+            responses.Add(initialScriptResponse);
+            int initalScriptCount = GetCountFromResponse(initialScriptResponse, out edi);
+            if (edi != null)
+            {
+                return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+            }
+            int count = initalScriptCount / 6000;
+            // if more than 100 count, loop and add response to list
+            while (count > 0)
+            {
+                skip += 6000;
+                var tmpResponse = FindAllFromTypeEndPoint(includePrerelease, isSearchingModule: false, skip, out edi);
+                if (edi != null)
+                {
+                    return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+                }
+                responses.Add(tmpResponse);
+                count--;
+            }
+
+            return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+        }
+
+        /// <summary>
+        /// Find method which allows for searching for packages with tag from a repository and returns latest version for each.
+        /// Examples: Search -Tag "JSON" -Repository MyNuGetServerFeed
+        /// API call: 
+        /// - Include prerelease: {repoUri}api/v2/Search()?$filter=IsAbsoluteLatestVersion&searchTerm=tag:JSON&includePrerelease=true
+        /// </summary>
+        public override FindResults FindTags(string[] tags, bool includePrerelease, ResourceType _type, out ExceptionDispatchInfo edi)
+        {
+            edi = null;
+            List<string> responses = new List<string>();
+
+            int skip = 0;
+            string initialScriptResponse = FindTagFromEndpoint(tags, includePrerelease, isSearchingModule: false, skip, out edi);
+            if (edi != null)
+            {
+                return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+            }
+            responses.Add(initialScriptResponse);
+            int initalScriptCount = GetCountFromResponse(initialScriptResponse, out edi);
+            if (edi != null)
+            {
+                return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+            }
+            int count = initalScriptCount / 100;
+            // if more than 100 count, loop and add response to list
+            while (count > 0)
+            {
+                // skip 100
+                skip += 100;
+                var tmpResponse = FindTagFromEndpoint(tags, includePrerelease, isSearchingModule: false,  skip, out edi);
+                if (edi != null)
+                {
+                    return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+                }
+                responses.Add(tmpResponse);
+                count--;
+            }
+
+            return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+        }
+
+        /// <summary>
+        /// Find method which allows for searching for all packages that have specified Command or DSCResource name.
+        /// </summary>
+        public override FindResults FindCommandOrDscResource(string[] tags, bool includePrerelease, bool isSearchingForCommands, out ExceptionDispatchInfo edi)
+        {
+            string errMsg = $"Find by CommandName or DSCResource is not supported for the V3 server repository {Repository.Name}";
+            edi = ExceptionDispatchInfo.Capture(new InvalidOperationException(errMsg));
+
+            return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+        }
+
+        /// <summary>
+        /// Find method which allows for searching for single name and returns latest version.
+        /// Name: no wildcard support
+        /// Examples: Search "PowerShellGet"
+        /// API call: 
+        /// - No prerelease: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
+        /// - Include prerelease: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
+        /// Implementation Note: Need to filter further for latest version (prerelease or non-prerelease dependening on user preference)
+        /// </summary>
+        public override FindResults FindName(string packageName, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        {
+            // Make sure to include quotations around the package name
+            var prerelease = includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion";
+
+            // This should return the latest stable version or the latest prerelease version (respectively)
+            // https://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'&$filter=IsLatestVersion and substringof('PSModule', Tags) eq true
+            // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
+            string idFilterPart = $" and Id eq '{packageName}'";
+            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter={prerelease}{idFilterPart}";
+
+            string response = HttpRequestCall(requestUrlV2, out edi);  
+            return new FindResults(stringResponse: new string[]{ response }, hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+        }
+
+        /// <summary>
+        /// Find method which allows for searching for single name and tag and returns latest version.
+        /// Name: no wildcard support
+        /// Examples: Search "PowerShellGet" -Tag "Provider"
+        /// Implementation Note: Need to filter further for latest version (prerelease or non-prerelease dependening on user preference)
+        /// </summary>
+        public override FindResults FindNameWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        {
+            // Make sure to include quotations around the package name
+            var prerelease = includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion";
+
+            // This should return the latest stable version or the latest prerelease version (respectively)
+            // https://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'&$filter=IsLatestVersion and substringof('PSModule', Tags) eq true
+            // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
+            string idFilterPart = $" and Id eq '{packageName}'";
+            string tagFilterPart = String.Empty;
+            foreach (string tag in tags)
+            {
+                tagFilterPart += $" and substringof('{tag}', Tags) eq true";
+            }
+
+            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter={prerelease}{idFilterPart}{tagFilterPart}";
+
+            string response = HttpRequestCall(requestUrlV2, out edi);
+            return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+        }
+
+        /// <summary>
+        /// Find method which allows for searching for single name with wildcards and returns latest version.
+        /// Name: supports wildcards
+        /// Examples: Search "PowerShell*"
+        /// API call: 
+        /// - No prerelease: http://www.powershellgallery.com/api/v2/Search()?$filter=IsLatestVersion&searchTerm='az*'
+        /// Implementation Note: filter additionally and verify ONLY package name was a match.
+        /// </summary>
+        public override FindResults FindNameGlobbing(string packageName, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        {
+            List<string> responses = new List<string>();
+            int skip = 0;
+
+            var initialResponse = FindNameGlobbing(packageName, type, includePrerelease, skip, out edi);
+            if (edi != null)
+            {
+                return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+            }
+
+            responses.Add(initialResponse);
+
+            // check count (regex)  425 ==> count/100  ~~>  4 calls 
+            int initalCount = GetCountFromResponse(initialResponse, out edi);  // count = 4
+            if (edi != null)
+            {
+                return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+            }
+            int count = initalCount / 100;
+            // if more than 100 count, loop and add response to list
+            while (count > 0)
+            {
+                // skip 100
+                skip += 100;
+                var tmpResponse = FindNameGlobbing(packageName, type, includePrerelease, skip, out edi);
+                if (edi != null)
+                {
+                    return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+                }
+                responses.Add(tmpResponse);
+                count--;
+            }
+
+            return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+        }
+
+        /// <summary>
+        /// Find method which allows for searching for single name with wildcards and tag and returns latest version.
+        /// Name: supports wildcards
+        /// Examples: Search "PowerShell*" -Tag "Provider"
+        /// Implementation Note: filter additionally and verify ONLY package name was a match.
+        /// </summary>
+        public override FindResults FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
+        {
+            List<string> responses = new List<string>();
+            int skip = 0;
+
+            var initialResponse = FindNameGlobbingWithTag(packageName, tags, type, includePrerelease, skip, out edi);
+            if (edi != null)
+            {
+                return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+            }
+
+            responses.Add(initialResponse);
+
+            // check count (regex)  425 ==> count/100  ~~>  4 calls 
+            int initalCount = GetCountFromResponse(initialResponse, out edi);  // count = 4
+            if (edi != null)
+            {
+                return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+            }
+            int count = initalCount / 100;
+            // if more than 100 count, loop and add response to list
+            while (count > 0)
+            {
+                // skip 100
+                skip += 100;
+                var tmpResponse = FindNameGlobbingWithTag(packageName, tags, type, includePrerelease, skip, out edi);
+                if (edi != null)
+                {
+                    return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+                }
+                responses.Add(tmpResponse);
+                count--;
+            }
+
+            return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+        }
+
+        /// <summary>
+        /// Find method which allows for searching for single name with version range.
+        /// Name: no wildcard support
+        /// Version: supports wildcards
+        /// Examples: Search "PowerShellGet" "[3.0.0.0, 5.0.0.0]"
+        ///           Search "PowerShellGet" "3.*"
+        /// API Call: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
+        /// Implementation note: Returns all versions, including prerelease ones. Later (in the API client side) we'll do filtering on the versions to satisfy what user provided.
+        /// </summary>
+        public override FindResults FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ExceptionDispatchInfo edi)
+        {
+            List<string> responses = new List<string>();
+            int skip = 0;
+
+            var initialResponse = FindVersionGlobbing(packageName, versionRange, includePrerelease, type, skip, getOnlyLatest, out edi);
+            if (edi != null)
+            {
+                return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+            }
+            responses.Add(initialResponse);
+
+            if (!getOnlyLatest)
+            {
+                int initalCount = GetCountFromResponse(initialResponse, out edi);
+                if (edi != null)
+                {
+                    return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+                }
+                int count = initalCount / 100;
+
+                while (count > 0)
+                {
+                    // skip 100
+                    skip += 100;
+                    var tmpResponse = FindVersionGlobbing(packageName, versionRange, includePrerelease, type, skip, getOnlyLatest, out edi);
+                    if (edi != null)
+                    {
+                        return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+                    }
+                    responses.Add(tmpResponse);
+                    count--;
+                }
+            }
+
+            return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+        }
+
+        /// <summary>
+        /// Find method which allows for searching for single name with specific version.
+        /// Name: no wildcard support
+        /// Version: no wildcard support
+        /// Examples: Search "PowerShellGet" "2.2.5"
+        /// API call: http://www.powershellgallery.com/api/v2/Packages(Id='PowerShellGet', Version='2.2.5')
+        /// </summary>
+        public override FindResults FindVersion(string packageName, string version, ResourceType type, out ExceptionDispatchInfo edi) 
+        {
+            // https://www.powershellgallery.com/api/v2/FindPackagesById()?id='blah'&includePrerelease=false&$filter= NormalizedVersion eq '1.1.0' and substringof('PSModule', Tags) eq true 
+            // Quotations around package name and version do not matter, same metadata gets returned.
+            // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
+            string idFilterPart = $" and Id eq '{packageName}'";
+            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter= NormalizedVersion eq '{version}'{idFilterPart}";
+            
+            string response = HttpRequestCall(requestUrlV2, out edi);  
+            return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+        }
+
+        /// <summary>
+        /// Find method which allows for searching for single name with specific version and tag.
+        /// Name: no wildcard support
+        /// Version: no wildcard support
+        /// Examples: Search "PowerShellGet" "2.2.5" -Tag "Provider"
+        /// </summary>
+        public override FindResults FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ExceptionDispatchInfo edi)
+        {
+            // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
+            string idFilterPart = $" and Id eq '{packageName}'";
+            string tagFilterPart = String.Empty;
+            foreach (string tag in tags)
+            {
+                tagFilterPart += $" and substringof('{tag}', Tags) eq true";
+            }
+
+            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter= NormalizedVersion eq '{version}'{idFilterPart}{tagFilterPart}";
+            
+            string response = HttpRequestCall(requestUrlV2, out edi);
+            return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: nugetServerFindResponseType);
+        }
+
+        /**  INSTALL APIS **/
+
+        /// <summary>
+        /// Installs specific package.
+        /// Name: no wildcard support.
+        /// Examples: Install "PowerShellGet"
+        /// Implementation Note:   if not prerelease: https://www.powershellgallery.com/api/v2/package/powershellget (Returns latest stable)
+        ///                        if prerelease, call into InstallVersion instead. 
+        /// </summary>
+        public override Stream InstallName(string packageName, bool includePrerelease, out ExceptionDispatchInfo edi)
+        {
+            var requestUrlV2 = $"{Repository.Uri}/package/{packageName}";
+
+            var response = HttpRequestCallForContent(requestUrlV2, out edi);
+            var responseStream = response.ReadAsStreamAsync().Result;
+            return responseStream;
+        }
+
+        /// <summary>
+        /// Installs package with specific name and version.
+        /// Name: no wildcard support.
+        /// Version: no wildcard support.
+        /// Examples: Install "PowerShellGet" -Version "3.0.0.0"
+        ///           Install "PowerShellGet" -Version "3.0.0-beta16"
+        /// API Call: https://www.powershellgallery.com/api/v2/package/Id/version (version can be prerelease)
+        /// </summary>    
+        public override Stream InstallVersion(string packageName, string version, out ExceptionDispatchInfo edi)
+        {
+            var requestUrlV2 = $"{Repository.Uri}/package/{packageName}/{version}";
+
+            var response = HttpRequestCallForContent(requestUrlV2, out edi);
+            var responseStream = response.ReadAsStreamAsync().Result;
+            return responseStream;
+        }
+
+        /// <summary>
+        /// Helper method that makes the HTTP request for the V2 server protocol url passed in for find APIs.
+        /// </summary>
+        private string HttpRequestCall(string requestUrlV2, out ExceptionDispatchInfo edi)
+        {
+            edi = null;
+            string response = string.Empty;
+
+            try
+            {
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUrlV2);
+                
+                response = SendV2RequestAsync(request, _sessionClient).GetAwaiter().GetResult();
+            }
+            catch (HttpRequestException e)
+            {
+                edi = ExceptionDispatchInfo.Capture(e);
+            }
+            catch (ArgumentNullException e)
+            {
+                edi = ExceptionDispatchInfo.Capture(e);
+            }
+            catch (InvalidOperationException e)
+            {
+                edi = ExceptionDispatchInfo.Capture(e);
+            }
+
+            return response;
+        }
+
+        /// <summary>
+        /// Helper method that makes the HTTP request for the V2 server protocol url passed in for install APIs.
+        /// </summary>
+        private HttpContent HttpRequestCallForContent(string requestUrlV2, out ExceptionDispatchInfo edi) 
+        {
+            edi = null;
+            HttpContent content = null;
+
+            try
+            {
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUrlV2);
+                
+                content = SendV2RequestForContentAsync(request, _sessionClient).GetAwaiter().GetResult();
+            }
+            catch (HttpRequestException e)
+            {
+                edi = ExceptionDispatchInfo.Capture(e);
+            }
+            catch (ArgumentNullException e)
+            {
+                edi = ExceptionDispatchInfo.Capture(e);
+            }
+            catch (InvalidOperationException e)
+            {
+                edi = ExceptionDispatchInfo.Capture(e);
+            }
+
+            return content;
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        /// <summary>
+        /// Helper method for string[] FindAll(string, PSRepositoryInfo, bool, bool, ResourceType, out string)
+        /// </summary>
+        private string FindAllFromTypeEndPoint(bool includePrerelease, bool isSearchingModule, int skip, out ExceptionDispatchInfo edi)
+        {
+            string typeEndpoint = isSearchingModule ? String.Empty : "/items/psscript";
+            string paginationParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=6000";
+            var prereleaseFilter = includePrerelease ? "IsAbsoluteLatestVersion&includePrerelease=true" : "IsLatestVersion";
+
+            var requestUrlV2 = $"{Repository.Uri}{typeEndpoint}/Search()?$filter={prereleaseFilter}{paginationParam}";
+
+            return HttpRequestCall(requestUrlV2, out edi);
+        }
+
+        /// <summary>
+        /// Helper method for string[] FindTag(string, PSRepositoryInfo, bool, bool, ResourceType, out string)
+        /// </summary>
+        private string FindTagFromEndpoint(string[] tags, bool includePrerelease, bool isSearchingModule, int skip, out ExceptionDispatchInfo edi)
+        {
+            string paginationParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=6000";
+            var prereleaseFilter = includePrerelease ? "$filter=IsAbsoluteLatestVersion&includePrerelease=true" : "$filter=IsLatestVersion";
+            string typeFilterPart = isSearchingModule ?  $" and substringof('PSModule', Tags) eq true" : $" and substringof('PSScript', Tags) eq true";
+            
+            string tagFilterPart = String.Empty;
+            foreach (string tag in tags)
+            {
+                tagFilterPart += $" and substringof('{tag}', Tags) eq true";
+            }
+
+            var requestUrlV2 = $"{Repository.Uri}/Search()?{prereleaseFilter}{typeFilterPart}{tagFilterPart}{paginationParam}";
+
+            return HttpRequestCall(requestUrlV2: requestUrlV2, out edi);  
+        }
+
+        /// <summary>
+        /// Helper method for string[] FindCommandOrDSCResource(string, PSRepositoryInfo, bool, bool, ResourceType, out string)
+        /// </summary>
+        private string FindCommandOrDscResource(string[] tags, bool includePrerelease, bool isSearchingForCommands, int skip, out ExceptionDispatchInfo edi)
+        {
+            // can only find from Modules endpoint
+            string paginationParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=6000";
+            var prereleaseFilter = includePrerelease ? "$filter=IsAbsoluteLatestVersion&includePrerelease=true" : "$filter=IsLatestVersion";
+
+            var tagPrefix = isSearchingForCommands ? "PSCommand_" : "PSDscResource_";
+            string tagSearchTermPart = String.Empty;
+            foreach (string tag in tags)
+            {
+                if (!String.IsNullOrEmpty(tagSearchTermPart))
+                {
+                    tagSearchTermPart += " ";
+                }
+
+                tagSearchTermPart += $"tag:{tagPrefix}{tag}";
+            }
+
+            var requestUrlV2 = $"{Repository.Uri}/Search()?{prereleaseFilter}&searchTerm='{tagSearchTermPart}'{paginationParam}";
+            return HttpRequestCall(requestUrlV2, out edi);
+        }
+
+        /// <summary>
+        /// Helper method for string[] FindNameGlobbing()
+        /// </summary>
+        private string FindNameGlobbing(string packageName, ResourceType type, bool includePrerelease, int skip, out ExceptionDispatchInfo edi)
+        {
+            // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and startswith(Id, 'PowerShell') and IsLatestVersion (stable)
+            // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and IsAbsoluteLatestVersion&includePrerelease=true
+            
+            string extraParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=100";
+            var prerelease = includePrerelease ? "IsAbsoluteLatestVersion&includePrerelease=true" : "IsLatestVersion";
+            string nameFilter;
+
+            var names = packageName.Split(new char[] {'*'}, StringSplitOptions.RemoveEmptyEntries);
+
+            if (names.Length == 0)
+            {
+                edi = ExceptionDispatchInfo.Capture(new ArgumentException("-Name '*' for V2 server protocol repositories is not supported"));
+                return string.Empty;
+            }
+            if (names.Length == 1)
+            {
+                if (packageName.StartsWith("*") && packageName.EndsWith("*"))
+                {
+                    // *get*
+                    nameFilter = $"substringof('{names[0]}', Id)";
+                }
+                else if (packageName.EndsWith("*"))
+                {
+                    // PowerShell*
+                    nameFilter = $"startswith(Id, '{names[0]}')";
+                }
+                else
+                {
+                    // *ShellGet
+                    nameFilter = $"endswith(Id, '{names[0]}')";
+                }
+            }
+            else if (names.Length == 2 && !packageName.StartsWith("*") && !packageName.EndsWith("*"))
+            {
+                // *pow*get*
+                // pow*get -> only support this
+                // pow*get*
+                // *pow*get
+                nameFilter = $"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')";
+            }
+            else 
+            {
+                edi = ExceptionDispatchInfo.Capture(new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."));
+                return string.Empty;
+            }
+
+            var requestUrlV2 = $"{Repository.Uri}/Search()?$filter={nameFilter} and {prerelease}{extraParam}";
+            
+            return HttpRequestCall(requestUrlV2, out edi);  
+        }
+
+        /// <summary>
+        /// Helper method for string[] FindNameGlobbingWithTag()
+        /// </summary>
+        private string FindNameGlobbingWithTag(string packageName, string[] tags, ResourceType type, bool includePrerelease, int skip, out ExceptionDispatchInfo edi)
+        {
+            // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and startswith(Id, 'PowerShell') and IsLatestVersion (stable)
+            // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and IsAbsoluteLatestVersion&includePrerelease=true
+            
+            string extraParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=100";
+            var prerelease = includePrerelease ? "IsAbsoluteLatestVersion&includePrerelease=true" : "IsLatestVersion";
+            string nameFilter;
+
+            var names = packageName.Split(new char[] {'*'}, StringSplitOptions.RemoveEmptyEntries);
+
+            if (names.Length == 0)
+            {
+                edi = ExceptionDispatchInfo.Capture(new ArgumentException("-Name '*' for V2 server protocol repositories is not supported"));
+                return string.Empty;
+            }
+            if (names.Length == 1)
+            {
+                if (packageName.StartsWith("*") && packageName.EndsWith("*"))
+                {
+                    // *get*
+                    nameFilter = $"substringof('{names[0]}', Id)";
+                }
+                else if (packageName.EndsWith("*"))
+                {
+                    // PowerShell*
+                    nameFilter = $"startswith(Id, '{names[0]}')";
+                }
+                else
+                {
+                    // *ShellGet
+                    nameFilter = $"endswith(Id, '{names[0]}')";
+                }
+            }
+            else if (names.Length == 2 && !packageName.StartsWith("*") && !packageName.EndsWith("*"))
+            {
+                // *pow*get*
+                // pow*get -> only support this
+                // pow*get*
+                // *pow*get
+                nameFilter = $"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')";
+            }
+            else 
+            {
+                edi = ExceptionDispatchInfo.Capture(new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."));
+                return string.Empty;
+            }
+
+            string tagFilterPart = String.Empty;
+            foreach (string tag in tags)
+            {
+                tagFilterPart += $" and substringof('{tag}', Tags) eq true";
+            }
+
+            var requestUrlV2 = $"{Repository.Uri}/Search()?$filter={nameFilter}{tagFilterPart} and {prerelease}{extraParam}";
+            
+            return HttpRequestCall(requestUrlV2, out edi);  
+        }
+
+        /// <summary>
+        /// Helper method for string[] FindVersionGlobbing()
+        /// </summary>
+        private string FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, int skip, bool getOnlyLatest, out ExceptionDispatchInfo edi)
+        {
+            //https://www.powershellgallery.com/api/v2//FindPackagesById()?id='blah'&includePrerelease=false&$filter= NormalizedVersion gt '1.0.0' and NormalizedVersion lt '2.2.5' and substringof('PSModule', Tags) eq true 
+            //https://www.powershellgallery.com/api/v2//FindPackagesById()?id='PowerShellGet'&includePrerelease=false&$filter= NormalizedVersion gt '1.1.1' and NormalizedVersion lt '2.2.5'
+            // NormalizedVersion doesn't include trailing zeroes
+            // Notes: this could allow us to take a version range (i.e (2.0.0, 3.0.0.0]) and deconstruct it and add options to the Filter for Version to describe that range
+            // will need to filter additionally, if IncludePrerelease=false, by default we get stable + prerelease both back
+            // Current bug: Find PSGet -Version "2.0.*" -> https://www.powershellgallery.com/api/v2//FindPackagesById()?id='PowerShellGet'&includePrerelease=false&$filter= Version gt '2.0.*' and Version lt '2.1'
+            // Make sure to include quotations around the package name
+
+            //and IsPrerelease eq false
+            // ex:
+            // (2.0.0, 3.0.0)
+            // $filter= NVersion gt '2.0.0' and NVersion lt '3.0.0'
+
+            // [2.0.0, 3.0.0]
+            // $filter= NVersion ge '2.0.0' and NVersion le '3.0.0'
+
+            // [2.0.0, 3.0.0)
+            // $filter= NVersion ge '2.0.0' and NVersion lt '3.0.0'
+
+            // (2.0.0, 3.0.0]
+            // $filter= NVersion gt '2.0.0' and NVersion le '3.0.0'
+
+            // [, 2.0.0]
+            // $filter= NVersion le '2.0.0'
+
+            string format = "NormalizedVersion {0} {1}";
+            string minPart = String.Empty;
+            string maxPart = String.Empty;
+
+            if (versionRange.MinVersion != null)
+            {
+                string operation = versionRange.IsMinInclusive ? "ge" : "gt";
+                minPart = String.Format(format, operation, $"'{versionRange.MinVersion.ToNormalizedString()}'");
+            }
+
+            if (versionRange.MaxVersion != null)
+            {
+                string operation = versionRange.IsMaxInclusive ? "le" : "lt";
+                maxPart = String.Format(format, operation, $"'{versionRange.MaxVersion.ToNormalizedString()}'");
+            }
+
+            string versionFilterParts = String.Empty;
+            if (!String.IsNullOrEmpty(minPart) && !String.IsNullOrEmpty(maxPart))
+            {
+                versionFilterParts += minPart + " and " + maxPart;
+            }
+            else if (!String.IsNullOrEmpty(minPart))
+            {
+                versionFilterParts += minPart;
+            }
+            else if (!String.IsNullOrEmpty(maxPart))
+            {
+                versionFilterParts += maxPart;
+            }
+
+            string filterQuery = "&$filter=";
+            filterQuery += includePrerelease ? string.Empty : "IsPrerelease eq false";
+            
+            string andOperator = " and ";
+            string joiningOperator = filterQuery.EndsWith("=") ? String.Empty : andOperator;
+            // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
+            string idFilterPart = $"{joiningOperator}Id eq '{packageName}'";
+            filterQuery += idFilterPart;
+            // filterQuery += type == ResourceType.Script ? $"{andOperator}substringof('PS{type.ToString()}', Tags) eq true" : String.Empty;
+
+            if (!String.IsNullOrEmpty(versionFilterParts))
+            {
+                // Check if includePrerelease is true, if it is we want to add "$filter"
+                // Single case where version is "*" (or "[,]") and includePrerelease is true, then we do not want to add "$filter" to the requestUrl.
+        
+                // Note: could be null/empty if Version was "*" -> [,]
+                filterQuery +=  $"{andOperator}{versionFilterParts}";
+            }
+
+            string topParam = getOnlyLatest ? "$top=1" : "$top=100"; // only need 1 package if interested in latest
+            string paginationParam = $"$inlinecount=allpages&$skip={skip}&{topParam}";
+
+            filterQuery = filterQuery.EndsWith("=") ? string.Empty : filterQuery;
+            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$orderby=NormalizedVersion desc&{paginationParam}{filterQuery}";
+
+            return HttpRequestCall(requestUrlV2, out edi);  
+        }
+
+        private string GetTypeFilterForRequest(ResourceType type) {
+            string typeFilterPart = string.Empty;
+            if (type == ResourceType.Script)
+            {
+                typeFilterPart += $" and substringof('PS{type.ToString()}', Tags) eq true ";
+            }
+            else if (type == ResourceType.Module)
+            {
+                typeFilterPart += $" and substringof('PS{ResourceType.Script.ToString()}', Tags) eq false ";
+            }
+
+            return typeFilterPart;
+        }
+
+        /// <summary>
+        /// Helper method that makes gets 'count' property from http response string.
+        /// The count property is used to determine the number of total results found (for pagination).
+        /// </summary>
+        public int GetCountFromResponse(string httpResponse, out ExceptionDispatchInfo edi)
+        {
+            edi = null;
+            int count = 0;
+
+            //Create the XmlDocument.
+            XmlDocument doc = new XmlDocument();
+
+            try
+            {
+                doc.LoadXml(httpResponse);
+            }
+            catch (XmlException e)
+            {
+                edi = ExceptionDispatchInfo.Capture(e);
+            }
+            if (edi != null)
+            {
+                return count;
+            }
+
+            XmlNodeList elemList = doc.GetElementsByTagName("m:count");
+            if (elemList.Count > 0)
+            {
+                XmlNode node = elemList[0];
+                count = int.Parse(node.InnerText);
+            }
+
+            return count;
+        }
+
+        /// <summary>
+        /// Helper method called by HttpRequestCall() that makes the HTTP request for string response.
+        /// </summary>
+        public static async Task<string> SendV2RequestAsync(HttpRequestMessage message, HttpClient s_client)
+        {
+            string errMsg = "Error occured while trying to retrieve response: ";
+            try
+            {
+                HttpResponseMessage response = await s_client.SendAsync(message);
+                response.EnsureSuccessStatusCode();
+                return response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            }
+            catch (HttpRequestException e)
+            {
+                throw new HttpRequestException(errMsg + e.Message);
+            }
+            catch (ArgumentNullException e)
+            {
+                throw new ArgumentNullException(errMsg + e.Message);
+            }
+            catch (InvalidOperationException e)
+            {
+                throw new InvalidOperationException(errMsg + e.Message);
+            }
+        }
+
+        /// <summary>
+        /// Helper method called by HttpRequestCallForContent() that makes the HTTP request for HTTP Content response.
+        /// </summary>
+        public static async Task<HttpContent> SendV2RequestForContentAsync(HttpRequestMessage message, HttpClient s_client)
+        {
+            string errMsg = "Error occured while trying to retrieve response for content: ";
+            try
+            {
+                HttpResponseMessage response = await s_client.SendAsync(message);
+                response.EnsureSuccessStatusCode();
+                return response.Content;
+            }
+            catch (HttpRequestException e)
+            {
+                throw new HttpRequestException(errMsg + e.Message);
+            }
+            catch (ArgumentNullException e)
+            {
+                throw new ArgumentNullException(errMsg + e.Message);
+            }
+            catch (InvalidOperationException e)
+            {
+                throw new InvalidOperationException(errMsg + e.Message);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/code/NuGetServerResponseUtil.cs
+++ b/src/code/NuGetServerResponseUtil.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         #endregion
 
-        #region V2 Specific Methods
+        #region NuGet.Server Specific Methods
 
         public XmlNode[] ConvertResponseToXML(string httpResponse) {
 

--- a/src/code/NuGetServerResponseUtil.cs
+++ b/src/code/NuGetServerResponseUtil.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.PowerShell.PSResourceGet.UtilClasses;
+using System;
+using System.Collections.Generic;
+using System.Xml;
+
+namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
+{
+    internal class NuGetServerResponseUtil : ResponseUtil
+    {
+        #region Members
+
+        internal override PSRepositoryInfo Repository { get; set; }
+
+        #endregion
+
+        #region Constructor
+
+        public NuGetServerResponseUtil(PSRepositoryInfo repository) : base(repository)
+        {
+            this.Repository = repository;
+        }
+
+        #endregion
+
+        #region Overriden Methods
+        public override IEnumerable<PSResourceResult> ConvertToPSResourceResult(FindResults responseResults)
+        {
+            // in FindHelper:
+            // serverApi.FindName() -> return responses, and out errRecord
+            // check outErrorRecord
+            // 
+            // v2Converter.ConvertToPSResourceInfo(responses) -> return PSResourceResult
+            // check resourceResult for error, write if needed
+            string[] responses = responseResults.StringResponse;
+
+            foreach (string response in responses)
+            {
+                var elemList = ConvertResponseToXML(response);
+                if (elemList.Length == 0)
+                {
+                    // this indicates we got a non-empty, XML response (as noticed for V2 server) but it's not a response that's meaningful (contains 'properties')
+                    string errorMsg = $"Package does not exist on the server.";
+                    yield return new PSResourceResult(returnedObject: null, errorMsg: errorMsg, isTerminatingError: false);
+                }
+
+                foreach (var element in elemList)
+                {
+                    if (!PSResourceInfo.TryConvertFromXml(element, out PSResourceInfo psGetInfo, Repository, out string errorMsg))
+                    {
+                        yield return new PSResourceResult(returnedObject: null, errorMsg: errorMsg, isTerminatingError: false);
+                    }
+
+                    // Unlisted versions will have a published year as 1900 or earlier.
+                    if (!psGetInfo.PublishedDate.HasValue || psGetInfo.PublishedDate.Value.Year > 1900)
+                    {
+                        yield return new PSResourceResult(returnedObject: psGetInfo, errorMsg: String.Empty, isTerminatingError: false);
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region V2 Specific Methods
+
+        public XmlNode[] ConvertResponseToXML(string httpResponse) {
+
+            //Create the XmlDocument.
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(httpResponse);
+
+            XmlNodeList elemList = doc.GetElementsByTagName("m:properties");
+            
+            XmlNode[] nodes = new XmlNode[elemList.Count]; 
+            for (int i = 0; i < elemList.Count; i++) 
+            {
+                nodes[i] = elemList[i]; 
+            }
+
+            return nodes;
+        }
+
+        #endregion
+    }
+}

--- a/src/code/PSRepositoryInfo.cs
+++ b/src/code/PSRepositoryInfo.cs
@@ -18,7 +18,8 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             unknown,
             v2,
             v3,
-            local
+            local,
+            nugetServer
         }
 
         #endregion

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -507,7 +507,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     }
                     else if (key.Equals("Tags"))
                     {
-                        metadata[key] = value.Split(new char[]{' '});
+                        metadata[key] = value.Split(new char[]{' '}, StringSplitOptions.RemoveEmptyEntries);
                     }
                     else if (key.Equals("Published"))
                     {

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -587,7 +587,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         }
 
                         // defaults to false
-                        // boolean value needs to be a lowercase string for it to be correctly parsed
+                        // Value for requireAcceptLicense key needs to be a lowercase string representation of the boolean for it to be correctly parsed from psData file.
+
                         string requireLicenseAcceptance = psData.ContainsKey("requirelicenseacceptance") ? psData["requirelicenseacceptance"].ToString().ToLower() : "false";
 
                         metadataElementsDictionary.Add("requireLicenseAcceptance", requireLicenseAcceptance);

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -543,7 +543,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     {
                         if (psData.ContainsKey("prerelease") && psData["prerelease"] is string preReleaseVersion)
                         {
-                            version = string.Format(@"{0}-{1}", version, preReleaseVersion);
+                            if (!string.IsNullOrEmpty(preReleaseVersion))
+                            {
+                                version = string.Format(@"{0}-{1}", version, preReleaseVersion);
+                            }
                         }
 
                         if (psData.ContainsKey("licenseuri") && psData["licenseuri"] is string licenseUri)

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -167,8 +167,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 ThrowTerminatingError(
                     new ErrorRecord(
                         new ArgumentException(
-                            "The path to the resource to publish is not in the correct format, point to a path or file of the module or script to publish."),
-                            "InvalidSourcePath",
+                            "The path to the resource to publish is not in the correct format or does not exist. Please provide the path of the root module (i.e. './<ModuleToPublish>/') or the path to the .psd1 (i.e. './<ModuleToPublish>/<ModuleToPublish>.psd1')."),
+                            "InvalidPublishPath",
                             ErrorCategory.InvalidArgument,
                             this));
             }
@@ -186,6 +186,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 pathToScriptFileToPublish = resolvedPath;
                 resourceType = ResourceType.Script;
+            }
+            else {
+                ThrowTerminatingError(
+                    new ErrorRecord(
+                        new ArgumentException(
+                            $"The publish path provided, '{resolvedPath}', is not a valid. Please provide a path to the root module (i.e. './<ModuleToPublish>/') or path to the .psd1 (i.e. './<ModuleToPublish>/<ModuleToPublish>.psd1')."),
+                            "InvalidPublishPath",
+                            ErrorCategory.InvalidArgument,
+                            this));
             }
 
             if (!String.IsNullOrEmpty(DestinationPath))
@@ -578,7 +587,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         }
 
                         // defaults to false
-                        string requireLicenseAcceptance = psData.ContainsKey("requirelicenseacceptance") ? psData["requirelicenseacceptance"].ToString() : "false";
+                        // boolean value needs to be a lowercase string for it to be correctly parsed
+                        string requireLicenseAcceptance = psData.ContainsKey("requirelicenseacceptance") ? psData["requirelicenseacceptance"].ToString().ToLower() : "false";
 
                         metadataElementsDictionary.Add("requireLicenseAcceptance", requireLicenseAcceptance);
 

--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -807,15 +807,23 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         {
             if (repoUri.AbsoluteUri.EndsWith("api/v2", StringComparison.OrdinalIgnoreCase))
             {
+                // Scenario: V2 server protocol repositories (i.e PSGallery)
                 return PSRepositoryInfo.APIVersion.v2;
             }
             else if (repoUri.AbsoluteUri.EndsWith("/index.json", StringComparison.OrdinalIgnoreCase))
             {
+                // Scenario: V3 server protocol repositories (i.e NuGet.org, Azure Artifacts (ADO), Artifactory, Github Packages, MyGet.org)
                 return PSRepositoryInfo.APIVersion.v3;
             }
             else if (repoUri.Scheme.Equals(Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
             {
+                // Scenario: local repositories
                 return PSRepositoryInfo.APIVersion.local;
+            }
+            else if (repoUri.AbsoluteUri.Contains("/nuget"))
+            {
+                // Scenario: ASP.Net application feed created with NuGet.Server to host packages
+                return PSRepositoryInfo.APIVersion.v2;
             }
             else
             {

--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -823,7 +823,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             else if (repoUri.AbsoluteUri.Contains("/nuget"))
             {
                 // Scenario: ASP.Net application feed created with NuGet.Server to host packages
-                return PSRepositoryInfo.APIVersion.v2;
+                return PSRepositoryInfo.APIVersion.nugetServer;
             }
             else
             {

--- a/src/code/ResponseUtilFactory.cs
+++ b/src/code/ResponseUtilFactory.cs
@@ -25,6 +25,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 case PSRepositoryInfo.APIVersion.local:
                     currentResponseUtil = new LocalResponseUtil(repository);
                     break;
+
+                case PSRepositoryInfo.APIVersion.unknown:
+                    break;
             }
 
             return currentResponseUtil;

--- a/src/code/ResponseUtilFactory.cs
+++ b/src/code/ResponseUtilFactory.cs
@@ -26,6 +26,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     currentResponseUtil = new LocalResponseUtil(repository);
                     break;
 
+                case PSRepositoryInfo.APIVersion.nugetServer:
+                    currentResponseUtil = new NuGetServerResponseUtil(repository);
+                    break;
+
                 case PSRepositoryInfo.APIVersion.unknown:
                     break;
             }

--- a/src/code/ServerFactory.cs
+++ b/src/code/ServerFactory.cs
@@ -27,6 +27,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     currentServer = new LocalServerAPICalls(repository, networkCredential);
                     break;
                 
+                case PSRepositoryInfo.APIVersion.nugetServer:
+                    currentServer = new NuGetServerAPICalls(repository, networkCredential);
+                    break;
+
                 case PSRepositoryInfo.APIVersion.unknown:
                     break;
 

--- a/src/code/ServerFactory.cs
+++ b/src/code/ServerFactory.cs
@@ -26,6 +26,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 case PSRepositoryInfo.APIVersion.local:
                     currentServer = new LocalServerAPICalls(repository, networkCredential);
                     break;
+                
+                case PSRepositoryInfo.APIVersion.unknown:
+                    break;
+
             }
 
             return currentServer;

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -25,7 +25,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private bool _isNuGetRepo { get; set; }
         private bool _isJFrogRepo { get; set; }
         private bool _isGHPkgsRepo { get; set; }
-        private bool _isMyGetRepo { get; set; }
         public FindResponseType v3FindResponseType = FindResponseType.ResponseString;
         private static readonly Hashtable[] emptyHashResponses = new Hashtable[]{};
         private static readonly string nugetRepoUri = "https://api.nuget.org/v3/index.json";
@@ -39,9 +38,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private static readonly string tagsName = "tags";
         private static readonly string catalogEntryProperty = "catalogEntry";
         private static readonly string packageContentProperty = "packageContent";
-        // MyGet.org repository responses from SearchQueryService have a peculiarity where the totalHits property int returned is 10,000 + actual number of hits.
-        // This is intentional on their end and "is to preserve the uninterupted pagination of NuGet within Visual Studio 2015".
-        private readonly int myGetTotalHitsBuffer = 10000;
 
         #endregion
 
@@ -62,7 +58,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             _isNuGetRepo = String.Equals(Repository.Uri.AbsoluteUri, nugetRepoUri, StringComparison.InvariantCultureIgnoreCase);
             _isJFrogRepo = Repository.Uri.AbsoluteUri.ToLower().Contains("jfrog.io");
             _isGHPkgsRepo = Repository.Uri.AbsoluteUri.ToLower().Contains("pkg.github.com");
-            _isMyGetRepo = Repository.Uri.AbsoluteUri.ToLower().Contains("myget.org");
         }
 
         #endregion
@@ -139,7 +134,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindNameGlobbing(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
-            if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo || _isMyGetRepo)
+            if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo)
             {
                 return FindNameGlobbingFromNuGetRepo(packageName, tags: Utils.EmptyStrArray, includePrerelease, out errRecord);
             }
@@ -158,7 +153,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
-            if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo || _isMyGetRepo)
+            if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo)
             {
                 return FindNameGlobbingFromNuGetRepo(packageName, tags, includePrerelease, out errRecord);
             }
@@ -1112,16 +1107,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         responseEntries.Add(entry.Clone());
                     }
 
-                    int reportedHits = 0;
+                    totalHits = 0;
                     if (pkgsDom.RootElement.TryGetProperty("totalHits", out JsonElement totalHitsElement))
                     {
-                        int.TryParse(totalHitsElement.ToString(), out reportedHits);
+                        int.TryParse(totalHitsElement.ToString(), out totalHits);
                     }
-
-                    // MyGet.org repository responses from SearchQueryService have a bug where the totalHits property int returned is 1000 + actual number of hits
-                    // so reduce totalHits by 1000 iff MyGet repository
-                    totalHits = _isMyGetRepo && reportedHits >= myGetTotalHitsBuffer ? reportedHits - myGetTotalHitsBuffer : reportedHits; 
-                    entries = responseEntries.ToArray();
                 }
             }
             catch (Exception e)

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -1117,6 +1117,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         int.TryParse(totalHitsElement.ToString(), out reportedHits);
                     }
 
+                    // MyGet.org repository responses from SearchQueryService have a bug where the totalHits property int returned is 1000 + actual number of hits
+                    // so reduce totalHits by 1000 iff MyGet repository
                     totalHits = _isMyGetRepo && reportedHits >= myGetTotalHitsBuffer ? reportedHits - myGetTotalHitsBuffer : reportedHits; 
                     entries = responseEntries.ToArray();
                 }

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -1108,7 +1108,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         int.TryParse(totalHitsElement.ToString(), out reportedHits);
                     }
 
-                    totalHits = _isMyGetRepo && reportedHits > myGetTotalHitsBuffer ? reportedHits - myGetTotalHitsBuffer : reportedHits; 
+                    totalHits = _isMyGetRepo && reportedHits >= myGetTotalHitsBuffer ? reportedHits - myGetTotalHitsBuffer : reportedHits; 
                     entries = responseEntries.ToArray();
                 }
             }

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -1109,13 +1109,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         responseEntries.Add(entry.Clone());
                     }
 
-                    // totalHits = 0;
                     totalHits = entryElement.GetArrayLength();
-                    // if (pkgsDom.RootElement.TryGetProperty("totalHits", out JsonElement totalHitsElement))
-                    // {
-                    //     int.TryParse(totalHitsElement.ToString(), out totalHits);
-                    // }
-
                     entries = responseEntries.ToArray();
                 }
             }

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -39,6 +39,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private static readonly string tagsName = "tags";
         private static readonly string catalogEntryProperty = "catalogEntry";
         private static readonly string packageContentProperty = "packageContent";
+        // MyGet.org repository responses from SearchQueryService have a bug where the totalHits property int returned is 1000 + actual number of hits
+        private readonly int myGetTotalHitsBuffer = 1000;
 
         #endregion
 
@@ -1109,7 +1111,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         responseEntries.Add(entry.Clone());
                     }
 
-                    totalHits = entryElement.GetArrayLength();
+                    int reportedHits = 0;
+                    if (pkgsDom.RootElement.TryGetProperty("totalHits", out JsonElement totalHitsElement))
+                    {
+                        int.TryParse(totalHitsElement.ToString(), out reportedHits);
+                    }
+
+                    totalHits = _isMyGetRepo && reportedHits > myGetTotalHitsBuffer ? reportedHits - myGetTotalHitsBuffer : reportedHits; 
                     entries = responseEntries.ToArray();
                 }
             }

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -1117,7 +1117,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         int.TryParse(totalHitsElement.ToString(), out reportedHits);
                     }
 
-                    totalHits = _isMyGetRepo && reportedHits > myGetTotalHitsBuffer ? reportedHits - myGetTotalHitsBuffer : reportedHits; 
+                    totalHits = _isMyGetRepo && reportedHits >= myGetTotalHitsBuffer ? reportedHits - myGetTotalHitsBuffer : reportedHits; 
                     entries = responseEntries.ToArray();
                 }
             }

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -39,7 +39,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private static readonly string tagsName = "tags";
         private static readonly string catalogEntryProperty = "catalogEntry";
         private static readonly string packageContentProperty = "packageContent";
-        // MyGet.org repository responses from SearchQueryService have a bug where the totalHits property int returned is 1000 + actual number of hits
+        // MyGet.org repository responses from SearchQueryService have a peculiarity where the totalHits property int returned is 10,000 + actual number of hits.
+        // This is intentional on their end and "is to preserve the uninterupted pagination of NuGet within Visual Studio 2015".
         private readonly int myGetTotalHitsBuffer = 10000;
 
         #endregion

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -1108,6 +1108,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         int.TryParse(totalHitsElement.ToString(), out reportedHits);
                     }
 
+                    // MyGet.org repository responses from SearchQueryService have a bug where the totalHits property int returned is 1000 + actual number of hits
+                    // so reduce totalHits by 1000 iff MyGet repository
                     totalHits = _isMyGetRepo && reportedHits >= myGetTotalHitsBuffer ? reportedHits - myGetTotalHitsBuffer : reportedHits; 
                     entries = responseEntries.ToArray();
                 }

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -24,7 +24,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private bool _isNuGetRepo { get; set; }
         private bool _isJFrogRepo { get; set; }
         private bool _isGHPkgsRepo { get; set; }
-        private bool _isMyGetRepo { get; set; }
         public FindResponseType v3FindResponseType = FindResponseType.ResponseString;
         private static readonly Hashtable[] emptyHashResponses = new Hashtable[]{};
         private static readonly string nugetRepoUri = "https://api.nuget.org/v3/index.json";
@@ -38,9 +37,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private static readonly string tagsName = "tags";
         private static readonly string catalogEntryProperty = "catalogEntry";
         private static readonly string packageContentProperty = "packageContent";
-        // MyGet.org repository responses from SearchQueryService have a peculiarity where the totalHits property int returned is 10,000 + actual number of hits.
-        // This is intentional on their end and "is to preserve the uninterupted pagination of NuGet within Visual Studio 2015".
-        private readonly int myGetTotalHitsBuffer = 10000;
 
         #endregion
 
@@ -61,7 +57,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             _isNuGetRepo = String.Equals(Repository.Uri.AbsoluteUri, nugetRepoUri, StringComparison.InvariantCultureIgnoreCase);
             _isJFrogRepo = Repository.Uri.AbsoluteUri.ToLower().Contains("jfrog.io");
             _isGHPkgsRepo = Repository.Uri.AbsoluteUri.ToLower().Contains("pkg.github.com");
-            _isMyGetRepo = Repository.Uri.AbsoluteUri.ToLower().Contains("myget.org");
         }
 
         #endregion
@@ -138,7 +133,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindNameGlobbing(string packageName, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
         {
-            if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo || _isMyGetRepo)
+            if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo)
             {
                 return FindNameGlobbingFromNuGetRepo(packageName, tags: Utils.EmptyStrArray, includePrerelease, out edi);
             }
@@ -157,7 +152,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
         {
-            if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo || _isMyGetRepo)
+            if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo)
             {
                 return FindNameGlobbingFromNuGetRepo(packageName, tags, includePrerelease, out edi);
             }
@@ -1103,16 +1098,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         responseEntries.Add(entry.Clone());
                     }
 
-                    int reportedHits = 0;
+                    totalHits = 0;
                     if (pkgsDom.RootElement.TryGetProperty("totalHits", out JsonElement totalHitsElement))
                     {
-                        int.TryParse(totalHitsElement.ToString(), out reportedHits);
+                        int.TryParse(totalHitsElement.ToString(), out totalHits);
                     }
-
-                    // MyGet.org repository responses from SearchQueryService have a bug where the totalHits property int returned is 1000 + actual number of hits
-                    // so reduce totalHits by 1000 iff MyGet repository
-                    totalHits = _isMyGetRepo && reportedHits >= myGetTotalHitsBuffer ? reportedHits - myGetTotalHitsBuffer : reportedHits; 
-                    entries = responseEntries.ToArray();
                 }
             }
             catch (Exception e)

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -1103,6 +1103,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     {
                         int.TryParse(totalHitsElement.ToString(), out totalHits);
                     }
+
+                    entries = responseEntries.ToArray();
                 }
             }
             catch (Exception e)

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private static readonly string catalogEntryProperty = "catalogEntry";
         private static readonly string packageContentProperty = "packageContent";
         // MyGet.org repository responses from SearchQueryService have a bug where the totalHits property int returned is 1000 + actual number of hits
-        private readonly int myGetTotalHitsBuffer = 1000;
+        private readonly int myGetTotalHitsBuffer = 10000;
 
         #endregion
 

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -1100,13 +1100,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         responseEntries.Add(entry.Clone());
                     }
 
-                    // totalHits = 0;
                     totalHits = entryElement.GetArrayLength();
-                    // if (pkgsDom.RootElement.TryGetProperty("totalHits", out JsonElement totalHitsElement))
-                    // {
-                    //     int.TryParse(totalHitsElement.ToString(), out totalHits);
-                    // }
-
                     entries = responseEntries.ToArray();
                 }
             }

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -1112,6 +1112,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     {
                         int.TryParse(totalHitsElement.ToString(), out totalHits);
                     }
+
+                    entries = responseEntries.ToArray();
                 }
             }
             catch (Exception e)

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -25,6 +25,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private bool _isNuGetRepo { get; set; }
         private bool _isJFrogRepo { get; set; }
         private bool _isGHPkgsRepo { get; set; }
+        private bool _isMyGetRepo { get; set; }
         public FindResponseType v3FindResponseType = FindResponseType.ResponseString;
         private static readonly Hashtable[] emptyHashResponses = new Hashtable[]{};
         private static readonly string nugetRepoUri = "https://api.nuget.org/v3/index.json";
@@ -58,6 +59,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             _isNuGetRepo = String.Equals(Repository.Uri.AbsoluteUri, nugetRepoUri, StringComparison.InvariantCultureIgnoreCase);
             _isJFrogRepo = Repository.Uri.AbsoluteUri.ToLower().Contains("jfrog.io");
             _isGHPkgsRepo = Repository.Uri.AbsoluteUri.ToLower().Contains("pkg.github.com");
+            _isMyGetRepo = Repository.Uri.AbsoluteUri.ToLower().Contains("myget.org");
         }
 
         #endregion
@@ -134,7 +136,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindNameGlobbing(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
-            if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo)
+            if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo || _isMyGetRepo)
             {
                 return FindNameGlobbingFromNuGetRepo(packageName, tags: Utils.EmptyStrArray, includePrerelease, out errRecord);
             }
@@ -153,7 +155,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
-            if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo)
+            if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo || _isMyGetRepo)
             {
                 return FindNameGlobbingFromNuGetRepo(packageName, tags, includePrerelease, out errRecord);
             }
@@ -1107,11 +1109,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         responseEntries.Add(entry.Clone());
                     }
 
-                    totalHits = 0;
-                    if (pkgsDom.RootElement.TryGetProperty("totalHits", out JsonElement totalHitsElement))
-                    {
-                        int.TryParse(totalHitsElement.ToString(), out totalHits);
-                    }
+                    // totalHits = 0;
+                    totalHits = entryElement.GetArrayLength();
+                    // if (pkgsDom.RootElement.TryGetProperty("totalHits", out JsonElement totalHitsElement))
+                    // {
+                    //     int.TryParse(totalHitsElement.ToString(), out totalHits);
+                    // }
 
                     entries = responseEntries.ToArray();
                 }

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -24,6 +24,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private bool _isNuGetRepo { get; set; }
         private bool _isJFrogRepo { get; set; }
         private bool _isGHPkgsRepo { get; set; }
+        private bool _isMyGetRepo { get; set; }
         public FindResponseType v3FindResponseType = FindResponseType.ResponseString;
         private static readonly Hashtable[] emptyHashResponses = new Hashtable[]{};
         private static readonly string nugetRepoUri = "https://api.nuget.org/v3/index.json";
@@ -57,6 +58,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             _isNuGetRepo = String.Equals(Repository.Uri.AbsoluteUri, nugetRepoUri, StringComparison.InvariantCultureIgnoreCase);
             _isJFrogRepo = Repository.Uri.AbsoluteUri.ToLower().Contains("jfrog.io");
             _isGHPkgsRepo = Repository.Uri.AbsoluteUri.ToLower().Contains("pkg.github.com");
+            _isMyGetRepo = Repository.Uri.AbsoluteUri.ToLower().Contains("myget.org");
         }
 
         #endregion
@@ -133,7 +135,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindNameGlobbing(string packageName, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
         {
-            if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo)
+            if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo || _isMyGetRepo)
             {
                 return FindNameGlobbingFromNuGetRepo(packageName, tags: Utils.EmptyStrArray, includePrerelease, out edi);
             }
@@ -152,7 +154,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ExceptionDispatchInfo edi)
         {
-            if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo)
+            if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo || _isMyGetRepo)
             {
                 return FindNameGlobbingFromNuGetRepo(packageName, tags, includePrerelease, out edi);
             }
@@ -1098,11 +1100,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         responseEntries.Add(entry.Clone());
                     }
 
-                    totalHits = 0;
-                    if (pkgsDom.RootElement.TryGetProperty("totalHits", out JsonElement totalHitsElement))
-                    {
-                        int.TryParse(totalHitsElement.ToString(), out totalHits);
-                    }
+                    // totalHits = 0;
+                    totalHits = entryElement.GetArrayLength();
+                    // if (pkgsDom.RootElement.TryGetProperty("totalHits", out JsonElement totalHitsElement))
+                    // {
+                    //     int.TryParse(totalHitsElement.ToString(), out totalHits);
+                    // }
 
                     entries = responseEntries.ToArray();
                 }

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -38,7 +38,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private static readonly string tagsName = "tags";
         private static readonly string catalogEntryProperty = "catalogEntry";
         private static readonly string packageContentProperty = "packageContent";
-        // MyGet.org repository responses from SearchQueryService have a bug where the totalHits property int returned is 1000 + actual number of hits
+        // MyGet.org repository responses from SearchQueryService have a peculiarity where the totalHits property int returned is 10,000 + actual number of hits.
+        // This is intentional on their end and "is to preserve the uninterupted pagination of NuGet within Visual Studio 2015".
         private readonly int myGetTotalHitsBuffer = 10000;
 
         #endregion

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private static readonly string catalogEntryProperty = "catalogEntry";
         private static readonly string packageContentProperty = "packageContent";
         // MyGet.org repository responses from SearchQueryService have a bug where the totalHits property int returned is 1000 + actual number of hits
-        private readonly int myGetTotalHitsBuffer = 1000;
+        private readonly int myGetTotalHitsBuffer = 10000;
 
         #endregion
 

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -392,6 +392,18 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         (Get-ChildItem $script:destinationPath).FullName | Should -Be $expectedPath
     }
 
+    It "Publish a module with -Path -Repository and -DestinationPath" {
+        $moduleName = "Pester"
+        $moduleVersion = "5.5.0"
+        Save-PSResource -Name $moduleName -Path $tmpRepoPath -Version $moduleVersion -Repository PSGallery -TrustRepository
+        $modulePath = Join-Path -Path $tmpRepoPath -ChildPath $moduleName 
+        $moduleVersionPath = Join-Path -Path $modulePath -ChildPath $moduleVersion
+        $moduleManifestPath = Join-path -Path $moduleVersionPath -ChildPath "$moduleName.psd1"
+        Publish-PSResource -Path $moduleManifestPath -Repository $testRepository2
+        $expectedPath = Join-Path -Path $script:repositoryPath2 -ChildPath "$moduleName.$moduleVersion.nupkg"
+        (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath
+    }
+
     It "Publish a module and clean up properly when file in module is readonly" {
         $version = "1.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -546,4 +546,12 @@ Describe "Test Publish-PSResource" -tags 'CI' {
 
         {Publish-PSResource -Path $incorrectdepmoduleversion -ErrorAction Stop} | Should -Throw -ErrorId "InvalidModuleManifest,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
     }
+
+    It "Publish a module with using an invalid file path (path to .psm1), should throw" {
+        $fileName = "$script:PublishModuleName.psm1"
+        $psm1Path = Join-Path -Path $script:PublishModuleBase -ChildPath $fileName
+        $null = New-Item -Path $psm1Path -ItemType File -Force
+
+        {Publish-PSResource -Path $psm1Path -Repository $testRepository2 -ErrorAction Stop} | Should -Throw -ErrorId "InvalidPublishPath,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Resolves #1206

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
