### PR TITLE
Bug fix for installing/saving a pkg found in lower priority repository

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -219,16 +219,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 string repoName = repo.Name;
                 _cmdletPassedIn.WriteVerbose(string.Format("Attempting to search for packages in '{0}'", repoName));
 
-
-                // if (repo.ApiVersion == PSRepositoryInfo.APIVersion.unknown)
-                // {
-                //     _cmdletPassedIn.ThrowTerminatingError(new ErrorRecord(
-                //         new ArgumentException($"Repository {repoName} has unknown API Version."),
-                //         "RepositoryAPIVersionUnknownError",
-                //         ErrorCategory.InvalidOperation,
-                //         this));
-                // }
-
                 if (repo.Trusted == false && !trustRepository && !_force)
                 {
                     _cmdletPassedIn.WriteVerbose("Checking if untrusted repository should be used");
@@ -259,6 +249,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
 
                 allPkgsInstalled.AddRange(installedPkgs);
+            }
+
+            if (_pkgNamesToInstall.Count > 0) {
+                _cmdletPassedIn.WriteError(new ErrorRecord(
+                        new ResourceNotFoundException($"Package(s) '{string.Join(", ", _pkgNamesToInstall)}' could not be installed from an."),
+                        "InstallPackageFailure",
+                        ErrorCategory.InvalidData,
+                        this));
             }
 
             return allPkgsInstalled;
@@ -447,6 +445,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             bool skipDependencyCheck,
             FindHelper findHelper)
         {
+            errRecord = null;
             List<PSResourceInfo> pkgsSuccessfullyInstalled = new List<PSResourceInfo>();
 
             // Install parent package to the temp directory,
@@ -478,7 +477,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     // At this point parent package is installed to temp path.
                     if (errRecord != null)
                     {
-                        _cmdletPassedIn.WriteError(errRecord);
+                        if (errRecord.FullyQualifiedErrorId.Equals("PackageNotFound"))
+                        {
+                            _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
+                        }
+                        else if (!errRecord.FullyQualifiedErrorId.Equals("InstallPackageFailure"))
+                        {
+                            _cmdletPassedIn.WriteError(errRecord);
+                        }
+
                         continue;
                     }
 
@@ -644,11 +651,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                 {
                     // V2Server API calls will return non-empty response when package is not found but fail at conversion time
-                    _cmdletPassedIn.WriteError(new ErrorRecord(
+                    errRecord = new ErrorRecord(
                                 new InvalidOrEmptyResponse($"Package '{pkgNameToInstall}' could not be installed", currentResult.exception),
                                 "InstallPackageFailure",
                                 ErrorCategory.InvalidData,
-                                this));
+                                this);
+                   
+                    _cmdletPassedIn.WriteVerbose($"Package '{pkgNameToInstall}' could not be installed from repository '{repository.name}'.");
                 }
                 else if (searchVersionType == VersionType.VersionRange)
                 {
@@ -885,7 +894,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         var message = String.Format("{0} package could not be installed with error: Module manifest file: {1} does not exist. This is not a valid PowerShell module.", pkgName, moduleManifest);
                         var ex = new ArgumentException(message);
                         error = new ErrorRecord(ex, "psdataFileNotExistError", ErrorCategory.ReadError, null);
-                        _pkgNamesToInstall.RemoveAll(x => x.Equals(pkgName, StringComparison.InvariantCultureIgnoreCase));
 
                         return false;
                     }
@@ -936,7 +944,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         var ex = new InvalidOperationException($"PSScriptFile could not be parsed");
                         error = new ErrorRecord(ex, "psScriptParseError", ErrorCategory.ReadError, null);
-                        _pkgNamesToInstall.RemoveAll(x => x.Equals(pkgName, StringComparison.InvariantCultureIgnoreCase));
 
                         return false;
                     }
@@ -958,7 +965,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     if (!CreateMetadataXMLFile(tempDirNameVersion, installPath, pkgToInstall, isModule, out error))
                     {
-                        _pkgNamesToInstall.RemoveAll(x => x.Equals(pkgToInstall.Name, StringComparison.InvariantCultureIgnoreCase));
                         return false;
                     }
                 }
@@ -990,7 +996,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     ErrorCategory.InvalidOperation,
                     _cmdletPassedIn);
 
-                _pkgNamesToInstall.RemoveAll(x => x.Equals(pkgName, StringComparison.InvariantCultureIgnoreCase));
                 return false;
             }
         }
@@ -1024,7 +1029,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     if (!CreateMetadataXMLFile(tempInstallPath, installPath, pkgToInstall, isModule: true, out error))
                     {
-                        _pkgNamesToInstall.RemoveAll(x => x.Equals(pkgName, StringComparison.InvariantCultureIgnoreCase));
                         return false;
                     }
                 }
@@ -1056,7 +1060,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         ErrorCategory.InvalidOperation,
                         _cmdletPassedIn);
 
-                _pkgNamesToInstall.RemoveAll(x => x.Equals(pkgName, StringComparison.InvariantCultureIgnoreCase));
                 return false;
             }
         }
@@ -1123,7 +1126,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             "InstallPackageFailed",
                             ErrorCategory.InvalidOperation,
                             _cmdletPassedIn));
-                    _pkgNamesToInstall.RemoveAll(x => x.Equals(pkgName, StringComparison.InvariantCultureIgnoreCase));
+
                     return false;
                 }
             }

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -445,7 +445,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             bool skipDependencyCheck,
             FindHelper findHelper)
         {
-            errRecord = null;
             List<PSResourceInfo> pkgsSuccessfullyInstalled = new List<PSResourceInfo>();
 
             // Install parent package to the temp directory,
@@ -657,7 +656,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                 ErrorCategory.InvalidData,
                                 this);
                    
-                    _cmdletPassedIn.WriteVerbose($"Package '{pkgNameToInstall}' could not be installed from repository '{repository.name}'.");
+                    _cmdletPassedIn.WriteVerbose($"Package '{pkgNameToInstall}' could not be installed from repository '{repository.Name}'.");
                 }
                 else if (searchVersionType == VersionType.VersionRange)
                 {

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -189,8 +189,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             List<PSResourceInfo> allPkgsInstalled = new List<PSResourceInfo>();
             bool sourceTrusted = false;
 
-            foreach (var repo in listOfRepositories)
+            // Loop through all the repositories provided (in priority order) until there no more packages to install. 
+            for (int i=0; i < listOfRepositories.Count && _pkgNamesToInstall.Count > 0; i++)
             {
+                PSRepositoryInfo repo = listOfRepositories[i];
                 sourceTrusted = repo.Trusted || trustRepository;
 
                 _networkCredential = Utils.SetNetworkCredential(repo, _networkCredential, _cmdletPassedIn);
@@ -476,11 +478,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     // At this point parent package is installed to temp path.
                     if (errRecord != null)
                     {
+                        // TODO:  Anam working on fix, this may need to be updated
                         if (errRecord.FullyQualifiedErrorId.Equals("PackageNotFound"))
                         {
                             _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
                         }
-                        else if (!errRecord.FullyQualifiedErrorId.Equals("InstallPackageFailure"))
+                        else
                         {
                             _cmdletPassedIn.WriteError(errRecord);
                         }
@@ -654,9 +657,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                 new InvalidOrEmptyResponse($"Package '{pkgNameToInstall}' could not be installed", currentResult.exception),
                                 "InstallPackageFailure",
                                 ErrorCategory.InvalidData,
-                                this);
-                   
-                    _cmdletPassedIn.WriteVerbose($"Package '{pkgNameToInstall}' could not be installed from repository '{repository.Name}'.");
+                                this);                   
                 }
                 else if (searchVersionType == VersionType.VersionRange)
                 {

--- a/test/InstallPSResourceTests/InstallPSResourceADOServer.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceADOServer.Tests.ps1
@@ -64,7 +64,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
         $pkg = Get-InstalledPSResource "NonExistantModule"
         $pkg | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
     }
 
     # Do some version testing, but Find-PSResource should be doing thorough testing

--- a/test/InstallPSResourceTests/InstallPSResourceGithubPackages.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceGithubPackages.Tests.ps1
@@ -67,7 +67,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
         $pkg = Get-InstalledPSResource "NonExistantModule"
         $pkg | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
     }
 
     # Do some version testing, but Find-PSResource should be doing thorough testing

--- a/test/InstallPSResourceTests/InstallPSResourceRepositorySearching.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceRepositorySearching.Tests.ps1
@@ -1,0 +1,137 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+$modPath = "$psscriptroot/../PSGetTestUtils.psm1"
+Import-Module $modPath -Force -Verbose
+
+$psmodulePaths = $env:PSModulePath -split ';'
+Write-Verbose -Verbose "Current module search paths: $psmodulePaths"
+
+Describe 'Test Install-PSResource for searching and looping through repositories' -tags 'CI' {
+
+    BeforeAll{
+        $testModuleName = "test_module"
+        $testModule2Name = "test_module2"
+        $testLocalModuleName = "test_local_mod"
+        $nonExistantModule = "NonExistantModule"
+        $testScriptName = "test_script"
+        $PSGalleryName = "PSGallery"
+        $NuGetGalleryName = "NuGetGallery"
+        $localRepoName = "localRepo"
+
+        Get-NewPSResourceRepositoryFile
+
+        $localRepoUriAddress = Join-Path -Path $TestDrive -ChildPath "testdir"
+        $null = New-Item $localRepoUriAddress -ItemType Directory -Force
+        Register-PSResourceRepository -Name $localRepoName -Uri $localRepoUriAddress
+
+        New-TestModule -moduleName $testModuleName -repoName localRepo -packageVersion "1.0.0" -prereleaseLabel "" -tags @()
+    }
+    AfterEach {
+        Uninstall-PSResource $testModuleName, $testModule2Name, $testLocalModuleName, $testScriptName, "RequiredModule1", "RequiredModule2", "RequiredModule3", "RequiredModule4", "RequiredModule5" -Version "*" -SkipDependencyCheck -ErrorAction SilentlyContinue
+    }
+    AfterAll {
+        Get-RevertPSResourceRepositoryFile
+    }
+
+    It "install resources from higest priority repository where it exists (without -Repository specified)" {
+        # Package "test_module" exists in the following repositories (in this order): localRepo, PSGallery, NuGetGallery
+        Install-PSResource -Name $testModuleName -TrustRepository -ErrorVariable err -ErrorAction SilentlyContinue
+        $err | Should -HaveCount 0
+
+        $res = Get-InstalledPSResource $testModuleName
+        $res | Should -Not -BeNullOrEmpty
+        $res.Repository | Should -Be $localRepoName
+    }
+
+    It "install resources from hightest priority repository where it exists and not write errors for repositories where it does not exist (without -Repository specified)" -Pending {
+        # Package "test_script" exists in the following repositories: PSGallery, NuGetGallery
+        $find = find-psresource -Name $testScriptName -Repository PSGallery
+        write-host $($find.Name)
+        Install-PSResource -Name $testScriptName -TrustRepository -ErrorVariable err -ErrorAction SilentlyContinue
+        $err | Should -HaveCount 0
+
+        $res = Get-InstalledPSResource $testScriptName
+        $res | Should -Not -BeNullOrEmpty
+        $res.Repository | Should -Be $PSGalleryName
+    }
+
+    It "should install resources that exist and not find ones that do not exist while reporting error (without -Repository specified)" -Pending {
+        Install-PSResource -Name $testScriptName,"NonExistantModule" -ErrorVariable err -ErrorAction SilentlyContinue
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+
+        $res = Get-InstalledPSResource $testScriptName
+        $res | Should -Not -BeNullOrEmpty
+        $res.Repository | Should -Be $PSGalleryName
+    }
+
+    It "should not find resource given nonexistant Name (without -Repository specified)" -Pending {
+        Install-PSResource -Name "NonExistantModule" -TrustRepository -ErrorVariable err -ErrorAction SilentlyContinue
+        $err | Should -HaveCount 1
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
+
+    It "install multiple resources from highest priority repository where it exists (without -Repository specified)" -Pending {
+        Install-PSResource -Name "test_module","test_module2" -TrustRepository -ErrorVariable err -ErrorAction SilentlyContinue
+        $err | Should -HaveCount 0
+
+        $res = Get-InstalledPSResource $testModuleName, $testModule2Name
+        $res | Should -Not -BeNullOrEmpty
+
+        $pkg1 = $res[0]
+        $pkg1.Name | Should -Be $testModuleName
+        $pkg1.Repository | Should -Be $PSGalleryName
+
+        $pkg2 = $res[1]
+        $pkg2.Name | Should -Be $testModule2Name
+        $pkg2.Repository | Should -Be $PSGalleryName
+    }
+
+    It "install resources from highest pattern matching repository where it exists (-Repository with wildcard)" {
+        # Package "test_script" exists in the following repositories: PSGallery, NuGetGallery
+        Install-PSResource -Name $testScriptName -Repository "*Gallery" -TrustRepository -ErrorVariable err -ErrorAction SilentlyContinue
+        $err | Should -HaveCount 0
+
+        $res = Get-InstalledPSResource $testScriptName
+        $res | Should -Not -BeNullOrEmpty
+        $res.Repository | Should -Be $PSGalleryName
+    }
+
+    It "should not allow for repository name with wildcard and non-wildcard name specified in same command run" -Pending {
+        { Install-PSResource -Name $testModuleName -Repository "*Gallery",$localRepoName } | Should -Throw -ErrorId "ErrorFilteringNamesForUnsupportedWildcards,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
+    }
+    
+    It "not install resource and write error if resource does not exist in any pattern matching repositories (-Repository with wildcard)" -Pending {
+        Install-PSResource -Name "nonExistantModule" -Repository "*Gallery" -TrustRepository -ErrorVariable err -ErrorAction SilentlyContinue
+        $err | Should -HaveCount 1
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
+
+    It "install resource from single specific repository (-Repository with single non-wildcard value)" {
+        Install-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository
+
+        $res = Get-InstalledPSResource $testModuleName
+        $res | Should -HaveCount 1
+        $res.Name | Should -Be $testModuleName
+        $res.Repository | Should -Be $PSGalleryName
+    }
+
+    It "not install resource if it does not exist in repository and write error (-Repository with single non-wildcard value)" -Pending {
+        Install-PSResource -Name $nonExistantModule -Repository $PSGalleryName -TrustRepository -ErrorVariable err -ErrorAction SilentlyContinue
+        $err | Should -HaveCount 1
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
+
+    It "install resource from highest priority repository where it exists (-Repository with multiple non-wildcard values)" {
+        $res = Find-PSResource -Name $testModuleName -Repository $PSGalleryName,$NuGetGalleryName
+        $res | Should -HaveCount 2
+
+        $pkg1 = $res[0]
+        $pkg1.Name | Should -Be $testModuleName
+        $pkg1.Repository | Should -Be $PSGalleryName
+
+        $pkg2 = $res[1]
+        $pkg2.Name | Should -Be $testModuleName
+        $pkg2.Repository | Should -Be $NuGetGalleryName
+    }
+}

--- a/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
@@ -555,7 +555,6 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
         $repo.ApiVersion | Should -Be "unknown"
 
         $res = Install-PSResource -Name "MyPackage" -Repository "UnknownTypeRepo" -ErrorAction SilentlyContinue -ErrorVariable err -PassThru
-        $err | Should -HaveCount 1
         $err[0].FullyQualifiedErrorId | Should -BeExactly "RepositoryApiVersionUnknown,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
         $res | Should -BeNullOrEmpty
     }

--- a/test/InstallPSResourceTests/InstallPSResourceV3Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV3Server.Tests.ps1
@@ -70,7 +70,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
         $pkg = Get-InstalledPSResource "NonExistantModule"
         $pkg.Name | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
     }
 
     # Do some version testing, but Find-PSResource should be doing thorough testing


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Similar to PR #1328, when `Save-PSResource` and `Install-PSResource` search through multiple repositories, each were previously writing errors for each repository it could not find the given package in along side the package information from the repository where it could find it.

If a package does exist in at least one repository, the changes in this PR will not write errors from the repositories where the package does not exist and instead writes verbose messages and still display package info for the repo where it is found.

If a package does not exist in any repositories, a message that states that package(s) were not found from any of the registered repositories will be displayed, along with any other errors unrelated to the package not being found (such as unauthorized exceptions).

## PR Context
Resolves #1286

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
