### PR TITLE
Bug fixes for script metadata

### DIFF
--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -901,7 +901,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     { "NormalizedVersion", nugetVersion.ToNormalizedString() }
                 };
 
-                ModuleSpecification[] requiredModules = pkgMetadata["RequiredModules"] as ModuleSpecification[];
+                ModuleSpecification[] requiredModules = pkgMetadata.ContainsKey("RequiredModules") ? pkgMetadata["RequiredModules"] as ModuleSpecification[] : new ModuleSpecification[]{};
 
                 psGetInfo = new PSResourceInfo(
                     additionalMetadata: additionalMetadataHashtable,

--- a/src/code/PSScriptHelp.cs
+++ b/src/code/PSScriptHelp.cs
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             for(int i = 0; i < commentLines.Length; i++)
             {
                 string line = commentLines[i];
-                if (line.Trim().StartsWith(".DESCRIPTION"))
+                if (line.Trim().StartsWith(".DESCRIPTION", StringComparison.OrdinalIgnoreCase))
                 {
                     parsingDescription = true;
                 }
@@ -128,7 +128,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 }
             }
 
-            Hashtable parsedHelpMetadata = new Hashtable();
+            Hashtable parsedHelpMetadata = new Hashtable(StringComparer.OrdinalIgnoreCase);
             parsedHelpMetadata.Add("DESCRIPTION", descriptionValue);
             if (helpContent.Count != 0)
             {

--- a/src/code/PSScriptMetadata.cs
+++ b/src/code/PSScriptMetadata.cs
@@ -249,7 +249,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             errors = Array.Empty<ErrorRecord>();
             List<ErrorRecord> errorsList = new List<ErrorRecord>();
 
-            Hashtable parsedHelpMetadata = new Hashtable();
+            Hashtable parsedHelpMetadata = new Hashtable(StringComparer.OrdinalIgnoreCase);
             char[] spaceDelimeter = new char[]{' '};
             string keyName = "";
             string value = "";

--- a/src/code/PSScriptMetadata.cs
+++ b/src/code/PSScriptMetadata.cs
@@ -173,7 +173,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             }
 
             // now populate the object instance
-            string[] spaceDelimeter = new string[]{" "};
+            string[] delimeter = new string[]{" ", ","};
 
             Uri parsedLicenseUri = null;
             if (!String.IsNullOrEmpty((string) parsedMetadata["LICENSEURI"]))
@@ -214,10 +214,10 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             ProjectUri = parsedProjectUri;
             IconUri = parsedIconUri;
             
-            Tags = Utils.GetStringArrayFromString(spaceDelimeter, (string) parsedMetadata["TAGS"]);;
-            ExternalModuleDependencies = Utils.GetStringArrayFromString(spaceDelimeter, (string) parsedMetadata["EXTERNALMODULEDEPENDENCIES"]);
-            RequiredScripts = Utils.GetStringArrayFromString(spaceDelimeter, (string) parsedMetadata["REQUIREDSCRIPTS"]);
-            ExternalScriptDependencies = Utils.GetStringArrayFromString(spaceDelimeter, (string) parsedMetadata["EXTERNALSCRIPTDEPENDENCIES"]);
+            Tags = Utils.GetStringArrayFromString(delimeter, (string) parsedMetadata["TAGS"]);;
+            ExternalModuleDependencies = Utils.GetStringArrayFromString(delimeter, (string) parsedMetadata["EXTERNALMODULEDEPENDENCIES"]);
+            RequiredScripts = Utils.GetStringArrayFromString(delimeter, (string) parsedMetadata["REQUIREDSCRIPTS"]);
+            ExternalScriptDependencies = Utils.GetStringArrayFromString(delimeter, (string) parsedMetadata["EXTERNALSCRIPTDEPENDENCIES"]);
             ReleaseNotes = (string) parsedMetadata["RELEASENOTES"] ?? String.Empty;
             PrivateData = (string) parsedMetadata["PRIVATEDATA"] ?? String.Empty;
 
@@ -234,7 +234,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             /**
             Comment lines can look like this:
 
-            .KEY1 value
+            .KEY1 value,
 
             .KEY2 value
 
@@ -250,7 +250,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             List<ErrorRecord> errorsList = new List<ErrorRecord>();
 
             Hashtable parsedHelpMetadata = new Hashtable(StringComparer.OrdinalIgnoreCase);
-            char[] spaceDelimeter = new char[]{' '};
+            char[] delimeter = new char[]{' ', ','};
             string keyName = "";
             string value = "";
 
@@ -278,7 +278,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     }
 
                     // setting count to 2 will get 1st separated string (key) into part[0] and the rest (value) into part[1] if any
-                    string[] parts = line.Trim().TrimStart('.').Split(separator: spaceDelimeter, count: 2);
+                    string[] parts = line.Trim().TrimStart('.').Split(separator: delimeter, count: 2);
                     keyName = parts[0];
                     value = parts.Length == 2 ? parts[1] : String.Empty;
                 }

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -484,11 +484,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             out Hashtable requiredModules)
         {
             WriteVerbose("Creating new nuspec file.");
+            bool isModule = resourceType != ResourceType.Script;
             requiredModules = new Hashtable();
 
             // A script will already have the metadata parsed into the parsedMetadatahash,
             // a module will still need the module manifest to be parsed.
-            if (resourceType == ResourceType.Module)
+            if (isModule)
             {
                 // Use the parsed module manifest data as 'parsedMetadataHash' instead of the passed-in data.
                 if (!Utils.TryReadManifestFile(
@@ -546,69 +547,103 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             // Look for Prerelease tag and then process any Tags in PrivateData > PSData
-            if (parsedMetadataHash.ContainsKey("PrivateData"))
+            if (isModule)
             {
-                if (parsedMetadataHash["PrivateData"] is Hashtable privateData &&
-                    privateData.ContainsKey("PSData"))
+                if (parsedMetadataHash.ContainsKey("PrivateData"))
                 {
-                    if (privateData["PSData"] is Hashtable psData)
+                    if (parsedMetadataHash["PrivateData"] is Hashtable privateData &&
+                        privateData.ContainsKey("PSData"))
                     {
-                        if (psData.ContainsKey("prerelease") && psData["prerelease"] is string preReleaseVersion)
+                        if (privateData["PSData"] is Hashtable psData)
                         {
-                            if (!string.IsNullOrEmpty(preReleaseVersion))
+                            if (psData.ContainsKey("prerelease") && psData["prerelease"] is string preReleaseVersion)
                             {
-                                version = string.Format(@"{0}-{1}", version, preReleaseVersion);
+                                if (!string.IsNullOrEmpty(preReleaseVersion))
+                                {
+                                    version = string.Format(@"{0}-{1}", version, preReleaseVersion);
+                                }
                             }
-                        }
 
-                        if (psData.ContainsKey("licenseuri") && psData["licenseuri"] is string licenseUri)
+                            if (psData.ContainsKey("licenseuri") && psData["licenseuri"] is string licenseUri)
 
-                        {
-                            metadataElementsDictionary.Add("licenseUrl", licenseUri.Trim());
-                        }
-
-                        if (psData.ContainsKey("projecturi") && psData["projecturi"] is string projectUri)
-                        {
-                            metadataElementsDictionary.Add("projectUrl", projectUri.Trim());
-                        }
-
-                        if (psData.ContainsKey("iconuri") && psData["iconuri"] is string iconUri)
-                        {
-                            metadataElementsDictionary.Add("iconUrl", iconUri.Trim());
-                        }
-
-                        if (psData.ContainsKey("releasenotes"))
-                        {
-                            if (psData["releasenotes"] is string releaseNotes)
                             {
-                                metadataElementsDictionary.Add("releaseNotes", releaseNotes.Trim());
+                                metadataElementsDictionary.Add("licenseUrl", licenseUri.Trim());
                             }
-                            else if (psData["releasenotes"] is string[] releaseNotesArr)
+
+                            if (psData.ContainsKey("projecturi") && psData["projecturi"] is string projectUri)
                             {
-                                metadataElementsDictionary.Add("releaseNotes", string.Join("\n", releaseNotesArr));
+                                metadataElementsDictionary.Add("projectUrl", projectUri.Trim());
                             }
-                        }
 
-                        // defaults to false
-                        // Value for requireAcceptLicense key needs to be a lowercase string representation of the boolean for it to be correctly parsed from psData file.
-
-                        string requireLicenseAcceptance = psData.ContainsKey("requirelicenseacceptance") ? psData["requirelicenseacceptance"].ToString().ToLower() : "false";
-
-                        metadataElementsDictionary.Add("requireLicenseAcceptance", requireLicenseAcceptance);
-
-
-                        if (psData.ContainsKey("Tags") && psData["Tags"] is Array manifestTags)
-                        {
-                            var tagArr = new List<string>();
-                            foreach (string tag in manifestTags)
+                            if (psData.ContainsKey("iconuri") && psData["iconuri"] is string iconUri)
                             {
-                                tagArr.Add(tag);
+                                metadataElementsDictionary.Add("iconUrl", iconUri.Trim());
                             }
-                            parsedMetadataHash["tags"] = string.Join(" ", tagArr.ToArray());
+
+                            if (psData.ContainsKey("releasenotes"))
+                            {
+                                if (psData["releasenotes"] is string releaseNotes)
+                                {
+                                    metadataElementsDictionary.Add("releaseNotes", releaseNotes.Trim());
+                                }
+                                else if (psData["releasenotes"] is string[] releaseNotesArr)
+                                {
+                                    metadataElementsDictionary.Add("releaseNotes", string.Join("\n", releaseNotesArr));
+                                }
+                            }
+
+                            // defaults to false
+                            // Value for requireAcceptLicense key needs to be a lowercase string representation of the boolean for it to be correctly parsed from psData file.
+
+                            string requireLicenseAcceptance = psData.ContainsKey("requirelicenseacceptance") ? psData["requirelicenseacceptance"].ToString().ToLower() : "false";
+
+                            metadataElementsDictionary.Add("requireLicenseAcceptance", requireLicenseAcceptance);
+
+
+                            if (psData.ContainsKey("Tags") && psData["Tags"] is Array manifestTags)
+                            {
+                                var tagArr = new List<string>();
+                                foreach (string tag in manifestTags)
+                                {
+                                    tagArr.Add(tag);
+                                }
+                                parsedMetadataHash["tags"] = string.Join(" ", tagArr.ToArray());
+                            }
                         }
                     }
                 }
             }
+            else
+            {
+                if (parsedMetadataHash.ContainsKey("licenseuri") && parsedMetadataHash["licenseuri"] is Uri licenseUri)
+
+                {
+                    metadataElementsDictionary.Add("licenseUrl", licenseUri.ToString().Trim());
+                }
+
+                if (parsedMetadataHash.ContainsKey("projecturi") && parsedMetadataHash["projecturi"] is Uri projectUri)
+                {
+                    metadataElementsDictionary.Add("projectUrl", projectUri.ToString().Trim());
+                }
+
+                if (parsedMetadataHash.ContainsKey("iconuri") && parsedMetadataHash["iconuri"] is Uri iconUri)
+                {
+                    metadataElementsDictionary.Add("iconUrl", iconUri.ToString().Trim());
+                }
+
+                if (parsedMetadataHash.ContainsKey("releaseNotes"))
+                {
+                    if (parsedMetadataHash["releasenotes"] is string releaseNotes)
+                    {
+                        metadataElementsDictionary.Add("releaseNotes", releaseNotes.Trim());
+                    }
+                    else if (parsedMetadataHash["releasenotes"] is string[] releaseNotesArr)
+                    {
+                        metadataElementsDictionary.Add("releaseNotes", string.Join("\n", releaseNotesArr));
+                    }
+                }
+            }
+
 
             if (NuGetVersion.TryParse(version, out _pkgVersion))
             {

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -636,13 +636,19 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             string tags = (resourceType == ResourceType.Script) ? "PSScript" : "PSModule";
-            if (parsedMetadataHash.ContainsKey("tags"))
+            if (parsedMetadataHash.ContainsKey("tags") && parsedMetadataHash["tags"] != null)
             {
-                if (parsedMetadataHash["tags"] != null)
+                if (parsedMetadataHash["tags"] is string[])
+                {
+                    string[] tagsArr = parsedMetadataHash["tags"] as string[];
+                    tags += " " + String.Join(" ", tagsArr);
+                }
+                else if (parsedMetadataHash["tags"] is string)
                 {
                     tags += " " + parsedMetadataHash["tags"].ToString().Trim();
                 }
             }
+
             metadataElementsDictionary.Add("tags", tags);
 
 

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -233,7 +233,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
 
         $res = Find-PSResource -Type Script -Repository $localRepo
         $res | Should -Not -BeNullOrEmpty
-        $res.Count | Should -Be 1
+        $res.Count | Should -Be 2
         $res.Type | Should -Be "Script"
     }
     

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -67,10 +67,10 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $pkgName = "Required-Script1"
         $requiredTag = "Tag1"
         Save-PSResource -Name $pkgName -Repository "PSGallery" -Path $localRepoUriAddress -AsNupkg
-        $res = Find-PSResource -Name $pkgName -Repository $localRepo
-        $res.Name | Should -Be $pkgName
-        $res.Repository | Should -Be $localRepo
-        $res.Tags | Should -Contain $requiredTag
+        # $res = Find-PSResource -Name $pkgName -Repository $localRepo
+        # $res.Name | Should -Be $pkgName
+        # $res.Repository | Should -Be $localRepo
+        # $res.Tags | Should -Contain $requiredTag
     }
 
     It "should not find resource given nonexistant Name" {

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -234,7 +234,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res = Find-PSResource -Type Script -Repository $localRepo
         $res | Should -Not -BeNullOrEmpty
         $res.Count | Should -Be 2
-        $res.Type | Should -Be "Script"
+        $res.Type | Should -Be @("Script", "Script")
     }
     
     It "find modules given -Type parameter" {

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -55,7 +55,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         # FindName()
         $pkgName = "test_nonpsresource"
         $requiredTag = "Tag1"
-        Save-PSResource -Name $pkgName -Repository "NuGetGallery" -Path $localRepoUriAddress -AsNupkg
+        Save-PSResource -Name $pkgName -Repository "NuGetGallery" -Path $localRepoUriAddress -AsNupkg -TrustRepository
         $res = Find-PSResource -Name $pkgName -Repository $localRepo
         $res.Name | Should -Be $pkgName
         $res.Repository | Should -Be $localRepo
@@ -66,7 +66,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         # FindName()
         $pkgName = "Required-Script1"
         $requiredTag = "Tag1"
-        Save-PSResource -Name $pkgName -Repository "PSGallery" -Path $localRepoUriAddress -AsNupkg
+        Save-PSResource -Name $pkgName -Repository "PSGallery" -Path $localRepoUriAddress -AsNupkg -TrustRepository
         # $res = Find-PSResource -Name $pkgName -Repository $localRepo
         # $res.Name | Should -Be $pkgName
         # $res.Repository | Should -Be $localRepo

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -62,6 +62,17 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res.Tags | Should -Contain $requiredTag
     }
 
+    It "find script without RequiredModules" {
+        # FindName()
+        $pkgName = "Required-Script1"
+        $requiredTag = "Tag1"
+        Save-PSResource -Name $pkgName -Repository "PSGallery" -Path $localRepoUriAddress -AsNupkg
+        $res = Find-PSResource -Name $pkgName -Repository $localRepo
+        $res.Name | Should -Be $pkgName
+        $res.Repository | Should -Be $localRepo
+        $res.Tags | Should -Contain $requiredTag
+    }
+
     It "should not find resource given nonexistant Name" {
         $res = Find-PSResource -Name NonExistantModule -Repository $localRepo -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty

--- a/test/PSScriptFileInfoTests/GetPSScriptFileInfo.Tests.ps1
+++ b/test/PSScriptFileInfoTests/GetPSScriptFileInfo.Tests.ps1
@@ -83,4 +83,36 @@ Describe "Test Get-PSScriptFileInfo" -tags 'CI' {
         $res.Name | Should -Be "ScriptWithInvalidProjectUri"
         $res.ScriptMetadataComment.ProjectUri | Should -BeNullOrEmpty
     }
+
+    It "should get script file object given script that has commas in Tags, ExternalModuleDependencies, RequiredScripts, and ExternalScriptDependencies fields" {
+        # Note: New-PSScriptFileInfo will NOT create script that has commas in these fields, but per user requests we want to account for scripts that may contain it
+        $scriptName = "ScriptWithCommaInTagsInSomeFields.ps1"
+        $scriptFilePath = Join-Path $script:testScriptsFolderPath -ChildPath $scriptName
+
+        $res = Get-PSScriptFileInfo $scriptFilePath
+        $foundTags = $res.ScriptMetadataComment.Tags
+        $foundExternalModuleDependencies = $res.ScriptMetadataComment.ExternalModuleDependencies
+        $foundRequiredScripts = $res.ScriptMetadataComment.RequiredScripts
+        $foundExternalScriptDependencies = $res.ScriptMetadataComment.ExternalScriptDependencies
+
+        $foundTags | Should -Be @("tag1", "tag2")
+        foreach($tag in $foundTags) {
+            $tag | Should -Not -Contain ","
+        }
+
+        $foundExternalModuleDependencies | Should -Be @("Storage", "ActiveDirectory")
+        foreach($modDep in $foundExternalModuleDependencies) {
+            $modDep | Should -Not -Contain ","
+        }
+
+        $foundRequiredScripts | Should -Be @("Script1", "Script2")
+        foreach($reqScript in $foundRequiredScripts) {
+            $modDep | Should -Not -Contain ","
+        }
+
+        $foundExternalScriptDependencies | Should -Be @("ExtScript1", "ExtScript2")
+        foreach($scriptDep in $foundExternalScriptDependencies) {
+            $modDep | Should -Not -Contain ","
+        }
+    }
 }

--- a/test/PSScriptFileInfoTests/TestPSScriptFile.Tests.ps1
+++ b/test/PSScriptFileInfoTests/TestPSScriptFile.Tests.ps1
@@ -73,4 +73,11 @@ Describe "Test Test-PSScriptFileInfo" -tags 'CI' {
 
         Test-PSScriptFileInfo $scriptFilePath | Should -Be $true        
     }
+
+    It "determine script file with varying case sensitivity for Script Metadata or Help Comment keys is valid" {
+        $scriptName = "VaryingCaseSensisityKeysScript.ps1"
+        $scriptFilePath = Join-Path $script:testScriptsFolderPath -ChildPath $scriptName
+
+        Test-PSScriptFileInfo $scriptFilePath | Should -Be $true
+    }
 }

--- a/test/PSScriptFileInfoTests/TestPSScriptFile.Tests.ps1
+++ b/test/PSScriptFileInfoTests/TestPSScriptFile.Tests.ps1
@@ -80,4 +80,12 @@ Describe "Test Test-PSScriptFileInfo" -tags 'CI' {
 
         Test-PSScriptFileInfo $scriptFilePath | Should -Be $true
     }
+
+    It "determine script file with commas in Tags, ExternalModuleDependencies, RequiredScripts, ExternalScriptDependencies is valid" {
+        # Note: New-PSScriptFileInfo will NOT create script that has commas in these fields, but per user requests we want to account for scripts that may contain it
+        $scriptName = "ScriptWithCommaInTagsInSomeFields.ps1"
+        $scriptFilePath = Join-Path $script:testScriptsFolderPath -ChildPath $scriptName
+
+        Test-PSScriptFileInfo $scriptFilePath | Should -Be $true
+    }
 }

--- a/test/testFiles/testScripts/ScriptWithCommaInTagsInSomeFields.ps1
+++ b/test/testFiles/testScripts/ScriptWithCommaInTagsInSomeFields.ps1
@@ -1,0 +1,14 @@
+<#PSScriptInfo
+.VERSION 1.0.0
+.GUID 51b7528e-072c-40b9-918f-336381b85137
+.AUTHOR CPG4285
+.TAGS tag1, tag2
+.EXTERNALMODULEDEPENDENCIES Storage, ActiveDirectory
+.REQUIREDSCRIPTS Script1, Script2
+.EXTERNALSCRIPTDEPENDENCIES ExtScript1, ExtScript2
+#>
+
+<#
+.DESCRIPTION
+This script is for demonstrating PSResourceGet module problems.
+#>

--- a/test/testFiles/testScripts/VaryingCaseSensisityKeysScript.ps1
+++ b/test/testFiles/testScripts/VaryingCaseSensisityKeysScript.ps1
@@ -1,0 +1,43 @@
+
+<#PSScriptInfo
+
+.VERSION 1.0
+
+.GUID 3951be04-bd06-4337-8dc3-a620bf539fbd
+
+.author annavied
+
+.COMPANYNAME
+
+.COPYrIGHT
+
+.TAGS
+
+.LICENSEURI
+
+.PROJECTURI
+
+.ICONURI
+
+.EXTERNALMODULEDEPENDENCIES 
+
+.REQUIREDSCRIPTS
+
+.EXTERNALSCRIPTDEPENDENCIES
+
+.RELEASENOTES
+
+
+.PRIVATEDATA
+
+#>
+
+<# 
+
+.DEScrIPTION 
+ this is a test for a script that will be published remotely 
+
+#> 
+Param()
+
+


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Bugfixes for:
* when script metadata does not contain RequiredModules, currently throws null pointer exception
* script file keys (for metadata and help comment blocks) should be case insensitive
* While `New-PSScriptFileInfo` creates ps1 without comma in the values for : `Tags`, `ExternalModuleDependencies`, `RequiredScripts`, `ExternalScriptDependencies`, if the ps1 file contains it anyways we should parse it correctly.
* When publishing scripts, the .nuspec file that is created does not contain `licenseUrl`, `projectUrl`, `iconUrl`, `releaseNotes` 

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Resolves #1220 #1244 #1239 #1243 

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
