### PR TITLE
Fix InstallHelper call to GetEnvironmentVariable() on Unix

### DIFF
--- a/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
@@ -525,6 +525,14 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
         write-Host $err[0]
         $err[0].FullyQualifiedErrorId | Should -BeExactly "GetAuthenticodeSignatureError,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
     }
+
+    # Unix test for installing scripts
+    It "Install script resource - Unix only" -Skip:(Get-IsWindows) {
+        # previously installing pester on Unix was throwing an error due to how the environment PATH variable was being gotten.
+        Install-PSResource -Name "Pester" -Repository $PSGalleryName -Reinstall -TrustRepository
+        $res = PowerShellGet\Get-InstalledPSResource "Pester"
+        $res.Name | Should -Be "Pester"
+    }
 }
 
 Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'ManualValidationOnly' {
@@ -554,14 +562,6 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'ManualValidati
         $pkg = Get-Module $testModuleName -ListAvailable
         $pkg.Name | Should -Be $testModuleName 
         $pkg.Path.Contains("/usr/") | Should -Be $true
-    }
-
-    # Unix test for installing scripts
-    It "Install script resource - Unix only" -Skip:(Get-IsWindows) {
-        # previously installing pester on Unix was throwing an error due to how the environment PATH variable was being gotten.
-        Install-PSResource -Name "Pester" -Repository $PSGalleryName -Reinstall
-        $res = PowerShellGet\Get-InstalledPSResource "Pester"
-        $res.Name | Should -Be "Pester"
     }
 
     # This needs to be manually tested due to prompt

--- a/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
@@ -530,7 +530,7 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
     It "Install script resource - Unix only" -Skip:(Get-IsWindows) {
         # previously installing pester on Unix was throwing an error due to how the environment PATH variable was being gotten.
         Install-PSResource -Name "Pester" -Repository $PSGalleryName -Reinstall -TrustRepository
-        $res = PowerShellGet\Get-InstalledPSResource "Pester"
+        $res = Get-InstalledPSResource "Pester"
         $res.Name | Should -Be "Pester"
     }
 }

--- a/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
@@ -556,6 +556,14 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'ManualValidati
         $pkg.Path.Contains("/usr/") | Should -Be $true
     }
 
+    # Unix test for installing scripts
+    It "Install script resource - Unix only" -Skip:(Get-IsWindows) {
+        # previously installing pester on Unix was throwing an error due to how the environment PATH variable was being gotten.
+        Install-PSResource -Name "Pester" -Repository $PSGalleryName -Reinstall
+        $res = PowerShellGet\Get-InstalledPSResource "Pester"
+        $res.Name | Should -Be "Pester"
+    }
+
     # This needs to be manually tested due to prompt
     It "Install resource that requires accept license without -AcceptLicense flag" {
         Install-PSResource -Name $testModuleName2 -Repository $TestGalleryName


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

.NET method `GetEnvironmentVariable(string, EnvironmentVariableTarget)` on Unix based systems does not support per-user and per-machine environment variable. For the 2nd parameter, only EnvironmentVariableTarget.Process will capture and store the environment variable's value.

This was not accounting for Unix before and throwing an error.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Resolves #1188 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
