### PR TITLE
Add more error handling to GetCountFromResponse() for V2 ServerApiCalls

### DIFF
--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -1,3 +1,4 @@
+using System.Text;
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
@@ -1026,21 +1027,26 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             try
             {
                 doc.LoadXml(httpResponse);
+                XmlNodeList elemList = doc.GetElementsByTagName("m:count");
+                if (elemList.Count > 0)
+                {
+                    XmlNode node = elemList[0];
+                    if (node == null || string.IsNullOrEmpty(node.InnerText))
+                    {
+                        errRecord = new ErrorRecord(new PSArgumentException("Count property from server response was empty, invalid or not present."), "GetCountFromResponse", ErrorCategory.InvalidData, this);
+                        return count;
+                    }
+
+                    count = int.Parse(node.InnerText);
+                }
             }
             catch (XmlException e)
             {
                 errRecord = new ErrorRecord(e, "GetCountFromResponse", ErrorCategory.InvalidData, this);
             }
-            if (errRecord != null)
+            catch (Exception e)
             {
-                return count;
-            }
-
-            XmlNodeList elemList = doc.GetElementsByTagName("m:count");
-            if (elemList.Count > 0)
-            {
-                XmlNode node = elemList[0];
-                count = int.Parse(node.InnerText);
+                errRecord = new ErrorRecord(e, "GetCountFromResponse", ErrorCategory.InvalidResult, this);
             }
 
             return count;

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -1033,7 +1033,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     XmlNode node = elemList[0];
                     if (node == null || string.IsNullOrEmpty(node.InnerText))
                     {
-                        errRecord = new ErrorRecord(new PSArgumentException("Count property from server response was empty, invalid or not present."), "GetCountFromResponse", ErrorCategory.InvalidData, this);
+                        errRecord = new ErrorRecord(new PSArgumentException("Count property from server response was empty, invalid or not present. If the server supports the V3 server protocol try modifying the repository URI endpoint and ApiVersion to reflect V3 server protocol."), "GetCountFromResponse", ErrorCategory.InvalidData, this);
                         return count;
                     }
 

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -868,7 +868,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string[] versionedResponseArr;
             var requestPkgMapping = registrationsBaseUrl.EndsWith("/") ? $"{registrationsBaseUrl}{packageName.ToLower()}/index.json" : $"{registrationsBaseUrl}/{packageName.ToLower()}/index.json";
 
-            Console.WriteLine(requestPkgMapping);
             string pkgMappingResponse = HttpRequestCall(requestPkgMapping, out errRecord);
             if (errRecord != null)
             {

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -868,6 +868,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string[] versionedResponseArr;
             var requestPkgMapping = registrationsBaseUrl.EndsWith("/") ? $"{registrationsBaseUrl}{packageName.ToLower()}/index.json" : $"{registrationsBaseUrl}/{packageName.ToLower()}/index.json";
 
+            Console.WriteLine(requestPkgMapping);
             string pkgMappingResponse = HttpRequestCall(requestPkgMapping, out errRecord);
             if (errRecord != null)
             {

--- a/test/InstallPSResourceTests/InstallPSResourceV3Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV3Server.Tests.ps1
@@ -67,7 +67,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
 
     It "Should not install resource given nonexistant name" {
         Install-PSResource -Name "NonExistantModule" -Repository $NuGetGalleryName -TrustRepository -ErrorVariable err -ErrorAction SilentlyContinue
-        $pkg = Get-InstalledPSResource "NonExistantModule"
+        $pkg = Get-InstalledPSResource "NonExistantModule" -ErrorAction SilentlyContinue
         $pkg.Name | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
@@ -112,7 +112,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
         {}
         $Error[0].FullyQualifiedErrorId | Should -be "IncorrectVersionFormat,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
 
-        $res = Get-InstalledPSResource $testModuleName
+        $res = Get-InstalledPSResource $testModuleName -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->
For the CloudSmith V2 server repository, our code currently throws an error because they have a count property in the response but it is not implemented. This PR adds error handling and better messaging for scenarios like this.
# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1364 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
