### PR TITLE
Bug fix for searching through local repositories with -Type parameter

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -441,10 +441,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             }
 
                             PSResourceInfo foundPkg = currentResult.returnedObject;
-                            parentPkgs.Add(foundPkg);
-                            _pkgsLeftToFind.Remove(foundPkg.Name);
-                            pkgsFound.Add(String.Format("{0}{1}", foundPkg.Name, foundPkg.Version.ToString()));
-                            yield return foundPkg;
+
+                            if (foundPkg.Type == _type || _type == ResourceType.None)
+                            {
+                                parentPkgs.Add(foundPkg);
+                                _pkgsLeftToFind.Remove(foundPkg.Name);
+                                pkgsFound.Add(String.Format("{0}{1}", foundPkg.Name, foundPkg.Version.ToString()));
+                                yield return foundPkg;
+                            }
                         }
                     }
                     else if(pkgName.Contains("*"))

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -1437,6 +1437,11 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         private static Dependency[] GetDependenciesForPs1(ModuleSpecification[] requiredModules)
         {
             List<Dependency> deps = new List<Dependency>();
+            if (requiredModules == null)
+            {
+                return deps.ToArray();
+            }
+
             foreach(ModuleSpecification depModule in requiredModules)
             {
                 // ModuleSpecification has Version, RequiredVersion, MaximumVersion

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -1437,7 +1437,6 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         private static Dependency[] GetDependenciesForPs1(ModuleSpecification[] requiredModules)
         {
             List<Dependency> deps = new List<Dependency>();
-
             foreach(ModuleSpecification depModule in requiredModules)
             {
                 // ModuleSpecification has Version, RequiredVersion, MaximumVersion

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -1437,10 +1437,6 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         private static Dependency[] GetDependenciesForPs1(ModuleSpecification[] requiredModules)
         {
             List<Dependency> deps = new List<Dependency>();
-            if (requiredModules == null)
-            {
-                return deps.ToArray();
-            }
 
             foreach(ModuleSpecification depModule in requiredModules)
             {

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -214,10 +214,8 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
 
         $res = Find-PSResource -Type Script -Repository $localRepo
         $res | Should -Not -BeNullOrEmpty
-        $res.Count | Should -BeGreaterOrEqual 1
-        foreach ($script in $res) {
-            $item.Type | Should -Be "Script"
-        }
+        $res.Count | Should -Be 1
+        $res.Type | Should -Be "Script"
     }
     
     It "find modules given -Type parameter" {
@@ -226,8 +224,8 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res = Find-PSResource -Type Module -Repository $localRepo
         $res | Should -Not -BeNullOrEmpty
         $res.Count | Should -BeGreaterOrEqual 1
-        foreach ($script in $res) {
-            $item.Type | Should -Be "Module"
+        foreach ($module in $res) {
+            $module.Type | Should -Be "Module"
         }
     }
 

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -209,6 +209,28 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res.Tags | Should -Contain $requiredTags[1]
     }
 
+    It "find scripts given -Type parameter" {
+        Get-ScriptResourcePublishedToLocalRepoTestDrive
+
+        $res = Find-PSResource -Type Script -Repository $localRepo
+        $res | Should -Not -BeNullOrEmpty
+        $res.Count | Should -BeGreaterOrEqual 1
+        foreach ($script in $res) {
+            $item.Type | Should -Be "Script"
+        }
+    }
+    
+    It "find modules given -Type parameter" {
+        Get-ScriptResourcePublishedToLocalRepoTestDrive
+
+        $res = Find-PSResource -Type Module -Repository $localRepo
+        $res | Should -Not -BeNullOrEmpty
+        $res.Count | Should -BeGreaterOrEqual 1
+        foreach ($script in $res) {
+            $item.Type | Should -Be "Module"
+        }
+    }
+
     It "find resource given CommandName" -Pending {
         $res = Find-PSResource -CommandName $commandName -Repository $localRepo
         $res | Should -Not -BeNullOrEmpty

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -210,7 +210,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
     }
 
     It "find scripts given -Type parameter" {
-        Get-ScriptResourcePublishedToLocalRepoTestDrive
+        Get-ScriptResourcePublishedToLocalRepoTestDrive "testScriptName" $localRepo "1.0.0"
 
         $res = Find-PSResource -Type Script -Repository $localRepo
         $res | Should -Not -BeNullOrEmpty
@@ -221,7 +221,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
     }
     
     It "find modules given -Type parameter" {
-        Get-ScriptResourcePublishedToLocalRepoTestDrive
+        Get-ScriptResourcePublishedToLocalRepoTestDrive "testScriptName" $localRepo "1.0.0"
 
         $res = Find-PSResource -Type Module -Repository $localRepo
         $res | Should -Not -BeNullOrEmpty

--- a/test/PSGetTestUtils.psm1
+++ b/test/PSGetTestUtils.psm1
@@ -351,7 +351,7 @@ function Get-ScriptResourcePublishedToLocalRepoTestDrive
 
     $scriptMetadata = Create-PSScriptMetadata @params
     Set-Content -Path $scriptFilePath -Value $scriptMetadata
-    Publish-PSResource -Path $scriptFilePath -Repository $scriptRepoName -Verbose
+    Publish-PSResource -Path $scriptFilePath -Repository $scriptRepoName
 }
 
 function Get-CommandResourcePublishedToLocalRepoTestDrive


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Bug fix for searching through local repositories with -Type parameter.  This PR allows for filtering on type.

## PR Context
Resolves #1219 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
