### PR TITLE
Bug fix for parsing required modules when publishing

### DIFF
--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -833,10 +833,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // Check to see that all dependencies are in the repository
             // Searches for each dependency in the repository the pkg is being pushed to,
             // If the dependency is not there, error
-            foreach (var dependency in dependencies.Keys)
+            foreach (DictionaryEntry dependency in dependencies)
             {
                 // Need to make individual calls since we're look for exact version numbers or ranges.
-                var depName = dependency as string;
+                var depName = dependency.Key as string;
                 // test version
                 string depVersion = dependencies[dependency] as string;
                 depVersion = string.IsNullOrWhiteSpace(depVersion) ? "*" : depVersion;

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -780,8 +780,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (!parsedMetadataHash.ContainsKey("requiredmodules"))
             {
                 return null;
-            }
-            var requiredModules = parsedMetadataHash["requiredmodules"];
+            }     
+            LanguagePrimitives.TryConvertTo<object[]>(parsedMetadataHash["requiredmodules"], out object[] requiredModules);
 
             // Required modules can be:
             //  a. An array of hash tables of module name and version
@@ -790,23 +790,27 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             //  d. A single string module name
 
             var dependenciesHash = new Hashtable();
-            if (LanguagePrimitives.TryConvertTo<Hashtable[]>(requiredModules, out Hashtable[] moduleList))
+            foreach (var reqModule in requiredModules)
             {
-                // instead of returning an array of hashtables,
-                // loop through the array and add each element of
-                foreach (Hashtable hash in moduleList)
+                if (LanguagePrimitives.TryConvertTo<Hashtable>(reqModule, out Hashtable moduleHash))
                 {
-                    dependenciesHash.Add(hash["ModuleName"], hash["ModuleVersion"]);
+                    if (moduleHash.ContainsKey("ModuleVersion"))
+                    {
+                        dependenciesHash.Add(moduleHash["ModuleName"], moduleHash["ModuleVersion"]);
+                    }
+                    else if (moduleHash.ContainsKey("RequiredVersion"))
+                    {
+                        dependenciesHash.Add(moduleHash["ModuleName"], moduleHash["RequiredVersion"]);
+                    }
+                    else {
+                        dependenciesHash.Add(moduleHash["ModuleName"], string.Empty);
+                    }
+                }
+                else if (LanguagePrimitives.TryConvertTo<string>(reqModule, out string moduleName))
+                {
+                    dependenciesHash.Add(moduleName, string.Empty);
                 }
             }
-            else if (LanguagePrimitives.TryConvertTo<string[]>(requiredModules, out string[] moduleNames))
-            {
-                foreach (var modName in moduleNames)
-                {
-                    dependenciesHash.Add(modName, string.Empty);
-                }
-            }
-
             var externalModuleDeps = parsedMetadataHash.ContainsKey("ExternalModuleDependencies") ? 
                         parsedMetadataHash["ExternalModuleDependencies"] : null;
 
@@ -832,7 +836,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             foreach (var dependency in dependencies.Keys)
             {
                 // Need to make individual calls since we're look for exact version numbers or ranges.
-                var depName = new[] { (string)dependency };
+                var depName = dependency as string;
                 // test version
                 string depVersion = dependencies[dependency] as string;
                 depVersion = string.IsNullOrWhiteSpace(depVersion) ? "*" : depVersion;
@@ -857,11 +861,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 var repository = new[] { repositoryName };
                 // Note: we set prerelease argument for FindByResourceName() to true because if no version is specified we want latest version (including prerelease).
                 // If version is specified it will get that one. There is also no way to specify a prerelease flag with RequiredModules hashtable of dependency so always try to get latest version.
-                var dependencyFound = findHelper.FindByResourceName(depName, ResourceType.Module, versionRange, nugetVersion, versionType, depVersion, prerelease: true, tag: null, repository, includeDependencies: false);
+                var dependencyFound = findHelper.FindByResourceName(new string[] { depName }, ResourceType.Module, versionRange, nugetVersion, versionType, depVersion, prerelease: true, tag: null, repository, includeDependencies: false);
                 if (dependencyFound == null || !dependencyFound.Any())
                 {
                    WriteError(new ErrorRecord(
-                       new ArgumentException($"Dependency '{depName.First()}' was not found in repository '{repositoryName}'.  Make sure the dependency is published to the repository before publishing this module."),
+                       new ArgumentException($"Dependency '{depName}' was not found in repository '{repositoryName}'.  Make sure the dependency is published to the repository before publishing this module."),
                        "DependencyNotFound",
                        ErrorCategory.ObjectNotFound,
                        this));

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -794,16 +794,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 if (LanguagePrimitives.TryConvertTo<Hashtable>(reqModule, out Hashtable moduleHash))
                 {
+                    string moduleName = moduleHash["ModuleName"] as string;
+
                     if (moduleHash.ContainsKey("ModuleVersion"))
                     {
-                        dependenciesHash.Add(moduleHash["ModuleName"], moduleHash["ModuleVersion"]);
+                        dependenciesHash.Add(moduleName, moduleHash["ModuleVersion"]);
                     }
                     else if (moduleHash.ContainsKey("RequiredVersion"))
                     {
-                        dependenciesHash.Add(moduleHash["ModuleName"], moduleHash["RequiredVersion"]);
+                        dependenciesHash.Add(moduleName, moduleHash["RequiredVersion"]);
                     }
                     else {
-                        dependenciesHash.Add(moduleHash["ModuleName"], string.Empty);
+                        dependenciesHash.Add(moduleName, string.Empty);
                     }
                 }
                 else if (LanguagePrimitives.TryConvertTo<string>(reqModule, out string moduleName))
@@ -838,7 +840,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // Need to make individual calls since we're look for exact version numbers or ranges.
                 var depName = dependency.Key as string;
                 // test version
-                string depVersion = dependencies[dependency] as string;
+                string depVersion = dependencies[depName] as string;
                 depVersion = string.IsNullOrWhiteSpace(depVersion) ? "*" : depVersion;
 
                 if (!Utils.TryGetVersionType(

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -677,15 +677,18 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $ModuleName = "ParentModule"
         $ModuleVersion = "1.0.0"
         $ModuleRoot = Join-Path -Path $script:PublishModuleBase -ChildPath $ModuleName
+        New-Item $ModuleRoot -ItemType Directory
         $ModuleManifestPath = Join-Path -Path $ModuleRoot -ChildPath "$ModuleName.psd1"
 
         $ReqModule1Name = "ReqModule1"
         $ReqModule1Version = "3.0.0"
         $ReqModule1Root = Join-Path -Path $script:PublishModuleBase -ChildPath $ReqModule1Name
+        New-Item $ReqModule1Root -ItemType Directory
         $ReqModule1ManifestPath = Join-Path -Path $ReqModule1Root -ChildPath "$ReqModule1Name.psd1"
 
         $ReqModule2Name = "ReqModule2"
         $ReqModule2Root = Join-Path -Path $script:PublishModuleBase -ChildPath $ReqModule2Name
+        New-Item $ReqModule2Root -ItemType Directory
         $ReqModule2ManifestPath = Join-Path -Path $reqModule2Root -ChildPath "$ReqModule2Name.psd1"
 
         New-ModuleManifest -Path $ModuleManifestPath -ModuleVersion $ModuleVersion -Description "$ModuleName module" -RequiredModules @( @{"ModuleName" = $ReqModule1Name; "ModuleVersion" = $ReqModule1Version},  $ReqModule2Name )

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -692,8 +692,8 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $ReqModule2ManifestPath = Join-Path -Path $reqModule2Root -ChildPath "$ReqModule2Name.psd1"
 
         New-ModuleManifest -Path $ModuleManifestPath -ModuleVersion $ModuleVersion -Description "$ModuleName module" -RequiredModules @( @{"ModuleName" = $ReqModule1Name; "ModuleVersion" = $ReqModule1Version},  $ReqModule2Name )
-        New-ModuleManifest -Path $ReqModule1ManifestPath -ModuleVersion $ModuleVersion -Description "$ModuleName module" -RequiredModules @( @{"ModuleName" = $ReqModule1Name; "ModuleVersion" = $ReqModule1Version},  $ReqModule2Name )
-        New-ModuleManifest -Path $ReqModule2ManifestPath -ModuleVersion $ModuleVersion -Description "$ModuleName module" -RequiredModules @( @{"ModuleName" = $ReqModule1Name; "ModuleVersion" = $ReqModule1Version},  $ReqModule2Name )
+        New-ModuleManifest -Path $ReqModule1ManifestPath -ModuleVersion $ReqModule1Version -Description "$ReqModule1Name module"
+        New-ModuleManifest -Path $ReqModule2ManifestPath -Description "$ReqModule1Name module"
 
         Publish-PSResource -Path $ReqModule1ManifestPath -Repository $testRepository2
         Publish-PSResource -Path $ReqModule2ManifestPath -Repository $testRepository2

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -89,8 +89,6 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         }
 
         # Path to folder, within our test folder, where we store invalid module and script files used for testing
-        $testDir = (get-item $psscriptroot).parent.FullName
-
         $script:testFilesFolderPath = Join-Path $testDir -ChildPath "testFiles"
 
         # Path to specifically to that invalid test modules folder
@@ -100,7 +98,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $script:testScriptsFolderPath = Join-Path $script:testFilesFolderPath -ChildPath "testScripts"
 
         # Create test module with missing required module
-        #CreateTestModule -Path $TestDrive -ModuleName 'ModuleWithMissingRequiredModule'
+        CreateTestModule -Path $TestDrive -ModuleName 'ModuleWithMissingRequiredModule'
     }
     AfterAll {
        Get-RevertPSResourceRepositoryFile

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -4,6 +4,8 @@
 $modPath = "$psscriptroot/../PSGetTestUtils.psm1"
 Import-Module $modPath -Force -Verbose
 
+$testDir = (get-item $psscriptroot).parent.FullName
+
 function CreateTestModule
 {
     param (

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -89,6 +89,8 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         }
 
         # Path to folder, within our test folder, where we store invalid module and script files used for testing
+        $testDir = (get-item $psscriptroot).parent.FullName
+
         $script:testFilesFolderPath = Join-Path $testDir -ChildPath "testFiles"
 
         # Path to specifically to that invalid test modules folder
@@ -98,7 +100,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $script:testScriptsFolderPath = Join-Path $script:testFilesFolderPath -ChildPath "testScripts"
 
         # Create test module with missing required module
-        CreateTestModule -Path $TestDrive -ModuleName 'ModuleWithMissingRequiredModule'
+        #CreateTestModule -Path $TestDrive -ModuleName 'ModuleWithMissingRequiredModule'
     }
     AfterAll {
        Get-RevertPSResourceRepositoryFile
@@ -691,12 +693,16 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         New-Item $ReqModule2Root -ItemType Directory
         $ReqModule2ManifestPath = Join-Path -Path $reqModule2Root -ChildPath "$ReqModule2Name.psd1"
 
-        New-ModuleManifest -Path $ModuleManifestPath -ModuleVersion $ModuleVersion -Description "$ModuleName module" -RequiredModules @( @{"ModuleName" = $ReqModule1Name; "ModuleVersion" = $ReqModule1Version},  $ReqModule2Name )
+        New-ModuleManifest -Path $ModuleManifestPath -ModuleVersion $ModuleVersion -Description "$ModuleName module" -RequiredModules @( @{ "ModuleName" = $ReqModule1Name; "ModuleVersion" = $ReqModule1Version },  $ReqModule2Name )
         New-ModuleManifest -Path $ReqModule1ManifestPath -ModuleVersion $ReqModule1Version -Description "$ReqModule1Name module"
         New-ModuleManifest -Path $ReqModule2ManifestPath -Description "$ReqModule1Name module"
-
+        
         Publish-PSResource -Path $ReqModule1ManifestPath -Repository $testRepository2
         Publish-PSResource -Path $ReqModule2ManifestPath -Repository $testRepository2
+
+        Install-PSResource $ReqModule1Name -Repository $testRepository2 -TrustRepository
+        Install-PSResource $ReqModule2Name -Repository $testRepository2 -TrustRepository
+
         Publish-PSResource -Path $ModuleManifestPath -Repository $testRepository2
 
         $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$ModuleName.$ModuleVersion.nupkg"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
RequiredModules were not being parsed correctly from a module manifest during publish time, thus when, for example, RequiredModules contained both a Hashtable and a string, the hashtable would be parsed as a string and incorrectly assume the module name was "System.Collections.Hashtable".  This PR loops through every element of RequiredModules and tries to parse each object individually instead of assuming that all types within RequiredModules are the same and attempting to parse the object as a whole. 

## PR Context
Resolves #1305 

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
