### PR TITLE
Update message for -WhatIf in Install-PSResource, Save-PSResource, and Update-PSResource

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -478,7 +478,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         continue;
                     }
 
-                    if (packagesHash.Count == 0) {
+                    if (packagesHash.Count == 0)
+                    {
                         continue;
                     }
 
@@ -543,6 +544,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                 continue;
                             }
                         }
+                    }
+
+                    // If -WhatIf is passed in, early out.
+                    if (!_cmdletPassedIn.ShouldProcess("Exit ShouldProcess"))
+                    {
+                        return pkgsSuccessfullyInstalled;
                     }
 
                     // Parent package and dependencies are now installed to temp directory.
@@ -663,36 +670,74 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return packagesHash;
             }
 
-            // Download the package.
-            string pkgName = pkgToInstall.Name;
-            Stream responseStream;
 
-            if (searchVersionType == VersionType.NoVersion && !_prerelease)
+            Hashtable updatedPackagesHash = packagesHash;
+
+            // -WhatIf processing.
+            if (_savePkg && !_cmdletPassedIn.ShouldProcess($"Package to save: '{pkgToInstall.Name}', version: '{pkgVersion}'"))
             {
-                responseStream = currentServer.InstallName(pkgName, _prerelease, out ErrorRecord installNameErrRecord);
-                if (installNameErrRecord != null)
+                if (!updatedPackagesHash.ContainsKey(pkgToInstall.Name))
                 {
-                    errRecord = installNameErrRecord;
-                    return packagesHash;
+                    updatedPackagesHash.Add(pkgToInstall.Name, new Hashtable(StringComparer.InvariantCultureIgnoreCase)
+                    {
+                        { "isModule", "" },
+                        { "isScript", "" },
+                        { "psResourceInfoPkg", pkgToInstall },
+                        { "tempDirNameVersionPath", tempInstallPath },
+                        { "pkgVersion", "" },
+                        { "scriptPath", ""  },
+                        { "installPath", "" }
+                    });
+                }
+            }
+            else if (!_cmdletPassedIn.ShouldProcess($"Package to install: '{pkgToInstall.Name}', version: '{pkgVersion}'"))
+            {
+                if (!updatedPackagesHash.ContainsKey(pkgToInstall.Name))
+                {
+                    updatedPackagesHash.Add(pkgToInstall.Name, new Hashtable(StringComparer.InvariantCultureIgnoreCase)
+                    {
+                        { "isModule", "" },
+                        { "isScript", "" },
+                        { "psResourceInfoPkg", pkgToInstall },
+                        { "tempDirNameVersionPath", tempInstallPath },
+                        { "pkgVersion", "" },
+                        { "scriptPath", ""  },
+                        { "installPath", "" }
+                    });
                 }
             }
             else
             {
-                responseStream = currentServer.InstallVersion(pkgName, pkgVersion, out ErrorRecord installVersionErrRecord);
-                if (installVersionErrRecord != null)
+                // Download the package.
+                string pkgName = pkgToInstall.Name;
+                Stream responseStream;
+
+                if (searchVersionType == VersionType.NoVersion && !_prerelease)
                 {
-                    errRecord = installVersionErrRecord;
+                    responseStream = currentServer.InstallName(pkgName, _prerelease, out ErrorRecord installNameErrRecord);
+                    if (installNameErrRecord != null)
+                    {
+                        errRecord = installNameErrRecord;
+                        return packagesHash;
+                    }
+                }
+                else
+                {
+                    responseStream = currentServer.InstallVersion(pkgName, pkgVersion, out ErrorRecord installVersionErrRecord);
+                    if (installVersionErrRecord != null)
+                    {
+                        errRecord = installVersionErrRecord;
+                        return packagesHash;
+                    }
+                }
+
+                bool installedToTempPathSuccessfully = _asNupkg ? TrySaveNupkgToTempPath(responseStream, tempInstallPath, pkgName, pkgVersion, pkgToInstall, packagesHash, out updatedPackagesHash, out errRecord) :
+                    TryInstallToTempPath(responseStream, tempInstallPath, pkgName, pkgVersion, pkgToInstall, packagesHash, out updatedPackagesHash, out errRecord);
+
+                if (!installedToTempPathSuccessfully)
+                {
                     return packagesHash;
                 }
-            }
-
-            Hashtable updatedPackagesHash;
-            bool installedToTempPathSuccessfully = _asNupkg ? TrySaveNupkgToTempPath(responseStream, tempInstallPath, pkgName, pkgVersion, pkgToInstall, packagesHash, out updatedPackagesHash, out errRecord) :
-                TryInstallToTempPath(responseStream, tempInstallPath, pkgName, pkgVersion, pkgToInstall, packagesHash, out updatedPackagesHash, out errRecord);
-
-            if (!installedToTempPathSuccessfully)
-            {
-                return packagesHash;
             }
 
             return updatedPackagesHash;

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -515,12 +515,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 ThrowTerminatingError(IncorrectVersionFormat);
             }
 
-            if (!ShouldProcess(string.Format("package to install: '{0}'", String.Join(", ", inputNameToInstall))))
-            {
-                WriteVerbose(string.Format("Install operation cancelled by user for packages: {0}", String.Join(", ", inputNameToInstall)));
-                return;
-            }
-
             var installedPkgs = _installHelper.BeginInstallPackages(
                 names: pkgNames,
                 versionRange: versionRange,

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -268,12 +268,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 pkgPrerelease = true;
             }
 
-            if (!ShouldProcess(string.Format("Resources to save: '{0}'", namesToSave)))
-            {
-                WriteVerbose(string.Format("Save operation cancelled by user for resources: {0}", namesToSave));
-                return;
-            }
-
             var installedPkgs = _installHelper.BeginInstallPackages(
                 names: namesToSave, 
                 versionRange: versionRange,

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -192,12 +192,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return;
             }
 
-            if (!ShouldProcess(string.Format("package to update: '{0}'", String.Join(", ", Name))))
-            {
-                WriteVerbose(string.Format("Update is cancelled by user for: {0}", String.Join(", ", Name)));
-                return;
-            }
-
             var installedPkgs = _installHelper.BeginInstallPackages(
                 names: namesToUpdate,
                 versionRange: versionRange,

--- a/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
@@ -331,7 +331,7 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
     }
 
     It "Install module using -WhatIf, should not install the module" {
-        Install-PSResource -Name $testModuleName -WhatIf
+        Install-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository -WhatIf
 
         $res = Get-InstalledPSResource $testModuleName
         $res | Should -BeNullOrEmpty


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR updates the messages for the `-WhatIf` parameter in `Install-PSResource`, `Save-PSResource`, and `Update-PSResource` so that it writes out the module names, dependencies and respective versions. 

## PR Context
Resolve #1159 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
