### PR TITLE
Fix error message for Publish-PSResource for MyGet.org feeds

### DIFF
--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -950,7 +950,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     else if (repoUri.Contains(".jfrog.io"))
                     {
                         // For JFrog Artifactory repository feeds when the ApiKey is provided, whether correct or incorrect, as JFrog does not require -ApiKey (but does require ApiKey to be present as password to -Credential).
-                        var message = String.Format("Repository '{0}': The ApiKey provided is not needed for JFrog Artifactory. Please try running again without the -ApiKey parameter but ensure that -Credential is provided with ApiKey as password. Exception: '{1}'", repoName, e.Message);
+                        var message = $"Could not publish to repository '{repoName}'. The ApiKey provided is not needed for JFrog Artifactory. Please try running again without the -ApiKey parameter but ensure that -Credential is provided with ApiKey as password. Exception: '{e.Message}'";
+
 
                         ex = new ArgumentException(message);
                         var Error403 = new ErrorRecord(ex, "403Error", ErrorCategory.PermissionDenied, null);

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -927,7 +927,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     else
                     {
                         // For ADO repository feeds that are public feeds, when the credentials are incorrect.
-                        var message = String.Format("Repository '{0}': The Credential provided was incorrect. Exception: '{1}'", repoName, e.Message);
+                        var message =$"Could not publish to repository '{repoName}'. The Credential provided was incorrect. Exception: '{e.Message}'";
+
 
                         ex = new ArgumentException(message);
                         var Error401 = new ErrorRecord(ex, "401Error", ErrorCategory.PermissionDenied, null);

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -980,7 +980,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 //  for ADO repository feeds that are private feeds the error thrown is different and the 401 is in the inner exception message
                 if (e.InnerException.Message.Contains("401"))
                 {
-                    var message = String.Format ("Repository '{0}': The Credential provided was incorrect. Exception '{1};", repoName, e.InnerException.Message);
+                    var message = $"Could not publish to repository '{repoName}'. The Credential provided was incorrect. Exception '{e.InnerException.Message}'";
+
 
                     var ex = new ArgumentException(message);
                     var ApiKeyError = new ErrorRecord(ex, "401FatalProtocolError", ErrorCategory.AuthenticationError, null);

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -935,7 +935,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
                 else if (e.Message.Contains("403"))
                 {
-                    if (repoUri.Contains("myget.org"))
+                    if (repoUri.Contains("myget.org") || repoUri.Contains(".jfrog.io"))
                     {
                         // For myGet.org repository feeds when the ApiKey is missing or incorrect.
                         var message = String.Format("Repository '{0}': The ApiKey provided is incorrect or missing. Please try running again with the -ApiKey parameter and correct API key value for the repository. Exception: '{1}'", repoName, e.Message);

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -935,10 +935,19 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
                 else if (e.Message.Contains("403"))
                 {
-                    if (repoUri.Contains("myget.org") || repoUri.Contains(".jfrog.io"))
+                    if (repoUri.Contains("myget.org"))
                     {
                         // For myGet.org repository feeds when the ApiKey is missing or incorrect.
                         var message = String.Format("Repository '{0}': The ApiKey provided is incorrect or missing. Please try running again with the -ApiKey parameter and correct API key value for the repository. Exception: '{1}'", repoName, e.Message);
+
+                        ex = new ArgumentException(message);
+                        var Error403 = new ErrorRecord(ex, "403Error", ErrorCategory.PermissionDenied, null);
+                        error = Error403;
+                    }
+                    else if (repoUri.Contains(".jfrog.io"))
+                    {
+                        // For JFrog Artifactory repository feeds when the ApiKey is provided, whether correct or incorrect, as JFrog does not require -ApiKey (but does require ApiKey to be present as password to -Credential).
+                        var message = String.Format("Repository '{0}': The ApiKey provided is not needed for JFrog Artifactory. Please try running again without the -ApiKey parameter but ensure that -Credential is provided with ApiKey as password. Exception: '{1}'", repoName, e.Message);
 
                         ex = new ArgumentException(message);
                         var Error403 = new ErrorRecord(ex, "403Error", ErrorCategory.PermissionDenied, null);

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -940,7 +940,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (repoUri.Contains("myget.org"))
                     {
                         // For myGet.org repository feeds when the ApiKey is missing or incorrect.
-                        var message = String.Format("Repository '{0}': The ApiKey provided is incorrect or missing. Please try running again with the -ApiKey parameter and correct API key value for the repository. Exception: '{1}'", repoName, e.Message);
+                        var message = $"Could not publish to repository '{repoName}'. The ApiKey provided is incorrect or missing. Please try running again with the -ApiKey parameter and correct API key value for the repository. Exception: '{e.Message}'";
+
 
                         ex = new ArgumentException(message);
                         var Error403 = new ErrorRecord(ex, "403Error", ErrorCategory.PermissionDenied, null);

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -968,7 +968,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 //  for ADO repository feeds that are private feeds the error thrown is different and the 401 is in the inner exception message
                 if (e.InnerException.Message.Contains("401"))
                 {
-                    var message = String.Format ("Repository '{0}': The Credential provided was incorrect. Exception {1}", repoName, e.InnerException.Message);
+                    var message = String.Format ("Repository '{0}': The Credential provided was incorrect. Exception '{1};", repoName, e.InnerException.Message);
+
                     var ex = new ArgumentException(message);
                     var ApiKeyError = new ErrorRecord(ex, "401FatalProtocolError", ErrorCategory.AuthenticationError, null);
                     error = ApiKeyError;

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -917,7 +917,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (e.Message.Contains("API"))
                     {
                         // For PSGallery when ApiKey is not provided.
-                        var message = String.Format("Repository '{0}': {1} Please try running again with the -ApiKey parameter and specific API key for the repository specified.", repoName, e.Message);
+                        var message = String.Format("Repository '{0}': Please try running again with the -ApiKey parameter and specific API key for the repository specified. Exception: {1}", repoName, e.Message);
                         ex = new ArgumentException(message);
                         var ApiKeyError = new ErrorRecord(ex, "401ApiKeyError", ErrorCategory.AuthenticationError, null);
                         error = ApiKeyError;
@@ -925,7 +925,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     else
                     {
                         // For ADO repository feeds that are public feeds, when the credentials are incorrect.
-                        var message = String.Format("Repository '{0}': {1} The Credential provided was incorrect.", repoName, e.Message);
+                        var message = String.Format("Repository '{0}': The Credential provided was incorrect. Exception: {1}", repoName, e.Message);
                         ex = new ArgumentException(message);
                         var Error401 = new ErrorRecord(ex, "401Error", ErrorCategory.PermissionDenied, null);
                         error = Error401;
@@ -933,8 +933,19 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
                 else if (e.Message.Contains("403"))
                 {
-                    var Error403 = new ErrorRecord(ex, "403Error", ErrorCategory.PermissionDenied, null);
-                    error = Error403;
+                    if (repoUri.Contains("myget.org"))
+                    {
+                        // For myGet.org repository feeds when the ApiKey is missing or incorrect.
+                        var message = String.Format("Repository '{0}': The ApiKey provided is incorrect or missing. Please try running again with the -ApiKey parameter and correct API key value for the repository. Exception: {1}", repoName, e.Message);
+                        ex = new ArgumentException(message);
+                        var Error403 = new ErrorRecord(ex, "403Error", ErrorCategory.PermissionDenied, null);
+                        error = Error403;
+                    }
+                    else
+                    {
+                        var Error403 = new ErrorRecord(ex, "403Error", ErrorCategory.PermissionDenied, null);
+                        error = Error403;
+                    }
                 }
                 else if (e.Message.Contains("409"))
                 {
@@ -954,7 +965,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 //  for ADO repository feeds that are private feeds the error thrown is different and the 401 is in the inner exception message
                 if (e.InnerException.Message.Contains("401"))
                 {
-                    var message = String.Format ("Repository '{0}': {1} The Credential provided was incorrect.", repoName, e.InnerException.Message);
+                    var message = String.Format ("Repository '{0}': The Credential provided was incorrect. Exception {1}", repoName, e.InnerException.Message);
                     var ex = new ArgumentException(message);
                     var ApiKeyError = new ErrorRecord(ex, "401FatalProtocolError", ErrorCategory.AuthenticationError, null);
                     error = ApiKeyError;

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -917,7 +917,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (e.Message.Contains("API"))
                     {
                         // For PSGallery when ApiKey is not provided.
-                        var message = String.Format("Repository '{0}': Please try running again with the -ApiKey parameter and specific API key for the repository specified. Exception: '{1}'", repoName, e.Message);
+                        var message = $"Could not publish to repository '{repoName}'. Please try running again with the -ApiKey parameter and the API key for the repository specified. Exception: '{e.Message}'";
+
 
                         ex = new ArgumentException(message);
                         var ApiKeyError = new ErrorRecord(ex, "401ApiKeyError", ErrorCategory.AuthenticationError, null);

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -938,7 +938,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (repoUri.Contains("myget.org"))
                     {
                         // For myGet.org repository feeds when the ApiKey is missing or incorrect.
-                        var message = String.Format("Repository '{0}': The ApiKey provided is incorrect or missing. Please try running again with the -ApiKey parameter and correct API key value for the repository. Exception: {1}", repoName, e.Message);
+                        var message = String.Format("Repository '{0}': The ApiKey provided is incorrect or missing. Please try running again with the -ApiKey parameter and correct API key value for the repository. Exception: '{1}'", repoName, e.Message);
+
                         ex = new ArgumentException(message);
                         var Error403 = new ErrorRecord(ex, "403Error", ErrorCategory.PermissionDenied, null);
                         error = Error403;

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -926,7 +926,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     else
                     {
                         // For ADO repository feeds that are public feeds, when the credentials are incorrect.
-                        var message = String.Format("Repository '{0}': The Credential provided was incorrect. Exception: {1}", repoName, e.Message);
+                        var message = String.Format("Repository '{0}': The Credential provided was incorrect. Exception: '{1}'", repoName, e.Message);
+
                         ex = new ArgumentException(message);
                         var Error401 = new ErrorRecord(ex, "401Error", ErrorCategory.PermissionDenied, null);
                         error = Error401;

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -917,7 +917,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (e.Message.Contains("API"))
                     {
                         // For PSGallery when ApiKey is not provided.
-                        var message = String.Format("Repository '{0}': Please try running again with the -ApiKey parameter and specific API key for the repository specified. Exception: {1}", repoName, e.Message);
+                        var message = String.Format("Repository '{0}': Please try running again with the -ApiKey parameter and specific API key for the repository specified. Exception: '{1}'", repoName, e.Message);
+
                         ex = new ArgumentException(message);
                         var ApiKeyError = new ErrorRecord(ex, "401ApiKeyError", ErrorCategory.AuthenticationError, null);
                         error = ApiKeyError;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Improve error messages presented when running Publish-PSResource for MyGet.org repository. When publishing to this type of repository errors can be written out when the -ApiKey value is missing or incorrect. The server side error message is not clear enough on its own so add to it.

## PR Context

Resolves #1246 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
