### PR TITLE
Update Uninstall depedency check to validate against pkg name and version

### DIFF
--- a/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
@@ -22,6 +22,7 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
 
     AfterEach {
         Uninstall-PSResource -Name $testModuleName -Version "*" -ErrorAction SilentlyContinue -SkipDependencyCheck
+        Uninstall-PSResource -Name "test_module" -Version "*" -ErrorAction SilentlyContinue -SkipDependencyCheck
     }
 
     AfterAll {
@@ -250,7 +251,10 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
     }
 
     It "Do not Uninstall module that is a dependency for another module" {
-        $null = Install-PSResource "test_module" -Repository $PSGalleryName -TrustRepository -WarningAction SilentlyContinue
+        Install-PSResource "test_module" -Repository $PSGalleryName -TrustRepository -Version "3.0.0" -Reinstall
+
+        $pkg = Get-InstalledPSResource "RequiredModule1"
+        $pkg | Should -Not -Be $null
 
         Uninstall-PSResource -Name "RequiredModule1" -ErrorVariable ev -ErrorAction SilentlyContinue
 

--- a/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
@@ -254,11 +254,13 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
         Install-PSResource "test_module" -Repository $PSGalleryName -TrustRepository -Version "3.0.0" -Reinstall
 
         $pkg = Get-InstalledPSResource "test_module"
-        write-host "$pkg"
+        write-host "$($pkg.Name)"
+        write-host "$($pkg.Version)"
 
         $pkg = Get-InstalledPSResource "RequiredModule1"
         $pkg | Should -Not -Be $null
-        write-host "$pkg"
+        write-host "$($pkg.Name)"
+        write-host "$($pkg.Version)"
 
         Uninstall-PSResource -Name "RequiredModule1" -ErrorVariable ev -ErrorAction SilentlyContinue
 

--- a/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
@@ -253,8 +253,12 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
     It "Do not Uninstall module that is a dependency for another module" {
         Install-PSResource "test_module" -Repository $PSGalleryName -TrustRepository -Version "3.0.0" -Reinstall
 
+        $pkg = Get-InstalledPSResource "test_module"
+        write-host "$pkg"
+
         $pkg = Get-InstalledPSResource "RequiredModule1"
         $pkg | Should -Not -Be $null
+        write-host "$pkg"
 
         Uninstall-PSResource -Name "RequiredModule1" -ErrorVariable ev -ErrorAction SilentlyContinue
 

--- a/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
@@ -33,7 +33,7 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
         Uninstall-PSResource -name $testModuleName -SkipDependencyCheck
         Get-InstalledPSResource $testModuleName | Should -BeNullOrEmpty
     }
-
+<#
     $testCases = @{Name="Test?Module";      ErrorId="ErrorFilteringNamesForUnsupportedWildcards"},
                  @{Name="Test[Module";      ErrorId="ErrorFilteringNamesForUnsupportedWildcards"}
 
@@ -212,7 +212,7 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
         $stableVersionPkgs = $res | Where-Object {$_.IsPrerelease -ne $true}
         $stableVersionPkgs.Count | Should -Be 2
     }
-
+#>
     It "uninstall all prerelease versions (which satisfy the range) when -Version range and -Prerelease parameter is specified" {
         Uninstall-PSResource -Name $testModuleName -Version "*" -SkipDependencyCheck
         Install-PSResource -Name $testModuleName -Version "2.5.0-beta" -Repository $PSGalleryName -TrustRepository
@@ -262,7 +262,9 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
         write-host "$($pkg.Name)"
         write-host "$($pkg.Version)"
 
-        Uninstall-PSResource -Name "RequiredModule1" -ErrorVariable ev -ErrorAction SilentlyContinue
+        Uninstall-PSResource -Name "RequiredModule1" -ErrorVariable ev -ErrorAction SilentlyContinue -Verbose
+
+        write-host $ev
 
         $pkg = Get-InstalledPSResource "RequiredModule1"
         $pkg | Should -Not -Be $null
@@ -279,7 +281,11 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
         $pkg = Get-InstalledPSResource "test_module"
         $pkg | Should -Not -Be $null
         $pkg.Count | Should -BeGreaterOrEqual 3
-        Uninstall-PSResource -Name "test_module" -Version "*" -ErrorVariable ev -ErrorAction SilentlyContinue
+
+        write-host "************* LOOOK HERE************************************"
+        write-host "$($pkg.Count)"
+        
+        Uninstall-PSResource -Name "test_module" -Version "*" -Verbose
 
         $pkg = Get-InstalledPSResource "test_module"
         $pkg | Should -Not -Be $null

--- a/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
@@ -282,7 +282,7 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
         $pkg | Should -Not -Be $null
         $pkg.Count | Should -BeGreaterOrEqual 3
 
-        write-host "************* LOOOK HERE************************************"
+        write-host "************* LOOK HERE************************************"
         write-host "$($pkg.Count)"
         
         Uninstall-PSResource -Name "test_module" -Version "*" -Verbose


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
When uninstalling a resource, checking all other packages to see if the package to be uninstalled is a dependency for another package only validates against package name, not against package version.  This PR, checks against package name and version(s).

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #665 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
