### PR TITLE
Add error handling for local repo pattern based searching

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -348,7 +348,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 ResponseUtil currentResponseUtil = ResponseUtilFactory.GetResponseUtil(currentRepository);
 
                 _cmdletPassedIn.WriteVerbose(string.Format("Searching in repository {0}", repositoriesToSearch[i].Name));
-
+                _cmdletPassedIn.WriteVerbose($"tags: {String.Join(",", _tag)}");
                 FindResults responses = currentServer.FindCommandOrDscResource(_tag, _prerelease, isSearchingForCommands, out ErrorRecord errRecord);
                 if (errRecord != null)
                 {

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -486,7 +486,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (pkgsFound.Count == 0 && tags.Length != 0)
             {
-                errRecord = new ErrorRecord(new LocalResourceNotFoundException($"Package(s) with Tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), "FindTagsPackageNotFound", ErrorCategory.ParserError, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package(s) with Tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), "FindTagsPackageNotFound", ErrorCategory.ParserError, this);
             }
 
             findResponse = new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: pkgsFound.ToArray(), responseType: _localServerFindResponseType);

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -651,9 +651,19 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 string packageFullName = Path.GetFileName(path);
                 MatchCollection matches = rx.Matches(packageFullName);
+                if (matches.Count == 0)
+                {
+                    continue;
+                }
+
                 Match match = matches[0];
 
                 GroupCollection groups = match.Groups;
+                if (groups.Count == 0)
+                {
+                    continue;
+                }
+
                 Capture group = groups[0];
 
                 string pkgFoundName = packageFullName.Substring(0, group.Index);
@@ -668,7 +678,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 string version = packageFullName.Substring(group.Index + 1, packageFullName.LastIndexOf('.') - group.Index - 1);
 
-                NuGetVersion.TryParse(version, out NuGetVersion nugetVersion); // TODO: err handle
+                if (!NuGetVersion.TryParse(version, out NuGetVersion nugetVersion))
+                {
+                    continue;
+                }
 
                 if (!nugetVersion.IsPrerelease || includePrerelease)
                 {

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -484,10 +484,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 pkgsFound.Add(pkgMetadata);
             }
 
-            if (pkgsFound.Count == 0)
+            if (pkgsFound.Count == 0 && tags.Length != 0)
             {
-                string parameterForError = tags.Length == 0 ? "Name '*'" : $"Tags '{String.Join(", ", tags)}'";
-                errRecord = new ErrorRecord(new LocalResourceNotFoundException($"Package(s) with {parameterForError} could not be found in repository '{Repository.Name}'."), "FindTagsPackageNotFound", ErrorCategory.ParserError, this);
+                errRecord = new ErrorRecord(new LocalResourceNotFoundException($"Package(s) with Tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), "FindTagsPackageNotFound", ErrorCategory.ParserError, this);
             }
 
             findResponse = new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: pkgsFound.ToArray(), responseType: _localServerFindResponseType);

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -269,4 +269,11 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
     It "Get definition for alias 'fdres'" {
         (Get-Alias fdres).Definition | Should -BeExactly 'Find-PSResource'
     }
+
+    It "not find resource with tag value that is non-existent for the packages" {
+        # Since this is pattern matching based search no error should be written out.
+        $res = Find-PSResource -Tag "nonexistenttag" -Repository $localRepo
+        $res | Should -BeNullOrEmpty
+        $err | Should -HaveCount 0
+    }
 }

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -274,6 +274,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         # Since this is pattern matching based search no error should be written out.
         $res = Find-PSResource -Tag "nonexistenttag" -Repository $localRepo -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
-        $err | Should -HaveCount 0
+        $err.Count | Should -Not -Be 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindTagsPackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 }

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -272,7 +272,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
 
     It "not find resource with tag value that is non-existent for the packages" {
         # Since this is pattern matching based search no error should be written out.
-        $res = Find-PSResource -Tag "nonexistenttag" -Repository $localRepo
+        $res = Find-PSResource -Tag "nonexistenttag" -Repository $localRepo -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err | Should -HaveCount 0
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Find against a local repo where the name contains wildcard, is "*", or is a tag search will search through all file names in the repository. If the package name isn't a match it need not throw an error but it should gracefully recognize and continue past that package onto the next. Currently it was not and was throwing array out of bounds exceptions.


<!-- Summarize your PR between here and the checklist. -->
Resolves #1299 #1297
## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
