### PR TITLE
Update Find looping and error handling to account for multiple package names

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -771,7 +771,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         /// <summary>
         /// Iterates over package names passed in by user, and populates them into a dictionary used to track discovery and thereby error reporting
-        /// for package names without wildcard. For package names with wildcard that were provided we don't write errors so this value is set to true to ensure this.
+        /// for package names without wildcard.
         /// </summary>
         private Dictionary<string, bool> GetPackageNamesPopulated(string[] pkgNames)
         {
@@ -783,11 +783,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     // for name without wildcard, we will report error if not found, so by default set isPkgFound value is set to false and then updated during package discovery.
                     pkgsToDiscover.Add(name, false);
-                }
-                else if (name.Contains("*") && !pkgsToDiscover.ContainsKey(name))
-                {
-                    // we will never report 'package not found' errors for package names with wildcards, so can set the isFound value to true so no error is reported.
-                    pkgsToDiscover.Add(name, true);
                 }
             }
 

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -758,7 +758,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             HashSet<string> pkgsToDiscover = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (string name in pkgNames)
             {
-                if (!name.Contains("*") && !pkgsToDiscover.Contains(name))
+                if (!name.Contains("*"))
                 {
                     pkgsToDiscover.Add(name);
                 }

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -187,21 +187,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                 this));
                 }
             }
-
-            /**
-            // Do not write out error message if -Name "*"
-            if (!pkgFound && !_pkgsLeftToFind.Contains("*"))
-            {
-                var msg = repository == null ? $"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' could not be found in any registered repositories." : 
-                    $"Package(s) '{string.Join(", ", _pkgsLeftToFind)}' could not be found in registered repositories: '{string.Join(", ", repositoryNamesToSearch)}'.";
-
-                _cmdletPassedIn.WriteError(new ErrorRecord(
-                            new ResourceNotFoundException(msg),
-                            "PackageNotFound",
-                            ErrorCategory.ObjectNotFound,
-                            this));
-            }
-            */
         }
 
         public IEnumerable<PSCommandResourceInfo> FindByCommandOrDscResource(

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -412,6 +412,16 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
+
+    It "should find resource and write error for other resource not found when multiple packages are specified" {
+        $res = Find-PSResource -Name $testModuleName,"NonExistantModule" -ErrorVariable err -ErrorAction SilentlyContinue
+        $res.Name | Should -Be $testModuleName
+        $res.Repository | Should -Be $PSGalleryName
+
+        $err.Count | Should -Be 1
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $res | Should -BeNullOrEmpty        
+    }
 }
 
 Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'ManualValidationOnly' {

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -420,7 +420,6 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
 
         $err.Count | Should -Be 1
         $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
-        $res | Should -BeNullOrEmpty        
     }
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Find-PSResource -Name "test_module","nonexistantPkg"
-> should return package test_module as found, but write error for nonexistantPkg. Previously we were not handling errors for multiple package names where one was not found.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
