### PR TITLE
Detect empty V2 server responses at ServerApiCall level instead of ResponseUtil level

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -631,7 +631,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                             {
                                 _cmdletPassedIn.WriteError(new ErrorRecord(
-                                    currentResult.Exception, 
+                                    currentResult.exception, 
                                     "FindAllConvertToPSResourceFailure", 
                                     ErrorCategory.InvalidResult, 
                                     this));
@@ -733,7 +733,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                 currentResult.exception, 
                                 "FindNameConvertToPSResourceFailure", 
                                 ErrorCategory.ObjectNotFound, 
-                                this););
+                                this));
 
                             continue;
                         }
@@ -852,7 +852,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                     currentResult.exception,
                                     "FindVersionGlobbingConvertToPSResourceFailure", 
                                     ErrorCategory.ObjectNotFound, 
-                                    this););
+                                    this));
 
                                 continue;
                             }

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -628,21 +628,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         foreach (PSResourceResult currentResult in currentResponseUtil.ConvertToPSResourceResult(responseResults: responses))
                         {
-                            // This currently catches for V2ServerApiCalls where the package was not found
                             if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                             {
-                                if (shouldReportErrorForEachRepo)
-                                {
-                                    _cmdletPassedIn.WriteError(new ErrorRecord(
-                                        new ResourceNotFoundException($"Package '{pkgName}' could not be found in repository '{repository.Name}", currentResult.exception), 
-                                        "FindAllConvertToPSResourceFailure", 
-                                        ErrorCategory.ObjectNotFound, 
-                                        this));
-                                }
-                                else
-                                {
-                                    _cmdletPassedIn.WriteVerbose($"Package '{pkgName}' could not be found in repository '{repository.Name}");
-                                }
+                                _cmdletPassedIn.WriteError(new ErrorRecord(
+                                    currentResult.Exception, 
+                                    "FindAllConvertToPSResourceFailure", 
+                                    ErrorCategory.InvalidResult, 
+                                    this));
 
                                 continue;
                             }
@@ -688,24 +680,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         foreach (PSResourceResult currentResult in currentResponseUtil.ConvertToPSResourceResult(responses))
                         {
-                            // This currently catches for V2ServerApiCalls where the package was not found
                             if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                             {
-                                string message = _tag.Length == 0 ? $"Package with name '{pkgName}' could not be found in repository '{repository.Name}'." : $"Package with name '{pkgName}' and tags '{tagsAsString}' could not be found in repository '{repository.Name}'.";
-                                errRecord = new ErrorRecord(
-                                            new ResourceNotFoundException(message, currentResult.exception), 
-                                            "FindNameGlobbingConvertToPSResourceFailure", 
-                                            ErrorCategory.ObjectNotFound, 
-                                            this);
-
-                                if (shouldReportErrorForEachRepo)
-                                {
-                                    _cmdletPassedIn.WriteError(errRecord);
-                                }
-                                else
-                                {
-                                    _cmdletPassedIn.WriteVerbose(message);
-                                }
+                                _cmdletPassedIn.WriteError(new ErrorRecord(
+                                    currentResult.exception, 
+                                    "FindNameGlobbingConvertToPSResourceFailure", 
+                                    ErrorCategory.InvalidResult, 
+                                    this));
 
                                 continue;
                             }
@@ -746,24 +727,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         }
 
                         PSResourceResult currentResult = currentResponseUtil.ConvertToPSResourceResult(responses).First();
-                        // This currently catches for V2ServerApiCalls where the package was not found
                         if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                         {
-                            string message = _tag.Length == 0 ? $"Package with name '{pkgName}' could not be found in repository '{repository.Name}'." : $"Package with name '{pkgName}' and tags '{tagsAsString}' could not be found in repository '{repository.Name}'.";
-                            errRecord = new ErrorRecord(
-                                        new ResourceNotFoundException(message, currentResult.exception), 
-                                        "FindNameConvertToPSResourceFailure", 
-                                        ErrorCategory.ObjectNotFound, 
-                                        this);
-
-                            if (shouldReportErrorForEachRepo)
-                            {
-                                _cmdletPassedIn.WriteError(errRecord);
-                            }
-                            else
-                            {
-                                _cmdletPassedIn.WriteVerbose(message);
-                            }
+                            _cmdletPassedIn.WriteError(new ErrorRecord(
+                                currentResult.exception, 
+                                "FindNameConvertToPSResourceFailure", 
+                                ErrorCategory.ObjectNotFound, 
+                                this););
 
                             continue;
                         }
@@ -815,23 +785,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         }
 
                         PSResourceResult currentResult = currentResponseUtil.ConvertToPSResourceResult(responses).First();
-                        // This currently catches for V2ServerApiCalls where the package was not found
                         if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                         {
-                            errRecord = new ErrorRecord(
-                                        new ResourceNotFoundException($"Package with name '{pkgName}', version '{_version}', and tags '{tagsAsString}' could not be found in repository '{repository.Name}'", currentResult.exception), 
-                                        "FindVersionConvertToPSResourceFailure", 
-                                        ErrorCategory.ObjectNotFound, 
-                                        this);
-
-                            if (shouldReportErrorForEachRepo)
-                            {
-                                _cmdletPassedIn.WriteError(errRecord);
-                            }
-                            else
-                            {
-                                _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
-                            }
+                            _cmdletPassedIn.WriteError(new ErrorRecord(
+                                currentResult.exception,
+                                "FindVersionConvertToPSResourceFailure", 
+                                ErrorCategory.ObjectNotFound, 
+                                this));
                             
                             continue;
                         }
@@ -862,7 +822,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         }
                         else
                         {
-                            var exMessage = "-Tag cannot be specified when using version range.";
+                            var exMessage = "-Tag parameter cannot be specified when using version range.";
                             var ex = new ArgumentException(exMessage);
                             var WildcardError = new ErrorRecord(ex, "InvalidWildCardUsage", ErrorCategory.InvalidOperation, null);
                             _cmdletPassedIn.WriteError(WildcardError);
@@ -888,21 +848,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             // This currently catches for V2ServerApiCalls where the package was not found
                             if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                             {
-                                errRecord = new ErrorRecord(
-                                            new ResourceNotFoundException($"Package with name '{pkgName}' and version '{_version}' could not be found in repository '{repository.Name}'", currentResult.exception),
-                                            "FindVersionGlobbingConvertToPSResourceFailure", 
-                                            ErrorCategory.ObjectNotFound, 
-                                            this);
-
-
-                                if (shouldReportErrorForEachRepo)
-                                {
-                                    _cmdletPassedIn.WriteError(errRecord);
-                                }
-                                else
-                                {
-                                    _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
-                                }
+                                _cmdletPassedIn.WriteError(new ErrorRecord(
+                                    currentResult.exception,
+                                    "FindVersionGlobbingConvertToPSResourceFailure", 
+                                    ErrorCategory.ObjectNotFound, 
+                                    this););
 
                                 continue;
                             }

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -478,15 +478,16 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     // At this point parent package is installed to temp path.
                     if (errRecord != null)
                     {
-                        // TODO:  Anam working on fix, this may need to be updated
-                        if (errRecord.FullyQualifiedErrorId.Equals("PackageNotFound"))
-                        {
-                            _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
-                        }
-                        else
-                        {
-                            _cmdletPassedIn.WriteError(errRecord);
-                        }
+                        _cmdletPassedIn.WriteError(errRecord);
+                        // // TODO:  Anam working on fix, this may need to be updated
+                        // if (errRecord.FullyQualifiedErrorId.Equals("PackageNotFound"))
+                        // {
+                        //     _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
+                        // }
+                        // else
+                        // {
+                        //     _cmdletPassedIn.WriteError(errRecord);
+                        // }
 
                         continue;
                     }
@@ -652,12 +653,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
                 {
-                    // V2Server API calls will return non-empty response when package is not found but fail at conversion time
                     errRecord = new ErrorRecord(
-                                new InvalidOrEmptyResponse($"Package '{pkgNameToInstall}' could not be installed", currentResult.exception),
-                                "InstallPackageFailure",
-                                ErrorCategory.InvalidData,
-                                this);                   
+                                    currentResult.exception, 
+                                    "FindConvertToPSResourceFailure", 
+                                    ErrorCategory.ObjectNotFound, 
+                                    this);
                 }
                 else if (searchVersionType == VersionType.VersionRange)
                 {

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -257,7 +257,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (_pkgNamesToInstall.Count > 0)
             {
-                Console.WriteLine("in here");
                 string repositoryWording = repositoryNamesToSearch.Count > 1 ? "registered repositories" : "repository";
                 _cmdletPassedIn.WriteError(new ErrorRecord(
                         new ResourceNotFoundException($"Package(s) '{string.Join(", ", _pkgNamesToInstall)}' could not be installed from {repositoryWording} '{String.Join(", ", repositoryNamesToSearch)}'."),

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -478,16 +478,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     // At this point parent package is installed to temp path.
                     if (errRecord != null)
                     {
-                        _cmdletPassedIn.WriteError(errRecord);
-                        // // TODO:  Anam working on fix, this may need to be updated
-                        // if (errRecord.FullyQualifiedErrorId.Equals("PackageNotFound"))
-                        // {
-                        //     _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
-                        // }
-                        // else
-                        // {
-                        //     _cmdletPassedIn.WriteError(errRecord);
-                        // }
+                        if (errRecord.FullyQualifiedErrorId.Equals("PackageNotFound"))
+                        {
+                            _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
+                        }
+                        else
+                        {
+                            _cmdletPassedIn.WriteError(errRecord);
+                        }
 
                         continue;
                     }

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -187,22 +187,24 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             var findHelper = new FindHelper(_cancellationToken, _cmdletPassedIn, _networkCredential);
             List<PSResourceInfo> allPkgsInstalled = new List<PSResourceInfo>();
+            List<string> repositoryNamesToSearch = new List<string>();
             bool sourceTrusted = false;
 
             // Loop through all the repositories provided (in priority order) until there no more packages to install. 
-            for (int i=0; i < listOfRepositories.Count && _pkgNamesToInstall.Count > 0; i++)
+            for (int i = 0; i < listOfRepositories.Count && _pkgNamesToInstall.Count > 0; i++)
             {
-                PSRepositoryInfo repo = listOfRepositories[i];
-                sourceTrusted = repo.Trusted || trustRepository;
+                PSRepositoryInfo currentRepository = listOfRepositories[i];
+                string repoName = currentRepository.Name;
+                sourceTrusted = currentRepository.Trusted || trustRepository;
 
-                _networkCredential = Utils.SetNetworkCredential(repo, _networkCredential, _cmdletPassedIn);
-                ServerApiCall currentServer = ServerFactory.GetServer(repo, _networkCredential);
+                _networkCredential = Utils.SetNetworkCredential(currentRepository, _networkCredential, _cmdletPassedIn);
+                ServerApiCall currentServer = ServerFactory.GetServer(currentRepository, _networkCredential);
 
                 if (currentServer == null)
                 {
                     // this indicates that PSRepositoryInfo.APIVersion = PSRepositoryInfo.APIVersion.unknown
                     _cmdletPassedIn.WriteError(new ErrorRecord(
-                    new PSInvalidOperationException($"Repository '{repo.Name}' is not a known repository type that is supported. Please file an issue for support at https://github.com/PowerShell/PSResourceGet/issues"),
+                    new PSInvalidOperationException($"Repository '{currentRepository.Name}' is not a known repository type that is supported. Please file an issue for support at https://github.com/PowerShell/PSResourceGet/issues"),
                     "RepositoryApiVersionUnknown",
                     ErrorCategory.InvalidArgument,
                     this));
@@ -210,7 +212,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     continue;
                 }
 
-                ResponseUtil currentResponseUtil = ResponseUtilFactory.GetResponseUtil(repo);
+                ResponseUtil currentResponseUtil = ResponseUtilFactory.GetResponseUtil(currentRepository);
                 bool installDepsForRepo = skipDependencyCheck;
 
                 // If no more packages to install, then return
@@ -218,10 +220,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     return allPkgsInstalled;
                 }
 
-                string repoName = repo.Name;
                 _cmdletPassedIn.WriteVerbose(string.Format("Attempting to search for packages in '{0}'", repoName));
 
-                if (repo.Trusted == false && !trustRepository && !_force)
+                if (currentRepository.Trusted == false && !trustRepository && !_force)
                 {
                     _cmdletPassedIn.WriteVerbose("Checking if untrusted repository should be used");
 
@@ -238,13 +239,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     continue;
                 }
 
-                if ((repo.ApiVersion == PSRepositoryInfo.APIVersion.v3) && (!installDepsForRepo))
+                repositoryNamesToSearch.Add(repoName);
+                if ((currentRepository.ApiVersion == PSRepositoryInfo.APIVersion.v3) && (!installDepsForRepo))
                 {
                     _cmdletPassedIn.WriteWarning("Installing dependencies is not currently supported for V3 server protocol repositories. The package will be installed without installing dependencies.");
                     installDepsForRepo = true;
                 }
 
-                var installedPkgs = InstallPackages(_pkgNamesToInstall.ToArray(), repo, currentServer, currentResponseUtil, scope, skipDependencyCheck, findHelper);
+                var installedPkgs = InstallPackages(_pkgNamesToInstall.ToArray(), currentRepository, currentServer, currentResponseUtil, scope, skipDependencyCheck, findHelper);
                 foreach (var pkg in installedPkgs)
                 {
                     _pkgNamesToInstall.RemoveAll(x => x.Equals(pkg.Name, StringComparison.InvariantCultureIgnoreCase));
@@ -253,9 +255,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 allPkgsInstalled.AddRange(installedPkgs);
             }
 
-            if (_pkgNamesToInstall.Count > 0) {
+            if (_pkgNamesToInstall.Count > 0)
+            {
+                Console.WriteLine("in here");
+                string repositoryWording = repositoryNamesToSearch.Count > 1 ? "registered repositories" : "repository";
                 _cmdletPassedIn.WriteError(new ErrorRecord(
-                        new ResourceNotFoundException($"Package(s) '{string.Join(", ", _pkgNamesToInstall)}' could not be installed from an."),
+                        new ResourceNotFoundException($"Package(s) '{string.Join(", ", _pkgNamesToInstall)}' could not be installed from {repositoryWording} '{String.Join(", ", repositoryNamesToSearch)}'."),
                         "InstallPackageFailure",
                         ErrorCategory.InvalidData,
                         this));

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -353,7 +353,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (String.IsNullOrEmpty(latestVersionPath))
             {
                 // means no package was found with this name
-                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name {packageName} could not be found in repository '{Repository.Name}'."), "FindNameFailure", ErrorCategory.ResourceUnavailable, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name {packageName} could not be found in repository '{Repository.Name}'."), "PackageNotFound", ErrorCategory.ResourceUnavailable, this);
                 return findResponse;
             }
 
@@ -366,7 +366,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // this condition will be true, for FindNameWithTags() when package satisfying that criteria is not met
             if (pkgMetadata.Count == 0)
             {
-                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), "FindNameFailure", ErrorCategory.ResourceUnavailable, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), "PackageNotFound", ErrorCategory.ResourceUnavailable, this);
             }
 
             findResponse = new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: new Hashtable[]{pkgMetadata}, responseType: _localServerFindResponseType);
@@ -444,7 +444,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (String.IsNullOrEmpty(pkgPath))
             {
                 // means no package was found with this name, version (and possibly tags).
-                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}', version '{version}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), "FindVersionFailure", ErrorCategory.ResourceUnavailable, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}', version '{version}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), "PackageNotFound", ErrorCategory.ResourceUnavailable, this);
                 return findResponse;
             }
 
@@ -457,7 +457,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // this condition will be true, for FindVersionWithTags() when package satisfying that criteria is not met
             if (pkgMetadata.Count == 0)
             {
-                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}', and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), "FindVersionFailure", ErrorCategory.InvalidResult, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}', and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), "PackageNotFound", ErrorCategory.InvalidResult, this);
             }
 
             findResponse = new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: new Hashtable[]{pkgMetadata}, responseType: _localServerFindResponseType);

--- a/src/code/Microsoft.PowerShell.PSResourceGet.csproj
+++ b/src/code/Microsoft.PowerShell.PSResourceGet.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Commands" Version="6.2.4" />
+    <PackageReference Include="NuGet.Commands" Version="6.7.0" />
     <PackageReference Include="NuGet.Common" Version="6.7.0" />
     <PackageReference Include="NuGet.Configuration" Version="6.7.0" />
     <PackageReference Include="NuGet.Packaging" Version="6.7.0" />

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -549,7 +549,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: new string[]{ string.Empty }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
             }
 
             int count = GetCountFromResponse(response, out errRecord);

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -316,7 +316,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             int count = GetCountFromResponse(response, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: new string[]{ string.Empty }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
             }
 
             if (count == 0)

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -1,4 +1,3 @@
-using System.Text;
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -306,7 +306,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
             string idFilterPart = $" and Id eq '{packageName}'";
             string typeFilterPart = GetTypeFilterForRequest(type);
-            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter={prerelease}{idFilterPart}{typeFilterPart}";
+            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$inlinecount=allpages&$filter={prerelease}{idFilterPart}{typeFilterPart}";
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             if (errRecord != null)
             {
@@ -350,8 +350,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 tagFilterPart += $" and substringof('{tag}', Tags) eq true";
             }
 
-            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter={prerelease}{idFilterPart}{typeFilterPart}{tagFilterPart}";
-
+            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$inlinecount=allpages&$filter={prerelease}{idFilterPart}{typeFilterPart}{tagFilterPart}";
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             if (errRecord != null)
             {
@@ -544,8 +543,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
             string idFilterPart = $" and Id eq '{packageName}'";
             string typeFilterPart = GetTypeFilterForRequest(type);
-            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter= NormalizedVersion eq '{version}'{idFilterPart}{typeFilterPart}";
-
+            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$inlinecount=allpages&$filter= NormalizedVersion eq '{version}'{idFilterPart}{typeFilterPart}";
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             if (errRecord != null)
             {
@@ -584,8 +582,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 tagFilterPart += $" and substringof('{tag}', Tags) eq true";
             }
 
-            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter= NormalizedVersion eq '{version}'{idFilterPart}{typeFilterPart}{tagFilterPart}";
-
+            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$inlinecount=allpages&$filter= NormalizedVersion eq '{version}'{idFilterPart}{typeFilterPart}{tagFilterPart}";
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             if (errRecord != null)
             {
@@ -721,7 +718,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             var prereleaseFilter = includePrerelease ? "IsAbsoluteLatestVersion&includePrerelease=true" : "IsLatestVersion";
 
             var requestUrlV2 = $"{Repository.Uri}{typeEndpoint}/Search()?$filter={prereleaseFilter}{paginationParam}";
-
             return HttpRequestCall(requestUrlV2, out errRecord);
         }
 
@@ -830,7 +826,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             string typeFilterPart = GetTypeFilterForRequest(type);
             var requestUrlV2 = $"{Repository.Uri}/Search()?$filter={nameFilter}{typeFilterPart} and {prerelease}{extraParam}";
-
             return HttpRequestCall(requestUrlV2, out errRecord);
         }
 
@@ -895,7 +890,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             string typeFilterPart = GetTypeFilterForRequest(type);
             var requestUrlV2 = $"{Repository.Uri}/Search()?$filter={nameFilter}{tagFilterPart}{typeFilterPart} and {prerelease}{extraParam}";
-
             return HttpRequestCall(requestUrlV2, out errRecord);
         }
 
@@ -996,7 +990,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             filterQuery = filterQuery.EndsWith("=") ? string.Empty : filterQuery;
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$orderby=NormalizedVersion desc&{paginationParam}{filterQuery}";
-
             return HttpRequestCall(requestUrlV2, out errRecord);
         }
 

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using Microsoft.VisualBasic.CompilerServices;
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
@@ -75,26 +77,32 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 string initialScriptResponse = FindAllFromTypeEndPoint(includePrerelease, isSearchingModule: false, scriptSkip, out errRecord);
                 if (errRecord != null)
                 {
-                    return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                    return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
-                responses.Add(initialScriptResponse);
-                int initalScriptCount = GetCountFromResponse(initialScriptResponse, out errRecord);
+
+                int initialScriptCount = GetCountFromResponse(initialScriptResponse, out errRecord);
                 if (errRecord != null)
                 {
-                    return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                    return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
-                int count = initalScriptCount / 6000;
-                // if more than 100 count, loop and add response to list
-                while (count > 0)
+
+                if (initialScriptCount != 0)
                 {
-                    scriptSkip += 6000;
-                    var tmpResponse = FindAllFromTypeEndPoint(includePrerelease, isSearchingModule: false, scriptSkip, out errRecord);
-                    if (errRecord != null)
+                    responses.Add(initialScriptResponse);
+                    int count = initialScriptCount / 6000;
+                    // if more than 100 count, loop and add response to list
+                    while (count > 0)
                     {
-                        return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                        scriptSkip += 6000;
+                        var tmpResponse = FindAllFromTypeEndPoint(includePrerelease, isSearchingModule: false, scriptSkip, out errRecord);
+                        if (errRecord != null)
+                        {
+                            return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                        }
+
+                        responses.Add(tmpResponse);
+                        count--;
                     }
-                    responses.Add(tmpResponse);
-                    count--;
                 }
             }
             if (type != ResourceType.Script)
@@ -103,27 +111,33 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 string initialModuleResponse = FindAllFromTypeEndPoint(includePrerelease, isSearchingModule: true, moduleSkip, out errRecord);
                 if (errRecord != null)
                 {
-                    return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                    return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
-                responses.Add(initialModuleResponse);
-                int initalModuleCount = GetCountFromResponse(initialModuleResponse, out errRecord);
+
+                int initialModuleCount = GetCountFromResponse(initialModuleResponse, out errRecord);
                 if (errRecord != null)
                 {
-                    return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                    return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
-                int count = initalModuleCount / 6000;
 
-                // if more than 100 count, loop and add response to list
-                while (count > 0)
+                if (initialModuleCount != 0)
                 {
-                    moduleSkip += 6000;
-                    var tmpResponse = FindAllFromTypeEndPoint(includePrerelease, isSearchingModule: true, moduleSkip, out errRecord);
-                    if (errRecord != null)
+                    responses.Add(initialModuleResponse);
+                    int count = initialModuleCount / 6000;
+
+                    // if more than 100 count, loop and add response to list
+                    while (count > 0)
                     {
-                        return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                        moduleSkip += 6000;
+                        var tmpResponse = FindAllFromTypeEndPoint(includePrerelease, isSearchingModule: true, moduleSkip, out errRecord);
+                        if (errRecord != null)
+                        {
+                            return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                        }
+
+                        responses.Add(tmpResponse);
+                        count--;
                     }
-                    responses.Add(tmpResponse);
-                    count--;
                 }
             }
 
@@ -147,13 +161,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 string initialScriptResponse = FindTagFromEndpoint(tags, includePrerelease, isSearchingModule: false, scriptSkip, out errRecord);
                 if (errRecord != null)
                 {
-                    return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                    return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
 
                 int initialScriptCount = GetCountFromResponse(initialScriptResponse, out errRecord);
                 if (errRecord != null)
                 {
-                    return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                    return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
 
                 if (initialScriptCount != 0)
@@ -168,8 +182,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         var tmpResponse = FindTagFromEndpoint(tags, includePrerelease, isSearchingModule: false,  scriptSkip, out errRecord);
                         if (errRecord != null)
                         {
-                            return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                            return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                         }
+
                         responses.Add(tmpResponse);
                         count--;
                     }
@@ -181,19 +196,19 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 string initialModuleResponse = FindTagFromEndpoint(tags, includePrerelease, isSearchingModule: true, moduleSkip, out errRecord);
                 if (errRecord != null)
                 {
-                    return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                    return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
 
-                int initalModuleCount = GetCountFromResponse(initialModuleResponse, out errRecord);
+                int initialModuleCount = GetCountFromResponse(initialModuleResponse, out errRecord);
                 if (errRecord != null)
                 {
-                    return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                    return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
 
-                if (initalModuleCount != 0)
+                if (initialModuleCount != 0)
                 {
                     responses.Add(initialModuleResponse);
-                    int count = initalModuleCount / 100;
+                    int count = initialModuleCount / 100;
                     // if more than 100 count, loop and add response to list
                     while (count > 0)
                     {
@@ -201,8 +216,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         var tmpResponse = FindTagFromEndpoint(tags, includePrerelease, isSearchingModule: true, moduleSkip, out errRecord);
                         if (errRecord != null)
                         {
-                            return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                            return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                         }
+
                         responses.Add(tmpResponse);
                         count--;
                     }
@@ -232,13 +248,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string initialResponse = FindCommandOrDscResource(tags, includePrerelease, isSearchingForCommands, skip, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
 
             int initialCount = GetCountFromResponse(initialResponse, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
 
             if (initialCount != 0)
@@ -252,8 +268,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     var tmpResponse = FindCommandOrDscResource(tags, includePrerelease, isSearchingForCommands, skip, out errRecord);
                     if (errRecord != null)
                     {
-                        return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                        return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                     }
+
                     responses.Add(tmpResponse);
                     count--;
                 }
@@ -293,6 +310,23 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string typeFilterPart = GetTypeFilterForRequest(type);
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter={prerelease}{idFilterPart}{typeFilterPart}";
             string response = HttpRequestCall(requestUrlV2, out errRecord);
+            if (errRecord != null)
+            {
+                return new FindResults(stringResponse: new string[]{ string.Empty }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+            }
+
+            int count = GetCountFromResponse(response, out errRecord);
+            if (errRecord != null)
+            {
+                return new FindResults(stringResponse: new string[]{ string.Empty }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+            }
+
+            if (count == 0)
+            {
+                string errMsg = $"Package with name '{packageName}' could not be found in repository '{Repository.Name}'.";
+                errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "FindNameFailure", ErrorCategory.ObjectNotFound, this);
+            }
+
             return new FindResults(stringResponse: new string[]{ response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
         }
 
@@ -321,6 +355,23 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter={prerelease}{idFilterPart}{typeFilterPart}{tagFilterPart}";
 
             string response = HttpRequestCall(requestUrlV2, out errRecord);
+            if (errRecord != null)
+            {
+                return new FindResults(stringResponse: new string[]{ string.Empty }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+            }
+
+            int count = GetCountFromResponse(response, out errRecord);
+            if (errRecord != null)
+            {
+                return new FindResults(stringResponse: new string[]{ string.Empty }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+            }
+
+            if (count == 0)
+            {
+                string errMsg = $"Package with name '{packageName}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'.";
+                errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "FindNameFailure", ErrorCategory.ObjectNotFound, this);
+            }
+
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
         }
 
@@ -340,7 +391,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             var initialResponse = FindNameGlobbing(packageName, type, includePrerelease, skip, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
 
             responses.Add(initialResponse);
@@ -349,8 +400,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             int initialCount = GetCountFromResponse(initialResponse, out errRecord);  // count = 4
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
+
+            // If count is 0, early out as this means no packages matching search criteria were found. We want to set the responses array to empty and not set ErrorRecord (as is a globbing scenario).
+            if (initialCount == 0)
+            {
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);   
+            }
+
             int count = (int)Math.Ceiling((double)(initialCount / 100));
             // if more than 100 count, loop and add response to list
             while (count > 0)
@@ -360,8 +418,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 var tmpResponse = FindNameGlobbing(packageName, type, includePrerelease, skip, out errRecord);
                 if (errRecord != null)
                 {
-                    return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                    return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
+
                 responses.Add(tmpResponse);
                 count--;
             }
@@ -383,7 +442,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             var initialResponse = FindNameGlobbingWithTag(packageName, tags, type, includePrerelease, skip, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
 
             responses.Add(initialResponse);
@@ -392,8 +451,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             int initialCount = GetCountFromResponse(initialResponse, out errRecord);  // count = 4
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
+
+            if (initialCount == 0)
+            {
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);   
+            }
+
             int count = (int)Math.Ceiling((double)(initialCount / 100));
             // if more than 100 count, loop and add response to list
             while (count > 0)
@@ -403,8 +468,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 var tmpResponse = FindNameGlobbingWithTag(packageName, tags, type, includePrerelease, skip, out errRecord);
                 if (errRecord != null)
                 {
-                    return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                    return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                 }
+
                 responses.Add(tmpResponse);
                 count--;
             }
@@ -429,17 +495,24 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             var initialResponse = FindVersionGlobbing(packageName, versionRange, includePrerelease, type, skip, getOnlyLatest, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
+
+            int initialCount = GetCountFromResponse(initialResponse, out errRecord);
+            if (errRecord != null)
+            {
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+            }
+
+            if (initialCount == 0)
+            {
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);   
+            }
+
             responses.Add(initialResponse);
 
             if (!getOnlyLatest)
             {
-                int initialCount = GetCountFromResponse(initialResponse, out errRecord);
-                if (errRecord != null)
-                {
-                    return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
-                }
                 int count = (int)Math.Ceiling((double)(initialCount / 100));
 
                 while (count > 0)
@@ -449,7 +522,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     var tmpResponse = FindVersionGlobbing(packageName, versionRange, includePrerelease, type, skip, getOnlyLatest, out errRecord);
                     if (errRecord != null)
                     {
-                        return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
+                        return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
                     }
                     responses.Add(tmpResponse);
                     count--;
@@ -476,6 +549,23 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter= NormalizedVersion eq '{version}'{idFilterPart}{typeFilterPart}";
 
             string response = HttpRequestCall(requestUrlV2, out errRecord);
+            if (errRecord != null)
+            {
+                return new FindResults(stringResponse: new string[]{ string.Empty }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+            }
+
+            int count = GetCountFromResponse(response, out errRecord);
+            if (errRecord != null)
+            {
+                return new FindResults(stringResponse: new string[]{ string.Empty }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+            }
+
+            if (count == 0)
+            {
+                string errMsg = $"Package with name '{packageName}', version '{version}' could not be found in repository '{Repository.Name}'.";
+                errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "FindVersionFailure", ErrorCategory.ObjectNotFound, this);
+            }
+
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
         }
 
@@ -499,6 +589,23 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter= NormalizedVersion eq '{version}'{idFilterPart}{typeFilterPart}{tagFilterPart}";
 
             string response = HttpRequestCall(requestUrlV2, out errRecord);
+            if (errRecord != null)
+            {
+                return new FindResults(stringResponse: new string[]{ string.Empty }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+            }
+
+            int count = GetCountFromResponse(response, out errRecord);
+            if (errRecord != null)
+            {
+                return new FindResults(stringResponse: new string[]{ string.Empty }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+            }
+
+            if (count == 0)
+            {
+                string errMsg = $"Package with name '{packageName}', version '{version}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'.";
+                errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "FindVersionFailure", ErrorCategory.ObjectNotFound, this);
+            }
+            
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
         }
 

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -322,7 +322,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (count == 0)
             {
                 string errMsg = $"Package with name '{packageName}' could not be found in repository '{Repository.Name}'.";
-                errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "FindNameFailure", ErrorCategory.ObjectNotFound, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
             }
 
             return new FindResults(stringResponse: new string[]{ response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
@@ -366,7 +366,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (count == 0)
             {
                 string errMsg = $"Package with name '{packageName}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'.";
-                errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "FindNameFailure", ErrorCategory.ObjectNotFound, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
             }
 
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
@@ -559,7 +559,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (count == 0)
             {
                 string errMsg = $"Package with name '{packageName}', version '{version}' could not be found in repository '{Repository.Name}'.";
-                errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "FindVersionFailure", ErrorCategory.ObjectNotFound, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
             }
 
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
@@ -598,7 +598,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (count == 0)
             {
                 string errMsg = $"Package with name '{packageName}', version '{version}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'.";
-                errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "FindVersionFailure", ErrorCategory.ObjectNotFound, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
             }
             
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -589,7 +589,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: new string[]{ string.Empty }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
             }
 
             int count = GetCountFromResponse(response, out errRecord);

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -595,7 +595,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             int count = GetCountFromResponse(response, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: new string[]{ string.Empty }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
             }
 
             if (count == 0)

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -355,7 +355,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: new string[]{ string.Empty }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
             }
 
             int count = GetCountFromResponse(response, out errRecord);

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -1,5 +1,3 @@
-using System.Security.Cryptography;
-using Microsoft.VisualBasic.CompilerServices;
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -310,7 +310,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: new string[]{ string.Empty }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
             }
 
             int count = GetCountFromResponse(response, out errRecord);

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -1,3 +1,4 @@
+using System.Text;
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
@@ -323,6 +324,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 string errMsg = $"Package with name '{packageName}' could not be found in repository '{Repository.Name}'.";
                 errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
+                response = string.Empty;
             }
 
             return new FindResults(stringResponse: new string[]{ response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
@@ -367,6 +369,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 string errMsg = $"Package with name '{packageName}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'.";
                 errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
+                response = string.Empty;
             }
 
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
@@ -560,6 +563,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 string errMsg = $"Package with name '{packageName}', version '{version}' could not be found in repository '{Repository.Name}'.";
                 errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
+                response = string.Empty;
             }
 
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
@@ -599,6 +603,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 string errMsg = $"Package with name '{packageName}', version '{version}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'.";
                 errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
+                response = string.Empty;
             }
             
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -361,7 +361,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             int count = GetCountFromResponse(response, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: new string[]{ string.Empty }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
             }
 
             if (count == 0)

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -555,7 +555,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             int count = GetCountFromResponse(response, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: new string[]{ string.Empty }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
             }
 
             if (count == 0)

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -531,7 +531,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (String.IsNullOrEmpty(latestVersionResponse))
             {
-                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}', version '{version}' could not be found in repository '{Repository.Name}'"), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}', version '{version}' could not be found in repository '{Repository.Name}'."), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
 
@@ -825,7 +825,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (errRecord != null)
             {
                 if (errRecord.Exception is ResourceNotFoundException) {
-                    errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}'", errRecord.Exception), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
+                    errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}'.", errRecord.Exception), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
                 }
 
                 return metadataElement;
@@ -873,7 +873,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 if (errRecord.Exception is ResourceNotFoundException)
                 {
-                    errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}.'", errRecord.Exception), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
+                    errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}'.", errRecord.Exception), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
                 }
 
                 return Utils.EmptyStrArray;

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -455,7 +455,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (String.IsNullOrEmpty(latestVersionResponse))
             {
                 string errMsg = $"Package with name '{packageName}' could not be found in repository '{Repository.Name}'.";
-                errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "FindNameFailure", ErrorCategory.InvalidResult, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
 
@@ -465,7 +465,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (errRecord == null)
                 {
                     string errMsg = $"Package with name '{packageName}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'.";
-                    errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "FindNameFailure", ErrorCategory.InvalidResult, this);
+                    errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
                 }
 
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -531,7 +531,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (String.IsNullOrEmpty(latestVersionResponse))
             {
-                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}', version '{version}' could not be found in repository '{Repository.Name}'"), "FindVersionFailure", ErrorCategory.InvalidResult, this);
+                errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}', version '{version}' could not be found in repository '{Repository.Name}'"), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
 
@@ -540,7 +540,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (errRecord == null)
                 {
                     string errMsg = $"FindVersion(): Package with name '{packageName}', version '{version}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'.";
-                    errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "FindVersionFailure", ErrorCategory.InvalidResult, this);
+                    errRecord = new ErrorRecord(new ResourceNotFoundException(errMsg), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
                 }
 
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -888,7 +888,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     JsonElement rootDom = pkgVersionEntry.RootElement;
                     if (!rootDom.TryGetProperty(itemsName, out JsonElement itemsElement) || itemsElement.GetArrayLength() == 0)
                     {
-                        errRecord = new ErrorRecord(new ArgumentException($"Response does not contain '{itemsName}' element for package with name '{packageName}' from repository '{Repository.Name}'."), " ", ErrorCategory.InvalidResult, this);
+                        errRecord = new ErrorRecord(new ArgumentException($"Response does not contain '{itemsName}' element for package with name '{packageName}' from repository '{Repository.Name}'."), "GetResponsesFromRegistrationsResourceFailure", ErrorCategory.InvalidResult, this);
                         return Utils.EmptyStrArray;
                     }
 

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -873,7 +873,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 if (errRecord.Exception is ResourceNotFoundException)
                 {
-                    errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}'", errRecord.Exception), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
+                    errRecord = new ErrorRecord(new ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}.'", errRecord.Exception), "PackageNotFound", ErrorCategory.ObjectNotFound, this);
                 }
 
                 return Utils.EmptyStrArray;

--- a/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
@@ -155,7 +155,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name, Version and Tag property (multiple tags)" {
@@ -175,7 +175,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTags -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resources given Tag property" {

--- a/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
@@ -109,7 +109,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name and Tag property (multiple tags)" {
@@ -127,7 +127,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTags -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resources when given Name with wildcard and Tag proprties" {

--- a/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
@@ -115,7 +115,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name and Tag property (multiple tags)" {
@@ -133,7 +133,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTags -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find all resources that satisfy Name pattern and have specified Tag (single tag)" {

--- a/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
@@ -192,7 +192,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name, Version and Tag property (multiple tags)" {
@@ -212,7 +212,7 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTags -Repository $GithubPackagesRepoName -Credential $credential -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resources given Tag property" {

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -77,7 +77,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $localRepo -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 
@@ -150,7 +150,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $localRepo -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -214,7 +214,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $localRepo -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 

--- a/test/FindPSResourceTests/FindPSResourceRepositorySearching.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceRepositorySearching.Tests.ps1
@@ -235,7 +235,7 @@ Describe 'Test Find-PSResource for searching and looping through repositories' -
         $res = Find-PSResource -Name "NonExistantPkg" -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err | Should -HaveCount 1
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "not find resource if it does not exist in repository and not write error given package Name with wildcard (-Repository with single non-wildcard value)" -Pending {
@@ -268,7 +268,7 @@ Describe 'Test Find-PSResource for searching and looping through repositories' -
         $pkg1.Name | Should -Be $pkgOnNuGetGallery
         $pkg1.Repository | Should -Be $NuGetGalleryName
 
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resource from repositories where it does not exist and not write error since package Name contains wilcard" -Pending {

--- a/test/FindPSResourceTests/FindPSResourceRepositorySearching.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceRepositorySearching.Tests.ps1
@@ -235,7 +235,7 @@ Describe 'Test Find-PSResource for searching and looping through repositories' -
         $res = Find-PSResource -Name "NonExistantPkg" -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err | Should -HaveCount 1
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "not find resource if it does not exist in repository and not write error given package Name with wildcard (-Repository with single non-wildcard value)" -Pending {
@@ -268,7 +268,7 @@ Describe 'Test Find-PSResource for searching and looping through repositories' -
         $pkg1.Name | Should -Be $pkgOnNuGetGallery
         $pkg1.Repository | Should -Be $NuGetGalleryName
 
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "should not find resource from repositories where it does not exist and not write error since package Name contains wilcard" -Pending {

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -292,7 +292,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name, Version and Tag property (multiple tags)" {
@@ -312,7 +312,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTags -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     # It "find all resources with specified tag given Tag property" {

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -34,7 +34,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 
@@ -215,7 +215,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name and Tag property (multiple tags)" {
@@ -233,7 +233,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTags -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find all resources that satisfy Name pattern and have specified Tag (single tag)" {
@@ -292,7 +292,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name, Version and Tag property (multiple tags)" {
@@ -312,7 +312,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTags -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionConvertToPSResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     # It "find all resources with specified tag given Tag property" {

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -34,7 +34,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name NonExistantModule -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 
@@ -215,7 +215,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name and Tag property (multiple tags)" {
@@ -233,7 +233,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTags -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find all resources that satisfy Name pattern and have specified Tag (single tag)" {

--- a/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
@@ -124,7 +124,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTag -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name and Tag property (multiple tags)" {
@@ -142,7 +142,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Tag $requiredTags -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find all resources that satisfy Name pattern and have specified Tag (single tag)" {
@@ -273,7 +273,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name "PMTestDependency1" -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
     
     # "carb*" is intentionally chosen as a sequence that will trigger pagination (ie more than 100 results),

--- a/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
@@ -201,7 +201,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "find resource that satisfies given Name, Version and Tag property (multiple tags)" {
@@ -221,7 +221,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTags -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     # It "find all resources with specified tag given Tag property" {

--- a/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
@@ -76,7 +76,7 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
         $res = Install-PSResource -Name "NonExistantModule" -Repository $localRepo -TrustRepository -PassThru -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
     }
 
     It "Should install resource given name and exact version with bracket syntax" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

Previously for scenarios where a package could not be found on the server, V2ServerApiCall responses returned were non-empty XML responses, so an error indicating package not found was not detected and errRecord was not populated. This meant that at the ResponseUtil level the response would try to be converted to a PSResourceInfo and throw an error and we would catch and error handle in FindHelper for the "Package not found" scenario.

This PR changes that. The parameter `$inlinecount=allpages` is added to the V2 request so that `count` is always returned in the response. This is used to detect a "Package not found" scenario and then an errRecord with FullyQualifiedErrorId "PackageNotFound" is returned and detected in FindHelper to properly error write or write verbose.

Changes were also made to the other ServerApiCalls classes to consistently return errRecords with FullyQualifiedErrorId "PackageNotFound" when a package isn't found.


# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1349
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
