### PR TITLE
Set-PSResourceRepository ran without -ApiVersion param should not reset it for the repository

### DIFF
--- a/src/code/SetPSResourceRepository.cs
+++ b/src/code/SetPSResourceRepository.cs
@@ -86,7 +86,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Specifies the Api version of the repository to be set.
         /// </sumamry>
         [Parameter(ParameterSetName = NameParameterSet)]
-        public PSRepositoryInfo.APIVersion ApiVersion { get; set; }
+        public PSRepositoryInfo.APIVersion? ApiVersion { get; set; } = null;
 
         /// <summary>
         /// Specifies vault and secret names as PSCredentialInfo for the repository.

--- a/src/code/SetPSResourceRepository.cs
+++ b/src/code/SetPSResourceRepository.cs
@@ -86,7 +86,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Specifies the Api version of the repository to be set.
         /// </sumamry>
         [Parameter(ParameterSetName = NameParameterSet)]
-        public PSRepositoryInfo.APIVersion? ApiVersion { get; set; } = null;
+        public PSRepositoryInfo.APIVersion ApiVersion { get; set; }
 
         /// <summary>
         /// Specifies vault and secret names as PSCredentialInfo for the repository.
@@ -119,6 +119,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
             }
 
+            PSRepositoryInfo.APIVersion? repoApiVersion = null;
+            if (MyInvocation.BoundParameters.ContainsKey(nameof(ApiVersion)))
+            {
+                repoApiVersion = ApiVersion;
+            }
+
             List<PSRepositoryInfo> items = new List<PSRepositoryInfo>();
 
             switch(ParameterSetName)
@@ -132,7 +138,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             Trusted, 
                             isSet,
                             DefaultPriority,
-                            ApiVersion,
+                            repoApiVersion,
                             CredentialInfo,
                             this,
                             out string errorMsg));

--- a/test/ResourceRepositoryTests/SetPSResourceRepository.Tests.ps1
+++ b/test/ResourceRepositoryTests/SetPSResourceRepository.Tests.ps1
@@ -332,4 +332,16 @@ Describe "Test Set-PSResourceRepository" -tags 'CI' {
         $res2 = Get-PSResourceRepository -Name "tempDriveRepo"
         $res2.Uri.LocalPath | Should -Be "\"
     }
+
+    It "should not change ApiVersion of repository if -ApiVersion parameter was not used" {
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path
+        $repo = Get-PSResourceRepository $TestRepoName1
+        $repoApiVersion = $repo.ApiVersion
+        $repoApiVersion | Should -Be "local"
+
+        Set-PSResourceRepository -Name $TestRepoName1 -Priority 25
+        $repo = Get-PSResourceRepository $TestRepoName1
+        $repo.ApiVersion | Should -Be "local"
+        $repo.Priority | Should -Be 25
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Currently, running `Set-PSResourceRepository` without the `-ApiVersion` parameter takes on the default value of ApiVersion.Unknown and changes it for the specified repository from the actual value to "unknown". Since ApiVersion is considered nullable the parameter should be too.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Resolves #1306 #1302 #1299 #1325 #1331
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
