### PR TITLE
Bug fix for file path version must match psd1 version error when publishing

### DIFF
--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -963,8 +963,15 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 }
                 catch (Exception e)
                 {
-                    errorMsg = $"Error occured while running 'Test-ModuleManifest': {e.Message}";
-                    return false;
+                    if (e.Message.EndsWith("Change the value of the ModuleVersion key to match the version folder name."))
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        errorMsg = $"Error occured while running 'Test-ModuleManifest': {e.Message}";
+                        return false;
+                    }
                 }
 
                 if (pwsh.HadErrors)

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -480,6 +480,20 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath
     }
 
+    It "Publish a module when the .psd1 version and the path version are different" {
+        $incorrectVersion = "15.2.4"
+        $correctVersion = "1.0.0"
+        $versionBase = (Join-Path -Path $script:PublishModuleBase  -ChildPath $incorrectVersion)
+        New-Item -Path $versionBase -ItemType Directory
+        $modManifestPath = (Join-Path -Path $versionBase -ChildPath "$script:PublishModuleName.psd1")
+        New-ModuleManifest -Path $modManifestPath -ModuleVersion $correctVersion -Description "$script:PublishModuleName module"
+
+        Publish-PSResource -Path $modManifestPath -Repository $testRepository2
+
+        $expectedPath = Join-Path -Path $script:repositoryPath2 -ChildPath "$script:PublishModuleName.$correctVersion.nupkg"
+        (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath
+    }
+
     It "publish a script locally"{
         $scriptName = "PSGetTestScript"
         $scriptVersion = "1.0.0"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR ensures that if a package version specified in the publish path is different than the version in the module manifest (or script file info) then the latter version takes precedence.  Any errors emitted by `Test-ModuleManifest` regarding this version mismatch are ignored.

## PR Context
Resolves #1106 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
