### PR TITLE
Allow for publishing a module that requires a prerelease dependency module

### DIFF
--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -787,7 +787,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 bool depPrerelease = depVersion.Contains("-");
 
                 var repository = new[] { repositoryName };
-                var dependencyFound = findHelper.FindByResourceName(depName, ResourceType.Module, versionRange, nugetVersion, versionType, depVersion, depPrerelease, null, repository, false);
+                var dependencyFound = findHelper.FindByResourceName(depName, ResourceType.Module, versionRange, nugetVersion, versionType, depVersion, true, null, repository, false);
                 if (dependencyFound == null || !dependencyFound.Any())
                 {
                     var message = String.Format("Dependency '{0}' was not found in repository '{1}'.  Make sure the dependency is published to the repository before publishing this module.", dependency, repositoryName);

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -331,7 +331,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         New-TestModule -Path $DepModuleRoot -ModuleName $DepModuleName -RepoName $testRepository2 -PackageVersion $DepVersion -prereleaseLabel $DepPrereleaseLabel  
         Install-PSResource -Name $DepModuleName -Repository $testRepository2 -TrustRepository -Prerelease
 
-        $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$DepModuleName.$DepVersion-$DepPrereleaseLabel.nupkg"
+        $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$DepModuleName.$DepVersion-$DepPrereleaseLabel.nupkg".ToLower()
         (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath
 
         $ParentModuleName = "TestModuleWithPrereleaseDep"
@@ -343,7 +343,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
 
         Publish-PSResource -Path $ParentManifestPath -Repository $testRepository2
 
-        $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$ParentModuleName.$ParentVersion.nupkg"
+        $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$ParentModuleName.$ParentVersion.nupkg".ToLower()
         (Get-ChildItem $script:repositoryPath2).FullName | Should -Contain $expectedPath
     }
 

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -322,15 +322,13 @@ Describe "Test Publish-PSResource" -tags 'CI' {
     }
 
     It "Publish a module with prerelease dependency" {
+        # look at functions in test utils for creating a module with prerelease
         $DepModuleName = "PrereleaseModule"
         $DepVersion = "1.0.0"
         $DepPrereleaseLabel = "beta"
         $DepModuleRoot = Join-Path -Path $script:PublishModuleBase -ChildPath $DepModuleName
-        New-Item -Path $DepModuleRoot -ItemType Directory -Force
-        $DepManifestPath = Join-Path -Path $DepModuleRoot -ChildPath "$DepModuleName.psd1"
-        New-ModuleManifest -Path $DepManifestPath -ModuleVersion $DepVersion -Description "$DepModuleName module" -Prerelease $DepPrereleaseLabel
 
-        Publish-PSResource -Path $DepManifestPath -Repository $testRepository2
+        New-TestModule -Path $DepModuleRoot -ModuleName $DepModuleName -RepoName $testRepository2 -PackageVersion $DepVersion -prereleaseLabel $DepPrereleaseLabel  
         Install-PSResource -Name $DepModuleName -Repository $testRepository2 -TrustRepository -Prerelease
 
         $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$DepModuleName.$DepVersion-$DepPrereleaseLabel.nupkg"

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -478,10 +478,10 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath
 
         $expectedPath = Join-Path -Path $script:destinationPath -ChildPath "$script:PublishModuleName.$version.nupkg"
-        (Get-ChildItem $script:destinationPath).FullName | Should -Be $expectedPath
+        (Get-ChildItem $script:destinationPath).FullName | Should -Contain $expectedPath
     }
 
-    It "Publish a module with -Path -Repository and -DestinationPath" {
+    It "Publish a module with with Pester as a dependency" {
         $moduleName = "Pester"
         $moduleVersion = "5.5.0"
         Save-PSResource -Name $moduleName -Path $tmpRepoPath -Version $moduleVersion -Repository PSGallery -TrustRepository

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -106,13 +106,13 @@ Describe "Test Publish-PSResource" -tags 'CI' {
     AfterEach {
         # Delete all contents of the repository without deleting the repository directory itself
         $pkgsToDelete = Join-Path -Path "$script:repositoryPath" -ChildPath "*"
-        Remove-Item $pkgsToDelete -Recurse
+        Remove-Item $pkgsToDelete -Recurse -Force -ErrorAction SilentlyContinue
 
         $pkgsToDelete = Join-Path -Path "$script:repositoryPath2" -ChildPath "*"
-        Remove-Item $pkgsToDelete -Recurse
+        Remove-Item $pkgsToDelete -Recurse -Force -ErrorAction SilentlyContinue
 
         $pkgsToDelete = Join-Path -Path $script:PublishModuleBase  -ChildPath "*"
-        Remove-Item $pkgsToDelete -Recurse -ErrorAction SilentlyContinue
+        Remove-Item $pkgsToDelete -Recurse -Force -ErrorAction SilentlyContinue
     }
 
     It "Publish module with required module not installed on the local machine using -SkipModuleManifestValidate" {
@@ -473,7 +473,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
 
         $expectedPath = Join-Path -Path $script:repositoryPath2 -ChildPath "$script:PublishModuleName.$version.nupkg"
 
-        (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath
+        (Get-ChildItem $script:repositoryPath2).FullName | Should -Contain $expectedPath
 
         $expectedPath = Join-Path -Path $script:destinationPath -ChildPath "$script:PublishModuleName.$version.nupkg"
         (Get-ChildItem $script:destinationPath).FullName | Should -Contain $expectedPath
@@ -488,7 +488,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $moduleManifestPath = Join-path -Path $moduleVersionPath -ChildPath "$moduleName.psd1"
         Publish-PSResource -Path $moduleManifestPath -Repository $testRepository2
         $expectedPath = Join-Path -Path $script:repositoryPath2 -ChildPath "$moduleName.$moduleVersion.nupkg"
-        (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath
+        (Get-ChildItem $script:repositoryPath2).FullName | Should -Contain $expectedPath
     }
 
     It "Publish a module and clean up properly when file in module is readonly" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
`Publish-PSResource` now allows publishing a module that requires a prerelease module.

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1250 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
