### PR TITLE
Add Find-PSResource examples for -Tag, -CommandName, -DscResourceName

### DIFF
--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -402,7 +402,7 @@ In these examples, the package TestModule has the following command names (i.e t
        Should return 'TestModule' from both 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository is not supported, it will be skipped.
        
 
-    * When the package exists in both repositories and multiple tags (existing and non-existant) are specified:
+    * When the package exists in both repositories and multiple Command names (existing and non-existant) are specified:
 
         eg: `Find-PSResource -CommandName 'Get-MyCommand1','NonExistantCommand'` or `Find-PSResource -CommandName 'Get-MyCommand1','NonExistantCommand' -Repository '*'`
         ```
@@ -495,7 +495,7 @@ In these examples, the package TestModule has the following command names (i.e t
 
         eg: `Find-PSResource -Tag 'Get-MyCommand1','NonExistantCommand' -Repository *Gallery`
         ```
-        Find-PSResource: Package with Command names 'Get-MyCommand1, NonExistantCommand' could not be found in registered repositories: 'PSGallery, NuGetGallery'.
+        Find-PSResource: Package with CommandName 'Get-MyCommand1, NonExistantCommand' could not be found in registered repositories: 'PSGallery, NuGetGallery'.
         ```        
         
 4) Searching with a Command name specified and multiple repository names specified, eg: `Find-PSResource -CommandName 'Get-MyCommand1' -Repository PSGallery, NuGetGallery`
@@ -555,6 +555,209 @@ In these examples, the package TestModule has the following command names (i.e t
         Since searching with `-CommandName` for NuGetGallery repository, it will not be searched and error written out.
         
 5) Searching with a Command name specified and both a repository name specified AND a repository name with a wildcard, eg: `Find-PSResource -CommandName 'Get-MyCommand1' -Repository *Gallery, otherRepository`
+
+    * This scenario is not supported due to the ambiguity that arises when a repository with a wildcard in its name is specified as well as a repository with a specific name. The command will display the following error:
+        ```
+        Find-PSResource: Repository name with wildcard is not allowed when another repository without wildcard is specified.
+        ```
+
+## `Find-PSResource` with `-DscResourceName` parameter ##
+
+In these examples, the package TestModule has the following DscResource names (i.e tag prepended with "PSDscResource_"): MyDscResource1, MyDscResource2.
+
+1) Searching with only a DscResource name specified, eg: `Find-PSResource -DscResourceName 'MyDscResource1'` or `Find-PSResource -DscResourceName 'MyDscResource1' -Repository '*'`
+    * When the package exists in both repositories:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'. Since searching with `-DscResourceName` for NuGetGallery repository is not supported, it will be skipped.
+
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'. Since searching with `-DscResourceName` for NuGetGallery repository is not supported, it will be skipped.
+
+    * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
+        ```
+        Find-PSResource: Package with DSCResourceName 'MyDscResource1' could not be found in any registered repositories.
+        ```
+        Since searching with `-DscResourceName` for NuGetGallery repository is not supported, it will be skipped.
+
+    * When the package exists in neither repository:
+        ```
+        Find-PSResource: Package with DSCResourceName 'MyDscResource1' could not be found in any registered repositories.
+        ```
+        Since searching with `-DSCResourceName` for NuGetGallery repository is not supported, it will be skipped.
+
+    * When the package exists in both repositories and multiple existing DSCResource names are specified:
+
+        eg: `Find-PSResource -DSCResourceName 'MyDscResource1','MyDscResource2'` or `Find-PSResource -DSCResourceName 'MyDscResource1', 'MyDscResource2' -Repository '*'`
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery
+        ```
+       Should return 'TestModule' from both 'PSGallery'. Since searching with `-DscResourceName` for NuGetGallery repository is not supported, it will be skipped.
+       
+
+    * When the package exists in both repositories and multiple DscResource names (existing and non-existant) are specified:
+
+        eg: `Find-PSResource -DscResourceName 'MyDscResource1','NonExistantDscResource'` or `Find-PSResource -DSCResourceName 'MyDscResource1','NonExistantDscResource' -Repository '*'`
+        ```
+        Find-PSResource: Package with DSCResourceName 'MyDscResource1, NonExistantDscResource' could not be found in any registered repositories.
+        ```
+
+2) Searching with a DscResource name and a repository specified, eg: `Find-PSResource -DscResourceName 'MyDscResource1' -Repository PSGallery`
+    * When the package exists in both repositories:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'.
+
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'.
+        
+    * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
+        ```
+        Package with DscResourceName 'MyDscResource1' could not be found in repository 'PSGallery'.
+        ```
+
+    * When the package exists in neither repository:
+        ```
+        Package with DSCResourceName 'MyDscResource1' could not be found in repository 'PSGallery'.
+        ```
+
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery) and multiple existing tags are specified:
+
+        eg: `Find-PSResource -DscResourceName 'MyDscResource1','MyDscResource2' -Repository PSGallery`
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+       Should return 'TestModule' from 'PSGallery'.
+
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery) and multiple tags (existing and non-existant) are specified:
+
+        eg: `Find-PSResource -DscResourceName 'MyDscResource1','NonExistantDscResource' -Repository PSGallery`
+        ```
+        Find-PSResource: Package with DSCResourceName 'MyDscResource1, MyDscResource2' could not be found in repository 'PSGallery'.
+        ```
+
+3) Searching with a DscResource name specified and wildcard repository, eg: `Find-PSResource -DscResourceName 'MyDscResource1' -Repository *Gallery`
+    * When the package exists in both repositories:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery
+        ```
+        Should return 'TestModule' from 'PSGallery'. Since searching with `-DscResourceName` for NuGetGallery repository is not supported, it will be skipped.
+        
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'.
+        
+    * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
+        ```
+        Find-PSResource: Package with DSCResourceName 'MyDscResource1' could not be found in any registered repositories.
+        ```
+        Since searching with `-DscResourceName` for NuGetGallery repository is not supported, it will be skipped.
+        
+    * When the package exists in neither repository:
+        ```
+        Find-PSResource: Package with DSCResourceName 'MyDscResource1' could not be found in registered repositories: 'PSGallery, NuGetGallery'.
+        ```
+
+    * When the package exists in both repositories and multiple existing DscResource names are specified:
+
+        eg: `Find-PSResource -DscResourceName 'MyDscResource1','MyDscResource2' -Repository *Gallery`
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'. Since searching with `-DscResourceName` for NuGetGallery repository is not supported, it will be skipped.
+
+    * When the package exists in both repositories and multiple DscResource names (existing and non-existant) are specified:
+
+        eg: `Find-PSResource -Tag 'MyDscResource1','NonExistantDscResource' -Repository *Gallery`
+        ```
+        Find-PSResource: Package with DSCResourceName 'MyDscResource1, NonExistantDscResource' could not be found in registered repositories: 'PSGallery, NuGetGallery'.
+        ```        
+        
+4) Searching with a DscResource name specified and multiple repository names specified, eg: `Find-PSResource -DscResourceName 'MyDscResource1' -Repository PSGallery, NuGetGallery`
+
+    * When the package exists in both repositories:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery
+        ```
+        Should return 'TestModule' from 'PSGallery'. Since searching with `-DscResourceName` for NuGetGallery repository is not supported, it will be skipped.
+        
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+
+        Find-PSResource: Find by DscResourceName or DSCResource is not supported for the V3 server protocol repository 'NuGetGallery'.
+        ```
+        Should return 'TestModule' from 'PSGallery'. Since searching with `-DscResourceName` for NuGetGallery repository is not supported, it will not be searched and error written out.
+        
+    * When the package exists the second repository (NuGetGallery), but not the first (PSGallery):
+        ```        
+        Find-PSResource: Find by DscResourceName or DSCResource is not supported for the V3 server protocol repository 'NuGetGallery'.
+        ```
+        Since searching with `-DscResourceName` for NuGetGallery repository is not supported, it will not be searched and error written out.
+        
+        
+    * When the package is in neither repository:
+        ```
+        Find-PSResource: Package with DSCResourceName 'MyDscResource1' could not be found in repository 'PSGallery'.
+        Find-PSResource: Find by CommandName or DSCResource is not supported for the V3 server protocol repository 'NuGetGallery'.
+        ```
+        Since searching with `-DscResourceName` for NuGetGallery repository, it will not be searched and error written out.
+
+    * When the package exists in both repositories and multiple existing DscResource names are specified:
+
+        eg: `Find-PSResource -DscResourceName 'MyDscResource1','MyDscResource2' -Repository PSGallery, NuGetGallery`
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery
+
+        Find-PSResource: Find by CommandName or DSCResource is not supported for the V3 server protocol repository 'NuGetGallery'.
+        ```
+        Since searching with `-DscResourceName` for NuGetGallery repository, it will not be searched and error written out.
+
+
+    * When the package exists in both repositories and multiple DscResource names (existing and non-existant) are specified:
+
+        eg: `Find-PSResource -DscResourceName 'MyDscResource1','NonExistantDscResource' -Repository PSGallery, NuGetGallery`
+        ```
+        Find-PSResource: Package with DscResource 'MyDscResource1' could not be found in repository 'PSGallery'.
+        Find-PSResource: Find by CommandName or DSCResource is not supported for the V3 server protocol repository 'NuGetGallery'.
+        ```
+        Since searching with `-DscResourceName` for NuGetGallery repository, it will not be searched and error written out.
+        
+5) Searching with a DscResource name specified and both a repository name specified AND a repository name with a wildcard, eg: `Find-PSResource -DscResourceName 'MyDscResource1' -Repository *Gallery, otherRepository`
 
     * This scenario is not supported due to the ambiguity that arises when a repository with a wildcard in its name is specified as well as a repository with a specific name. The command will display the following error:
         ```

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -194,7 +194,6 @@ In these examples, the package TestModule has the following tags: Tag1, Tag2.
         ```
        Should return 'TestModule' from both 'PSGallery' and 'NuGetGallery'.
        
-
     * When the package exists in both repositories and multiple tags (existing and non-existant) are specified:
 
         eg: `Find-PSResource -Tag 'Tag1','NonExistantTag'` or `Find-PSResource -Tag 'Tag1','NonExistantTag' -Repository '*'`
@@ -274,7 +273,7 @@ In these examples, the package TestModule has the following tags: Tag1, Tag2.
         
     * When the package exists in neither repository:
         ```
-        Find-PSResource: Package with Tags 'Tag1' could not be found in registered repositories: 'NuGetGallery, PSGallery'.
+        Find-PSResource: Package with Tags 'Tag1' could not be found in registered repositories: 'PSGallery, NuGetGallery'.
         ```
 
     * When the package exists in both repositories and multiple existing tags are specified:
@@ -293,8 +292,8 @@ In these examples, the package TestModule has the following tags: Tag1, Tag2.
         eg: `Find-PSResource -Tag 'Tag1','NonExistantTag' -Repository *Gallery`
         ```
         Find-PSResource: Package with Tags 'Tag1, NonExistantTag' could not be found in registered repositories: 'PSGallery, NuGetGallery'.
-        ```        
-        
+        ```
+
 4) Searching with a tag specified and multiple repository names specified, eg: `Find-PSResource -Tag 'Tag1' -Repository PSGallery, NuGetGallery`
 
     * When the package exists in both repositories:
@@ -350,8 +349,8 @@ In these examples, the package TestModule has the following tags: Tag1, Tag2.
         eg: `Find-PSResource -Tag 'Tag1','NonExistantTag' -Repository PSGallery, NuGetGallery`
         ```
         Find-PSResource: Package with Tags 'Tag1, NonExistantTag' could not be found in registered repositories: 'PSGallery, NuGetGallery'.
-        ```        
-        
+        ```
+
 5) Searching with a tag specified and both a repository name specified AND a repository name with a wildcard, eg: `Find-PSResource -Tag 'Tag1' -Repository *Gallery, otherRepository`
 
     * This scenario is not supported due to the ambiguity that arises when a repository with a wildcard in its name is specified as well as a repository with a specific name. The command will display the following error:
@@ -361,16 +360,16 @@ In these examples, the package TestModule has the following tags: Tag1, Tag2.
 
 ## `Find-PSResource` with `-CommandName` parameter ##
 
-In these examples, the package TestModule has the following command names (i.e tag prepended with "PSCommand_"): Get-MyCommand.
+In these examples, the package TestModule has the following command names (i.e tag prepended with "PSCommand_"): Get-MyCommand1, Get-MyCommand2.
 
-1) Searching with only a tag specified, eg: `Find-PSResource -CommandName 'Get-MyCommand'` or `Find-PSResource -CommandName 'Get-MyCommand' -Repository '*'`
+1) Searching with only a Command name specified, eg: `Find-PSResource -CommandName 'Get-MyCommand1'` or `Find-PSResource -CommandName 'Get-MyCommand1' -Repository '*'`
     * When the package exists in both repositories:
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------
         TestModule  1.0.0.0            PSGallery 
         ```
-       Should return 'TestModule' from both 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository, it will be skipped.
+        Should return 'TestModule' from 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository is not supported, it will be skipped.
 
     * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
         ```
@@ -378,19 +377,19 @@ In these examples, the package TestModule has the following command names (i.e t
         ----        ------- ---------- ----------
         TestModule  1.0.0.0            PSGallery 
         ```
-        Should return 'TestModule' from 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository, it will be skipped.
+        Should return 'TestModule' from 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository is not supported, it will be skipped.
 
     * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
         ```
-        Find-PSResource: Package with CommandName 'Get-TargetResource' could not be found in any registered repositories.
+        Find-PSResource: Package with CommandName 'Get-MyCommand1' could not be found in any registered repositories.
         ```
-        Since searching with `-CommandName` for NuGetGallery repository, it will be skipped.
+        Since searching with `-CommandName` for NuGetGallery repository is not supported, it will be skipped.
 
     * When the package exists in neither repository:
         ```
-        Find-PSResource: Package with CommandName 'Get-TargetResource' could not be found in any registered repositories.
+        Find-PSResource: Package with CommandName 'Get-MyCommand1' could not be found in any registered repositories.
         ```
-        Since searching with `-CommandName` for NuGetGallery repository, it will be skipped.
+        Since searching with `-CommandName` for NuGetGallery repository is not supported, it will be skipped.
 
     * When the package exists in both repositories and multiple existing Command names are specified:
 
@@ -400,7 +399,7 @@ In these examples, the package TestModule has the following command names (i.e t
         ----        ------- ---------- ----------
         TestModule  1.0.0.0            PSGallery
         ```
-       Should return 'TestModule' from both 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository, it will be skipped.
+       Should return 'TestModule' from both 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository is not supported, it will be skipped.
        
 
     * When the package exists in both repositories and multiple tags (existing and non-existant) are specified:
@@ -410,7 +409,7 @@ In these examples, the package TestModule has the following command names (i.e t
         Find-PSResource: Package with CommandName 'Get-MyCommand1, NonExistantCommand' could not be found in any registered repositories.
         ```
 
-2) Searching with a tag and a repository specified, eg: `Find-PSResource -CommandName 'Get-MyCommand1' -Repository PSGallery`
+2) Searching with a Command name and a repository specified, eg: `Find-PSResource -CommandName 'Get-MyCommand1' -Repository PSGallery`
     * When the package exists in both repositories:
         ```
         Name        Version Prerelease Repository
@@ -445,7 +444,7 @@ In these examples, the package TestModule has the following command names (i.e t
         ----        ------- ---------- ----------
         TestModule  1.0.0.0            PSGallery 
         ```
-       Should return 'TestModule' from both 'PSGallery'.
+       Should return 'TestModule' from 'PSGallery'.
 
     * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery) and multiple tags (existing and non-existant) are specified:
 
@@ -454,14 +453,14 @@ In these examples, the package TestModule has the following command names (i.e t
         Find-PSResource: Package with CommandName 'Get-MyCommand1, Get-MyCommand2' could not be found in repository 'PSGallery'.
         ```
 
-3) Searching with a tag specified and wildcard repository, eg: `Find-PSResource -CommandName 'Get-MyCommand1' -Repository *Gallery`
+3) Searching with a Command name specified and wildcard repository, eg: `Find-PSResource -CommandName 'Get-MyCommand1' -Repository *Gallery`
     * When the package exists in both repositories:
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------
         TestModule  1.0.0.0            PSGallery
         ```
-        Should return 'TestModule' from 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository, it will be skipped.
+        Should return 'TestModule' from 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository is not supported, it will be skipped.
         
     * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
         ```
@@ -473,34 +472,33 @@ In these examples, the package TestModule has the following command names (i.e t
         
     * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
         ```
-        Find-PSResource: Package with CommandName 'Get-TargetResource' could not be found in any registered repositories.
+        Find-PSResource: Package with CommandName 'Get-MyCommand1' could not be found in any registered repositories.
         ```
-        Since searching with `-CommandName` for NuGetGallery repository, it will be skipped.
+        Since searching with `-CommandName` for NuGetGallery repository is not supported, it will be skipped.
         
     * When the package exists in neither repository:
         ```
         Find-PSResource: Package with CommandName 'Get-MyCommand1' could not be found in registered repositories: 'PSGallery, NuGetGallery'.
         ```
 
-    * When the package exists in both repositories and multiple existing tags are specified:
+    * When the package exists in both repositories and multiple existing Command names are specified:
 
-        eg: `Find-PSResource -CommandName 'Get-MyCommand1','Tag2' -Repository *Gallery`
+        eg: `Find-PSResource -CommandName 'Get-MyCommand1','Get-MyCommand2' -Repository *Gallery`
         ```
         Name        Version Prerelease Repository
         ----        ------- ---------- ----------
         TestModule  1.0.0.0            PSGallery 
-        TestModule  1.0.0.0            NuGetGallery 
         ```
-        Should return 'TestModule' from 'PSGallery' and 'NuGetGallery'.
+        Should return 'TestModule' from 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository is not supported, it will be skipped.
 
-    * When the package exists in both repositories and multiple tags (existing and non-existant) are specified:
+    * When the package exists in both repositories and multiple Command names (existing and non-existant) are specified:
 
-        eg: `Find-PSResource -Tag 'Tag1','NonExistantTag' -Repository *Gallery`
+        eg: `Find-PSResource -Tag 'Get-MyCommand1','NonExistantCommand' -Repository *Gallery`
         ```
-        Find-PSResource: Package with Tags 'Tag1, NonExistantTag' could not be found in registered repositories: 'PSGallery, NuGetGallery'.
+        Find-PSResource: Package with Command names 'Get-MyCommand1, NonExistantCommand' could not be found in registered repositories: 'PSGallery, NuGetGallery'.
         ```        
         
-4) Searching with a tag specified and multiple repository names specified, eg: `Find-PSResource -CommandName 'Get-MyCommand1' -Repository PSGallery, NuGetGallery`
+4) Searching with a Command name specified and multiple repository names specified, eg: `Find-PSResource -CommandName 'Get-MyCommand1' -Repository PSGallery, NuGetGallery`
 
     * When the package exists in both repositories:
         ```
@@ -508,7 +506,7 @@ In these examples, the package TestModule has the following command names (i.e t
         ----        ------- ---------- ----------
         TestModule  1.0.0.0            PSGallery
         ```
-        Should return 'TestModule' from 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository, it will be skipped.
+        Should return 'TestModule' from 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository is not supported, it will be skipped.
         
     * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
         ```
@@ -518,13 +516,13 @@ In these examples, the package TestModule has the following command names (i.e t
 
         Find-PSResource: Find by CommandName or DSCResource is not supported for the V3 server protocol repository 'NuGetGallery'.
         ```
-        Should return 'TestModule' from 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository, it will not be searched and error written out.
+        Should return 'TestModule' from 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository is not supported, it will not be searched and error written out.
         
     * When the package exists the second repository (NuGetGallery), but not the first (PSGallery):
         ```        
         Find-PSResource: Find by CommandName or DSCResource is not supported for the V3 server protocol repository 'NuGetGallery'.
         ```
-        Since searching with `-CommandName` for NuGetGallery repository, it will not be searched and error written out.
+        Since searching with `-CommandName` for NuGetGallery repository is not supported, it will not be searched and error written out.
         
         
     * When the package is in neither repository:
@@ -556,7 +554,7 @@ In these examples, the package TestModule has the following command names (i.e t
         ```
         Since searching with `-CommandName` for NuGetGallery repository, it will not be searched and error written out.
         
-5) Searching with a tag specified and both a repository name specified AND a repository name with a wildcard, eg: `Find-PSResource -CommandName 'Get-MyCommand1' -Repository *Gallery, otherRepository`
+5) Searching with a Command name specified and both a repository name specified AND a repository name with a wildcard, eg: `Find-PSResource -CommandName 'Get-MyCommand1' -Repository *Gallery, otherRepository`
 
     * This scenario is not supported due to the ambiguity that arises when a repository with a wildcard in its name is specified as well as a repository with a specific name. The command will display the following error:
         ```

--- a/Examples/FindRepositorySearchingExamples.md
+++ b/Examples/FindRepositorySearchingExamples.md
@@ -11,7 +11,9 @@ PSGallery    https://www.powershellgallery.com/api/v2 True    50
 NuGetGallery https://api.nuget.org/v3/index.json      True    60
 ```
 
-Note that PSGallery is a lower priority than NuGetGallery.
+Note that PSGallery has a lower priority than NuGetGallery.
+
+## `Find-PSResource` with `-Name` parameter ##
 
 1) Searching with only a package name specified, eg: `Find-PSResource 'TestModule'` or `Find-PSResource 'TestModule' -Repository '*'`
     * When the package exists in both repositories:
@@ -62,11 +64,11 @@ Note that PSGallery is a lower priority than NuGetGallery.
         
     * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
         ```
-        Package with name 'TestModule' could not be found in repository 'PSGallery'.
+        Find-PSResource: Package with name 'TestModule' could not be found in repository 'PSGallery'.
         ```
     * When the package exists in neither repository:
         ```
-        Package with name 'TestModule' could not be found in repository 'PSGallery'.
+        Find-PSResource: Package with name 'TestModule' could not be found in repository 'PSGallery'.
         ```
         
 3) Searching with a package name specified and wildcard repository, eg: `Find-PSResource 'TestModule' -Repository *Gallery`
@@ -97,7 +99,7 @@ Note that PSGallery is a lower priority than NuGetGallery.
         
     * When the package exists in neither repository:
         ```
-        Package 'TestModule' could not be found in registered repositories: 'PSGallery, NuGetGallery'.
+        Find-PSResource: Package 'TestModule' could not be found in registered repositories: 'PSGallery, NuGetGallery'.
         ```
         
 4) Searching with a package name specified and multiple repository names specified, eg: `Find-PSResource 'TestModule' -Repository PSGallery, NuGetGallery`
@@ -140,6 +142,421 @@ Note that PSGallery is a lower priority than NuGetGallery.
         ```
         
 5) Searching with a package name specified and both a repository name specified AND a repository name with a wildcard, eg: `Find-PSResource 'TestModule' -Repository *Gallery, otherRepository`
+
+    * This scenario is not supported due to the ambiguity that arises when a repository with a wildcard in its name is specified as well as a repository with a specific name. The command will display the following error:
+        ```
+        Find-PSResource: Repository name with wildcard is not allowed when another repository without wildcard is specified.
+        ```
+
+## `Find-PSResource` with `-Tag` parameter ##
+
+In these examples, the package TestModule has the following tags: Tag1, Tag2.
+
+1) Searching with only a tag specified, eg: `Find-PSResource -Tag 'Tag1'` or `Find-PSResource -Tag 'Tag1' -Repository '*'`
+    * When the package exists in both repositories:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+       Should return 'TestModule' from both 'PSGallery' and 'NuGetGallery'.
+
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'.
+
+    * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+        Should return 'TestModule' from 'NuGetGallery'.
+
+    * When the package exists in neither repository:
+        ```
+        Find-PSResource: Package with Tags 'Tag1' could not be found in any registered repositories.
+        ```
+
+    * When the package exists in both repositories and multiple existing tags are specified:
+
+        eg: `Find-PSResource -Tag 'Tag1','Tag2'` or `Find-PSResource -Tag 'Tag1','Tag2' -Repository '*'`
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+       Should return 'TestModule' from both 'PSGallery' and 'NuGetGallery'.
+       
+
+    * When the package exists in both repositories and multiple tags (existing and non-existant) are specified:
+
+        eg: `Find-PSResource -Tag 'Tag1','NonExistantTag'` or `Find-PSResource -Tag 'Tag1','NonExistantTag' -Repository '*'`
+        ```
+        Find-PSResource: Package with Tags 'Tag1, NonExistantTag' could not be found in any registered repositories.
+        ```
+
+2) Searching with a tag and a repository specified, eg: `Find-PSResource -Tag 'Tag1' -Repository PSGallery`
+    * When the package exists in both repositories:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'.
+
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'.
+        
+    * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
+        ```
+        Package with Tags 'Tag1' could not be found in repository 'PSGallery'.
+        ```
+
+    * When the package exists in neither repository:
+        ```
+        Package with Tags 'Tag1' could not be found in repository 'PSGallery'.
+        ```
+
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery) and multiple existing tags are specified:
+
+        eg: `Find-PSResource -Tag 'Tag1','Tag2' -Repository PSGallery`
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+       Should return 'TestModule' from both 'PSGallery'.
+
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery) and multiple tags (existing and non-existant) are specified:
+
+        eg: `Find-PSResource -Tag 'Tag1','NonExistantTag' -Repository PSGallery`
+        ```
+        Find-PSResource: Package with Tags 'Tag1, NonExistantTag' could not be found in repository 'PSGallery'.
+        ```
+
+3) Searching with a tag specified and wildcard repository, eg: `Find-PSResource -Tag 'Tag1' -Repository *Gallery`
+    * When the package exists in both repositories:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery' and 'NuGetGallery'.
+        
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'.
+        
+    * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+        Should return 'TestModule' from 'NuGetGallery'.
+        
+    * When the package exists in neither repository:
+        ```
+        Find-PSResource: Package with Tags 'Tag1' could not be found in registered repositories: 'NuGetGallery, PSGallery'.
+        ```
+
+    * When the package exists in both repositories and multiple existing tags are specified:
+
+        eg: `Find-PSResource -Tag 'Tag1','Tag2' -Repository *Gallery`
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery' and 'NuGetGallery'.
+
+    * When the package exists in both repositories and multiple tags (existing and non-existant) are specified:
+
+        eg: `Find-PSResource -Tag 'Tag1','NonExistantTag' -Repository *Gallery`
+        ```
+        Find-PSResource: Package with Tags 'Tag1, NonExistantTag' could not be found in registered repositories: 'PSGallery, NuGetGallery'.
+        ```        
+        
+4) Searching with a tag specified and multiple repository names specified, eg: `Find-PSResource -Tag 'Tag1' -Repository PSGallery, NuGetGallery`
+
+    * When the package exists in both repositories:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery' and 'NuGetGallery'.
+        
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        
+        Find-PSResource: Package with Tags 'Tag1' could not be found in repository 'NuGetGallery'.
+        ```
+        Should return 'TestModule' from 'PSGallery'.
+       
+        
+    * When the package exists the second repository (NuGetGallery), but not the first (PSGallery):
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            NuGetGallery 
+        
+        Find-PSResource: Package with Tags 'Tag1' could not be found in repository 'PSGallery'.
+        ```
+        Should return 'TestModule' from 'NuGetGallery'.
+        
+        
+    * When the package is in neither repository:
+        ```
+        Find-PSResource: Package with Tags 'Tag1' could not be found in repository 'PSGallery'.
+        Find-PSResource: Package with Tags 'Tag1' could not be found in repository 'NuGetGallery'.
+        ```
+
+    * When the package exists in both repositories and multiple existing tags are specified:
+
+        eg: `Find-PSResource -Tag 'Tag1','Tag2' -Repository PSGallery, NuGetGallery`
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery' and 'NuGetGallery'.
+
+    * When the package exists in both repositories and multiple tags (existing and non-existant) are specified:
+
+        eg: `Find-PSResource -Tag 'Tag1','NonExistantTag' -Repository PSGallery, NuGetGallery`
+        ```
+        Find-PSResource: Package with Tags 'Tag1, NonExistantTag' could not be found in registered repositories: 'PSGallery, NuGetGallery'.
+        ```        
+        
+5) Searching with a tag specified and both a repository name specified AND a repository name with a wildcard, eg: `Find-PSResource -Tag 'Tag1' -Repository *Gallery, otherRepository`
+
+    * This scenario is not supported due to the ambiguity that arises when a repository with a wildcard in its name is specified as well as a repository with a specific name. The command will display the following error:
+        ```
+        Find-PSResource: Repository name with wildcard is not allowed when another repository without wildcard is specified.
+        ```
+
+## `Find-PSResource` with `-CommandName` parameter ##
+
+In these examples, the package TestModule has the following command names (i.e tag prepended with "PSCommand_"): Get-MyCommand.
+
+1) Searching with only a tag specified, eg: `Find-PSResource -CommandName 'Get-MyCommand'` or `Find-PSResource -CommandName 'Get-MyCommand' -Repository '*'`
+    * When the package exists in both repositories:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+       Should return 'TestModule' from both 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository, it will be skipped.
+
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository, it will be skipped.
+
+    * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
+        ```
+        Find-PSResource: Package with CommandName 'Get-TargetResource' could not be found in any registered repositories.
+        ```
+        Since searching with `-CommandName` for NuGetGallery repository, it will be skipped.
+
+    * When the package exists in neither repository:
+        ```
+        Find-PSResource: Package with CommandName 'Get-TargetResource' could not be found in any registered repositories.
+        ```
+        Since searching with `-CommandName` for NuGetGallery repository, it will be skipped.
+
+    * When the package exists in both repositories and multiple existing Command names are specified:
+
+        eg: `Find-PSResource -CommandName 'Get-MyCommand1','Get-MyCommand2'` or `Find-PSResource -CommandName 'Get-MyCommand1','Get-MyCommand2' -Repository '*'`
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery
+        ```
+       Should return 'TestModule' from both 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository, it will be skipped.
+       
+
+    * When the package exists in both repositories and multiple tags (existing and non-existant) are specified:
+
+        eg: `Find-PSResource -CommandName 'Get-MyCommand1','NonExistantCommand'` or `Find-PSResource -CommandName 'Get-MyCommand1','NonExistantCommand' -Repository '*'`
+        ```
+        Find-PSResource: Package with CommandName 'Get-MyCommand1, NonExistantCommand' could not be found in any registered repositories.
+        ```
+
+2) Searching with a tag and a repository specified, eg: `Find-PSResource -CommandName 'Get-MyCommand1' -Repository PSGallery`
+    * When the package exists in both repositories:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'.
+
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'.
+        
+    * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
+        ```
+        Package with CommandName 'Get-MyCommand1' could not be found in repository 'PSGallery'.
+        ```
+
+    * When the package exists in neither repository:
+        ```
+        Package with CommandName 'Get-MyCommand1' could not be found in repository 'PSGallery'.
+        ```
+
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery) and multiple existing tags are specified:
+
+        eg: `Find-PSResource -CommandName 'Get-MyCommand1','Get-MyCommand2' -Repository PSGallery`
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+       Should return 'TestModule' from both 'PSGallery'.
+
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery) and multiple tags (existing and non-existant) are specified:
+
+        eg: `Find-PSResource -CommandName 'Get-MyCommand1','NonExistantCommand' -Repository PSGallery`
+        ```
+        Find-PSResource: Package with CommandName 'Get-MyCommand1, Get-MyCommand2' could not be found in repository 'PSGallery'.
+        ```
+
+3) Searching with a tag specified and wildcard repository, eg: `Find-PSResource -CommandName 'Get-MyCommand1' -Repository *Gallery`
+    * When the package exists in both repositories:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery
+        ```
+        Should return 'TestModule' from 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository, it will be skipped.
+        
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery'.
+        
+    * When the package exists in the second repository (NuGetGallery), but not the first (PSGallery):
+        ```
+        Find-PSResource: Package with CommandName 'Get-TargetResource' could not be found in any registered repositories.
+        ```
+        Since searching with `-CommandName` for NuGetGallery repository, it will be skipped.
+        
+    * When the package exists in neither repository:
+        ```
+        Find-PSResource: Package with CommandName 'Get-MyCommand1' could not be found in registered repositories: 'PSGallery, NuGetGallery'.
+        ```
+
+    * When the package exists in both repositories and multiple existing tags are specified:
+
+        eg: `Find-PSResource -CommandName 'Get-MyCommand1','Tag2' -Repository *Gallery`
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+        TestModule  1.0.0.0            NuGetGallery 
+        ```
+        Should return 'TestModule' from 'PSGallery' and 'NuGetGallery'.
+
+    * When the package exists in both repositories and multiple tags (existing and non-existant) are specified:
+
+        eg: `Find-PSResource -Tag 'Tag1','NonExistantTag' -Repository *Gallery`
+        ```
+        Find-PSResource: Package with Tags 'Tag1, NonExistantTag' could not be found in registered repositories: 'PSGallery, NuGetGallery'.
+        ```        
+        
+4) Searching with a tag specified and multiple repository names specified, eg: `Find-PSResource -CommandName 'Get-MyCommand1' -Repository PSGallery, NuGetGallery`
+
+    * When the package exists in both repositories:
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery
+        ```
+        Should return 'TestModule' from 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository, it will be skipped.
+        
+    * When the package exists in the first repository (PSGallery), but not the second (NuGetGallery):
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery 
+
+        Find-PSResource: Find by CommandName or DSCResource is not supported for the V3 server protocol repository 'NuGetGallery'.
+        ```
+        Should return 'TestModule' from 'PSGallery'. Since searching with `-CommandName` for NuGetGallery repository, it will not be searched and error written out.
+        
+    * When the package exists the second repository (NuGetGallery), but not the first (PSGallery):
+        ```        
+        Find-PSResource: Find by CommandName or DSCResource is not supported for the V3 server protocol repository 'NuGetGallery'.
+        ```
+        Since searching with `-CommandName` for NuGetGallery repository, it will not be searched and error written out.
+        
+        
+    * When the package is in neither repository:
+        ```
+        Find-PSResource: Package with Command 'Get-MyCommand1' could not be found in repository 'PSGallery'.
+        Find-PSResource: Find by CommandName or DSCResource is not supported for the V3 server protocol repository 'NuGetGallery'.
+        ```
+        Since searching with `-CommandName` for NuGetGallery repository, it will not be searched and error written out.
+
+    * When the package exists in both repositories and multiple existing Command names are specified:
+
+        eg: `Find-PSResource -CommandName 'Get-MyCommand1','Get-MyCommand2' -Repository PSGallery, NuGetGallery`
+        ```
+        Name        Version Prerelease Repository
+        ----        ------- ---------- ----------
+        TestModule  1.0.0.0            PSGallery
+
+        Find-PSResource: Find by CommandName or DSCResource is not supported for the V3 server protocol repository 'NuGetGallery'.
+        ```
+        Since searching with `-CommandName` for NuGetGallery repository, it will not be searched and error written out.
+
+
+    * When the package exists in both repositories and multiple Command names (existing and non-existant) are specified:
+
+        eg: `Find-PSResource -CommandName 'Get-MyCommand1','NonExistantCommand' -Repository PSGallery, NuGetGallery`
+        ```
+        Find-PSResource: Package with Command 'Get-MyCommand1' could not be found in repository 'PSGallery'.
+        Find-PSResource: Find by CommandName or DSCResource is not supported for the V3 server protocol repository 'NuGetGallery'.
+        ```
+        Since searching with `-CommandName` for NuGetGallery repository, it will not be searched and error written out.
+        
+5) Searching with a tag specified and both a repository name specified AND a repository name with a wildcard, eg: `Find-PSResource -CommandName 'Get-MyCommand1' -Repository *Gallery, otherRepository`
 
     * This scenario is not supported due to the ambiguity that arises when a repository with a wildcard in its name is specified as well as a repository with a specific name. The command will display the following error:
         ```


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
