### PR TITLE
Update release.yml to disable pushing to PS AzDo feed

### DIFF
--- a/.ci/release.yml
+++ b/.ci/release.yml
@@ -5,39 +5,39 @@ parameters:
   displayNameJob2: 'Release PSResourceGet to PSGallery'
 
 jobs:
-- job: ${{ parameters.jobName1 }}
-  pool:
-    name: 1ES
-    demands:
-    - ImageOverride -equals PSMMS2019-Secure
-  displayName: ${{ parameters.displayNameJob1 }}
+#- job: ${{ parameters.jobName1 }}
+#  pool:
+#    name: 1ES
+#    demands:
+#    - ImageOverride -equals PSMMS2019-Secure
+#  displayName: ${{ parameters.displayNameJob1 }}
 
-  steps:
-  - task: DownloadPipelineArtifact@2
-    displayName: 'Download PSResourceGet module artifacts'
-    inputs:
-      artifact: nupkg
-      patterns: '**/*.nupkg'
-      downloadPath: '$(Pipeline.Workspace)/nuget'
+#  steps:
+#  - task: DownloadPipelineArtifact@2
+#    displayName: 'Download PSResourceGet module artifacts'
+#    inputs:
+#      artifact: nupkg
+#      patterns: '**/*.nupkg'
+#      downloadPath: '$(Pipeline.Workspace)/nuget'
 
-  - powershell: |
-      $package = (Get-ChildItem '$(Pipeline.Workspace)/nuget/Microsoft.PowerShell.PSResourceGet.*.nupkg').FullName
-      $package
-      $vstsCommandString = "vso[task.setvariable variable=NugetPkgPath]${package}"
-      Write-Host "sending " + $vstsCommandString
-      Write-Host "##$vstsCommandString"
-    displayName: 'Capture PSResourceGet module NuGet package path and set environment variable'
+  #- powershell: |
+  #    $package = (Get-ChildItem '$(Pipeline.Workspace)/nuget/Microsoft.PowerShell.PSResourceGet.*.nupkg').FullName
+  #    $package
+  #    $vstsCommandString = "vso[task.setvariable variable=NugetPkgPath]${package}"
+  #    Write-Host "sending " + $vstsCommandString
+  #    Write-Host "##$vstsCommandString"
+  #  displayName: 'Capture PSResourceGet module NuGet package path and set environment variable'
 
-  - task: NuGetCommand@2
-    displayName: 'Push PSResourceGet module artifacts to PowerShell ADO feed'
-    inputs:
-      command: push
-      packagesToPush: '$(NugetPkgPath)'
-      nuGetFeedType: external
-      publishFeedCredentials: PSCoreReleasePush
+  #- task: NuGetCommand@2
+  #  displayName: 'Push PSResourceGet module artifacts to PowerShell ADO feed'
+  #  inputs:
+  #    command: push
+  #    packagesToPush: '$(NugetPkgPath)'
+  #    nuGetFeedType: external
+  #    publishFeedCredentials: PSCoreReleasePush
 
 - job: ${{ parameters.jobName2 }}
-  dependsOn: ${{ parameters.jobName1 }}
+  # dependsOn: ${{ parameters.jobName1 }}
   pool:
     name: 1ES
     demands:


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Temporary disablement of pushinng to AzDo feed for PS.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
