### PR TITLE
Updating prerelease version should update to latest prerelease version

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -626,7 +626,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     break;
             }
 
-            PSResourceResult currentResult = currentResponseUtil.ConvertToPSResourceResult(responseResults: responses).First();
+            PSResourceResult currentResult = currentResponseUtil.ConvertToPSResourceResult(responseResults: responses).FirstOrDefault();
 
             if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
             {

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -322,7 +322,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             // if the latest installed version is a prerelease version, automatically include prerelease versions when updating.
-            if (!string.IsNullOrWhiteSpace(installedPackages.First().Value.Prerelease))
+            if (installedPackages.First().Value.IsPrerelease)
             {
                 latestInstalledIsPrerelease = true;
             }

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -185,7 +185,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return;
             }
 
-            var namesToUpdate = ProcessPackageNames(Name, versionRange, nugetVersion, versionType);
+            var namesToUpdate = ProcessPackageNames(Name, versionRange, nugetVersion, versionType, out bool latestInstalledIsPrerelease);
 
             if (namesToUpdate.Length == 0)
             {
@@ -204,7 +204,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 nugetVersion: nugetVersion,
                 versionType: versionType,
                 versionString: Version,
-                prerelease: Prerelease,
+                prerelease: latestInstalledIsPrerelease,
                 repository: Repository,
                 acceptLicense: AcceptLicense,
                 quiet: Quiet,
@@ -259,8 +259,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string[] namesToProcess,
             VersionRange versionRange,
             NuGetVersion nuGetVersion,
-            VersionType versionType)
+            VersionType versionType,
+            out bool latestInstalledIsPrerelease)
         {
+            latestInstalledIsPrerelease = false;
+
             namesToProcess = Utils.ProcessNameWildcards(
                 pkgNames: namesToProcess,
                 removeWildcardEntries:false, 
@@ -318,6 +321,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return Utils.EmptyStrArray;
             }
 
+            // if the latest installed version is a prerelease version, automatically include prerelease versions when updating.
+            if (!string.IsNullOrWhiteSpace(installedPackages.First().Value.Prerelease))
+            {
+                latestInstalledIsPrerelease = true;
+            }
+
             // Find all packages selected for updating in provided repositories.
             var repositoryPackages = new Dictionary<string, PSResourceInfo>(StringComparer.InvariantCultureIgnoreCase);
             foreach (var foundResource in _findHelper.FindByResourceName(
@@ -327,7 +336,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 nugetVersion: nuGetVersion,
                 versionType: versionType,
                 version: Version,
-                prerelease: Prerelease,
+                prerelease: latestInstalledIsPrerelease,
                 tag: null,
                 repository: Repository,
                 includeDependencies: !SkipDependencyCheck))

--- a/test/UpdatePSResourceTests/UpdatePSResourceV2Tests.ps1
+++ b/test/UpdatePSResourceTests/UpdatePSResourceV2Tests.ps1
@@ -172,6 +172,24 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
         $isPkgUpdated | Should -Be $true
     }
 
+    It "Update prerelease version to a higher prerelease version not using -Prerelease parameter" {
+        Install-PSResource -Name $testModuleName3 -Version "0.0.99-beta1" -Repository $PSGalleryName -TrustRepository
+        Update-PSResource -Name $testModuleName3 -Repository $PSGalleryName -TrustRepository
+        $res = Get-InstalledPSResource -Name $testModuleName3
+        $res | Should -Not -BeNullOrEmpty
+        $isPkgUpdated = $false
+        foreach ($pkg in $res)
+        {
+            if ([System.Version]$pkg.Version -ge [System.Version]"1.0.0")
+            {
+                $pkg.Prerelease | Should -Be "beta2"
+                $isPkgUpdated = $true
+            }
+        }
+
+        $isPkgUpdated | Should -Be $true
+    }
+
     # Windows only
     It "update resource under CurrentUser scope" -skip:(!($IsWindows -and (Test-IsAdmin))) {
         # TODO: perhaps also install TestModule with the highest version (the one above 1.2.0.0) to the AllUsers path too


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
`Update-PSResource` should update a prerelease version of a resource  to the latest prerelease version without needing the `-Prerelease` parameter.

## PR Context

Resolves #1196 
Resolves #890 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
