### PR TITLE
Support Credential Persistence for Publish-PSResource

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -132,7 +132,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             for (int i = 0; i < repositoriesToSearch.Count && _pkgsLeftToFind.Count > 0 ; i++)
             {
                 PSRepositoryInfo currentRepository = repositoriesToSearch[i];
-                SetNetworkCredential(currentRepository);
+                _networkCredential = Utils.SetNetworkCredential(currentRepository, _networkCredential, _cmdletPassedIn);
                 ServerApiCall currentServer = ServerFactory.GetServer(currentRepository, _networkCredential);
                 if (currentServer == null)
                 {
@@ -234,7 +234,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 PSRepositoryInfo currentRepository = repositoriesToSearch[i];
                 
-                SetNetworkCredential(currentRepository);
+                _networkCredential = Utils.SetNetworkCredential(currentRepository, _networkCredential, _cmdletPassedIn);
                 ServerApiCall currentServer = ServerFactory.GetServer(currentRepository, _networkCredential);
                 if (currentServer == null)
                 {
@@ -354,7 +354,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             for (int i = 0; i < repositoriesToSearch.Count && _tagsLeftToFind.Any(); i++)
             {
                 PSRepositoryInfo currentRepository = repositoriesToSearch[i];
-                SetNetworkCredential(currentRepository);
+                _networkCredential = Utils.SetNetworkCredential(currentRepository, _networkCredential, _cmdletPassedIn);
                 ServerApiCall currentServer = ServerFactory.GetServer(currentRepository, _networkCredential);
                 if (currentServer == null)
                 {
@@ -666,21 +666,21 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
         }
 
-        private void SetNetworkCredential(PSRepositoryInfo repository)
-        {
-            // Explicitly passed in Credential takes precedence over repository CredentialInfo.
-            if (_networkCredential == null && repository.CredentialInfo != null)
-            {
-                PSCredential repoCredential = Utils.GetRepositoryCredentialFromSecretManagement(
-                    repository.Name,
-                    repository.CredentialInfo,
-                    _cmdletPassedIn);
+        // private void SetNetworkCredential(PSRepositoryInfo repository)
+        // {
+        //     // Explicitly passed in Credential takes precedence over repository CredentialInfo.
+        //     if (_networkCredential == null && repository.CredentialInfo != null)
+        //     {
+        //         PSCredential repoCredential = Utils.GetRepositoryCredentialFromSecretManagement(
+        //             repository.Name,
+        //             repository.CredentialInfo,
+        //             _cmdletPassedIn);
 
-                _networkCredential = new NetworkCredential(repoCredential.UserName, repoCredential.Password);
+        //         _networkCredential = new NetworkCredential(repoCredential.UserName, repoCredential.Password);
 
-                _cmdletPassedIn.WriteVerbose("credential successfully read from vault and set for repository: " + repository.Name);
-            }
-        }
+        //         _cmdletPassedIn.WriteVerbose("credential successfully read from vault and set for repository: " + repository.Name);
+        //     }
+        // }
 
         #endregion
 

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -666,22 +666,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
         }
 
-        // private void SetNetworkCredential(PSRepositoryInfo repository)
-        // {
-        //     // Explicitly passed in Credential takes precedence over repository CredentialInfo.
-        //     if (_networkCredential == null && repository.CredentialInfo != null)
-        //     {
-        //         PSCredential repoCredential = Utils.GetRepositoryCredentialFromSecretManagement(
-        //             repository.Name,
-        //             repository.CredentialInfo,
-        //             _cmdletPassedIn);
-
-        //         _networkCredential = new NetworkCredential(repoCredential.UserName, repoCredential.Password);
-
-        //         _cmdletPassedIn.WriteVerbose("credential successfully read from vault and set for repository: " + repository.Name);
-        //     }
-        // }
-
         #endregion
 
         #region Internal Client Search Methods

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -187,22 +187,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 sourceTrusted = repo.Trusted || trustRepository;
 
-                // Explicitly passed in Credential takes precedence over repository CredentialInfo.
-                if (_networkCredential == null && repo.CredentialInfo != null)
-                {
-                    PSCredential repoCredential = Utils.GetRepositoryCredentialFromSecretManagement(
-                        repo.Name,
-                        repo.CredentialInfo,
-                        _cmdletPassedIn);
-
-                    var username = repoCredential.UserName;
-                    var password = repoCredential.Password;
-
-                    _networkCredential = new NetworkCredential(username, password);
-
-                    _cmdletPassedIn.WriteVerbose("credential successfully read from vault and set for repository: " + repo.Name);
-                }
-
+                _networkCredential = Utils.SetNetworkCredential(repo, _networkCredential, _cmdletPassedIn);
                 ServerApiCall currentServer = ServerFactory.GetServer(repo, _networkCredential);
                 ResponseUtil currentResponseUtil = ResponseUtilFactory.GetResponseUtil(repo);
                 bool installDepsForRepo = skipDependencyCheck;

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -1030,22 +1030,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
               isPasswordClearText: true,
               String.Empty));
         }
-
-        // private void SetNetworkCredential(PSRepositoryInfo repository)
-        // {
-        //     // Explicitly passed in Credential takes precedence over repository CredentialInfo.
-        //     if (_networkCredential == null && repository.CredentialInfo != null)
-        //     {
-        //         PSCredential repoCredential = Utils.GetRepositoryCredentialFromSecretManagement(
-        //             repository.Name,
-        //             repository.CredentialInfo,
-        //             this);
-
-        //         _networkCredential = new NetworkCredential(repoCredential.UserName, repoCredential.Password);
-
-        //         WriteVerbose("credential successfully read from vault and set for repository: " + repository.Name);
-        //     }
-        // }
     
     #endregion
   }

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -369,7 +369,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     return;
                 }
 
-                SetNetworkCredential(repository);
+                _networkCredential = Utils.SetNetworkCredential(repository, _networkCredential, this);
 
                 // Check if dependencies already exist within the repo if:
                 // 1) the resource to publish has dependencies and
@@ -1031,21 +1031,21 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
               String.Empty));
         }
 
-        private void SetNetworkCredential(PSRepositoryInfo repository)
-        {
-            // Explicitly passed in Credential takes precedence over repository CredentialInfo.
-            if (_networkCredential == null && repository.CredentialInfo != null)
-            {
-                PSCredential repoCredential = Utils.GetRepositoryCredentialFromSecretManagement(
-                    repository.Name,
-                    repository.CredentialInfo,
-                    this);
+        // private void SetNetworkCredential(PSRepositoryInfo repository)
+        // {
+        //     // Explicitly passed in Credential takes precedence over repository CredentialInfo.
+        //     if (_networkCredential == null && repository.CredentialInfo != null)
+        //     {
+        //         PSCredential repoCredential = Utils.GetRepositoryCredentialFromSecretManagement(
+        //             repository.Name,
+        //             repository.CredentialInfo,
+        //             this);
 
-                _networkCredential = new NetworkCredential(repoCredential.UserName, repoCredential.Password);
+        //         _networkCredential = new NetworkCredential(repoCredential.UserName, repoCredential.Password);
 
-                WriteVerbose("credential successfully read from vault and set for repository: " + repository.Name);
-            }
-        }
+        //         WriteVerbose("credential successfully read from vault and set for repository: " + repository.Name);
+        //     }
+        // }
     
     #endregion
   }

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1,3 +1,4 @@
+using System.Net;
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
@@ -666,6 +667,27 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             return result;
         }
 
+        public static NetworkCredential SetNetworkCredential(
+            PSRepositoryInfo repository,
+            NetworkCredential networkCredential,
+            PSCmdlet cmdletPassedIn)
+        {
+            // Explicitly passed in Credential takes precedence over repository CredentialInfo.
+            if (networkCredential == null && repository.CredentialInfo != null)
+            {
+                PSCredential repoCredential = Utils.GetRepositoryCredentialFromSecretManagement(
+                    repository.Name,
+                    repository.CredentialInfo,
+                    cmdletPassedIn);
+
+                networkCredential = new NetworkCredential(repoCredential.UserName, repoCredential.Password);
+
+                cmdletPassedIn.WriteVerbose("credential successfully read from vault and set for repository: " + repository.Name);
+            }
+
+            return networkCredential;
+        }
+        
         #endregion
 
         #region Path methods


### PR DESCRIPTION
PublishPSResource code needs to pull vault name and cred secret asociated with registered repo when publishing. Currently if the credential is registered with the repository (via SecretManagement and SecretStore), it will not pull the credential correctly and throw a 401 error about credential being missing or incorrect.

Publish-PSResource now works in both ways:

1)
`$cred = Get-Credential`
`Publish-PSResource -Path "./<MyModule>/<MyModule.psd1>" -Credential $cred -ApiKey <ApiKeyForRepo>`

2)
`$cred = Get-Credential`
`Set-Secret -Name "CredSecret" -Secret $cred`
`$psCredInfo = New-Object Microsoft.PowerShell.PSResourceGet.UtilClasses.PSCredentialInfo("SecretStore", "CredSecret")`
`Register-PSResourceRepository -Name "MyAdoFeed" -Uri $url -CredentialInfo $psCredInfo`
`Publish-PSResource -Repository "MyAdoFeed" -Path "./<MyModule>/<MyModule.psd1>" -ApiKey <ApiKeyForRepo>`

For ADO, -ApiKey value can be arbitrary string value. The docs are going to be updated with all this info.
For CredentialPersistence, only supported secret type is `PSCredential`


# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Resolves #1201 #969 #101 #1203

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
