### PR TITLE
Bug fix for saving dependency modules in version range format

### DIFF
--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -808,7 +808,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // Adding 1 because we want to retrieve all the prerelease versions for the max version and PSGallery views prerelease as higher than its stable
                 // eg 3.0.0-prerelease > 3.0.0
                 string maxString = includePrerelease ? $"{versionRange.MaxVersion.Major}.{versionRange.MaxVersion.Minor + 1}" :
-                                $"{versionRange.MinVersion.ToNormalizedString()}";
+                                $"{versionRange.MaxVersion.ToNormalizedString()}";
                 if (NuGetVersion.TryParse(maxString, out NuGetVersion maxVersion))
                 {
                     maxPart = String.Format(format, operation, $"'{maxVersion.ToNormalizedString()}'");

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -807,7 +807,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 string operation = versionRange.IsMaxInclusive ? "le" : "lt";
                 // Adding 1 because we want to retrieve all the prerelease versions for the max version and PSGallery views prerelease as higher than its stable
                 // eg 3.0.0-prerelease > 3.0.0
-                string maxString = $"{versionRange.MaxVersion.Major}.{versionRange.MaxVersion.Minor + 1}";
+                string maxString = includePrerelease ? $"{versionRange.MaxVersion.Major}.{versionRange.MaxVersion.Minor + 1}" :
+                                $"{versionRange.MinVersion.ToNormalizedString()}";
                 if (NuGetVersion.TryParse(maxString, out NuGetVersion maxVersion))
                 {
                     maxPart = String.Format(format, operation, $"'{maxVersion.ToNormalizedString()}'");

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -379,6 +379,12 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res.Count | Should -BeGreaterOrEqual 7 
     }
 
+    It "find a specific version using NuGet versioning bracket syntax" {
+        $res = Find-PSResource -Name $testModuleName -Version "[3.0.0,3.0.0]" -Repository $PSGalleryName
+        $res | Should -Not -BeNullOrEmpty
+        $res.Version | Should -Be "3.0.0"
+    }
+
     It "not find resource and error handle when repository's ApiVersion is ApiVersion.unknown" {
         Register-PSResourceRepository -Name "UnknownTypeRepo" -Uri "https://org.MyCompany.com/repository/shared-feed/" -Trusted
         $repo = Get-PSResourceRepository -Name "UnknownTypeRepo"

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -382,7 +382,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
     It "find a specific version using NuGet versioning bracket syntax" {
         $res = Find-PSResource -Name $testModuleName -Version "[3.0.0,3.0.0]" -Repository $PSGalleryName
         $res | Should -Not -BeNullOrEmpty
-        $res.Version | Should -Be "3.0.0"
+        $res.Version | Should -Be "3.0.0.0"
     }
 
     It "not find resource and error handle when repository's ApiVersion is ApiVersion.unknown" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Bug fix for finding a module with version specified as a version range (eg. "[1.2.2, 1.2.2]").  

## PR Context
Resolves #1313 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
