### PR TITLE
fix find repo looping to not use highest priority repo matching

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -763,8 +763,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         {
                             errRecord = new ErrorRecord(
                                         new ResourceNotFoundException($"Package with name '{pkgName}', version '{_version}', and tags '{tagsAsString}' could not be found in repository '{repository.Name}'", currentResult.exception), 
-                                        "FindNameConvertToPSResourceFailure", 
-                                        ErrorCategory.InvalidResult, 
+                                        "PackageNotFound", 
+                                        ErrorCategory.ObjectNotFound, 
                                         this);
 
                             if (shouldReportError)
@@ -835,8 +835,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             {
                                 errRecord = new ErrorRecord(
                                             new ResourceNotFoundException($"Package with name '{pkgName}' and version '{_version}' could not be found in repository '{repository.Name}'", currentResult.exception),
-                                            "FindNameConvertToPSResourceFailure", 
-                                            ErrorCategory.InvalidResult, 
+                                            "PackageNotFound", 
+                                            ErrorCategory.ObjectNotFound, 
                                             this);
 
                                 if (shouldReportError)

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -98,6 +98,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
 
                 // TODO: if repo names includes wildcards and nonwildcard names- write error and stop
+                // -Repository *Gallery, localRepo
                 bool containsWildcard = false;
                 bool containsNonWildcard = false;
                 foreach (string repoName in repository)
@@ -540,7 +541,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                 {
                                     _cmdletPassedIn.WriteError(new ErrorRecord(
                                         new ResourceNotFoundException($"Package '{pkgName}' could not be found in repository '{repository.Name}", currentResult.exception), 
-                                        "PackageNotFound", 
+                                        "FindAllConvertToPSResourceFailure", 
                                         ErrorCategory.ObjectNotFound, 
                                         this));
                                 }
@@ -611,7 +612,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                 string message = _tag.Length == 0 ? $"Package with name '{pkgName}' could not be found in repository '{repository.Name}'." : $"Package with name '{pkgName}' and tags '{tagsAsString}' could not be found in repository '{repository.Name}'.";
                                 errRecord = new ErrorRecord(
                                             new ResourceNotFoundException(message, currentResult.exception), 
-                                            "PackageNotFound", 
+                                            "FindNameGlobbingConvertToPSResourceFailure", 
                                             ErrorCategory.ObjectNotFound, 
                                             this);
 
@@ -682,7 +683,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             string message = _tag.Length == 0 ? $"Package with name '{pkgName}' could not be found in repository '{repository.Name}'." : $"Package with name '{pkgName}' and tags '{tagsAsString}' could not be found in repository '{repository.Name}'.";
                             errRecord = new ErrorRecord(
                                         new ResourceNotFoundException(message, currentResult.exception), 
-                                        "PackageNotFound", 
+                                        "FindNameConvertToPSResourceFailure", 
                                         ErrorCategory.ObjectNotFound, 
                                         this);
 
@@ -763,7 +764,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         {
                             errRecord = new ErrorRecord(
                                         new ResourceNotFoundException($"Package with name '{pkgName}', version '{_version}', and tags '{tagsAsString}' could not be found in repository '{repository.Name}'", currentResult.exception), 
-                                        "PackageNotFound", 
+                                        "FindVersionConvertToPSResourceFailure", 
                                         ErrorCategory.ObjectNotFound, 
                                         this);
 
@@ -835,7 +836,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             {
                                 errRecord = new ErrorRecord(
                                             new ResourceNotFoundException($"Package with name '{pkgName}' and version '{_version}' could not be found in repository '{repository.Name}'", currentResult.exception),
-                                            "PackageNotFound", 
+                                            "FindVersionGlobbingConvertToPSResourceFailure", 
                                             ErrorCategory.ObjectNotFound, 
                                             this);
 

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -62,7 +62,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             bool prerelease,
             string[] tag,
             string[] repository,
-            bool includeDependencies)
+            bool includeDependencies,
+            bool suppressErrors)
         {
             _type = type;
             _version = version;
@@ -190,7 +191,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 _cmdletPassedIn.WriteVerbose(string.Format("Searching in repository {0}", repositoriesToSearch[i].Name));
 
-                bool shouldReportErrorForEachRepo = !_repositoryNameContainsWildcard;
+                bool shouldReportErrorForEachRepo = !suppressErrors && !_repositoryNameContainsWildcard;
                 foreach (PSResourceInfo currentPkg in SearchByNames(currentServer, currentResponseUtil, currentRepository, shouldReportErrorForEachRepo: shouldReportErrorForEachRepo, isInstallOperation: false))
                 {
                     if (currentPkg == null) {
@@ -208,7 +209,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
             }
 
-            if (_repositoryNameContainsWildcard)
+            if (!suppressErrors && _repositoryNameContainsWildcard)
             {
                 // Scenarios: Find-PSResource -Name "pkg" -> write error only if pkg wasn't found in any registered repositories
                 // Scenarios: Find-PSResource -Name "pkg" -Repository *Gallery -> write error if only if pkg wasn't found in any matching repositories.

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -523,7 +523,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         foreach (PSResourceResult currentResult in currentResponseUtil.ConvertToPSResourceResult(responseResults: responses))
                         {
-                            // Note: this currently catches for V2ServerApiCalls. TODO: eventually move off this.
+                            // This currently catches for V2ServerApiCalls where the package was not found
                             if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                             {
                                 if (shouldReportErrorForEachRepo)
@@ -583,6 +583,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         foreach (PSResourceResult currentResult in currentResponseUtil.ConvertToPSResourceResult(responses))
                         {
+                            // This currently catches for V2ServerApiCalls where the package was not found
                             if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                             {
                                 string message = _tag.Length == 0 ? $"Package with name '{pkgName}' could not be found in repository '{repository.Name}'." : $"Package with name '{pkgName}' and tags '{tagsAsString}' could not be found in repository '{repository.Name}'.";
@@ -640,7 +641,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         }
 
                         PSResourceResult currentResult = currentResponseUtil.ConvertToPSResourceResult(responses).First();
-                        
+                        // This currently catches for V2ServerApiCalls where the package was not found
                         if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                         {
                             string message = _tag.Length == 0 ? $"Package with name '{pkgName}' could not be found in repository '{repository.Name}'." : $"Package with name '{pkgName}' and tags '{tagsAsString}' could not be found in repository '{repository.Name}'.";
@@ -709,7 +710,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         }
 
                         PSResourceResult currentResult = currentResponseUtil.ConvertToPSResourceResult(responses).First();
-                        
+                        // This currently catches for V2ServerApiCalls where the package was not found
                         if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                         {
                             errRecord = new ErrorRecord(
@@ -756,7 +757,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         }
                         else
                         {
-                            var exMessage = "Name cannot contain or equal wildcard when using version range";
+                            var exMessage = "-Tag cannot be specified when using version range.";
                             var ex = new ArgumentException(exMessage);
                             var WildcardError = new ErrorRecord(ex, "InvalidWildCardUsage", ErrorCategory.InvalidOperation, null);
                             _cmdletPassedIn.WriteError(WildcardError);
@@ -765,18 +766,21 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         if (errRecord != null)
                         {
-                            if (errRecord.Exception is ResourceNotFoundException)
+                            if (shouldReportErrorForEachRepo)
+                            {
+                                _cmdletPassedIn.WriteError(errRecord);
+                            }
+                            else
                             {
                                 _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
                             }
-                            else {
-                                _cmdletPassedIn.WriteError(errRecord);
-                            }
+
                             continue;
                         }
 
                         foreach (PSResourceResult currentResult in currentResponseUtil.ConvertToPSResourceResult(responses))
                         {
+                            // This currently catches for V2ServerApiCalls where the package was not found
                             if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                             {
                                 errRecord = new ErrorRecord(
@@ -784,6 +788,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                             "FindVersionGlobbingConvertToPSResourceFailure", 
                                             ErrorCategory.ObjectNotFound, 
                                             this);
+
 
                                 if (shouldReportErrorForEachRepo)
                                 {

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -189,7 +189,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 _cmdletPassedIn.WriteVerbose(string.Format("Searching in repository {0}", repositoriesToSearch[i].Name));
 
                 bool shouldReportErrorForEachRepo = !suppressErrors && !_repositoryNameContainsWildcard;
-                foreach (PSResourceInfo currentPkg in SearchByNames(currentServer, currentResponseUtil, currentRepository, shouldReportErrorForEachRepo: shouldReportErrorForEachRepo))
+                foreach (PSResourceInfo currentPkg in SearchByNames(currentServer, currentResponseUtil, currentRepository, shouldReportErrorForEachRepo))
                 {
                     if (currentPkg == null) {
                         continue;

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -190,8 +190,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 _cmdletPassedIn.WriteVerbose(string.Format("Searching in repository {0}", repositoriesToSearch[i].Name));
 
-                bool shouldReportError = !_repositoryNameContainsWildcard;
-                foreach (PSResourceInfo currentPkg in SearchByNames(currentServer, currentResponseUtil, currentRepository, shouldReportError: shouldReportError, isInstallOperation: false))
+                bool shouldReportErrorForEachRepo = !_repositoryNameContainsWildcard;
+                foreach (PSResourceInfo currentPkg in SearchByNames(currentServer, currentResponseUtil, currentRepository, shouldReportErrorForEachRepo: shouldReportErrorForEachRepo, isInstallOperation: false))
                 {
                     if (currentPkg == null) {
                         continue;
@@ -495,7 +495,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         #region Private Client Search Methods
 
-        private IEnumerable<PSResourceInfo> SearchByNames(ServerApiCall currentServer, ResponseUtil currentResponseUtil, PSRepositoryInfo repository, bool shouldReportError, bool isInstallOperation)
+        private IEnumerable<PSResourceInfo> SearchByNames(ServerApiCall currentServer, ResponseUtil currentResponseUtil, PSRepositoryInfo repository, bool shouldReportErrorForEachRepo, bool isInstallOperation)
         {
             ErrorRecord errRecord = null;
             List<PSResourceInfo> parentPkgs = new List<PSResourceInfo>();
@@ -512,7 +512,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         FindResults responses = currentServer.FindAll(_prerelease, _type, out errRecord);
                         if (errRecord != null)
                         {
-                            if (shouldReportError)
+                            if (shouldReportErrorForEachRepo)
                             {
                                 _cmdletPassedIn.WriteError(errRecord);
                             }
@@ -537,7 +537,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             // Note: this currently catches for V2ServerApiCalls. TODO: eventually move off this.
                             if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                             {
-                                if (shouldReportError)
+                                if (shouldReportErrorForEachRepo)
                                 {
                                     _cmdletPassedIn.WriteError(new ErrorRecord(
                                         new ResourceNotFoundException($"Package '{pkgName}' could not be found in repository '{repository.Name}", currentResult.exception), 
@@ -585,7 +585,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         if (errRecord != null)
                         {
-                            if (shouldReportError)
+                            if (shouldReportErrorForEachRepo)
                             {
                                 _cmdletPassedIn.WriteError(errRecord);
                             }
@@ -616,7 +616,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                             ErrorCategory.ObjectNotFound, 
                                             this);
 
-                                if (shouldReportError)
+                                if (shouldReportErrorForEachRepo)
                                 {
                                     _cmdletPassedIn.WriteError(errRecord);
                                 }
@@ -656,7 +656,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         if (errRecord != null)
                         {
-                            if (shouldReportError)
+                            if (shouldReportErrorForEachRepo)
                             {
                                 _cmdletPassedIn.WriteError(errRecord);
                             }
@@ -687,7 +687,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                         ErrorCategory.ObjectNotFound, 
                                         this);
 
-                            if (shouldReportError)
+                            if (shouldReportErrorForEachRepo)
                             {
                                 _cmdletPassedIn.WriteError(errRecord);
                             }
@@ -738,7 +738,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         if (errRecord != null)
                         {
-                            if (shouldReportError)
+                            if (shouldReportErrorForEachRepo)
                             {
                                 _cmdletPassedIn.WriteError(errRecord);
                             }
@@ -768,7 +768,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                         ErrorCategory.ObjectNotFound, 
                                         this);
 
-                            if (shouldReportError)
+                            if (shouldReportErrorForEachRepo)
                             {
                                 _cmdletPassedIn.WriteError(errRecord);
                             }
@@ -840,7 +840,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                             ErrorCategory.ObjectNotFound, 
                                             this);
 
-                                if (shouldReportError)
+                                if (shouldReportErrorForEachRepo)
                                 {
                                     _cmdletPassedIn.WriteError(errRecord);
                                 }

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -97,7 +97,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                 this));
                 }
 
-                // Iff repository entries includes wildcards and nonwildcard names, write terminating error
+                // If repository entries includes wildcards and non-wildcard names, write terminating error
                 // Ex: -Repository *Gallery, localRepo
                 bool containsWildcard = false;
                 bool containsNonWildcard = false;

--- a/src/code/FindPSResource.cs
+++ b/src/code/FindPSResource.cs
@@ -254,7 +254,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 prerelease: Prerelease,
                 tag: Tag,
                 repository: Repository,
-                includeDependencies: IncludeDependencies))
+                includeDependencies: IncludeDependencies,
+                suppressErrors: false))
             {
                 WriteObject(pkg);
             }

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -220,14 +220,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 _cmdletPassedIn.WriteVerbose(string.Format("Attempting to search for packages in '{0}'", repoName));
 
 
-                if (repo.ApiVersion == PSRepositoryInfo.APIVersion.unknown)
-                {
-                    _cmdletPassedIn.ThrowTerminatingError(new ErrorRecord(
-                        new ArgumentException($"Repository {repoName} has unknown API Version."),
-                        "RepositoryAPIVersionUnknownError",
-                        ErrorCategory.InvalidOperation,
-                        this));
-                }
+                // if (repo.ApiVersion == PSRepositoryInfo.APIVersion.unknown)
+                // {
+                //     _cmdletPassedIn.ThrowTerminatingError(new ErrorRecord(
+                //         new ArgumentException($"Repository {repoName} has unknown API Version."),
+                //         "RepositoryAPIVersionUnknownError",
+                //         ErrorCategory.InvalidOperation,
+                //         this));
+                // }
 
                 if (repo.Trusted == false && !trustRepository && !_force)
                 {

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -863,7 +863,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 var repository = new[] { repositoryName };
                 // Note: we set prerelease argument for FindByResourceName() to true because if no version is specified we want latest version (including prerelease).
                 // If version is specified it will get that one. There is also no way to specify a prerelease flag with RequiredModules hashtable of dependency so always try to get latest version.
-                var dependencyFound = findHelper.FindByResourceName(new string[] { depName }, ResourceType.Module, versionRange, nugetVersion, versionType, depVersion, prerelease: true, tag: null, repository, includeDependencies: false);
+                var dependencyFound = findHelper.FindByResourceName(new string[] { depName }, ResourceType.Module, versionRange, nugetVersion, versionType, depVersion, prerelease: true, tag: null, repository, includeDependencies: false, suppressErrors: true);
                 if (dependencyFound == null || !dependencyFound.Any())
                 {
                    WriteError(new ErrorRecord(

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -334,7 +334,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 prerelease: latestInstalledIsPrerelease || Prerelease,
                 tag: null,
                 repository: Repository,
-                includeDependencies: !SkipDependencyCheck))
+                includeDependencies: !SkipDependencyCheck,
+                suppressErrors: false))
             {
                 if (!repositoryPackages.ContainsKey(foundResource.Name))
                 {

--- a/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 
@@ -109,7 +109,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name and Tag property (multiple tags)" {
@@ -127,7 +127,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTags -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resources when given Name with wildcard and Tag proprties" {
@@ -155,7 +155,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name, Version and Tag property (multiple tags)" {
@@ -175,7 +175,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTags -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resources given Tag property" {

--- a/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 

--- a/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
@@ -35,7 +35,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource(s) given wildcard Name" {
@@ -115,7 +115,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name and Tag property (multiple tags)" {
@@ -133,7 +133,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTags -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find all resources that satisfy Name pattern and have specified Tag (single tag)" {
@@ -192,7 +192,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name, Version and Tag property (multiple tags)" {
@@ -212,7 +212,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTags -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resources given Tag property" {

--- a/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
@@ -35,7 +35,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource(s) given wildcard Name" {

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -77,7 +77,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $localRepo -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 
@@ -150,7 +150,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $localRepo -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -214,7 +214,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $localRepo -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 

--- a/test/FindPSResourceTests/FindPSResourceRepositorySearching.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceRepositorySearching.Tests.ps1
@@ -17,33 +17,13 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $NuGetGalleryName = "NuGetGallery"
         $localRepoName = "localRepo"
 
-        # $testModuleName2 = "test_local_mod2"
-        # $commandName = "cmd1"
-        # $dscResourceName = "dsc1"
-        # $prereleaseLabel = ""
         Get-NewPSResourceRepositoryFile
 
         $localRepoUriAddress = Join-Path -Path $TestDrive -ChildPath "testdir"
         $null = New-Item $localRepoUriAddress -ItemType Directory -Force
         Register-PSResourceRepository -Name $localRepoName -Uri $localRepoUriAddress
 
-        
-
-        # Register-LocalRepos
-
-        # $localRepoUriAddress = Join-Path -Path $TestDrive -ChildPath "testdir"
-        # $tagsEscaped = @("'Test'", "'Tag2'", "'$cmdName'", "'$dscName'")
-        # $prereleaseLabel = "alpha001"
-
         New-TestModule -moduleName $testModuleName -repoName localRepo -packageVersion "1.0.0" -prereleaseLabel "" -tags @()
-        # New-TestModule -moduleName $testLocalModuleName -repoName $localRepo -packageVersion "1.0.0" -prereleaseLabel "" -tags @()
-
-        # New-TestModule -moduleName $testModuleName -repoName $localRepo -packageVersion "3.0.0" -prereleaseLabel "" -tags @() -dscResourceToExport $dscResourceName -commandToExport $commandName
-        # New-TestModule -moduleName $testModuleName -repoName $localRepo -packageVersion "5.0.0" -prereleaseLabel "" -tags $tagsEscaped
-        # New-TestModule -moduleName $testModuleName -repoName $localRepo -packageVersion "5.2.5" -prereleaseLabel $prereleaseLabel -tags $tagsEscaped
-
-        # New-TestModule -moduleName $testModuleName2 -repoName $localRepo -packageVersion "5.0.0" -prereleaseLabel "" -tags $tagsEscaped
-        # New-TestModule -moduleName $testModuleName2 -repoName $localRepo -packageVersion "5.2.5" -prereleaseLabel $prereleaseLabel -tags $tagsEscaped
     }
 
     AfterAll {
@@ -80,6 +60,14 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $pkg2 = $res[1]
         $pkg2.Name | Should -Be $testScriptName
         $pkg2.Repository | Should -Be $NuGetGalleryName
+    }
+
+    It "should not find resource given nonexistant Name (without -Repository specified)" {
+        $res = Find-PSResource -Name "NonExistantModule" -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -BeNullOrEmpty
+        $err.Count | Should -Be 1
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $res | Should -BeNullOrEmpty
     }
 
     It "find resources from all pattern matching repositories where it exists (-Repository with wildcard)" {

--- a/test/FindPSResourceTests/FindPSResourceRepositorySearching.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceRepositorySearching.Tests.ps1
@@ -1,0 +1,180 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+$modPath = "$psscriptroot/../PSGetTestUtils.psm1"
+Import-Module $modPath -Force -Verbose
+
+$psmodulePaths = $env:PSModulePath -split ';'
+Write-Verbose -Verbose "Current module search paths: $psmodulePaths"
+
+Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
+
+    BeforeAll{
+        $testModuleName = "test_module"
+        $testLocalModuleName = "test_local_mod"
+        $testScriptName = "test_script"
+        $PSGalleryName = "PSGallery"
+        $NuGetGalleryName = "NuGetGallery"
+        $localRepoName = "localRepo"
+
+        # $testModuleName2 = "test_local_mod2"
+        # $commandName = "cmd1"
+        # $dscResourceName = "dsc1"
+        # $prereleaseLabel = ""
+        Get-NewPSResourceRepositoryFile
+
+        $localRepoUriAddress = Join-Path -Path $TestDrive -ChildPath "testdir"
+        $null = New-Item $localRepoUriAddress -ItemType Directory -Force
+        Register-PSResourceRepository -Name $localRepoName -Uri $localRepoUriAddress
+
+        
+
+        # Register-LocalRepos
+
+        # $localRepoUriAddress = Join-Path -Path $TestDrive -ChildPath "testdir"
+        # $tagsEscaped = @("'Test'", "'Tag2'", "'$cmdName'", "'$dscName'")
+        # $prereleaseLabel = "alpha001"
+
+        New-TestModule -moduleName $testModuleName -repoName localRepo -packageVersion "1.0.0" -prereleaseLabel "" -tags @()
+        # New-TestModule -moduleName $testLocalModuleName -repoName $localRepo -packageVersion "1.0.0" -prereleaseLabel "" -tags @()
+
+        # New-TestModule -moduleName $testModuleName -repoName $localRepo -packageVersion "3.0.0" -prereleaseLabel "" -tags @() -dscResourceToExport $dscResourceName -commandToExport $commandName
+        # New-TestModule -moduleName $testModuleName -repoName $localRepo -packageVersion "5.0.0" -prereleaseLabel "" -tags $tagsEscaped
+        # New-TestModule -moduleName $testModuleName -repoName $localRepo -packageVersion "5.2.5" -prereleaseLabel $prereleaseLabel -tags $tagsEscaped
+
+        # New-TestModule -moduleName $testModuleName2 -repoName $localRepo -packageVersion "5.0.0" -prereleaseLabel "" -tags $tagsEscaped
+        # New-TestModule -moduleName $testModuleName2 -repoName $localRepo -packageVersion "5.2.5" -prereleaseLabel $prereleaseLabel -tags $tagsEscaped
+    }
+
+    AfterAll {
+        Get-RevertPSResourceRepositoryFile
+    }
+
+    It "find resources from all repositories where it exists (without -Repository specified)" {
+        # Package "test_module" exists in the following repositories: PSGallery, NuGetGallery, and localRepo
+        $res = Find-PSResource -Name $testModuleName -ErrorVariable err -ErrorAction SilentlyContinue
+        $err | Should -HaveCount 0
+        $res | Should -HaveCount 3
+        $pkg1 = $res[0]
+        $pkg1.Name | Should -Be $testModuleName
+        $pkg1.Repository | Should -Be $localRepoName
+
+        $pkg2 = $res[1]
+        $pkg2.Name | Should -Be $testModuleName
+        $pkg2.Repository | Should -Be $PSGalleryName
+        
+        $pkg3 = $res[2]
+        $pkg3.Name | Should -Be $testModuleName
+        $pkg3.Repository | Should -Be $NuGetGalleryName
+    }
+
+    It "find resources from all repositories where it exists and not write errors for repositories where it does not exist (without -Repository specified)" {
+        # Package "test_script" exists in the following repositories: PSGallery, NuGetGallery
+        $res = Find-PSResource -Name $testScriptName -ErrorVariable err -ErrorAction SilentlyContinue
+        $err | Should -HaveCount 0
+        $res | Should -HaveCount 2
+        $pkg1 = $res[0]
+        $pkg1.Name | Should -Be $testScriptName
+        $pkg1.Repository | Should -Be $PSGalleryName
+
+        $pkg2 = $res[1]
+        $pkg2.Name | Should -Be $testScriptName
+        $pkg2.Repository | Should -Be $NuGetGalleryName
+    }
+
+    It "find resources from all pattern matching repositories where it exists (-Repository with wildcard)" {
+        # Package "test_script" exists in the following repositories: PSGallery, NuGetGallery
+        $res = Find-PSResource -Name $testScriptName -Repository "*Gallery" -ErrorVariable err -ErrorAction SilentlyContinue
+        $err | Should -HaveCount 0
+        $res | Should -HaveCount 2
+        $pkg1 = $res[0]
+        $pkg1.Name | Should -Be $testScriptName
+        $pkg1.Repository | Should -Be $PSGalleryName
+
+        $pkg2 = $res[1]
+        $pkg2.Name | Should -Be $testScriptName
+        $pkg2.Repository | Should -Be $NuGetGalleryName
+    }
+
+    # It "find resources from pattern matching repositories where it exists and error report for specific repositories (-Repository with wildcard and specific repositories)" {
+    #     # Package "test_script" exists in the following repositories: PSGallery, NuGetGallery
+    #     $res = Find-PSResource -Name $testScriptName -Repository "*Gallery",$localRepoName -ErrorVariable err -ErrorAction SilentlyContinue
+    #     $err | Should -HaveCount 1
+    #     $res | Should -HaveCount 2
+    #     $pkg1 = $res[0]
+    #     $pkg1.Name | Should -Be $testScriptName
+    #     $pkg1.Repository | Should -Be $PSGalleryName
+
+    #     $pkg2 = $res[1]
+    #     $pkg2.Name | Should -Be $testScriptName
+    #     $pkg2.Repository | Should -Be $NuGetGalleryName
+
+    #     $err.Count | Should -Be 1
+    #     $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    # }
+
+    # It "not find resources from pattern matching repositories if it doesn't exist and only write for for specific repositories (-Repository with wildcard and specific repositories)" {
+    #     # Package "nonExistantPkg" does not exist in any repo
+    #     # TODO: determine behavior
+    #     $res = Find-PSResource -Name "nonExistantPkg" -Repository "*Gallery",$localRepoName -ErrorVariable err -ErrorAction SilentlyContinue
+    #     $err | Should -HaveCount 1
+    #     $res | Should -HaveCount 2
+    #     $pkg1 = $res[0]
+    #     $pkg1.Name | Should -Be $testScriptName
+    #     $pkg1.Repository | Should -Be $PSGalleryName
+
+    #     $pkg2 = $res[1]
+    #     $pkg2.Name | Should -Be $testScriptName
+    #     $pkg2.Repository | Should -Be $NuGetGalleryName
+
+    #     $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    # }
+
+    It "not find resource and write error if resource does not exist in any pattern matching repositories (-Repository with wildcard)" {
+        $res = Find-PSResource -Name "nonExistantPkg" -Repository "*Gallery" -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -BeNullOrEmpty
+        $err | Should -HaveCount 1
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
+
+    It "find resource from single specific repository (-Repository with single non-wildcard value)" {
+        $res = Find-PSResource -Name $testModuleName -Repository $PSGalleryName
+        $res | Should -HaveCount 1
+        $res.Name | Should -Be $testModuleName
+        $res.Repository | Should -Be $PSGalleryName
+    }
+
+    It "not find resource if it does not exist in repository and write error (-Repository with single non-wildcard value)" {
+        $res = Find-PSResource -Name "nonExistantPkg" -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -BeNullOrEmpty
+        $err | Should -HaveCount 1
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
+
+    It "find resource from all repositories where it exists (-Repository with multiple non-wildcard values)" {
+        $res = Find-PSResource -Name $testModuleName -Repository $PSGalleryName,$NuGetGalleryName
+        $res | Should -HaveCount 2
+
+        $pkg1 = $res[0]
+        $pkg1.Name | Should -Be $testModuleName
+        $pkg1.Repository | Should -Be $PSGalleryName
+
+        $pkg2 = $res[1]
+        $pkg2.Name | Should -Be $testModuleName
+        $pkg2.Repository | Should -Be $NuGetGalleryName
+    }
+
+    It "find resource from all repositories where it exists and write errors for those it does not exist from (-Repository with multiple non-wildcard values)" {
+        # Package "test_module3" exists in the following repositories: NuGetGalleryName
+        $pkgOnNuGetGallery = "test_module3"
+        $res = Find-PSResource -Name $pkgOnNuGetGallery -Repository $PSGalleryName,$NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -HaveCount 1
+        $err | Should -HaveCount 1
+
+        $pkg1 = $res[0]
+        $pkg1.Name | Should -Be $pkgOnNuGetGallery
+        $pkg1.Repository | Should -Be $NuGetGalleryName
+
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
+}

--- a/test/FindPSResourceTests/FindPSResourceRepositorySearching.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceRepositorySearching.Tests.ps1
@@ -62,12 +62,87 @@ Describe 'Test Find-PSResource for searching and looping through repositories' -
         $pkg2.Repository | Should -Be $NuGetGalleryName
     }
 
+    It "should find resources that exist and not find ones that do not exist while reporting error (without -Repository specified)" {
+        $res = Find-PSResource -Name $testScriptName,"NonExistantModule" -ErrorVariable err -ErrorAction SilentlyContinue
+        $err | Should -HaveCount 1
+        $res | Should -HaveCount 2
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+
+        $pkg1 = $res[0]
+        $pkg1.Name | Should -Be $testScriptName
+        $pkg1.Repository | Should -Be $PSGalleryName
+
+        $pkg2 = $res[1]
+        $pkg2.Name | Should -Be $testScriptName
+        $pkg2.Repository | Should -Be $NuGetGalleryName
+    }
+
     It "should not find resource given nonexistant Name (without -Repository specified)" {
         $res = Find-PSResource -Name "NonExistantModule" -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
-        $err.Count | Should -Be 1
+        $err | Should -HaveCount 1
         $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
+    }
+
+    It "find multiple resources from all repositories where it exists (without -Repository specified)" {
+        $res = Find-PSResource -Name "test_module","test_module2" -ErrorVariable err -ErrorAction SilentlyContinue
+        $err | Should -HaveCount 0
+        $res | Should -HaveCount 5
+
+        $pkg1 = $res[0]
+        $pkg1.Name | Should -Be "test_module"
+        $pkg1.Repository | Should -Be $localRepoName
+
+        $pkg2 = $res[1]
+        $pkg2.Name | Should -Be "test_module"
+        $pkg2.Repository | Should -Be $PSGalleryName
+
+        $pkg3 = $res[2]
+        $pkg3.Name | Should -Be "test_module2"
+        $pkg3.Repository | Should -Be $PSGalleryName
+
+        $pkg4 = $res[3]
+        $pkg4.Name | Should -Be "test_module"
+        $pkg4.Repository | Should -Be $NuGetGalleryName
+
+        $pkg5 = $res[4]
+        $pkg5.Name | Should -Be "test_module2"
+        $pkg5.Repository | Should -Be $NuGetGalleryName
+    }
+
+    It "find multiple resources from all repositories where it exists where package Name contains wildcard (without -Repository specified)" {
+        $res = Find-PSResource -Name "test_module*" -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -HaveCount 9
+        $err | Should -HaveCount 0
+
+        $pkgFoundinLocalRepo = $false
+        $pkgFoundinPSGallery = $false
+        $pkgFoundinNuGetGallery = $false
+        foreach ($pkg in $res)
+        {
+            if ($pkg.Repository -eq $localRepoName)
+            {
+                $pkgFoundinLocalRepo = $true
+            }
+            elseif ($pkg.Repository -eq $PSGalleryName) {
+                $pkgFoundinPSGallery = $true
+            }
+            elseif ($pkg.Repository -eq $NuGetGalleryName)
+            {
+                $pkgFoundinNuGetGallery = $true
+            }
+        }
+
+        $pkgFoundinLocalRepo | Should -BeTrue
+        $pkgFoundinPSGallery | Should -BeTrue
+        $pkgFoundinNuGetGallery | Should -BeTrue
+    }
+
+    It "should not find resources if they do not exist in any repository and not write error given package Name contains wildcard (without -Repository specified)" {
+        $res = Find-PSResource -Name "NonExistantPkg*" -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -HaveCount 0
+        $err | Should -HaveCount 0
     }
 
     It "find resources from all pattern matching repositories where it exists (-Repository with wildcard)" {
@@ -117,11 +192,21 @@ Describe 'Test Find-PSResource for searching and looping through repositories' -
         $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
+    It "should not allow for repository name with wildcard and non-wildcard name specified in same command run" {
+        {Find-PSResource -Name "test_module" -Repository "*Gallery",$localRepoName} | Should -Throw -ErrorId "ErrorFilteringNamesForUnsupportedWildcards,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
+    
     It "not find resource and write error if resource does not exist in any pattern matching repositories (-Repository with wildcard)" {
         $res = Find-PSResource -Name "nonExistantPkg" -Repository "*Gallery" -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err | Should -HaveCount 1
         $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
+
+    It "not find resource that does not exist in any repository and not write error given package Name with wildcards (-Repository with wildcard)" {
+        $res = Find-PSResource -Name "NonExistantPkg*" -Repository "*Gallery" -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -HaveCount 0
+        $err | Should -HaveCount 0
     }
 
     It "find resource from single specific repository (-Repository with single non-wildcard value)" {
@@ -132,10 +217,16 @@ Describe 'Test Find-PSResource for searching and looping through repositories' -
     }
 
     It "not find resource if it does not exist in repository and write error (-Repository with single non-wildcard value)" {
-        $res = Find-PSResource -Name "nonExistantPkg" -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
+        $res = Find-PSResource -Name "NonExistantPkg" -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err | Should -HaveCount 1
         $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
+
+    It "not find resource if it does not exist in repository and not write error given package Name with wildcard (-Repository with single non-wildcard value)" -Pending {
+        $res = Find-PSResource -Name "NonExistantPkg*" -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -HaveCount 0
+        $err | Should -HaveCount 0
     }
 
     It "find resource from all repositories where it exists (-Repository with multiple non-wildcard values)" {
@@ -163,5 +254,11 @@ Describe 'Test Find-PSResource for searching and looping through repositories' -
         $pkg1.Repository | Should -Be $NuGetGalleryName
 
         $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
+
+    It "should not find resource from repositories where it does not exist and not write error since package Name contains wilcard" -Pending {
+        $res = Find-PSResource -Name "NonExistantPkg*" -Repository $PSGalleryName,$NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -HaveCount 0
+        $err | Should -HaveCount 0
     }
 }

--- a/test/FindPSResourceTests/FindPSResourceRepositorySearching.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceRepositorySearching.Tests.ps1
@@ -84,39 +84,38 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $pkg2.Repository | Should -Be $NuGetGalleryName
     }
 
-    # It "find resources from pattern matching repositories where it exists and error report for specific repositories (-Repository with wildcard and specific repositories)" {
-    #     # Package "test_script" exists in the following repositories: PSGallery, NuGetGallery
-    #     $res = Find-PSResource -Name $testScriptName -Repository "*Gallery",$localRepoName -ErrorVariable err -ErrorAction SilentlyContinue
-    #     $err | Should -HaveCount 1
-    #     $res | Should -HaveCount 2
-    #     $pkg1 = $res[0]
-    #     $pkg1.Name | Should -Be $testScriptName
-    #     $pkg1.Repository | Should -Be $PSGalleryName
+    It "find resources from pattern matching repositories where it exists and error report for specific repositories (-Repository with wildcard and specific repositories)" -Pending {
+        # Package "test_script" exists in the following repositories: PSGallery, NuGetGallery
+        $res = Find-PSResource -Name $testScriptName -Repository "*Gallery",$localRepoName -ErrorVariable err -ErrorAction SilentlyContinue
+        $err | Should -HaveCount 1
+        $res | Should -HaveCount 2
+        $pkg1 = $res[0]
+        $pkg1.Name | Should -Be $testScriptName
+        $pkg1.Repository | Should -Be $PSGalleryName
 
-    #     $pkg2 = $res[1]
-    #     $pkg2.Name | Should -Be $testScriptName
-    #     $pkg2.Repository | Should -Be $NuGetGalleryName
+        $pkg2 = $res[1]
+        $pkg2.Name | Should -Be $testScriptName
+        $pkg2.Repository | Should -Be $NuGetGalleryName
 
-    #     $err.Count | Should -Be 1
-    #     $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
-    # }
+        $err.Count | Should -Be 1
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
 
-    # It "not find resources from pattern matching repositories if it doesn't exist and only write for for specific repositories (-Repository with wildcard and specific repositories)" {
-    #     # Package "nonExistantPkg" does not exist in any repo
-    #     # TODO: determine behavior
-    #     $res = Find-PSResource -Name "nonExistantPkg" -Repository "*Gallery",$localRepoName -ErrorVariable err -ErrorAction SilentlyContinue
-    #     $err | Should -HaveCount 1
-    #     $res | Should -HaveCount 2
-    #     $pkg1 = $res[0]
-    #     $pkg1.Name | Should -Be $testScriptName
-    #     $pkg1.Repository | Should -Be $PSGalleryName
+    It "not find resources from pattern matching repositories if it doesn't exist and only write for for specific repositories (-Repository with wildcard and specific repositories)" -Pending {
+        # Package "nonExistantPkg" does not exist in any repo
+        $res = Find-PSResource -Name "nonExistantPkg" -Repository "*Gallery",$localRepoName -ErrorVariable err -ErrorAction SilentlyContinue
+        $err | Should -HaveCount 1
+        $res | Should -HaveCount 2
+        $pkg1 = $res[0]
+        $pkg1.Name | Should -Be $testScriptName
+        $pkg1.Repository | Should -Be $PSGalleryName
 
-    #     $pkg2 = $res[1]
-    #     $pkg2.Name | Should -Be $testScriptName
-    #     $pkg2.Repository | Should -Be $NuGetGalleryName
+        $pkg2 = $res[1]
+        $pkg2.Name | Should -Be $testScriptName
+        $pkg2.Repository | Should -Be $NuGetGalleryName
 
-    #     $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
-    # }
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
 
     It "not find resource and write error if resource does not exist in any pattern matching repositories (-Repository with wildcard)" {
         $res = Find-PSResource -Name "nonExistantPkg" -Repository "*Gallery" -ErrorVariable err -ErrorAction SilentlyContinue

--- a/test/FindPSResourceTests/FindPSResourceRepositorySearching.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceRepositorySearching.Tests.ps1
@@ -7,7 +7,7 @@ Import-Module $modPath -Force -Verbose
 $psmodulePaths = $env:PSModulePath -split ';'
 Write-Verbose -Verbose "Current module search paths: $psmodulePaths"
 
-Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
+Describe 'Test Find-PSResource for searching and looping through repositories' -tags 'CI' {
 
     BeforeAll{
         $testModuleName = "test_module"

--- a/test/FindPSResourceTests/FindPSResourceRepositorySearching.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceRepositorySearching.Tests.ps1
@@ -148,7 +148,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res = Find-PSResource -Name "nonExistantPkg" -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err | Should -HaveCount 1
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource from all repositories where it exists (-Repository with multiple non-wildcard values)" {
@@ -175,6 +175,6 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $pkg1.Name | Should -Be $pkgOnNuGetGallery
         $pkg1.Repository | Should -Be $NuGetGalleryName
 
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 }

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -34,7 +34,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 
@@ -215,7 +215,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name and Tag property (multiple tags)" {
@@ -233,7 +233,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTags -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find all resources that satisfy Name pattern and have specified Tag (single tag)" {
@@ -292,7 +292,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name, Version and Tag property (multiple tags)" {
@@ -312,7 +312,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTags -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     # It "find all resources with specified tag given Tag property" {
@@ -365,13 +365,6 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
             $item.Version.ToString() + $item.Prerelease | Should -Not -Be "1.0.0-beta1"
         }
     }
-    
-    It "find resource from highest priority repo only" {
-        $res = Find-PSResource -Name "testmodule99"
-        $res.Name | Should -Be "testmodule99"
-        $res.Count | Should -Be 1
-        $res.Repository | Should -Be $PSGalleryName
-    }
 
     It "find all resources within a version range, including prereleases" {
         $res = Find-PSResource -Name "PSReadLine" -Version "(2.0,2.1)" -Prerelease -Repository $PSGalleryName
@@ -403,23 +396,6 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res | Should -Not -BeNullOrEmpty
         $res.Version | Should -Be "2.1.0"
         $err.Count | Should -Be 0
-    }
-
-    It "should not find resource given nonexistant Name and no specified repository" {
-        $res = Find-PSResource -Name NonExistantModule -ErrorVariable err -ErrorAction SilentlyContinue
-        $res | Should -BeNullOrEmpty
-        $err.Count | Should -Be 1
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
-        $res | Should -BeNullOrEmpty
-    }
-
-    It "should find resource and write error for other resource not found when multiple packages are specified" {
-        $res = Find-PSResource -Name $testModuleName,"NonExistantModule" -ErrorVariable err -ErrorAction SilentlyContinue
-        $res.Name | Should -Be $testModuleName
-        $res.Repository | Should -Be $PSGalleryName
-
-        $err.Count | Should -Be 1
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 }
 

--- a/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
@@ -124,7 +124,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name and Tag property (multiple tags)" {
@@ -142,7 +142,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTags -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find all resources that satisfy Name pattern and have specified Tag (single tag)" {
@@ -201,7 +201,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name, Version and Tag property (multiple tags)" {
@@ -221,7 +221,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTags -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     # It "find all resources with specified tag given Tag property" {
@@ -273,7 +273,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name "PMTestDependency1" -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
     
     # "carb*" is intentionally chosen as a sequence that will trigger pagination (ie more than 100 results),

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -287,7 +287,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $dependencyVersion = "2.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module" -RequiredModules @(@{ModuleName = 'PackageManagement'; ModuleVersion = '1.4.4' })
 
-        {Publish-PSResource -Path $script:PublishModuleBase -ErrorAction Stop} | Should -Throw -ErrorId "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
+        {Publish-PSResource -Path $script:PublishModuleBase -ErrorAction Stop} | Should -Throw -ErrorId "DependencyNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
     }
 
 

--- a/test/PublishPSResourceTests/PublishPSResourceADOServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceADOServer.Tests.ps1
@@ -108,13 +108,4 @@ Describe "Test Publish-PSResource" -tags 'CI' {
 
         $Error[0].FullyQualifiedErrorId | Should -be "401FatalProtocolError,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
     }
-
-    It "Should not publish module to ADO repository feed (private) when ApiKey is not provided" {
-        $version = "1.0.0"
-        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
-
-        Publish-PSResource -Path $script:PublishModuleBase -Repository $ADOPrivateRepoName -Credential $correctPrivateRepoCred -ErrorAction SilentlyContinue
-
-        $Error[0].FullyQualifiedErrorId | Should -be "400ApiKeyError,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
-    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Find-PSResource previously conducted search with highest priority repository matching. While searching through multiple repositories, it would write errors for the repositories it couldn't find the package from, and after it found it from a repository it would not continue searching.

Our search will now follow the below scenarios/rules:
* `Find-PSResource "pkg"` (without `-Repository`): search all repositories registered, return "pkg" from each repository where it is found, if "pkg" is not found in any repo report error
* `Find-PSResource "pkg" -Repository *Gallery`: search all repositories whose names match the pattern (i.e PSGallery, NuGetGallery), return "pkg" from each of these repositories where it exists, if "pkg" is not found in any repo report error
* `Find-PSResource "pkg" -Repository PSGallery`: search specific repository, return "pkg" from it if found, if not found report error
* `Find-PSResource "pkg" -Repository PSGallery, NuGetGallery`: search specific repositories, for each: repo return "pkg" if found but if not write error.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1286 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
