### PR TITLE
Bug fix for saving Az dependencies

### DIFF
--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -839,9 +839,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (versionRange.MaxVersion != null)
             {
                 string operation = versionRange.IsMaxInclusive ? "le" : "lt";
-                // Adding '99' because we want to retrieve all the prerelease versions for the max version and PSGallery views prerelease as higher than its stable
+                // Adding '9' as a digit to the end of the patch portion of the version
+                // because we want to retrieve all the prerelease versions for the upper end of the range
+                // and PSGallery views prerelease as higher than its stable.
                 // eg 3.0.0-prerelease > 3.0.0
-                string maxString = includePrerelease ? $"{versionRange.MaxVersion.Major}.{versionRange.MaxVersion.Minor}.{versionRange.MaxVersion.Patch + 99}" :
+                // If looking for '[1.9.9,1.9.9]' including prerelease values, this will search for '[1.9.9,1.9.99]' 
+                // and find any pkg versions that are 1.9.9-prerelease.
+                string maxString = includePrerelease ? $"{versionRange.MaxVersion.Major}.{versionRange.MaxVersion.Minor}.{versionRange.MaxVersion.Patch.ToString() + "9"}" :
                                  $"{versionRange.MaxVersion.ToNormalizedString()}";
                 if (NuGetVersion.TryParse(maxString, out NuGetVersion maxVersion))
                 {

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -839,9 +839,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (versionRange.MaxVersion != null)
             {
                 string operation = versionRange.IsMaxInclusive ? "le" : "lt";
-                // Adding 1 because we want to retrieve all the prerelease versions for the max version and PSGallery views prerelease as higher than its stable
+                // Adding '99' because we want to retrieve all the prerelease versions for the max version and PSGallery views prerelease as higher than its stable
                 // eg 3.0.0-prerelease > 3.0.0
-                string maxString = includePrerelease ? $"{versionRange.MaxVersion.Major}.{versionRange.MaxVersion.Minor}.{versionRange.MaxVersion.Patch + 1}" :
+                string maxString = includePrerelease ? $"{versionRange.MaxVersion.Major}.{versionRange.MaxVersion.Minor}.{versionRange.MaxVersion.Patch + 99}" :
                                  $"{versionRange.MaxVersion.ToNormalizedString()}";
                 if (NuGetVersion.TryParse(maxString, out NuGetVersion maxVersion))
                 {

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -841,8 +841,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 string operation = versionRange.IsMaxInclusive ? "le" : "lt";
                 // Adding 1 because we want to retrieve all the prerelease versions for the max version and PSGallery views prerelease as higher than its stable
                 // eg 3.0.0-prerelease > 3.0.0
-                string maxString = includePrerelease ? $"{versionRange.MaxVersion.Major}.{versionRange.MaxVersion.Minor + 1}" :
-                                $"{versionRange.MaxVersion.ToNormalizedString()}";
+                string maxString = includePrerelease ? $"{versionRange.MaxVersion.Major}.{versionRange.MaxVersion.Minor}.{versionRange.MaxVersion.Patch}.{versionRange.MaxVersion.Revision + 1}" :
+                                 $"{versionRange.MaxVersion.ToNormalizedString()}";
                 if (NuGetVersion.TryParse(maxString, out NuGetVersion maxVersion))
                 {
                     maxPart = String.Format(format, operation, $"'{maxVersion.ToNormalizedString()}'");

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -843,7 +843,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // because we want to retrieve all the prerelease versions for the upper end of the range
                 // and PSGallery views prerelease as higher than its stable.
                 // eg 3.0.0-prerelease > 3.0.0
-                // If looking for '[1.9.9,1.9.9]' including prerelease values, this will search for '[1.9.9,1.9.99]' 
+                // If looking for versions within '[1.9.9,1.9.9]' including prerelease values, this will change it to search for '[1.9.9,1.9.99]' 
                 // and find any pkg versions that are 1.9.9-prerelease.
                 string maxString = includePrerelease ? $"{versionRange.MaxVersion.Major}.{versionRange.MaxVersion.Minor}.{versionRange.MaxVersion.Patch.ToString() + "9"}" :
                                  $"{versionRange.MaxVersion.ToNormalizedString()}";

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -841,7 +841,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 string operation = versionRange.IsMaxInclusive ? "le" : "lt";
                 // Adding 1 because we want to retrieve all the prerelease versions for the max version and PSGallery views prerelease as higher than its stable
                 // eg 3.0.0-prerelease > 3.0.0
-                string maxString = includePrerelease ? $"{versionRange.MaxVersion.Major}.{versionRange.MaxVersion.Minor}.{versionRange.MaxVersion.Patch}.{versionRange.MaxVersion.Revision + 1}" :
+                string maxString = includePrerelease ? $"{versionRange.MaxVersion.Major}.{versionRange.MaxVersion.Minor}.{versionRange.MaxVersion.Patch + 1}" :
                                  $"{versionRange.MaxVersion.ToNormalizedString()}";
                 if (NuGetVersion.TryParse(maxString, out NuGetVersion maxVersion))
                 {

--- a/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
@@ -566,10 +566,11 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
     #  
     It "install resource when version has a nine in the digit and -Prerelease parameter is passed in" {
         $moduleName = "TestModuleVersionWithNine"
-        Install-PSResource -Name $moduleName -Repository "PSGallery" -Version "[1.9.9, 1.9.9]" -Prerelease
+        $version = "1.9.9"
+        Install-PSResource -Name $moduleName -Repository $PSGalleryName -TrustRepository -Version "[$version, $version]" -Prerelease
         $res = Get-InstalledPSResource $moduleName
         $res | Should -Not -BeNullOrEmpty
-        $res.Version | Should -Be "1.9.9"
+        $res.Version | Should -Be $version
     }
 }
 

--- a/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
@@ -559,6 +559,18 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
         $err[0].FullyQualifiedErrorId | Should -BeExactly "RepositoryApiVersionUnknown,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
         $res | Should -BeNullOrEmpty
     }
+
+    # This is testing FindVersionGlobbing when it creates the 'maxString' variable, 
+    # specifically when the prerelease versions need to be accounted for since that's when PSResourceGet 
+    # modifies the version range to also account for prerelease versions.
+    #  
+    It "install resource when version has a nine in the digit and -Prerelease parameter is passed in" {
+        $moduleName = "TestModuleVersionWithNine"
+        Install-PSResource -Name $moduleName -Repository "PSGallery" -Version "[1.9.9, 1.9.9]" -Prerelease
+        $res = Get-InstalledPSResource $moduleName
+        $res | Should -Not -BeNullOrEmpty
+        $res.Version | Should -Be "1.9.9"
+    }
 }
 
 Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'ManualValidationOnly' {

--- a/test/PublishPSResourceTests/PublishPSResourceADOServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceADOServer.Tests.ps1
@@ -108,13 +108,4 @@ Describe "Test Publish-PSResource" -tags 'CI' {
 
         $Error[0].FullyQualifiedErrorId | Should -be "401FatalProtocolError,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
     }
-
-    It "Should not publish module to ADO repository feed (private) when ApiKey is not provided" {
-        $version = "1.0.0"
-        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
-
-        Publish-PSResource -Path $script:PublishModuleBase -Repository $ADOPrivateRepoName -Credential $correctPrivateRepoCred -ErrorAction SilentlyContinue
-
-        $Error[0].FullyQualifiedErrorId | Should -be "400ApiKeyError,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
-    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Bug fix for a somewhat obscure bug installing or saving a module (seen with some of Az's dependency modules) from the PowerShell Gallery.  If installing a module using a version range and prerelease is true, this bug will occur if the lower value in the version range has a 9 in it. 

This is because since the PSGallery views '3.0.0-prerelease' as being a higher version than '3.0.0', when a request goes out to the Gallery, PSResourceGet searches just beyond that version. For example:  if looking for 1.9.0, PSResource get would look for a range of [1.9.0, 1.10.0] to ensure it's catching all the 1.9.0 prereleases.

However, in another Gallery bug, the Gallery views 1.9.0 as being a greater version than 1.10.0, so incorrect results are returned from the server.

This PR is a small fix for a very narrow situation and meant to accommodate for many scenarios (specifically when installing dependencies and especially Az dependencies).

However, the larger issue is that the Gallery always views '9.0' as being greater than '10.0'.  This is out of scope for PSResourceGet, and requires a more thorough investigation with both the PSGallery code base and potentially PSResourceGet if work arounds are required client side.

## PR Context

Resolves #1341 


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
