### PR TITLE
Publish should find prerelease dependency versions.

### DIFF
--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -221,15 +221,20 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (String.IsNullOrEmpty(latestVersionPath))
             {
                 errRecord = new ErrorRecord(new LocalResourceEmpty($"'{packageName}' is not present in repository"), "InstallNameFailure", ErrorCategory.ResourceUnavailable, this);
+                return fs;
             }
-            else
-            {
-                fs = new FileStream(latestVersionPath, FileMode.Open, FileAccess.Read);
 
+            try
+            {            
+                fs = new FileStream(latestVersionPath, FileMode.Open, FileAccess.Read);
                 if (fs == null)
                 {
                     errRecord = new ErrorRecord(new LocalResourceEmpty("The contents of the package file for specified resource was empty or invalid"), "InstallNameFailure", ErrorCategory.ResourceUnavailable, this);
                 }
+            }
+            catch (Exception e)
+            {
+                errRecord = new ErrorRecord(e, "InstallNameFailure", ErrorCategory.ReadError, this);
             }
 
             return fs;
@@ -272,8 +277,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (String.IsNullOrEmpty(pkgVersionPath))
             {
                 errRecord = new ErrorRecord(new LocalResourceEmpty($"'{packageName}' is not present in repository"), "InstallNameFailure", ErrorCategory.ResourceUnavailable, this);
+                return fs;
             }
-            else
+
+            try
             {
                 fs = new FileStream(pkgVersionPath, FileMode.Open, FileAccess.Read);
 
@@ -281,6 +288,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     errRecord = new ErrorRecord(new LocalResourceEmpty("The contents of the package file for specified resource was empty or invalid"), "InstallNameFailure", ErrorCategory.ResourceUnavailable, this);
                 }
+            }
+            catch (Exception e)
+            {
+                errRecord = new ErrorRecord(e, "InstallVersionFailure", ErrorCategory.ReadError, this);
             }
 
             return fs;

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -265,7 +265,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 if (!String.IsNullOrEmpty(packageFullName) && pkgNamePattern.IsMatch(packageFullName))
                 {
-                    pkgVersionPath = packageFullName;
+                    pkgVersionPath = path;
                 }
             }
 

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -456,10 +456,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     try
                     {
                         var nupkgName = _pkgName + "." + _pkgVersion.ToNormalizedString() + ".nupkg";
-                        string srcPath = System.IO.Path.Combine(outputNupkgDir, nupkgName);
-                        // The file that gets created upon Copy should have lowercased package name.
-                        string destPath = System.IO.Path.Combine(DestinationPath, nupkgName.ToLower());
-                        File.Copy(srcPath, destPath);
+                        File.Copy(System.IO.Path.Combine(outputNupkgDir, nupkgName), System.IO.Path.Combine(DestinationPath, nupkgName));
                     }
                     catch (Exception e) {
                         var message = string.Format("Error moving .nupkg into destination path '{0}' due to: '{1}'.", DestinationPath, e.Message);

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -857,7 +857,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 var repository = new[] { repositoryName };
                 // Note: we set prerelease argument for FindByResourceName() to true because if no version is specified we want latest version (including prerelease).
                 // If version is specified it will get that one. There is also no way to specify a prerelease flag with RequiredModules hashtable of dependency so always try to get latest version.
-                var dependencyFound = findHelper.FindByResourceName(depName, ResourceType.Module, versionRange, nugetVersion, versionType, depVersion, true, null, repository, false);
+                var dependencyFound = findHelper.FindByResourceName(depName, ResourceType.Module, versionRange, nugetVersion, versionType, depVersion, prerelease: true, tag: null, repository, includeDependencies: false);
                 if (dependencyFound == null || !dependencyFound.Any())
                 {
                    WriteError(new ErrorRecord(

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -859,7 +859,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 bool depPrerelease = depVersion.Contains("-");
 
                 var repository = new[] { repositoryName };
-                var dependencyFound = findHelper.FindByResourceName(depName, ResourceType.Module, versionRange, nugetVersion, versionType, depVersion, depPrerelease, null, repository, false);
+                var dependencyFound = findHelper.FindByResourceName(depName, ResourceType.Module, versionRange, nugetVersion, versionType, depVersion, true, null, repository, false);
                 if (dependencyFound == null || !dependencyFound.Any())
                 {
                    WriteError(new ErrorRecord(

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -853,9 +853,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 // Search for and return the dependency if it's in the repository.
                 FindHelper findHelper = new FindHelper(_cancellationToken, this, _networkCredential);
-                bool depPrerelease = depVersion.Contains("-");
 
                 var repository = new[] { repositoryName };
+                // Note: we set prerelease argument for FindByResourceName() to true because if no version is specified we want latest version (including prerelease).
+                // If version is specified it will get that one. There is also no way to specify a prerelease flag with RequiredModules hashtable of dependency so always try to get latest version.
                 var dependencyFound = findHelper.FindByResourceName(depName, ResourceType.Module, versionRange, nugetVersion, versionType, depVersion, true, null, repository, false);
                 if (dependencyFound == null || !dependencyFound.Any())
                 {

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -656,4 +656,30 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $expectedPkgBaseName = "$($script:PublishModuleName).$($version)"
         (Get-ChildItem $script:repositoryPath2).BaseName | Should -Be $expectedPkgBaseName.ToLower()
     }
+
+    It "Publish a module with prerelease dependency" {
+        # look at functions in test utils for creating a module with prerelease
+        $DepModuleName = "PrereleaseModule"
+        $DepVersion = "1.0.0"
+        $DepPrereleaseLabel = "beta"
+        $DepModuleRoot = Join-Path -Path $script:PublishModuleBase -ChildPath $DepModuleName
+
+        New-TestModule -Path $DepModuleRoot -ModuleName $DepModuleName -RepoName $testRepository2 -PackageVersion $DepVersion -prereleaseLabel $DepPrereleaseLabel  
+        Install-PSResource -Name $DepModuleName -Repository $testRepository2 -TrustRepository -Prerelease
+
+        $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$DepModuleName.$DepVersion-$DepPrereleaseLabel.nupkg".ToLower()
+        (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath
+
+        $ParentModuleName = "TestModuleWithPrereleaseDep"
+        $ParentVersion = "1.0.0"
+        $ParentModuleRoot = Join-Path -Path $script:PublishModuleBase -ChildPath $ParentModuleName
+        New-Item -Path $ParentModuleRoot -ItemType Directory -Force
+        $ParentManifestPath = Join-Path -Path $ParentModuleRoot -ChildPath "$ParentModuleName.psd1"
+        New-ModuleManifest -Path $ParentManifestPath -ModuleVersion $ParentVersion -Description "$ParentPkgName module" -RequiredModules $DepModuleName
+
+        Publish-PSResource -Path $ParentManifestPath -Repository $testRepository2
+
+        $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$ParentModuleName.$ParentVersion.nupkg".ToLower()
+        (Get-ChildItem $script:repositoryPath2).FullName | Should -Contain $expectedPath
+    }
 }

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -656,7 +656,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         New-TestModule -Path $DepModuleRoot -ModuleName $DepModuleName -RepoName $testRepository2 -PackageVersion $DepVersion -prereleaseLabel $DepPrereleaseLabel  
         Install-PSResource -Name $DepModuleName -Repository $testRepository2 -TrustRepository -Prerelease
 
-        $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$DepModuleName.$DepVersion-$DepPrereleaseLabel.nupkg".ToLower()
+        $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$DepModuleName.$DepVersion-$DepPrereleaseLabel.nupkg"
         (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath
 
         $ParentModuleName = "TestModuleWithPrereleaseDep"
@@ -668,7 +668,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
 
         Publish-PSResource -Path $ParentManifestPath -Repository $testRepository2
 
-        $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$ParentModuleName.$ParentVersion.nupkg".ToLower()
+        $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$ParentModuleName.$ParentVersion.nupkg"
         (Get-ChildItem $script:repositoryPath2).FullName | Should -Contain $expectedPath
     }
 }

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -645,17 +645,6 @@ Describe "Test Publish-PSResource" -tags 'CI' {
     It "Get definition for alias 'pbres'" {
         (Get-Alias pbres).Definition | Should -BeExactly 'Publish-PSResource'
     }
-    
-    It "Publish a module and ensure package nupkg name is lowercased" {
-        $version = "1.0.0"
-        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
-
-        Publish-PSResource -Path $script:PublishModuleBase -Repository $testRepository2 -SkipDependenciesCheck
-        $res = Find-PSResource -Name $script:PublishModuleName -Repository $testRepository2
-        $res | Should -Not -BeNullOrEmpty
-        $expectedPkgBaseName = "$($script:PublishModuleName).$($version)"
-        (Get-ChildItem $script:repositoryPath2).BaseName | Should -Be $expectedPkgBaseName.ToLower()
-    }
 
     It "Publish a module with prerelease dependency" {
         # look at functions in test utils for creating a module with prerelease


### PR DESCRIPTION
When finding dependency packages for Publish, detect prerelease versions of the dependency packages if specific version is not specified.

Additionally, when writing tests we found that LocalServerApi.InstallVersion() File.Exists() call fails for Linux as Linux is case sensitive platform. Using wildcard matching should allow the (dep) package to be found. Currently it is not able to be found.

Also undoes changes of PR #1276 as that solution towards the case sensitivity issue for Linux was not sufficient/correct.


<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Resolves #1250 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
