### PR TITLE
Bug fix for searching through multiple repositories, some of which do not contain pkg to find

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -150,10 +150,20 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 _cmdletPassedIn.WriteVerbose(string.Format("Searching in repository {0}", repositoriesToSearch[i].Name));
 
+                bool pkgFound = false;
                 foreach (PSResourceInfo currentPkg in SearchByNames(currentServer, currentResponseUtil, currentRepository))
                 {
+                    pkgFound = currentPkg != null;
                     yield return currentPkg;
-                }   
+                }
+
+                if (!pkgFound) {
+                    _cmdletPassedIn.WriteError(new ErrorRecord(
+                                new ResourceNotFoundException($"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' cound not be found in any registered repositories."),
+                                "PackageNotFound",
+                                ErrorCategory.ObjectNotFound,
+                                this));
+                }
             }
         }
 

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -158,7 +158,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
             }
 
-            if (!pkgFound)
+            // Do not write out error message if -Name "*"
+            if (!pkgFound && !_pkgsLeftToFind.Contains("*"))
             {
                 _cmdletPassedIn.WriteError(new ErrorRecord(
                             new ResourceNotFoundException($"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' cound not be found in any registered repositories."),

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -280,11 +280,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                     {
-                        _cmdletPassedIn.WriteError(new ErrorRecord(
-                                    new PackageNotFoundException($"'{tag}' could not be found", currentResult.exception), 
+                        errRecord = new ErrorRecord(
+                                    new ResourceNotFoundException($"'{tag}' could not be found", currentResult.exception), 
                                     "FindCmdOrDscToPSResourceObjFailure", 
                                     ErrorCategory.NotSpecified, 
-                                    this));
+                                    this);
+
+                        _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
+                        
                         continue;
                     }
 
@@ -414,11 +417,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                     {
-                        _cmdletPassedIn.WriteError(new ErrorRecord(
-                                    new PackageNotFoundException($"Tags '{String.Join(", ", _tag)}' could not be found" , currentResult.exception), 
+                        errRecord = new ErrorRecord(
+                                    new ResourceNotFoundException($"Tags '{String.Join(", ", _tag)}' could not be found" , currentResult.exception), 
                                     "FindTagConvertToPSResourceFailure", 
                                     ErrorCategory.InvalidResult, 
-                                    this));
+                                    this);
+
+                        _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
+
                         continue;
                     }
 
@@ -461,11 +467,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         {
                             if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                             {
-                                _cmdletPassedIn.WriteError(new ErrorRecord(
-                                            new PackageNotFoundException($"Package '{pkgName}' could not be found", currentResult.exception), 
-                                            "FindAllConvertToPSResourceFailure", 
-                                            ErrorCategory.InvalidResult, 
-                                            this));
+                               _cmdletPassedIn.WriteVerbose($"Package '{pkgName}' could not be found");
                                 continue;
                             }
 
@@ -516,12 +518,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             {
                                 // write warning?
                                 string message = _tag.Length == 0 ? $"Package '{pkgName}' could not be found." : $"Package '{pkgName}' with tags '{tagsAsString}' could not be found.";
-
-                                _cmdletPassedIn.WriteError(new ErrorRecord(
-                                            new PackageNotFoundException(message, currentResult.exception), 
+                                errRecord = new ErrorRecord(
+                                            new ResourceNotFoundException(message, currentResult.exception), 
                                             "FindNameGlobbingConvertToPSResourceFailure", 
                                             ErrorCategory.InvalidResult, 
-                                            this));
+                                            this);
+                                
+                                _cmdletPassedIn.WriteVerbose(message);
+
                                 continue;
                             }
 
@@ -568,11 +572,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         {
                             string message = _tag.Length == 0 ? $"Package '{pkgName}' could not be found." : $"Package '{pkgName}' with tags '{tagsAsString}' could not be found.";
 
-                            _cmdletPassedIn.WriteError(new ErrorRecord(
-                                        new PackageNotFoundException(message, currentResult.exception), 
-                                        "FindNameConvertToPSResourceFailure", 
-                                        ErrorCategory.InvalidResult, 
-                                        this));
+                            _cmdletPassedIn.WriteVerbose(message);
+
                             continue;
                         }
 
@@ -627,11 +628,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         
                         if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                         {
-                            _cmdletPassedIn.WriteError(new ErrorRecord(
-                                        new PackageNotFoundException($"Package '{pkgName}' with version '{_version}', and tags '{tagMsg}' could not be found", currentResult.exception), 
+                            errRecord = new ErrorRecord(
+                                        new ResourceNotFoundException($"Package '{pkgName}' with version '{_version}', and tags '{tagMsg}' could not be found", currentResult.exception), 
                                         "FindNameConvertToPSResourceFailure", 
-                                        ErrorCategory.NotSpecified, 
-                                        this));
+                                        ErrorCategory.InvalidResult, 
+                                        this);
+
+                            _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
+                            
                             continue;
                         }
 
@@ -685,12 +689,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         {
                             if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                             {
-                                // write warning?
-                                _cmdletPassedIn.WriteError(new ErrorRecord(
-                                            new PackageNotFoundException($"Package '{pkgName}' with version '{_version}' could not be found", currentResult.exception), 
+                                errRecord = new ErrorRecord(
+                                            new ResourceNotFoundException($"Package '{pkgName}' with version '{_version}' could not be found", currentResult.exception), 
                                             "FindNameConvertToPSResourceFailure", 
                                             ErrorCategory.InvalidResult, 
-                                            this));
+                                            this);
+                                
+                                _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
+
                                 continue;
                             }
 
@@ -773,7 +779,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                         {
                             _cmdletPassedIn.WriteError(new ErrorRecord(
-                                        new PackageNotFoundException($"Dependency package '{dep.Name}' could not be found in repository '{repository.Name}'", currentResult.exception), 
+                                        new ResourceNotFoundException($"Dependency package '{dep.Name}' could not be found in repository '{repository.Name}'", currentResult.exception), 
                                         "DependencyPackageNotFound", 
                                         ErrorCategory.ObjectNotFound, 
                                         this));
@@ -823,8 +829,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         {
                             if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                             {
-                                 _cmdletPassedIn.WriteError(new ErrorRecord(
-                                            new PackageNotFoundException($"Dependency package '{dep.Name}' with version range '{dep.VersionRange}' could not be found in repository '{repository.Name}'", currentResult.exception), 
+                                _cmdletPassedIn.WriteError(new ErrorRecord(
+                                            new ResourceNotFoundException($"Dependency package '{dep.Name}' with version range '{dep.VersionRange}' could not be found in repository '{repository.Name}'", currentResult.exception), 
                                             "DependencyPackageNotFound", 
                                             ErrorCategory.ObjectNotFound, 
                                             this));

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -158,8 +158,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (currentPkg == null) {
                         continue;
                     }
+
                     pkgFound = true;
-                    
                     yield return currentPkg;
                 }
             }

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -129,6 +129,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 yield break;
             }
 
+            bool pkgFound = false;
             for (int i = 0; i < repositoriesToSearch.Count && _pkgsLeftToFind.Count > 0 ; i++)
             {
                 PSRepositoryInfo currentRepository = repositoriesToSearch[i];
@@ -150,20 +151,20 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 _cmdletPassedIn.WriteVerbose(string.Format("Searching in repository {0}", repositoriesToSearch[i].Name));
 
-                bool pkgFound = false;
                 foreach (PSResourceInfo currentPkg in SearchByNames(currentServer, currentResponseUtil, currentRepository))
                 {
                     pkgFound = currentPkg != null;
                     yield return currentPkg;
                 }
+            }
 
-                if (!pkgFound) {
-                    _cmdletPassedIn.WriteError(new ErrorRecord(
-                                new ResourceNotFoundException($"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' cound not be found in any registered repositories."),
-                                "PackageNotFound",
-                                ErrorCategory.ObjectNotFound,
-                                this));
-                }
+            if (!pkgFound)
+            {
+                _cmdletPassedIn.WriteError(new ErrorRecord(
+                            new ResourceNotFoundException($"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' cound not be found in any registered repositories."),
+                            "PackageNotFound",
+                            ErrorCategory.ObjectNotFound,
+                            this));
             }
         }
 

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -478,7 +478,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         {
                             if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                             {
-                                _cmdletPassedIn.WriteVerbose($"Package '{pkgName}' could not be found in repository '{repository.Name}");
+                               _cmdletPassedIn.WriteVerbose($"Package '{pkgName}' could not be found in repository '{repository.Name}");
                                 continue;
                             }
 

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -516,7 +516,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         {
                             if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                             {
-                                // write warning?
                                 string message = _tag.Length == 0 ? $"Package '{pkgName}' could not be found." : $"Package '{pkgName}' with tags '{tagsAsString}' could not be found.";
                                 errRecord = new ErrorRecord(
                                             new ResourceNotFoundException(message, currentResult.exception), 

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -255,7 +255,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 FindResults responses = currentServer.FindCommandOrDscResource(tag, _prerelease, isSearchingForCommands, out ErrorRecord errRecord);
                 if (errRecord != null)
                 {
-                    _cmdletPassedIn.WriteError(errRecord);
+                    if (errRecord.Exception is ResourceNotFoundException)
+                    {
+                        _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
+                    }
+                    else {
+                        _cmdletPassedIn.WriteError(errRecord);
+                    }
                     continue;
                 }
 
@@ -383,7 +389,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 if (errRecord != null)
                 {
-                    _cmdletPassedIn.WriteError(errRecord);
+                    if (errRecord.Exception is ResourceNotFoundException)
+                    {
+                        _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
+                    }
+                    else {
+                        _cmdletPassedIn.WriteError(errRecord);
+                    }
                     continue;
                 }
 
@@ -424,7 +436,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         FindResults responses = currentServer.FindAll(_prerelease, _type, out errRecord);
                         if (errRecord != null)
                         {
-                            _cmdletPassedIn.WriteError(errRecord);
+                            if (errRecord.Exception is ResourceNotFoundException)
+                            {
+                                _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
+                            }
+                            else {
+                                _cmdletPassedIn.WriteError(errRecord);
+                            }
                             continue;
                         }
 
@@ -471,7 +489,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         if (errRecord != null)
                         {
-                            _cmdletPassedIn.WriteError(errRecord);
+                            if (errRecord.Exception is ResourceNotFoundException)
+                            {
+                                _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
+                            }
+                            else {
+                                _cmdletPassedIn.WriteError(errRecord);
+                            }
                             continue;
                         }
 
@@ -517,7 +541,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         if (errRecord != null)
                         {
-                            _cmdletPassedIn.WriteError(errRecord);
+                            if (errRecord.Exception is ResourceNotFoundException)
+                            {
+                                _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
+                            }
+                            else {
+                                _cmdletPassedIn.WriteError(errRecord);
+                            }
                             continue;
                         }
 
@@ -572,7 +602,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         if (errRecord != null)
                         {
-                            _cmdletPassedIn.WriteError(errRecord);
+                            if (errRecord.Exception is ResourceNotFoundException)
+                            {
+                                _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
+                            }
+                            else {
+                                _cmdletPassedIn.WriteError(errRecord);
+                            }
                             continue;
                         }
 
@@ -624,7 +660,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         if (errRecord != null)
                         {
-                            _cmdletPassedIn.WriteError(errRecord);
+                            if (errRecord.Exception is ResourceNotFoundException)
+                            {
+                                _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
+                            }
+                            else {
+                                _cmdletPassedIn.WriteError(errRecord);
+                            }
                             continue;
                         }
 
@@ -704,7 +746,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         FindResults responses = currentServer.FindName(dep.Name, _prerelease, _type, out ErrorRecord errRecord);
                         if (errRecord != null)
                         {
-                            _cmdletPassedIn.WriteError(errRecord);
+                            if (errRecord.Exception is ResourceNotFoundException)
+                            {
+                                _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
+                            }
+                            else {
+                                _cmdletPassedIn.WriteError(errRecord);
+                            }
                             yield return null;
                             continue;
                         }
@@ -738,7 +786,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         FindResults responses = currentServer.FindVersionGlobbing(dep.Name, dep.VersionRange, _prerelease, ResourceType.None, getOnlyLatest: true, out ErrorRecord errRecord);
                         if (errRecord != null)
                         {
-                            _cmdletPassedIn.WriteError(errRecord);
+                            if (errRecord.Exception is ResourceNotFoundException)
+                            {
+                                _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
+                            }
+                            else {
+                                _cmdletPassedIn.WriteError(errRecord);
+                            }
                             yield return null;
                             continue;
                         }

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -167,7 +167,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // Do not write out error message if -Name "*"
             if (!pkgFound && !_pkgsLeftToFind.Contains("*"))
             {
-                var msg = repository.Length == 0 ? $"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' could not be found in any registered repositories." : $"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' could not be found in registered repositories: '{string.Join(", ", repositoryNamesToSearch)}'.";
+                var msg = repository == null ? $"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' could not be found in any registered repositories." : 
+                    $"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' could not be found in registered repositories: '{string.Join(", ", repositoryNamesToSearch)}'.";
 
                 _cmdletPassedIn.WriteError(new ErrorRecord(
                             new ResourceNotFoundException(msg),

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -130,9 +130,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             bool pkgFound = false;
+            List<string> repositoryNamesToSearch = new List<string>();
             for (int i = 0; i < repositoriesToSearch.Count && _pkgsLeftToFind.Count > 0 ; i++)
             {
                 PSRepositoryInfo currentRepository = repositoriesToSearch[i];
+                repositoryNamesToSearch.Add(currentRepository.Name);
                 _networkCredential = Utils.SetNetworkCredential(currentRepository, _networkCredential, _cmdletPassedIn);
                 ServerApiCall currentServer = ServerFactory.GetServer(currentRepository, _networkCredential);
                 if (currentServer == null)
@@ -165,8 +167,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // Do not write out error message if -Name "*"
             if (!pkgFound && !_pkgsLeftToFind.Contains("*"))
             {
-                var msg = string.IsNullOrWhitespace(repository) ? $"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' could not be found in any registered repositories." :
-                             $"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' could not be found in registered repositories: '{string.Join(", ", repositoriesToSearch}'.";
+                var msg = repository.Length == 0 ? $"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' could not be found in any registered repositories." : $"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' could not be found in registered repositories: '{string.Join(", ", repositoryNamesToSearch)}'.";
 
                 _cmdletPassedIn.WriteError(new ErrorRecord(
                             new ResourceNotFoundException(msg),

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -162,7 +162,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (!pkgFound && !_pkgsLeftToFind.Contains("*"))
             {
                 _cmdletPassedIn.WriteError(new ErrorRecord(
-                            new ResourceNotFoundException($"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' cound not be found in any registered repositories."),
+                            new ResourceNotFoundException($"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' could not be found in any registered repositories."),
                             "PackageNotFound",
                             ErrorCategory.ObjectNotFound,
                             this));

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -153,7 +153,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 foreach (PSResourceInfo currentPkg in SearchByNames(currentServer, currentResponseUtil, currentRepository))
                 {
-                    pkgFound = currentPkg != null;
+                    if (currentPkg == null) {
+                        continue;
+                    }
+                    pkgFound = true;
+                    
                     yield return currentPkg;
                 }
             }

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -161,8 +161,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // Do not write out error message if -Name "*"
             if (!pkgFound && !_pkgsLeftToFind.Contains("*"))
             {
+                var msg = string.IsNullOrWhitespace(repository) ? $"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' could not be found in any registered repositories." :
+                             $"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' could not be found in registered repositories: '{string.Join(", ", repositoriesToSearch}'.";
+
                 _cmdletPassedIn.WriteError(new ErrorRecord(
-                            new ResourceNotFoundException($"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' could not be found in any registered repositories."),
+                            new ResourceNotFoundException(msg),
                             "PackageNotFound",
                             ErrorCategory.ObjectNotFound,
                             this));
@@ -469,7 +472,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         {
                             if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                             {
-                               _cmdletPassedIn.WriteVerbose($"Package '{pkgName}' could not be found");
+                                _cmdletPassedIn.WriteVerbose($"Package '{pkgName}' could not be found in repository '{repository.Name}");
                                 continue;
                             }
 

--- a/src/code/GetInstalledPSResource.cs
+++ b/src/code/GetInstalledPSResource.cs
@@ -185,7 +185,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (pkgsNotFound.Count > 0)
             {
                 WriteError(new ErrorRecord(
-                    new PackageNotFoundException($"No match was found for package '{string.Join(", ", pkgsNotFound)}'."),
+                    new ResourceNotFoundException($"No match was found for package '{string.Join(", ", pkgsNotFound)}'."),
                     "InstalledPackageNotFound",
                     ErrorCategory.ObjectNotFound,
                     this));

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -353,7 +353,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // this condition will be true, for FindNameWithTags() when package satisfying that criteria is not met
             if (pkgMetadata.Count == 0)
             {
-                errRecord = new ErrorRecord(new SpecifiedTagsNotFoundException($"Package with name '{packageName}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), "FindNameFailure", ErrorCategory.ResourceUnavailable, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), "FindNameFailure", ErrorCategory.ResourceUnavailable, this);
             }
 
             findResponse = new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: new Hashtable[]{pkgMetadata}, responseType: _localServerFindResponseType);
@@ -444,7 +444,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // this condition will be true, for FindVersionWithTags() when package satisfying that criteria is not met
             if (pkgMetadata.Count == 0)
             {
-                errRecord = new ErrorRecord(new SpecifiedTagsNotFoundException($"Package with name '{packageName}', and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), "FindVersionFailure", ErrorCategory.InvalidResult, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}', and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), "FindVersionFailure", ErrorCategory.InvalidResult, this);
             }
 
             findResponse = new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: new Hashtable[]{pkgMetadata}, responseType: _localServerFindResponseType);

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -340,7 +340,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (String.IsNullOrEmpty(latestVersionPath))
             {
                 // means no package was found with this name
-                errRecord = new ErrorRecord(new LocalResourceNotFoundException($"Package with name {packageName} could not be found in repository '{Repository.Name}'."), "FindNameFailure", ErrorCategory.ResourceUnavailable, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name {packageName} could not be found in repository '{Repository.Name}'."), "FindNameFailure", ErrorCategory.ResourceUnavailable, this);
                 return findResponse;
             }
 
@@ -431,7 +431,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (String.IsNullOrEmpty(pkgPath))
             {
                 // means no package was found with this name, version (and possibly tags).
-                errRecord = new ErrorRecord(new LocalResourceNotFoundException($"Package with name '{packageName}', version '{version}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), "FindVersionFailure", ErrorCategory.ResourceUnavailable, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}', version '{version}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), "FindVersionFailure", ErrorCategory.ResourceUnavailable, this);
                 return findResponse;
             }
 

--- a/src/code/NuGetServerResponseUtil.cs
+++ b/src/code/NuGetServerResponseUtil.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (elemList.Length == 0)
                 {
                     // this indicates we got a non-empty, XML response (as noticed for V2 server) but it's not a response that's meaningful (contains 'properties')
-                    Exception notFoundException = new V2ResourceNotFoundException("Package does not exist on the server");
+                    Exception notFoundException = new ResourceNotFoundException("Package does not exist on the server");
 
                     yield return new PSResourceResult(returnedObject: null, exception: notFoundException, isTerminatingError: false);
                 }

--- a/src/code/PSGetException.cs
+++ b/src/code/PSGetException.cs
@@ -13,14 +13,6 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         }
     }
 
-    public class PackageNotFoundException : Exception
-    {
-        public PackageNotFoundException(string message, Exception innerException = null)
-            : base(message, innerException)
-        {
-        }
-    }
-
     public class UnauthorizedException : Exception
     {
         public UnauthorizedException(string message, Exception innerException = null)

--- a/src/code/PSGetException.cs
+++ b/src/code/PSGetException.cs
@@ -5,17 +5,9 @@ using System;
 
 namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 {
-    public class V3ResourceNotFoundException : Exception
+    public class ResourceNotFoundException : Exception
     {
-        public V3ResourceNotFoundException(string message, Exception innerException = null)
-            : base (message, innerException)
-        {
-        }
-    }
-
-    public class V2ResourceNotFoundException : Exception
-    {
-        public V2ResourceNotFoundException(string message, Exception innerException = null)
+        public ResourceNotFoundException(string message, Exception innerException = null)
             : base(message, innerException)
         {
         }

--- a/src/code/PSGetException.cs
+++ b/src/code/PSGetException.cs
@@ -45,14 +45,6 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         }
     }
 
-    public class SpecifiedTagsNotFoundException : Exception
-    {
-        public SpecifiedTagsNotFoundException(string message, Exception innerException = null)
-            : base (message)
-        {
-        }
-    }
-
     public class InvalidOrEmptyResponse : Exception
     {
         public InvalidOrEmptyResponse(string message, Exception innerException = null)

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -192,7 +192,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
 
                 errRecords.Add(new ErrorRecord(
-                    new PackageNotFoundException(message),
+                    new ResourceNotFoundException(message),
                     "ResourceNotInstalled",
                     ErrorCategory.ObjectNotFound,
                     this));

--- a/src/code/V2ResponseUtil.cs
+++ b/src/code/V2ResponseUtil.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (elemList.Length == 0)
                 {
                     // this indicates we got a non-empty, XML response (as noticed for V2 server) but it's not a response that's meaningful (contains 'properties')
-                    Exception notFoundException = new V2ResourceNotFoundException("Package does not exist on the server");
+                    Exception notFoundException = new ResourceNotFoundException("Package does not exist on the server");
 
                     yield return new PSResourceResult(returnedObject: null, exception: notFoundException, isTerminatingError: false);
                 }

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -931,8 +931,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // ADO feed will return a 401 if a package does not exist on the feed, with the following message:
                 // 401 (Unauthorized - No local versions of package 'NonExistentModule'; please provide authentication to access
                 // versions from upstream that have not yet been saved to your feed. (DevOps Activity ID: 5E5CF528-5B3D-481D-95B5-5DDB5476D7EF))
-                if (responseStatusCode.Equals(HttpStatusCode.Unauthorized) && !e.Message.Contains("access versions from upstream that have not yet been saved to your feed"))
+                if (responseStatusCode.Equals(HttpStatusCode.Unauthorized))
                 {
+                    if (e.Message.Contains("access versions from upstream that have not yet been saved to your feed"))
+                    {
+                        throw new ResourceNotFoundException(Utils.FormatRequestsExceptions(e, message));
+                    }
+
                     throw new UnauthorizedException(Utils.FormatCredentialRequestExceptions(e));
                 }
 

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -518,7 +518,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 response = SendV2RequestAsync(request, _sessionClient).GetAwaiter().GetResult();
             }
-            catch (V3ResourceNotFoundException e)
+            catch (ResourceNotFoundException e)
             {
                 errRecord = new ErrorRecord(e, "ResourceNotFound", ErrorCategory.InvalidResult, this);
             }
@@ -926,7 +926,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 if (responseStatusCode.Equals(HttpStatusCode.NotFound))
                 {
-                    throw new V2ResourceNotFoundException(Utils.FormatRequestsExceptions(e, message));
+                    throw new ResourceNotFoundException(Utils.FormatRequestsExceptions(e, message));
                 }
                 // ADO feed will return a 401 if a package does not exist on the feed, with the following message:
                 // 401 (Unauthorized - No local versions of package 'NonExistentModule'; please provide authentication to access
@@ -965,7 +965,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 if (responseStatusCode.Equals(HttpStatusCode.NotFound))
                 {
-                    throw new V2ResourceNotFoundException(Utils.FormatRequestsExceptions(e, message));
+                    throw new ResourceNotFoundException(Utils.FormatRequestsExceptions(e, message));
                 }
                 if (responseStatusCode.Equals(HttpStatusCode.Unauthorized))
                 {

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -445,7 +445,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (String.IsNullOrEmpty(latestVersionResponse))
             {
                 string errMsg = $"Package with name '{packageName}' could not be found in repository '{Repository.Name}'.";
-                errRecord = new ErrorRecord(new SpecifiedTagsNotFoundException(errMsg), "FindNameFailure", ErrorCategory.InvalidResult, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "FindNameFailure", ErrorCategory.InvalidResult, this);
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
 
@@ -455,7 +455,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (errRecord == null)
                 {
                     string errMsg = $"Package with name '{packageName}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'.";
-                    errRecord = new ErrorRecord(new SpecifiedTagsNotFoundException(errMsg), "FindNameFailure", ErrorCategory.InvalidResult, this);
+                    errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "FindNameFailure", ErrorCategory.InvalidResult, this);
                 }
 
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -521,7 +521,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (String.IsNullOrEmpty(latestVersionResponse))
             {
-                errRecord = new ErrorRecord(new InvalidOrEmptyResponse($"Package with name '{packageName}', version '{version}' could not be found in repository '{Repository.Name}'"), "FindVersionFailure", ErrorCategory.InvalidResult, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}', version '{version}' could not be found in repository '{Repository.Name}'"), "FindVersionFailure", ErrorCategory.InvalidResult, this);
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
 
@@ -530,7 +530,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (errRecord == null)
                 {
                     string errMsg = $"FindVersion(): Package with name '{packageName}', version '{version}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'.";
-                    errRecord = new ErrorRecord(new SpecifiedTagsNotFoundException(errMsg), "FindVersionFailure", ErrorCategory.InvalidResult, this);
+                    errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "FindVersionFailure", ErrorCategory.InvalidResult, this);
                 }
 
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -828,7 +828,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     JsonElement rootDom = metadataEntries.RootElement;
                     if (!rootDom.TryGetProperty(itemsName, out JsonElement innerItemsElement))
                     {
-                        errRecord = new ErrorRecord(new ArgumentException($"'{itemsName}' element for package with name '{packageName}' could not be found in JFrog repository '{Repository.Name}'"), "GetElementForJFrogRepoFailure", ErrorCategory.InvalidResult, this);
+                        errRecord = new ErrorRecord(new ResourceNotFoundException($"'{itemsName}' element for package with name '{packageName}' could not be found in JFrog repository '{Repository.Name}'"), "GetElementForJFrogRepoFailure", ErrorCategory.InvalidResult, this);
                         return metadataElement;
                     }
 

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -1215,8 +1215,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // ADO feed will return a 401 if a package does not exist on the feed, with the following message:
                 // 401 (Unauthorized - No local versions of package 'NonExistentModule'; please provide authentication to access
                 // versions from upstream that have not yet been saved to your feed. (DevOps Activity ID: 5E5CF528-5B3D-481D-95B5-5DDB5476D7EF))
-                if (responseStatusCode.Equals(HttpStatusCode.Unauthorized) && !e.Message.Contains("access versions from upstream that have not yet been saved to your feed"))
+                if (responseStatusCode.Equals(HttpStatusCode.Unauthorized))
                 {
+                    if (e.Message.Contains("access versions from upstream that have not yet been saved to your feed"))
+                    {
+                        throw new ResourceNotFoundException(Utils.FormatRequestsExceptions(e, message));
+                    }
+
                     throw new UnauthorizedException(Utils.FormatCredentialRequestExceptions(e));
                 }
 

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -758,7 +758,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             else
             {
-                errRecord = new ErrorRecord(new V3ResourceNotFoundException($"RegistrationBaseUrl resource could not be found for repository '{Repository.Name}'"), "FindRegistrationsBaseUrlFailure", ErrorCategory.InvalidResult, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException($"RegistrationBaseUrl resource could not be found for repository '{Repository.Name}'"), "FindRegistrationsBaseUrlFailure", ErrorCategory.InvalidResult, this);
             }
 
             return registrationsBaseUrl;
@@ -791,7 +791,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             else
             {
-                errRecord = new ErrorRecord(new V3ResourceNotFoundException($"SearchQueryService resource could not be found for Repository '{Repository.Name}'"), "FindSearchQueryServiceFailure", ErrorCategory.InvalidResult, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException($"SearchQueryService resource could not be found for Repository '{Repository.Name}'"), "FindSearchQueryServiceFailure", ErrorCategory.InvalidResult, this);
             }
 
             return searchQueryServiceUrl;
@@ -814,8 +814,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string response = HttpRequestCall(metadataUri, out errRecord);
             if (errRecord != null)
             {
-                if (errRecord.Exception is V3ResourceNotFoundException) {
-                    errRecord = new ErrorRecord(new V3ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}'", errRecord.Exception), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
+                if (errRecord.Exception is ResourceNotFoundException) {
+                    errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}'", errRecord.Exception), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
                 }
 
                 return metadataElement;
@@ -861,9 +861,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string pkgMappingResponse = HttpRequestCall(requestPkgMapping, out errRecord);
             if (errRecord != null)
             {
-                if (errRecord.Exception is V3ResourceNotFoundException)
+                if (errRecord.Exception is ResourceNotFoundException)
                 {
-                    errRecord = new ErrorRecord(new V3ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}'", errRecord.Exception), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
+                    errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}'", errRecord.Exception), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
                 }
 
                 return Utils.EmptyStrArray;
@@ -1150,7 +1150,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 response = SendV3RequestAsync(request, _sessionClient).GetAwaiter().GetResult();
             }
-            catch (V3ResourceNotFoundException e)
+            catch (ResourceNotFoundException e)
             {
                 errRecord = new ErrorRecord(e, "ResourceNotFound", ErrorCategory.InvalidResult, this);
             }
@@ -1210,7 +1210,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             catch (HttpRequestException e)
             {
                 if (responseStatusCode.Equals(HttpStatusCode.NotFound)) {
-                    throw new V3ResourceNotFoundException(Utils.FormatRequestsExceptions(e, message));
+                    throw new ResourceNotFoundException(Utils.FormatRequestsExceptions(e, message));
                 }
                 // ADO feed will return a 401 if a package does not exist on the feed, with the following message:
                 // 401 (Unauthorized - No local versions of package 'NonExistentModule'; please provide authentication to access
@@ -1250,7 +1250,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 if (responseStatusCode.Equals(HttpStatusCode.NotFound))
                 {
-                    throw new V3ResourceNotFoundException(Utils.FormatRequestsExceptions(e, message));
+                    throw new ResourceNotFoundException(Utils.FormatRequestsExceptions(e, message));
                 }
                 if (responseStatusCode.Equals(HttpStatusCode.Unauthorized))
                 {

--- a/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
@@ -109,7 +109,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name and Tag property (multiple tags)" {
@@ -127,7 +127,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTags -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resources when given Name with wildcard and Tag proprties" {
@@ -155,7 +155,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name, Version and Tag property (multiple tags)" {
@@ -175,7 +175,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTags -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resources given Tag property" {

--- a/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "HttpRequestCallFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 

--- a/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
@@ -115,7 +115,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name and Tag property (multiple tags)" {
@@ -133,7 +133,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTags -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find all resources that satisfy Name pattern and have specified Tag (single tag)" {
@@ -192,7 +192,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name, Version and Tag property (multiple tags)" {
@@ -212,7 +212,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTags -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resources given Tag property" {

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -77,7 +77,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $localRepo -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -150,7 +150,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $localRepo -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 
@@ -214,7 +214,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $localRepo -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -286,8 +286,8 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res.Tags | Should -Contain $requiredTag
     }
 
-    It "should not find resource if Name, Version and Tag property are not all satisfied (single tag)" {
-        # FindVersionWithTag()
+    It "" {
+        # FindVersionWithTag()should not find resource if Name, Version and Tag property are not all satisfied (single tag)
         $requiredTag = "windows" # tag "windows" is not present for test_module package
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
@@ -393,6 +393,21 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name "MyPackage" -Repository "UnknownTypeRepo" -ErrorAction SilentlyContinue -ErrorVariable err
         $err | Should -Not -BeNullOrEmpty
         $err[0].FullyQualifiedErrorId | Should -BeExactly "RepositoryApiVersionUnknown,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $res | Should -BeNullOrEmpty
+    }
+
+    It "find a module that does not exist in the highest priority repository, but does exist in a lower priority repository" {
+        $res = Find-PSResource -Name "NewpsGetTestModule" -ErrorVariable err
+        $res | Should -Not -BeNullOrEmpty
+        $res.Version | Should -Be "2.1.0"
+        $err.Count | Should -Be 0
+    }
+
+    It "should not find resource given nonexistant Name and no specified repository" {
+        $res = Find-PSResource -Name NonExistantModule -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -BeNullOrEmpty
+        $err.Count | Should -Be 1
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 }

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -215,7 +215,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name and Tag property (multiple tags)" {
@@ -292,7 +292,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name, Version and Tag property (multiple tags)" {

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -286,8 +286,8 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res.Tags | Should -Contain $requiredTag
     }
 
-    It "" {
-        # FindVersionWithTag()should not find resource if Name, Version and Tag property are not all satisfied (single tag)
+    It "should not find resource if Name, Version and Tag property are not all satisfied (single tag)" {
+        # FindVersionWithTag()
         $requiredTag = "windows" # tag "windows" is not present for test_module package
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -394,6 +394,8 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $err | Should -Not -BeNullOrEmpty
         $err[0].FullyQualifiedErrorId | Should -BeExactly "RepositoryApiVersionUnknown,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
+
+        Unregister-PSResourceRepository -Name "UnknownTypeRepo"
     }
 
     It "find a module that does not exist in the highest priority repository, but does exist in a lower priority repository" {

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -34,7 +34,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 
@@ -233,7 +233,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTags -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find all resources that satisfy Name pattern and have specified Tag (single tag)" {
@@ -312,7 +312,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTags -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     # It "find all resources with specified tag given Tag property" {
@@ -391,7 +391,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $repo.ApiVersion | Should -Be "unknown"
 
         $res = Find-PSResource -Name "MyPackage" -Repository "UnknownTypeRepo" -ErrorAction SilentlyContinue -ErrorVariable err
-        $err | Should -HaveCount 1
+        $err | Should -Not -BeNullOrEmpty
         $err[0].FullyQualifiedErrorId | Should -BeExactly "RepositoryApiVersionUnknown,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }

--- a/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
@@ -124,7 +124,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name and Tag property (multiple tags)" {
@@ -142,7 +142,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTags -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find all resources that satisfy Name pattern and have specified Tag (single tag)" {
@@ -201,7 +201,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name, Version and Tag property (multiple tags)" {
@@ -221,7 +221,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTags -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     # It "find all resources with specified tag given Tag property" {
@@ -273,7 +273,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name "PMTestDependency1" -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
     
     # "carb*" is intentionally chosen as a sequence that will trigger pagination (ie more than 100 results),

--- a/test/InstallPSResourceTests/InstallPSResourceADOServer.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceADOServer.Tests.ps1
@@ -64,7 +64,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
         $pkg = Get-InstalledPSResource "NonExistantModule"
         $pkg | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "HttpRequestCallFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
     }
 
     # Do some version testing, but Find-PSResource should be doing thorough testing

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -287,7 +287,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $dependencyVersion = "2.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module" -RequiredModules @(@{ModuleName = 'PackageManagement'; ModuleVersion = '1.4.4' })
 
-        {Publish-PSResource -Path $script:PublishModuleBase -ErrorAction Stop} | Should -Throw -ErrorId "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
+        {Publish-PSResource -Path $script:PublishModuleBase -ErrorAction Stop} | Should -Throw -ErrorId "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
     }
 
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
When `Find-PSResource` searches through multiple repositories, it was previously writing errors for each repository it could not find the given package in along side the package information from the repository where it could find it.

If a package does exist in at least one repository, the changes in this PR will not write errors from the repositories where the package does not exist and instead writes verbose messages and still display package info for the repo where it is found.

If a package does not exist in any repositories, a message that states: "Package(s) '<PackageName>' could not be found in any registered repositories."  will be displayed, along with any other errors unrelated to the package not being found (such as unauthorized exceptions).

## PR Context

Resolves the first part of issue #1286 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
