### PR TITLE
Bug fix for publishing with ExternalModuleDependencies

### DIFF
--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -725,7 +725,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 return null;
             }
-
             var requiredModules = parsedMetadataHash["requiredmodules"];
 
             // Required modules can be:
@@ -749,6 +748,20 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 foreach (var modName in moduleNames)
                 {
                     dependenciesHash.Add(modName, string.Empty);
+                }
+            }
+
+            var externalModuleDeps = parsedMetadataHash.ContainsKey("ExternalModuleDependencies") ? 
+                        parsedMetadataHash["ExternalModuleDependencies"] : null;
+
+            if (externalModuleDeps != null && LanguagePrimitives.TryConvertTo<string[]>(externalModuleDeps, out string[] externalModuleNames))
+            {
+                foreach (var extModName in externalModuleNames)
+                {
+                    if (dependenciesHash.ContainsKey(extModName))
+                    {
+                        dependenciesHash.Remove(extModName);
+                    }
                 }
             }
 

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -529,6 +529,18 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         (Get-ChildItem $script:repositoryPath).FullName | Should -Be $expectedPath
     }
 
+    It "should publish a script with sExternalModuleDependencies that are not published" {
+        $scriptName = "test"
+        $scriptVersion = "1.0.0"
+        $scriptPath = Join-Path -Path $script:testScriptsFolderPath -ChildPath "$scriptName.ps1"
+        New-PSScriptFileInfo -Description 'test' -Version $scriptVersion -RequiredModules @{ModuleName='testModule'} -ExternalModuleDependencies 'testModule' -Path $scriptPath -Force
+
+        Publish-PSResource -Path $scriptPath 
+
+        $expectedPath = Join-Path -Path $script:repositoryPath  -ChildPath "$scriptName.$scriptVersion.nupkg"
+        (Get-ChildItem $script:repositoryPath).FullName | Should -Be $expectedPath
+    }
+
     It "should write error and not publish script when Author property is missing" {
         $scriptName = "InvalidScriptMissingAuthor.ps1"
         $scriptVersion = "1.0.0"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
`Publish-PSResource` now looks at ExternalModuleDependencies when checking that dependencies exist in the repository that the parent package is being published to.  If modules are listed under `ExternalModuleDependencies`, they're removed from the list of dependencies that need to be searched for in the repository.

## PR Context
Resolves #1245 

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
