### PR TITLE
Fix Pagination for V3 globbing scenarios

### DIFF
--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -815,11 +815,6 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 // Scenario: V3 server protocol repositories (i.e NuGet.org, Azure Artifacts (ADO), Artifactory, Github Packages, MyGet.org)
                 return PSRepositoryInfo.APIVersion.v3;
             }
-            else if (repoUri.Scheme.Equals(Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
-            {
-                // Scenario: local repositories
-                return PSRepositoryInfo.APIVersion.local;
-            }
             else if (repoUri.AbsoluteUri.EndsWith("/nuget", StringComparison.OrdinalIgnoreCase))
             {
                 // Scenario: ASP.Net application feed created with NuGet.Server to host packages

--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -835,7 +835,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 // Scenario: local repositories
                 return PSRepositoryInfo.APIVersion.local;
             }
-            else if (repoUri.AbsoluteUri.Contains("/nuget"))
+            else if (repoUri.AbsoluteUri.EndsWith("/nuget", StringComparison.OrdinalIgnoreCase))
             {
                 // Scenario: ASP.Net application feed created with NuGet.Server to host packages
                 return PSRepositoryInfo.APIVersion.nugetServer;

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -314,7 +314,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             var matchingPkgEntries = GetVersionedPackageEntriesFromSearchQueryResource(querySearchTerm, includePrerelease, out errRecord);
-            Console.WriteLine(matchingPkgEntries.Count);
             if (errRecord != null)
             {
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -655,7 +654,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // Get initial response
             int skip = 0;
             string query = $"{searchQueryServiceUrl}?q={queryTerm}&prerelease={includePrerelease}&semVerLevel=2.0.0&skip={skip}&take=100";
-            Console.WriteLine($"Query: {query}");
 
             // Get responses for all packages that contain the required tags
             pkgEntries.AddRange(GetJsonElementArr(query, dataName, out int initialCount, out errRecord).ToList());

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -314,6 +314,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             var matchingPkgEntries = GetVersionedPackageEntriesFromSearchQueryResource(querySearchTerm, includePrerelease, out errRecord);
+            Console.WriteLine(matchingPkgEntries.Count);
             if (errRecord != null)
             {
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -654,16 +655,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // Get initial response
             int skip = 0;
             string query = $"{searchQueryServiceUrl}?q={queryTerm}&prerelease={includePrerelease}&semVerLevel=2.0.0&skip={skip}&take=100";
+            Console.WriteLine($"Query: {query}");
 
             // Get responses for all packages that contain the required tags
             pkgEntries.AddRange(GetJsonElementArr(query, dataName, out int initialCount, out errRecord).ToList());
 
-            // check count (ie "totalHits") 425 ==> count/100  ~~> 5 calls
-            int count = initialCount / 100;
+            // check count (ie "totalHits") 425 ==> count/100  ~~> 4 calls ~~> + 1 = 5 calls
+            int count = initialCount / 100 + 1;
             // if more than 100 count, loop and add response to list
             while (count > 0)
             {
                 skip += 100;
+                query = $"{searchQueryServiceUrl}?q={queryTerm}&prerelease={includePrerelease}&semVerLevel=2.0.0&skip={skip}&take=100";
                 pkgEntries.AddRange(GetJsonElementArr(query, dataName, out int unneededCount, out errRecord).ToList());
                 count--;
             }

--- a/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
@@ -278,12 +278,12 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
     
     # "carb*" is intentionally chosen as a sequence that will trigger pagination (ie more than 100 results),
     # but is not too time consuming.
-    # There are currently between 300-350 packages that should be returned
+    # There are currently between 236 packages that should be returned
     It "Should find more than 100 packages that contain 'carb*' in the name" {
         # Tests pagination
         $res = Find-PSResource -Name "carb*" -Repository $NuGetGalleryName
         $res | Should -Not -BeNullOrEmpty
-        $res.Count | Should -BeGreaterThan 300
+        $res.Count | Should -BeGreaterOrEqual 236
     }
 
     It "should throw unauthorized exception if private repository with no credentials" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Previously skip was not being updated in the query even though it's being computed.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
