### PR TITLE
Repository searching examples

### DIFF
--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -128,7 +128,8 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         
     * When the package is in neither repository:
         ```
-        Find-PSResource: Package 'TestModule' could not be found.
+        Find-PSResource: Package with name 'TestModule' could not be found in repository 'PSGallery'.
+        Find-PSResource: Package with name 'TestModule' could not be found in repository 'NuGetGallery'.
         ```
         
 5) Searching with a package name specified and both a repository name specified AND a repository name with a wildcard, eg: `Find-PSResource 'TestModule' -Repository *Gallery, LocalRepo`

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -125,6 +125,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         TestModule  1.0.0.0            NuGetGallery 
         ```
         Should return 'TestModule' from 'NuGetGallery'.
+        Find-PSResource: Package with name 'TestModule' could not be found in repository 'PSGallery'.
         
     * When the package is in neither repository:
         ```

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -131,6 +131,8 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         
 5) Searching with a package name specified and both a repository name specified AND a repository name with a wildcard, eg: `Find-PSResource 'TestModule' -Repository *Gallery, LocalRepo`
+
+    * For all scenarios:
         ```
         Find-PSResource: Package 'TestModule' could not be found.
         ```

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -11,6 +11,8 @@ PSGallery    https://www.powershellgallery.com/api/v2 True    50
 NuGetGallery https://api.nuget.org/v3/index.json      True    60
 ```
 
+Note that PSGallery is a lower priority than NuGetGallery.
+
 1) Searching with only a package name specified, eg: `Find-PSResource 'TestModule'` or `Find-PSResource 'TestModule' -Repository '*'`
     * When the package exists in both repositories:
         ```
@@ -21,7 +23,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
        Should return 'TestModule' from both 'PSGallery' and 'NuGetGallery'.
        
-    * When the package exists in the first repository, but not the second:
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------
@@ -29,7 +31,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should return 'TestModule' from 'PSGallery'.
 
-    * When the package exists in the second repository, but not the first:
+    * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------
@@ -37,7 +39,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should return 'TestModule' from 'NuGetGallery'.
 
-    * When the package is in neither repository:
+    * When the package exists in neither repository:
         ```
         Find-PSResource: Package 'TestModule' could not be found in any registered repositories.
         ```
@@ -50,7 +52,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should return 'TestModule' from 'PSGallery'.
 
-    * When the package is in the first repository (PSGallery), but not the second (NuGetGallery):
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------
@@ -58,11 +60,11 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should return 'TestModule' from 'PSGallery'.
         
-    * When the package is the second repository, but not the first:
+    * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
         ```
         Package with name 'TestModule' could not be found in repository 'PSGallery'.
         ```
-    * When the package is in neither repository:
+    * When the package exists in neither repository:
         ```
         Find-PSResource: Package 'TestModule' could not be found.
         ```
@@ -77,7 +79,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should return 'TestModule' from 'PSGallery' and 'NuGetGallery'.
         
-    * When the package is in the first repository, but not the second:
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------
@@ -85,7 +87,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should return 'TestModule' from 'PSGallery'.
         
-    * When the package exists in the second repository, but not the first:
+    * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------
@@ -93,7 +95,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should return 'TestModule' from 'NuGetGallery'.
         
-    * When the package is in neither repository:
+    * When the package exists in neither repository:
         ```
         Find-PSResource: Package 'TestModule' could not be found.
         ```
@@ -109,23 +111,27 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should return 'TestModule' from 'PSGallery' and 'NuGetGallery'.
         
-    * When the package is in the first repository, but not the second:
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------
         TestModule  1.0.0.0            PSGallery 
+        
+        Find-PSResource: Package with name 'TestModule' could not be found in repository 'NuGetGallery'.
         ```
         Should return 'TestModule' from 'PSGallery'.
-        Find-PSResource: Package with name 'TestModule' could not be found in repository 'NuGetGallery'.
+       
         
-    * When the package is the second repository, but not the first:
+    * When the package exists the second repository (NuGetGallery), but not the first (PSGallery):
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------
         TestModule  1.0.0.0            NuGetGallery 
+        
+        Find-PSResource: Package with name 'TestModule' could not be found in repository 'PSGallery'.
         ```
         Should return 'TestModule' from 'NuGetGallery'.
-        Find-PSResource: Package with name 'TestModule' could not be found in repository 'PSGallery'.
+        
         
     * When the package is in neither repository:
         ```
@@ -133,7 +139,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         Find-PSResource: Package with name 'TestModule' could not be found in repository 'NuGetGallery'.
         ```
         
-5) Searching with a package name specified and both a repository name specified AND a repository name with a wildcard, eg: `Find-PSResource 'TestModule' -Repository *Gallery, LocalRepo`
+5) Searching with a package name specified and both a repository name specified AND a repository name with a wildcard, eg: `Find-PSResource 'TestModule' -Repository *Gallery, PSGallery`
 
     * For all scenarios:
         ```

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -66,7 +66,7 @@ Note that PSGallery is a lower priority than NuGetGallery.
         ```
     * When the package exists in neither repository:
         ```
-        Find-PSResource: Package 'TestModule' could not be found.
+        Package with name 'TestModule' could not be found in repository 'PSGallery'.
         ```
         
 3) Searching with a package name specified and wildcard repository, eg: `Find-PSResource 'TestModule' -Repository *Gallery`

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -97,7 +97,7 @@ Note that PSGallery is a lower priority than NuGetGallery.
         
     * When the package exists in neither repository:
         ```
-        Find-PSResource: Package 'TestModule' could not be found.
+        Package 'TestModule' could not be found in registered repositories: 'PSGallery, NuGetGallery'.
         ```
         
 4) Searching with a package name specified and multiple repository names specified, eg: `Find-PSResource 'TestModule' -Repository PSGallery, NuGetGallery`

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -139,7 +139,7 @@ Note that PSGallery is a lower priority than NuGetGallery.
         Find-PSResource: Package with name 'TestModule' could not be found in repository 'NuGetGallery'.
         ```
         
-5) Searching with a package name specified and both a repository name specified AND a repository name with a wildcard, eg: `Find-PSResource 'TestModule' -Repository *Gallery, PSGallery`
+5) Searching with a package name specified and both a repository name specified AND a repository name with a wildcard, eg: `Find-PSResource 'TestModule' -Repository *Gallery, otherRepository`
 
     * This scenario is not supported due to the ambiguity that arises when a repository with a wildcard in its name is specified as well as a repository with a specific name. The command will display the following error:
         ```

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -60,7 +60,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         
     * When the package is the second repository, but not the first:
         ```
-        Find-PSResource: Package 'TestModule' could not be found.
+        Package with name 'TestModule' could not be found in repository 'PSGallery'.
         ```
     * When the package is in neither repository:
         ```

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -85,7 +85,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should return 'TestModule' from 'PSGallery'.
         
-    * When the package is the second repository, but not the first:
+    * When the package exists in the second repository, but not the first:
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -39,7 +39,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
 
     * When the package is in neither repository:
         ```
-        Find-PSResource: Package 'TestModule' could not be found.
+        Find-PSResource: Package 'TestModule' could not be found in any registered repositories.
         ```
 2) Searching with a package name and a repository specified, eg: `Find-PSResource 'TestModule' -Repository PSGallery`
     * When the package exists in both repositories:

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -1,7 +1,7 @@
 
 # Examples for `Find-PSResource` searching through repositories.
 
-These examples will go through a number of scenarios related to `Find-PSResource` searching through repositories to show what the expected outcome will be. `Find-PSResource` will return all resources that match the criteria specified.
+These examples will go through a number of scenarios related to `Find-PSResource` searching through repositories to show what the expected outcome will be. `Find-PSResource` will return resources from all repositories that match the criteria specified.
 In all these examples, the repositories registered and their priorities are as follows:
 
 ```

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -1,7 +1,7 @@
 
 # Examples for `Find-PSResource` searching through repositories.
 
-These examples will go through a number of scenarios related to `Find-PSResource` searching through repositories to show what the expected outcome will be.
+These examples will go through a number of scenarios related to `Find-PSResource` searching through repositories to show what the expected outcome will be. `Find-PSResource` will return all resources that match the criteria specified.
 In all these examples, the repositories registered and their priorities are as follows:
 
 ```
@@ -141,7 +141,7 @@ Note that PSGallery is a lower priority than NuGetGallery.
         
 5) Searching with a package name specified and both a repository name specified AND a repository name with a wildcard, eg: `Find-PSResource 'TestModule' -Repository *Gallery, PSGallery`
 
-    * For all scenarios:
+    * This scenario is not supported due to the ambiguity that arises when a repository with a wildcard in its name is specified as well as a repository with a specific name. The command will display the following error:
         ```
         Find-PSResource: Package 'TestModule' could not be found.
         ```

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -143,5 +143,5 @@ Note that PSGallery is a lower priority than NuGetGallery.
 
     * This scenario is not supported due to the ambiguity that arises when a repository with a wildcard in its name is specified as well as a repository with a specific name. The command will display the following error:
         ```
-        Find-PSResource: Package 'TestModule' could not be found.
+        Find-PSResource: Repository name with wildcard is not allowed when another repository without wildcard is specified.
         ```

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -29,7 +29,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should return 'TestModule' from 'PSGallery'.
 
-    * When the package is the second repository, but not the first:
+    * When the package exists in the second repository, but not the first:
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -50,7 +50,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should return 'TestModule' from 'PSGallery'.
 
-    * When the package is in the first repository, but not the second:
+    * When the package is in the first repository (PSGallery), but not the second (NuGetGallery):
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -21,7 +21,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
        Should return 'TestModule' from both 'PSGallery' and 'NuGetGallery'.
        
-    * When the package is in the first repository, but not the second:
+    * When the package exists in the first repository, but not the second:
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -116,6 +116,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         TestModule  1.0.0.0            PSGallery 
         ```
         Should return 'TestModule' from 'PSGallery'.
+        Find-PSResource: Package with name 'TestModule' could not be found in repository 'NuGetGallery'.
         
     * When the package is the second repository, but not the first:
         ```

--- a/Examples/InstallRepositorySearchingExamples.md
+++ b/Examples/InstallRepositorySearchingExamples.md
@@ -94,7 +94,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         
     * When the package exists in neither repository:
         ```
-        Install-PSResource: Package 'TestModule' could not be found.
+        Install-PSResource: Package(s) 'TestModule' could not be installed from registered repositories 'PSGallery, NuGetGallery'.
         ```
         
 4) Installing with a package name specified and multiple repository names specified, eg: `Install-PSResource 'TestModule' -Repository PSGallery, NuGetGallery -PassThru`

--- a/Examples/InstallRepositorySearchingExamples.md
+++ b/Examples/InstallRepositorySearchingExamples.md
@@ -58,7 +58,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should install 'TestModule' from 'PSGallery'.
         
-    * When the package exists the second repository (NuGetGallery), but not the first (PSGallery):
+    * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
         ```
         Install-PSResource: Package 'TestModule' could not be found.
         ```

--- a/Examples/InstallRepositorySearchingExamples.md
+++ b/Examples/InstallRepositorySearchingExamples.md
@@ -1,7 +1,7 @@
 
 # Examples for `Install-PSResource` searching through repositories.
 
-These examples will go through a number of scenarios related to `Install-PSResource` searching through repositories to show what the expected outcome will be. `Install-PSResource` will return the resource from the highest priority repository that matches the criteria specified.
+These examples will go through a number of scenarios related to `Install-PSResource` searching through repositories to install from to show what the expected outcome will be. `Install-PSResource` will install the resource from the repository with the highest priority (i.e. the smallest number) that matches the criteria specified.
 In all these examples, the repositories registered and their priorities are as follows:
 
 ```

--- a/Examples/InstallRepositorySearchingExamples.md
+++ b/Examples/InstallRepositorySearchingExamples.md
@@ -1,0 +1,135 @@
+
+# Examples for `Install-PSResource` searching through repositories.
+
+These examples will go through a number of scenarios related to `Install-PSResource` searching through repositories to show what the expected outcome will be.
+In all these examples, the repositories registered and their priorities are as follows:
+
+```
+Name         Uri                                      Trusted Priority
+----         ---                                      ------- --------
+PSGallery    https://www.powershellgallery.com/api/v2 True    50
+NuGetGallery https://api.nuget.org/v3/index.json      True    60
+```
+
+1) Installing with only a package name specified, eg: `Install-PSResource 'TestModule' -PassThru` or `Install-PSResource 'TestModule' -Repository '*' -PassThru`
+    * When the package exists in both repositories:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+       Should install 'TestModule' from 'PSGallery'.
+       
+    * When the package is in the first repository, but not the second:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should install 'TestModule' from 'PSGallery'.
+
+    * When the package is the second repository, but not the first:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+        Should install 'TestModule' from 'NuGetGallery'.
+
+    * When the package is in neither repository:
+        ```
+        Install-PSResource: Package 'TestModule' could not be found.
+        ```
+2) Installing with a package name and a repository specified, eg: `Install-PSResource 'TestModule' -Repository PSGallery -PassThru`
+
+    * When the package exists in both repositories:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should install 'TestModule' from 'PSGallery'.
+
+    * When the package is in the first repository, but not the second:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should install 'TestModule' from 'PSGallery'.
+        
+    * When the package is the second repository, but not the first:
+        ```
+        Install-PSResource: Package 'TestModule' could not be found.
+        ```
+    * When the package is in neither repository:
+        ```
+        Install-PSResource: Package 'TestModule' could not be found.
+        ```
+        
+3) Installing with a package name specified and wildcard repository, eg: `Install-PSResource 'TestModule' -Repository *Gallery -PassThru`
+    * When the package exists in both repositories:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should install 'TestModule' from 'PSGallery'.
+        
+    * When the package is in the first repository, but not the second:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should install 'TestModule' from 'PSGallery'.
+        
+    * When the package is the second repository, but not the first:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+        Should install 'TestModule' from 'NuGetGallery'.
+        
+    * When the package is in neither repository:
+        ```
+        Install-PSResource: Package 'TestModule' could not be found.
+        ```
+        
+4) Installing with a package name specified and multiple repository names specified, eg: `Install-PSResource 'TestModule' -Repository PSGallery, NuGetGallery -PassThru`
+
+    * When the package exists in both repositories:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should install 'TestModule' from 'PSGallery'.
+        
+    * When the package is in the first repository, but not the second:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should install 'TestModule' from 'PSGallery'.
+        
+    * When the package is the second repository, but not the first:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+        Should install 'TestModule' from 'NuGetGallery'.
+        
+    * When the package is in neither repository:
+        ```
+        Install-PSResource: Package 'TestModule' could not be found.
+        ```
+        
+5) Installing with a package name specified and both a repository name specified AND a repository name with a wildcard, eg: `Install-PSResource 'TestModule' -Repository *Gallery, LocalRepo`.
+    * For all scenarios:
+        ```
+        Install-PSResource: Package 'TestModule' could not be found.
+        ```

--- a/Examples/InstallRepositorySearchingExamples.md
+++ b/Examples/InstallRepositorySearchingExamples.md
@@ -1,7 +1,7 @@
 
 # Examples for `Install-PSResource` searching through repositories.
 
-These examples will go through a number of scenarios related to `Install-PSResource` searching through repositories to show what the expected outcome will be.
+These examples will go through a number of scenarios related to `Install-PSResource` searching through repositories to show what the expected outcome will be. `Install-PSResource` will return the resource from the highest priority repository that matches the criteria specified.
 In all these examples, the repositories registered and their priorities are as follows:
 
 ```
@@ -20,7 +20,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
        Should install 'TestModule' from 'PSGallery'.
        
-    * When the package is in the first repository, but not the second:
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------
@@ -28,7 +28,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should install 'TestModule' from 'PSGallery'.
 
-    * When the package is the second repository, but not the first:
+    * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------
@@ -36,7 +36,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should install 'TestModule' from 'NuGetGallery'.
 
-    * When the package is in neither repository:
+    * When the package exists in neither repository:
         ```
         Install-PSResource: Package 'TestModule' could not be found.
         ```
@@ -50,7 +50,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should install 'TestModule' from 'PSGallery'.
 
-    * When the package is in the first repository, but not the second:
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------
@@ -58,11 +58,11 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should install 'TestModule' from 'PSGallery'.
         
-    * When the package is the second repository, but not the first:
+    * When the package exists the second repository (NuGetGallery), but not the first (PSGallery):
         ```
         Install-PSResource: Package 'TestModule' could not be found.
         ```
-    * When the package is in neither repository:
+    * When the package exists in neither repository:
         ```
         Install-PSResource: Package 'TestModule' could not be found.
         ```
@@ -76,7 +76,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should install 'TestModule' from 'PSGallery'.
         
-    * When the package is in the first repository, but not the second:
+    * When the package exists in the first repository (PSSGallery), but not the second (NuGetGallery):
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------
@@ -84,7 +84,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should install 'TestModule' from 'PSGallery'.
         
-    * When the package is the second repository, but not the first:
+    * When the package exists in the second repository (PSGallery), but not the first (NuGetGallery):
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------
@@ -92,7 +92,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should install 'TestModule' from 'NuGetGallery'.
         
-    * When the package is in neither repository:
+    * When the package exists in neither repository:
         ```
         Install-PSResource: Package 'TestModule' could not be found.
         ```
@@ -107,7 +107,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should install 'TestModule' from 'PSGallery'.
         
-    * When the package is in the first repository, but not the second:
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------
@@ -115,7 +115,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should install 'TestModule' from 'PSGallery'.
         
-    * When the package is the second repository, but not the first:
+    * When the package exists the second repository (NuGetGallery), but not the first (PSGallery):
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------
@@ -123,13 +123,13 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should install 'TestModule' from 'NuGetGallery'.
         
-    * When the package is in neither repository:
+    * When the package exists in neither repository:
         ```
         Install-PSResource: Package 'TestModule' could not be found.
         ```
         
 5) Installing with a package name specified and both a repository name specified AND a repository name with a wildcard, eg: `Install-PSResource 'TestModule' -Repository *Gallery, LocalRepo`.
-    * For all scenarios:
+    * This scenario is not supported due to the ambiguity that arises when a repository with a wildcard in its name is specified as well as a repository with a specific name. The command will display the following error:
         ```
         Install-PSResource: Package 'TestModule' could not be found.
         ```

--- a/Examples/InstallRepositorySearchingExamples.md
+++ b/Examples/InstallRepositorySearchingExamples.md
@@ -38,7 +38,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
 
     * When the package exists in neither repository:
         ```
-        Install-PSResource: Package 'TestModule' could not be found.
+        Install-PSResource: Package(s) 'TestModule' could not be installed from registered repositories 'PSGallery, NuGetGallery'.
         ```
 2) Installing with a package name and a repository specified, eg: `Install-PSResource 'TestModule' -Repository PSGallery -PassThru`
 

--- a/Examples/InstallRepositorySearchingExamples.md
+++ b/Examples/InstallRepositorySearchingExamples.md
@@ -64,7 +64,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
     * When the package exists in neither repository:
         ```
-        Install-PSResource: Package 'TestModule' could not be found.
+        Install-PSResource: Package(s) 'TestModule' could not be installed from repository 'PSGallery'.
         ```
         
 3) Installing with a package name specified and wildcard repository, eg: `Install-PSResource 'TestModule' -Repository *Gallery -PassThru`

--- a/Examples/InstallRepositorySearchingExamples.md
+++ b/Examples/InstallRepositorySearchingExamples.md
@@ -60,7 +60,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         
     * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
         ```
-        Install-PSResource: Package 'TestModule' could not be found.
+        Install-PSResource: Package(s) 'TestModule' could not be installed from repository 'PSGallery'.
         ```
     * When the package exists in neither repository:
         ```

--- a/Examples/InstallRepositorySearchingExamples.md
+++ b/Examples/InstallRepositorySearchingExamples.md
@@ -131,5 +131,5 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
 5) Installing with a package name specified and both a repository name specified AND a repository name with a wildcard, eg: `Install-PSResource 'TestModule' -Repository *Gallery, LocalRepo`.
     * This scenario is not supported due to the ambiguity that arises when a repository with a wildcard in its name is specified as well as a repository with a specific name. The command will display the following error:
         ```
-        Install-PSResource: Package 'TestModule' could not be found.
+        Install-PSResource: Repository name with wildcard is not allowed when another repository without wildcard is specified.
         ```

--- a/Examples/InstallRepositorySearchingExamples.md
+++ b/Examples/InstallRepositorySearchingExamples.md
@@ -115,7 +115,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         ```
         Should install 'TestModule' from 'PSGallery'.
         
-    * When the package exists the second repository (NuGetGallery), but not the first (PSGallery):
+    * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------

--- a/Examples/InstallRepositorySearchingExamples.md
+++ b/Examples/InstallRepositorySearchingExamples.md
@@ -128,7 +128,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         Install-PSResource: Package 'TestModule' could not be found.
         ```
         
-5) Installing with a package name specified and both a repository name specified AND a repository name with a wildcard, eg: `Install-PSResource 'TestModule' -Repository *Gallery, LocalRepo`.
+5) Installing with a package name specified and both a repository name specified AND a repository name with a wildcard, eg: `Install-PSResource 'TestModule' -Repository *Gallery, otherRepository`.
     * This scenario is not supported due to the ambiguity that arises when a repository with a wildcard in its name is specified as well as a repository with a specific name. The command will display the following error:
         ```
         Install-PSResource: Repository name with wildcard is not allowed when another repository without wildcard is specified.

--- a/Examples/InstallRepositorySearchingExamples.md
+++ b/Examples/InstallRepositorySearchingExamples.md
@@ -125,7 +125,7 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
         
     * When the package exists in neither repository:
         ```
-        Install-PSResource: Package 'TestModule' could not be found.
+        Install-PSResource: Package(s) 'TestModule' could not be installed from registered repositories 'PSGallery, NuGetGallery'.
         ```
         
 5) Installing with a package name specified and both a repository name specified AND a repository name with a wildcard, eg: `Install-PSResource 'TestModule' -Repository *Gallery, otherRepository`.

--- a/Examples/RepositorySearchingExamples.md
+++ b/Examples/RepositorySearchingExamples.md
@@ -13,40 +13,124 @@ NuGetGallery https://api.nuget.org/v3/index.json      True    60
 
 1) Searching with only a package name specified, eg: `Find-PSResource 'TestModule'` or `Find-PSResource 'TestModule' -Repository '*'`
     * When the package exists in both repositories:
-      
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+       Should return 'TestModule' from both 'PSGallery' and 'NuGetGallery'.
+       
     * When the package is in the first repository, but not the second:
-    
-    * When the package is the second repository, but not the first:
-    
-    * When the package is in neither repository:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'.
 
+    * When the package is the second repository, but not the first:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+        Should return 'TestModule' from 'NuGetGallery'.
+
+    * When the package is in neither repository:
+        ```
+        Find-PSResource: Package 'TestModule' could not be found.
+        ```
 2) Searching with a package name and a repository specified, eg: `Find-PSResource 'TestModule' -Repository PSGallery`
     * When the package exists in both repositories:
-      
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'.
+
     * When the package is in the first repository, but not the second:
-    
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'.
+        
     * When the package is the second repository, but not the first:
-    
+        ```
+        Find-PSResource: Package 'TestModule' could not be found.
+        ```
     * When the package is in neither repository:
-    
+        ```
+        Find-PSResource: Package 'TestModule' could not be found.
+        ```
+        
 3) Searching with a package name specified and wildcard repository, eg: `Find-PSResource 'TestModule' -Repository *Gallery`
     * When the package exists in both repositories:
-      
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery' and 'NuGetGallery'.
+        
     * When the package is in the first repository, but not the second:
-    
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'.
+        
     * When the package is the second repository, but not the first:
-    
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+        Should return 'TestModule' from 'NuGetGallery'.
+        
     * When the package is in neither repository:
-
+        ```
+        Find-PSResource: Package 'TestModule' could not be found.
+        ```
+        
 4) Searching with a package name specified and multiple repository names specified, eg: `Find-PSResource 'TestModule' -Repository PSGallery, NuGetGallery`
 
     * When the package exists in both repositories:
-      
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery' and 'NuGetGallery'.
+        
     * When the package is in the first repository, but not the second:
-    
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'.
+        
     * When the package is the second repository, but not the first:
-    
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+        Should return 'TestModule' from 'NuGetGallery'.
+        
     * When the package is in neither repository:
-
+        ```
+        Find-PSResource: Package 'TestModule' could not be found.
+        ```
+        
 5) Searching with a package name specified and both a repository name specified AND a repository name with a wildcard, eg: `Find-PSResource 'TestModule' -Repository *Gallery, LocalRepo`
-    
+        ```
+        Find-PSResource: Package 'TestModule' could not be found.
+        ```

--- a/Examples/RepositorySearchingExamples.md
+++ b/Examples/RepositorySearchingExamples.md
@@ -1,0 +1,52 @@
+
+# Examples for `Find-PSResource` searching through repositories.
+
+These examples will go through a number of scenarios related to `Find-PSResource` searching through repositories to show what the expected outcome will be.
+In all these examples, the repositories registered and their priorities are as follows:
+
+```
+Name         Uri                                      Trusted Priority
+----         ---                                      ------- --------
+PSGallery    https://www.powershellgallery.com/api/v2 True    50
+NuGetGallery https://api.nuget.org/v3/index.json      True    60
+```
+
+1) Searching with only a package name specified, eg: `Find-PSResource 'TestModule'` or `Find-PSResource 'TestModule' -Repository '*'`
+    * When the package exists in both repositories:
+      
+    * When the package is in the first repository, but not the second:
+    
+    * When the package is the second repository, but not the first:
+    
+    * When the package is in neither repository:
+
+2) Searching with a package name and a repository specified, eg: `Find-PSResource 'TestModule' -Repository PSGallery`
+    * When the package exists in both repositories:
+      
+    * When the package is in the first repository, but not the second:
+    
+    * When the package is the second repository, but not the first:
+    
+    * When the package is in neither repository:
+    
+3) Searching with a package name specified and wildcard repository, eg: `Find-PSResource 'TestModule' -Repository *Gallery`
+    * When the package exists in both repositories:
+      
+    * When the package is in the first repository, but not the second:
+    
+    * When the package is the second repository, but not the first:
+    
+    * When the package is in neither repository:
+
+4) Searching with a package name specified and multiple repository names specified, eg: `Find-PSResource 'TestModule' -Repository PSGallery, NuGetGallery`
+
+    * When the package exists in both repositories:
+      
+    * When the package is in the first repository, but not the second:
+    
+    * When the package is the second repository, but not the first:
+    
+    * When the package is in neither repository:
+
+5) Searching with a package name specified and both a repository name specified AND a repository name with a wildcard, eg: `Find-PSResource 'TestModule' -Repository *Gallery, LocalRepo`
+    


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Documented examples for searching `Find-PSResource` and `Install-PSResource` searching through repositories. 

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Also resolves #1286 

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
