### PR TITLE
Add custom user agent string to API calls

### DIFF
--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -35,12 +35,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         #endregion
 
-        #region Overriden Methods 
+        #region Overriden Methods
 
         /// <summary>
         /// Find method which allows for searching for all packages from a repository and returns latest version for each.
         /// Examples: Search -Repository PSGallery
-        /// API call: 
+        /// API call:
         /// - No prerelease: http://www.powershellgallery.com/api/v2/Search()?$filter=IsLatestVersion
         /// </summary>
         public override FindResults FindAll(bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Find method which allows for searching for packages with tag from a repository and returns latest version for each.
         /// Examples: Search -Tag "JSON" -Repository PSGallery
-        /// API call: 
+        /// API call:
         /// - Include prerelease: http://www.powershellgallery.com/api/v2/Search()?$filter=IsAbsoluteLatestVersion&searchTerm=tag:JSON&includePrerelease=true
         /// </summary>
         public override FindResults FindTags(string[] tags, bool includePrerelease, ResourceType _type, out ErrorRecord errRecord)
@@ -72,7 +72,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Find method which allows for searching for single name and returns latest version.
         /// Name: no wildcard support
         /// Examples: Search "PowerShellGet"
-        /// API call: 
+        /// API call:
         /// - No prerelease: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
         /// - Include prerelease: http://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'
         /// Implementation Note: Need to filter further for latest version (prerelease or non-prerelease dependening on user preference)
@@ -97,7 +97,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Find method which allows for searching for single name with wildcards and returns latest version.
         /// Name: supports wildcards
         /// Examples: Search "PowerShell*"
-        /// API call: 
+        /// API call:
         /// - No prerelease: http://www.powershellgallery.com/api/v2/Search()?$filter=IsLatestVersion&searchTerm='az*'
         /// Implementation Note: filter additionally and verify ONLY package name was a match.
         /// </summary>
@@ -165,7 +165,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Search "PowerShellGet" "2.2.5"
         /// API call: http://www.powershellgallery.com/api/v2/Packages(Id='PowerShellGet', Version='2.2.5')
         /// </summary>
-        public override FindResults FindVersion(string packageName, string version, ResourceType type, out ErrorRecord errRecord) 
+        public override FindResults FindVersion(string packageName, string version, ResourceType type, out ErrorRecord errRecord)
         {
             return FindVersionHelper(packageName, version, Utils.EmptyStrArray, type, out errRecord);
         }
@@ -188,7 +188,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Name: no wildcard support.
         /// Examples: Install "PowerShellGet"
         /// Implementation Note:   if not prerelease: https://www.powershellgallery.com/api/v2/package/powershellget (Returns latest stable)
-        ///                        if prerelease, call into InstallVersion instead. 
+        ///                        if prerelease, call into InstallVersion instead.
         /// </summary>
         public override Stream InstallName(string packageName, bool includePrerelease, out ErrorRecord errRecord)
         {
@@ -242,7 +242,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Install "PowerShellGet" -Version "3.0.0.0"
         ///           Install "PowerShellGet" -Version "3.0.0-beta16"
         /// API Call: https://www.powershellgallery.com/api/v2/package/Id/version (version can be prerelease)
-        /// </summary>    
+        /// </summary>
         public override Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord)
         {
             errRecord = null;
@@ -255,7 +255,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 version = pkgVersion.ToNormalizedString();
             }
-            
+
             string packageFullName = $"{packageName.ToLower()}.{version}.nupkg";
             string packagePath = Path.Combine(Repository.Uri.LocalPath, packageFullName);
             if (!File.Exists(packagePath))
@@ -367,7 +367,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             return findResponse;
         }
-        
+
         /// <summary>
         /// Helper method called by FindVersion() and FindVersionWithTag()
         /// </summary>
@@ -398,7 +398,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                     if (nugetVersion == requiredVersion)
                     {
-                        string pkgFullName = $"{actualPkgName}.{nugetVersion.ToString()}.nupkg";           
+                        string pkgFullName = $"{actualPkgName}.{nugetVersion.ToString()}.nupkg";
                         pkgPath = Path.Combine(Repository.Uri.LocalPath, pkgFullName);
                         break;
                     }
@@ -728,7 +728,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     break;
                 }
             }
-            
+
             return isTagMatch;
         }
 
@@ -761,7 +761,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         {
                             nuspecHashtable.Add(key, value);
                         }
-                    }  
+                    }
 
                 }
             }
@@ -770,7 +770,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 errRecord = new ErrorRecord(e, "GetHashtableForNuspecFailure", ErrorCategory.ReadError, this);
             }
 
-            return nuspecHashtable;        
+            return nuspecHashtable;
         }
 
         /// <summary>

--- a/src/code/NuGetServerAPICalls.cs
+++ b/src/code/NuGetServerAPICalls.cs
@@ -29,7 +29,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         #region Constructor
 
-        public NuGetServerAPICalls (PSRepositoryInfo repository, NetworkCredential networkCredential) : base (repository, networkCredential)
+        public NuGetServerAPICalls (PSRepositoryInfo repository, NetworkCredential networkCredential, string userAgentString) : base (repository, networkCredential)
         {
             this.Repository = repository;
             HttpClientHandler handler = new HttpClientHandler()
@@ -38,16 +38,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             };
 
             _sessionClient = new HttpClient(handler);
+            _sessionClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", userAgentString);
         }
 
         #endregion
 
-        #region Overriden Methods 
+        #region Overriden Methods
 
         /// <summary>
         /// Find method which allows for searching for all packages from a repository and returns latest version for each.
         /// Examples: Search -Repository MyNuGetServer
-        /// API call: 
+        /// API call:
         /// - No prerelease: {repoUri}/api/v2/Search()?$filter=IsLatestVersion
         /// </summary>
         public override FindResults FindAll(bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
@@ -90,7 +91,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Find method which allows for searching for packages with tag from a repository and returns latest version for each.
         /// Examples: Search -Tag "JSON" -Repository PSGallery
-        /// API call: 
+        /// API call:
         /// - Include prerelease: {repoUri}/api/v2/Search()?$filter=IsAbsoluteLatestVersion&searchTerm=tag:JSON&includePrerelease=true
         /// </summary>
         public override FindResults FindTags(string[] tags, bool includePrerelease, ResourceType _type, out ErrorRecord errRecord)
@@ -146,7 +147,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Find method which allows for searching for single name and returns latest version.
         /// Name: no wildcard support
         /// Examples: Search "PowerShellGet"
-        /// API call: 
+        /// API call:
         /// - No prerelease: {repoUri}/api/v2/FindPackagesById()?id='PowerShellGet'
         /// - Include prerelease: {repoUri}/api/v2/FindPackagesById()?id='PowerShellGet'
         /// Implementation Note: Need to filter further for latest version (prerelease or non-prerelease dependening on user preference)
@@ -162,7 +163,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string idFilterPart = $" and Id eq '{packageName}'";
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter={prerelease}{idFilterPart}";
 
-            string response = HttpRequestCall(requestUrlV2, out errRecord);  
+            string response = HttpRequestCall(requestUrlV2, out errRecord);
             return new FindResults(stringResponse: new string[]{ response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
         }
 
@@ -197,7 +198,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Find method which allows for searching for single name with wildcards and returns latest version.
         /// Name: supports wildcards
         /// Examples: Search "PowerShell*"
-        /// API call: 
+        /// API call:
         /// - No prerelease: {repoUri}/api/v2/Search()?$filter=IsLatestVersion&searchTerm='az*'
         /// Implementation Note: filter additionally and verify ONLY package name was a match.
         /// </summary>
@@ -214,7 +215,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             responses.Add(initialResponse);
 
-            // check count (regex)  425 ==> count/100  ~~>  4 calls 
+            // check count (regex)  425 ==> count/100  ~~>  4 calls
             int initalCount = GetCountFromResponse(initialResponse, out errRecord);  // count = 4
             if (errRecord != null)
             {
@@ -258,7 +259,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             responses.Add(initialResponse);
 
-            // check count (regex)  425 ==> count/100  ~~>  4 calls 
+            // check count (regex)  425 ==> count/100  ~~>  4 calls
             int initalCount = GetCountFromResponse(initialResponse, out errRecord);  // count = 4
             if (errRecord != null)
             {
@@ -340,15 +341,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Search "PowerShellGet" "2.2.5"
         /// API call: {repoUri}/api/v2/Packages(Id='PowerShellGet', Version='2.2.5')
         /// </summary>
-        public override FindResults FindVersion(string packageName, string version, ResourceType type, out ErrorRecord errRecord) 
+        public override FindResults FindVersion(string packageName, string version, ResourceType type, out ErrorRecord errRecord)
         {
-            // https://www.powershellgallery.com/api/v2/FindPackagesById()?id='blah'&includePrerelease=false&$filter= NormalizedVersion eq '1.1.0' and substringof('PSModule', Tags) eq true 
+            // https://www.powershellgallery.com/api/v2/FindPackagesById()?id='blah'&includePrerelease=false&$filter= NormalizedVersion eq '1.1.0' and substringof('PSModule', Tags) eq true
             // Quotations around package name and version do not matter, same metadata gets returned.
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
             string idFilterPart = $" and Id eq '{packageName}'";
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter= NormalizedVersion eq '{version}'{idFilterPart}";
-            
-            string response = HttpRequestCall(requestUrlV2, out errRecord);  
+
+            string response = HttpRequestCall(requestUrlV2, out errRecord);
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
         }
 
@@ -369,7 +370,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter= NormalizedVersion eq '{version}'{idFilterPart}{tagFilterPart}";
-            
+
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
         }
@@ -381,7 +382,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Name: no wildcard support.
         /// Examples: Install "PowerShellGet"
         /// Implementation Note:   if not prerelease: https://www.powershellgallery.com/api/v2/package/powershellget (Returns latest stable)
-        ///                        if prerelease, call into InstallVersion instead. 
+        ///                        if prerelease, call into InstallVersion instead.
         /// </summary>
         public override Stream InstallName(string packageName, bool includePrerelease, out ErrorRecord errRecord)
         {
@@ -399,7 +400,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Install "PowerShellGet" -Version "3.0.0.0"
         ///           Install "PowerShellGet" -Version "3.0.0-beta16"
         /// API Call: https://www.powershellgallery.com/api/v2/package/Id/version (version can be prerelease)
-        /// </summary>    
+        /// </summary>
         public override Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord)
         {
             var requestUrlV2 = $"{Repository.Uri}/package/{packageName}/{version}";
@@ -420,7 +421,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             try
             {
                 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUrlV2);
-                
+
                 response = SendV2RequestAsync(request, _sessionClient).GetAwaiter().GetResult();
             }
             catch (HttpRequestException e)
@@ -442,7 +443,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method that makes the HTTP request for the V2 server protocol url passed in for install APIs.
         /// </summary>
-        private HttpContent HttpRequestCallForContent(string requestUrlV2, out ErrorRecord errRecord) 
+        private HttpContent HttpRequestCallForContent(string requestUrlV2, out ErrorRecord errRecord)
         {
             errRecord = null;
             HttpContent content = null;
@@ -450,7 +451,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             try
             {
                 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUrlV2);
-                
+
                 content = SendV2RequestForContentAsync(request, _sessionClient).GetAwaiter().GetResult();
             }
             catch (HttpRequestException e)
@@ -493,7 +494,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         {
             string paginationParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=6000";
             var prereleaseFilter = includePrerelease ? "$filter=IsAbsoluteLatestVersion&includePrerelease=true" : "$filter=IsLatestVersion";
-            
+
             string tagFilterPart = String.Empty;
             foreach (string tag in tags)
             {
@@ -502,7 +503,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             var requestUrlV2 = $"{Repository.Uri}/Search()?{prereleaseFilter}{tagFilterPart}{paginationParam}";
 
-            return HttpRequestCall(requestUrlV2: requestUrlV2, out errRecord);  
+            return HttpRequestCall(requestUrlV2: requestUrlV2, out errRecord);
         }
 
         /// <summary>
@@ -512,64 +513,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         {
             // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and startswith(Id, 'PowerShell') and IsLatestVersion (stable)
             // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and IsAbsoluteLatestVersion&includePrerelease=true
-            
-            string extraParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=100";
-            var prerelease = includePrerelease ? "IsAbsoluteLatestVersion&includePrerelease=true" : "IsLatestVersion";
-            string nameFilter;
 
-            var names = packageName.Split(new char[] {'*'}, StringSplitOptions.RemoveEmptyEntries);
-
-            if (names.Length == 0)
-            {
-                errRecord = new ErrorRecord(new ArgumentException("-Name '*' for V2 server protocol repositories is not supported"), "FindNameGlobbingFailure", ErrorCategory.InvalidArgument, this); 
-
-                return string.Empty;
-            }
-            if (names.Length == 1)
-            {
-                if (packageName.StartsWith("*") && packageName.EndsWith("*"))
-                {
-                    // *get*
-                    nameFilter = $"substringof('{names[0]}', Id)";
-                }
-                else if (packageName.EndsWith("*"))
-                {
-                    // PowerShell*
-                    nameFilter = $"startswith(Id, '{names[0]}')";
-                }
-                else
-                {
-                    // *ShellGet
-                    nameFilter = $"endswith(Id, '{names[0]}')";
-                }
-            }
-            else if (names.Length == 2 && !packageName.StartsWith("*") && !packageName.EndsWith("*"))
-            {
-                // *pow*get*
-                // pow*get -> only support this
-                // pow*get*
-                // *pow*get
-                nameFilter = $"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')";
-            }
-            else 
-            {
-                errRecord = new ErrorRecord(new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."), "FindNameGlobbingFailure", ErrorCategory.InvalidArgument, this);
-                return string.Empty;
-            }
-
-            var requestUrlV2 = $"{Repository.Uri}/Search()?$filter={nameFilter} and {prerelease}{extraParam}";
-            
-            return HttpRequestCall(requestUrlV2, out errRecord);  
-        }
-
-        /// <summary>
-        /// Helper method for string[] FindNameGlobbingWithTag()
-        /// </summary>
-        private string FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, int skip, out ErrorRecord errRecord)
-        {
-            // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and startswith(Id, 'PowerShell') and IsLatestVersion (stable)
-            // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and IsAbsoluteLatestVersion&includePrerelease=true
-            
             string extraParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=100";
             var prerelease = includePrerelease ? "IsAbsoluteLatestVersion&includePrerelease=true" : "IsLatestVersion";
             string nameFilter;
@@ -608,7 +552,64 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // *pow*get
                 nameFilter = $"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')";
             }
-            else 
+            else
+            {
+                errRecord = new ErrorRecord(new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."), "FindNameGlobbingFailure", ErrorCategory.InvalidArgument, this);
+                return string.Empty;
+            }
+
+            var requestUrlV2 = $"{Repository.Uri}/Search()?$filter={nameFilter} and {prerelease}{extraParam}";
+
+            return HttpRequestCall(requestUrlV2, out errRecord);
+        }
+
+        /// <summary>
+        /// Helper method for string[] FindNameGlobbingWithTag()
+        /// </summary>
+        private string FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, int skip, out ErrorRecord errRecord)
+        {
+            // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and startswith(Id, 'PowerShell') and IsLatestVersion (stable)
+            // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and IsAbsoluteLatestVersion&includePrerelease=true
+
+            string extraParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=100";
+            var prerelease = includePrerelease ? "IsAbsoluteLatestVersion&includePrerelease=true" : "IsLatestVersion";
+            string nameFilter;
+
+            var names = packageName.Split(new char[] {'*'}, StringSplitOptions.RemoveEmptyEntries);
+
+            if (names.Length == 0)
+            {
+                errRecord = new ErrorRecord(new ArgumentException("-Name '*' for V2 server protocol repositories is not supported"), "FindNameGlobbingFailure", ErrorCategory.InvalidArgument, this);
+
+                return string.Empty;
+            }
+            if (names.Length == 1)
+            {
+                if (packageName.StartsWith("*") && packageName.EndsWith("*"))
+                {
+                    // *get*
+                    nameFilter = $"substringof('{names[0]}', Id)";
+                }
+                else if (packageName.EndsWith("*"))
+                {
+                    // PowerShell*
+                    nameFilter = $"startswith(Id, '{names[0]}')";
+                }
+                else
+                {
+                    // *ShellGet
+                    nameFilter = $"endswith(Id, '{names[0]}')";
+                }
+            }
+            else if (names.Length == 2 && !packageName.StartsWith("*") && !packageName.EndsWith("*"))
+            {
+                // *pow*get*
+                // pow*get -> only support this
+                // pow*get*
+                // *pow*get
+                nameFilter = $"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')";
+            }
+            else
             {
                 errRecord = new ErrorRecord(new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."), "FindNameGlobbing", ErrorCategory.InvalidArgument, this);
 
@@ -622,8 +623,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             var requestUrlV2 = $"{Repository.Uri}/Search()?$filter={nameFilter}{tagFilterPart} and {prerelease}{extraParam}";
-            
-            return HttpRequestCall(requestUrlV2, out errRecord);  
+
+            return HttpRequestCall(requestUrlV2, out errRecord);
         }
 
         /// <summary>
@@ -631,7 +632,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private string FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, int skip, bool getOnlyLatest, out ErrorRecord errRecord)
         {
-            //https://www.powershellgallery.com/api/v2//FindPackagesById()?id='blah'&includePrerelease=false&$filter= NormalizedVersion gt '1.0.0' and NormalizedVersion lt '2.2.5' and substringof('PSModule', Tags) eq true 
+            //https://www.powershellgallery.com/api/v2//FindPackagesById()?id='blah'&includePrerelease=false&$filter= NormalizedVersion gt '1.0.0' and NormalizedVersion lt '2.2.5' and substringof('PSModule', Tags) eq true
             //https://www.powershellgallery.com/api/v2//FindPackagesById()?id='PowerShellGet'&includePrerelease=false&$filter= NormalizedVersion gt '1.1.1' and NormalizedVersion lt '2.2.5'
             // NormalizedVersion doesn't include trailing zeroes
             // Notes: this could allow us to take a version range (i.e (2.0.0, 3.0.0.0]) and deconstruct it and add options to the Filter for Version to describe that range
@@ -688,7 +689,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             string filterQuery = "&$filter=";
             filterQuery += includePrerelease ? string.Empty : "IsPrerelease eq false";
-            
+
             string andOperator = " and ";
             string joiningOperator = filterQuery.EndsWith("=") ? String.Empty : andOperator;
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
@@ -699,7 +700,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 // Check if includePrerelease is true, if it is we want to add "$filter"
                 // Single case where version is "*" (or "[,]") and includePrerelease is true, then we do not want to add "$filter" to the requestUrl.
-        
+
                 // Note: could be null/empty if Version was "*" -> [,]
                 filterQuery +=  $"{andOperator}{versionFilterParts}";
             }
@@ -710,7 +711,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             filterQuery = filterQuery.EndsWith("=") ? string.Empty : filterQuery;
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$orderby=NormalizedVersion desc&{paginationParam}{filterQuery}";
 
-            return HttpRequestCall(requestUrlV2, out errRecord);  
+            return HttpRequestCall(requestUrlV2, out errRecord);
         }
 
         /// <summary>

--- a/src/code/ServerApiCall.cs
+++ b/src/code/ServerApiCall.cs
@@ -34,9 +34,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         }
 
         #endregion
-        
+
         #region Methods
-        // High level design: Find-PSResource >>> IFindPSResource (loops, version checks, etc.) >>> IServerAPICalls (call to repository endpoint/url)    
+        // High level design: Find-PSResource >>> IFindPSResource (loops, version checks, etc.) >>> IServerAPICalls (call to repository endpoint/url)
 
         /// <summary>
         /// Find method which allows for searching for all packages from a repository and returns latest version for each.
@@ -113,7 +113,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Name: no wildcard support.
         /// Examples: Install "PowerShellGet"
         /// Implementation Note:   if not prerelease: https://www.powershellgallery.com/api/v2/package/powershellget (Returns latest stable)
-        ///                        if prerelease, the calling method should first call IFindPSResource.FindName(), 
+        ///                        if prerelease, the calling method should first call IFindPSResource.FindName(),
         ///                             then find the exact version to install, then call into install version
         /// </summary>
         public abstract Stream InstallName(string packageName, bool includePrerelease, out ErrorRecord errRecord);
@@ -125,10 +125,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Version: no wildcard support.
         /// Examples: Install "PowerShellGet" -Version "3.0.0.0"
         ///           Install "PowerShellGet" -Version "3.0.0-beta16"
-        /// </summary>    
+        /// </summary>
         public abstract Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord);
 
         #endregion
-    
+
     }
 }

--- a/src/code/ServerFactory.cs
+++ b/src/code/ServerFactory.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private static string _psResourceGetVersion;
         private static string _distributionChannel;
 
-        internal static string UserAgentString => $"PSResourceGet/{_psResourceGetVersion} PowerShell/{_psVersion} ({_distributionChannel})";
+        internal static string UserAgentString => $"PSResourceGet/{_psResourceGetVersion} PowerShell/{_psVersion} DistributionChannel/{_distributionChannel}";
     }
 
     internal class ServerFactory

--- a/src/code/ServerFactory.cs
+++ b/src/code/ServerFactory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         {
             using (System.Management.Automation.PowerShell ps = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace))
             {
-                _psVersion = ps.AddCommand("Get-Variable").AddParameter("Name", "PSVersionTable").Invoke()[0].Members["PSVersion"].Value.ToString();
+                _psVersion = ps.AddScript("$PSVersionTable.PSVersion.ToString()").Invoke<string>()[0];
             }
 
             _psResourceGetVersion = typeof(UserAgentInfo).Assembly.GetName().Version.ToString();

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         #region Constructor
 
-        public V3ServerAPICalls(PSRepositoryInfo repository, NetworkCredential networkCredential) : base(repository, networkCredential)
+        public V3ServerAPICalls(PSRepositoryInfo repository, NetworkCredential networkCredential, string userAgentString) : base(repository, networkCredential)
         {
             this.Repository = repository;
 
@@ -58,6 +58,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             };
 
             _sessionClient = new HttpClient(handler);
+            _sessionClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", userAgentString);
 
             _isNuGetRepo = String.Equals(Repository.Uri.AbsoluteUri, nugetRepoUri, StringComparison.InvariantCultureIgnoreCase);
             _isJFrogRepo = Repository.Uri.AbsoluteUri.ToLower().Contains("jfrog.io");
@@ -238,7 +239,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Version: no wildcard support
         /// Examples: Search "NuGet.Server.Core" "3.0.0-beta" -Tag "core"
         /// We use the latest RegistrationBaseUrl version resource we can find and check if contains an entry with the package name, then match to the specified version.
-        /// </summary>     
+        /// </summary>
         public override FindResults FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ErrorRecord errRecord)
         {
             return FindVersionHelper(packageName, version, tags: tags, type, out errRecord);
@@ -262,7 +263,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Version: no wildcard support.
         /// Examples: Install "Newtonsoft.json" -Version "1.0.0.0"
         ///           Install "Newtonsoft.json" -Version "2.5.0-beta"
-        /// </summary>    
+        /// </summary>
         public override Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord)
         {
             if (!NuGetVersion.TryParse(version, out NuGetVersion requiredVersion))
@@ -354,7 +355,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         matchingResponses.Add(pkgEntry.ToString());
                     }
                 }
-                    
+
                 catch (Exception e)
                 {
                     errRecord = new ErrorRecord(e, "GetEntriesFromSearchQueryResourceFailure", ErrorCategory.InvalidResult, this);
@@ -367,12 +368,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         /// <summary>
         /// Helper method called by FindTags() for special case where repository is NuGet.org repository.
-        /// </summary>        
+        /// </summary>
         private FindResults FindTagsFromNuGetRepo(string[] tags, bool includePrerelease, out ErrorRecord errRecord)
         {
             string tagsQueryTerm = $"tags:{String.Join(" ", tags)}";
             // Get responses for all packages that contain the required tags
-            // example query: 
+            // example query:
             var tagPkgEntries = GetVersionedPackageEntriesFromSearchQueryResource(tagsQueryTerm, includePrerelease, out errRecord);
             if (errRecord != null)
             {
@@ -459,7 +460,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             return new FindResults(stringResponse: new string[] { latestVersionResponse }, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
         }
-        
+
         /// <summary>
         /// Helper method called by FindVersion() and FindVersionWithTag()
         /// </summary>
@@ -595,9 +596,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             pkgStream = content.ReadAsStreamAsync().Result;
-            return pkgStream;  
+            return pkgStream;
         }
-        
+
         /// <summary>
         /// Gets the versioned package entries from the RegistrationsBaseUrl resource
         /// i.e when the package Name being searched for does not contain wildcard
@@ -647,14 +648,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return pkgEntries;
             }
 
-            // Get initial response 
+            // Get initial response
             int skip = 0;
             string query = $"{searchQueryServiceUrl}?q={queryTerm}&prerelease={includePrerelease}&semVerLevel=2.0.0&skip={skip}&take=100";
 
             // Get responses for all packages that contain the required tags
             pkgEntries.AddRange(GetJsonElementArr(query, dataName, out int initialCount, out errRecord).ToList());
 
-            // check count (ie "totalHits") 425 ==> count/100  ~~> 5 calls 
+            // check count (ie "totalHits") 425 ==> count/100  ~~> 5 calls
             int count = initialCount / 100;
             // if more than 100 count, loop and add response to list
             while (count > 0)
@@ -713,7 +714,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             return resources;
         }
-        
+
         /// <summary>
         /// Gets the resource of type "RegistrationBaseUrl" from the repository's resources.
         /// A repository can have multiple resources of type "RegistrationsBaseUrl" so it finds the best match according to the guideline comment in the method.
@@ -927,7 +928,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             errRecord = new ErrorRecord(new ArgumentException($"Response does not contain inner '{property}' element for package '{packageName}' from repository '{Repository.Name}'."), "GetResponsesFromRegistrationsResourceFailure", ErrorCategory.InvalidResult, this);
                             continue;
                         }
-                        
+
                         // If metadata has a "listed" property, but it's set to false, skip this package version
                         if (property.Equals("catalogEntry") && metadataElement.TryGetProperty("listed", out JsonElement listedElement))
                         {
@@ -1010,7 +1011,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 errRecord = new ErrorRecord(e, "LatestVersionFirstSearchFailure", ErrorCategory.InvalidResult, this);
                 return true;
             }
-        
+
             return latestVersionFirst;
         }
 
@@ -1083,7 +1084,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     break;
                 }
             }
-            
+
             return isTagMatch;
         }
 
@@ -1096,7 +1097,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             JsonElement[] entries = new JsonElement[0];
             totalHits = 0;
             try
-            { 
+            {
                 string response = HttpRequestCall(request, out errRecord);
                 if (errRecord != null)
                 {
@@ -1120,7 +1121,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                     // MyGet.org repository responses from SearchQueryService have a bug where the totalHits property int returned is 1000 + actual number of hits
                     // so reduce totalHits by 1000 iff MyGet repository
-                    totalHits = _isMyGetRepo && reportedHits >= myGetTotalHitsBuffer ? reportedHits - myGetTotalHitsBuffer : reportedHits; 
+                    totalHits = _isMyGetRepo && reportedHits >= myGetTotalHitsBuffer ? reportedHits - myGetTotalHitsBuffer : reportedHits;
                     entries = responseEntries.ToArray();
                 }
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add a custom user agent string with PSResourceGet version, PowerShell version and POWERSHELL_DISTRIBUTION_CHANNEL.
This will help us understand usage.

Bunch of whitespace cleanup.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
