### PR TITLE
Bug fix for updating to a prerelease module

### DIFF
--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -257,7 +257,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             VersionType versionType,
             out bool latestInstalledIsPrerelease)
         {
-            latestInstalledIsPrerelease = false;
+            latestInstalledIsPrerelease = Prerelease;
 
             namesToProcess = Utils.ProcessNameWildcards(
                 pkgNames: namesToProcess,

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -199,7 +199,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 nugetVersion: nugetVersion,
                 versionType: versionType,
                 versionString: Version,
-                prerelease: latestInstalledIsPrerelease,
+                prerelease: latestInstalledIsPrerelease || Prerelease,
                 repository: Repository,
                 acceptLicense: AcceptLicense,
                 quiet: Quiet,
@@ -257,7 +257,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             VersionType versionType,
             out bool latestInstalledIsPrerelease)
         {
-            latestInstalledIsPrerelease = Prerelease;
+            latestInstalledIsPrerelease = false;
 
             namesToProcess = Utils.ProcessNameWildcards(
                 pkgNames: namesToProcess,
@@ -331,7 +331,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 nugetVersion: nuGetVersion,
                 versionType: versionType,
                 version: Version,
-                prerelease: latestInstalledIsPrerelease,
+                prerelease: latestInstalledIsPrerelease || Prerelease,
                 tag: null,
                 repository: Repository,
                 includeDependencies: !SkipDependencyCheck))

--- a/test/UpdatePSResourceTests/UpdatePSResourceV2Tests.ps1
+++ b/test/UpdatePSResourceTests/UpdatePSResourceV2Tests.ps1
@@ -172,6 +172,24 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
         $isPkgUpdated | Should -Be $true
     }
 
+    It "Update resource to explicit prerelease version using NuGet syntax" {
+        Install-PSResource -Name $testModuleName -Version "1.0.0.0" -Repository $PSGalleryName -TrustRepository
+        Update-PSResource -Name $testModuleName -Version "[5.2.5-alpha001]" -Prerelease -Repository $PSGalleryName -TrustRepository
+        $res = Get-InstalledPSResource -Name $testModuleName
+        $res | Should -Not -BeNullOrEmpty
+        $isPkgUpdated = $false
+        foreach ($pkg in $res)
+        {
+            if ([System.Version]$pkg.Version -eq [System.Version]"5.2.5")
+            {
+                $pkg.Prerelease | Should -Be "alpha001"
+                $isPkgUpdated = $true
+            }
+        }
+
+        $isPkgUpdated | Should -Be $true
+    }
+
     It "Update prerelease version to a higher prerelease version not using -Prerelease parameter" {
         Install-PSResource -Name $testModuleName3 -Version "0.0.99-beta1" -Repository $PSGalleryName -TrustRepository
         Update-PSResource -Name $testModuleName3 -Repository $PSGalleryName -TrustRepository


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
`-Prerelease` parameter was being ignored in `Update-PSResource`.  This PR ensures both `latestInstalledIsPrerelease` and `Prerelease` are checked when determining whether to allow searching for a prerelease package.

## PR Context

Resolves #1311 


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
