### PR TITLE
Bug fix for finding all versions of a package returning correct results and incorrect "package not found" error

### DIFF
--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -244,7 +244,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (initialCount != 0)
             {
                 responses.Add(initialResponse);
-                int count = initialCount / 100;
+                int count = (int)Math.Ceiling((double)(initialCount / 100));
 
                 while (count > 0)
                 {
@@ -346,12 +346,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             responses.Add(initialResponse);
 
             // check count (regex)  425 ==> count/100  ~~>  4 calls
-            int initalCount = GetCountFromResponse(initialResponse, out errRecord);  // count = 4
+            int initialCount = GetCountFromResponse(initialResponse, out errRecord);  // count = 4
             if (errRecord != null)
             {
                 return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
-            int count = initalCount / 100;
+            int count = (int)Math.Ceiling((double)(initialCount / 100));
             // if more than 100 count, loop and add response to list
             while (count > 0)
             {
@@ -389,12 +389,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             responses.Add(initialResponse);
 
             // check count (regex)  425 ==> count/100  ~~>  4 calls
-            int initalCount = GetCountFromResponse(initialResponse, out errRecord);  // count = 4
+            int initialCount = GetCountFromResponse(initialResponse, out errRecord);  // count = 4
             if (errRecord != null)
             {
                 return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
-            int count = initalCount / 100;
+            int count = (int)Math.Ceiling((double)(initialCount / 100));
             // if more than 100 count, loop and add response to list
             while (count > 0)
             {
@@ -435,12 +435,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (!getOnlyLatest)
             {
-                int initalCount = GetCountFromResponse(initialResponse, out errRecord);
+                int initialCount = GetCountFromResponse(initialResponse, out errRecord);
                 if (errRecord != null)
                 {
                     return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
-                int count = initalCount / 100;
+                int count = (int)Math.Ceiling((double)(initialCount / 100));
 
                 while (count > 0)
                 {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This is bug fix for an off by one error for the 'count' variable that gets calculated when paging through package metadata for the v2 server.

 ```PowerShell

Find-PSResource "aws.tools.elasticloadbalancing" -version "*"

Name                           Version   Prerelease Repository Description
----                           -------   ---------- ---------- -----------
AWS.Tools.ElasticLoadBalancing 4.1.99               PSGallery  The ElasticLoadBalancing module of AWS Tools for PowerShell lets developers and administrators manage Elastic Load Balancing from the Power…
AWS.Tools.ElasticLoadBalancing 4.1.98               PSGallery  The ElasticLoadBalancing module of AWS Tools for PowerShell lets developers and administrators manage Elastic Load Balancing from the Power…
AWS.Tools.ElasticLoadBalancing 4.1.97               PSGallery  The ElasticLoadBalancing module of AWS Tools for PowerShell 
...
AWS.Tools.ElasticLoadBalancing 3.3.618.1            PSGallery  [PRERELEASE] The ElasticLoadBalancing module of AWS Tools for PowerShell lets developers and administrators manage Elastic Load Balancing f…
AWS.Tools.ElasticLoadBalancing 3.3.618.0            PSGallery  [PRERELEASE] The ElasticLoadBalancing module of AWS Tools for PowerShell lets developers and administrators manage Elastic Load Balancing f…

Package 'AWS.Tools.ElasticLoadBalancing' with version '*' could not be found.
```

This PR fixes the off by one error so that no incorrect errors or verbose messages are displayed saying that package could not be found if all package versions are in fact found.
 
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
