### PR TITLE
Publish-PSResource should create nupkg packages with lowercased name

### DIFF
--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -444,7 +444,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     {
                         var exMessage = string.Format("Destination path does not exist: {0}", DestinationPath);
                         var ex = new ArgumentException(exMessage);
-                        var InvalidDestinationPath = new ErrorRecord(ex, "InvalidDestinationPath", ErrorCategory.InvalidArgument, null);
+                        var InvalidDestinationPath = new ErrorRecord(ex, "InvalidDestinationPath", ErrorCategory.InvalidArgument, targetObject: null);
+
                         WriteError(InvalidDestinationPath);
                         return;
                     }

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -440,6 +440,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // If -DestinationPath is specified then also publish the .nupkg there
                 if (!string.IsNullOrWhiteSpace(DestinationPath))
                 {
+                    if (!Directory.Exists(DestinationPath))
+                    {
+                        var exMessage = string.Format("Destination path does not exist and cannot be created: {0}", DestinationPath);
+                        var ex = new ArgumentException(exMessage);
+                        var InvalidDestinationPath = new ErrorRecord(ex, "InvalidDestinationPath", ErrorCategory.InvalidArgument, null);
+                        WriteError(InvalidDestinationPath);
+                        return;
+                    }
+
                     try
                     {
                         var nupkgName = _pkgName + "." + _pkgVersion.ToNormalizedString() + ".nupkg";

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -443,6 +443,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     try
                     {
                         var nupkgName = _pkgName + "." + _pkgVersion.ToNormalizedString() + ".nupkg";
+                        nupkgName = nupkgName.ToLower();
                         File.Copy(System.IO.Path.Combine(outputNupkgDir, nupkgName), System.IO.Path.Combine(DestinationPath, nupkgName));
                     }
                     catch (Exception e) {

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -443,8 +443,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     try
                     {
                         var nupkgName = _pkgName + "." + _pkgVersion.ToNormalizedString() + ".nupkg";
-                        nupkgName = nupkgName.ToLower();
-                        File.Copy(System.IO.Path.Combine(outputNupkgDir, nupkgName), System.IO.Path.Combine(DestinationPath, nupkgName));
+                        string srcPath = System.IO.Path.Combine(outputNupkgDir, nupkgName);
+                        // The file that gets created upon Copy should have lowercased package name.
+                        string destPath = System.IO.Path.Combine(DestinationPath, nupkgName.ToLower());
+                        File.Copy(srcPath, destPath);
                     }
                     catch (Exception e) {
                         var message = string.Format("Error moving .nupkg into destination path '{0}' due to: '{1}'.", DestinationPath, e.Message);

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -442,7 +442,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     if (!Directory.Exists(DestinationPath))
                     {
-                        var exMessage = string.Format("Destination path does not exist and cannot be created: {0}", DestinationPath);
+                        var exMessage = string.Format("Destination path does not exist: {0}", DestinationPath);
                         var ex = new ArgumentException(exMessage);
                         var InvalidDestinationPath = new ErrorRecord(ex, "InvalidDestinationPath", ErrorCategory.InvalidArgument, null);
                         WriteError(InvalidDestinationPath);

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -641,4 +641,15 @@ Describe "Test Publish-PSResource" -tags 'CI' {
 
         {Publish-PSResource -Path $psm1Path -Repository $testRepository2 -ErrorAction Stop} | Should -Throw -ErrorId "InvalidPublishPath,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
     }
+
+    It "Publish a module and ensure package nupkg name is lowercased" {
+        $version = "1.0.0"
+        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
+
+        Publish-PSResource -Path $script:PublishModuleBase -Repository $testRepository2 -SkipDependenciesCheck
+        $res = Find-PSResource -Name $script:PublishModuleName -Repository $testRepository2
+        $res | Should -Not -BeNullOrEmpty
+        $expectedPkgBaseName = "$($script:PublishModuleName).$($version)"
+        (Get-ChildItem $script:repositoryPath2).BaseName | Should -Be $expectedPkgBaseName.ToLower()
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
