### PR TITLE
Update V3 server logic to detect inner items or inner @id element

### DIFF
--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -1035,8 +1035,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             return versionedResponseArr;
         }
 
-
-
         /// <summary>
         /// Returns true if the metadata entries are arranged in descending order with respect to the package's version.
         /// ADO feeds usually return version entries in descending order, but Nuget.org repository returns them in ascending order.

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -811,10 +811,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// For some packages (i.e that we know of JFrog repo and some packages on NuGet.org), the metadata is located under outer "items" element > "@id" element > inner "items" element
         /// This requires a different search than if it were under outer "items" element > inner "items" element.
         /// </summary>
-        private JsonElement GetMetadataElementForIdLinkElement(JsonElement idLinkElement, string packageName, out string lowerVersion, out string upperVersion, out ErrorRecord errRecord)
+        private JsonElement GetMetadataElementForIdLinkElement(JsonElement idLinkElement, string packageName, out string upperVersion, out ErrorRecord errRecord)
         {
             upperVersion = String.Empty;
-            lowerVersion = String.Empty;
             // Since JsonElement is not a nullable type, can't return null as default value.
             JsonElement metadataElement = idLinkElement;
 
@@ -847,18 +846,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         upperVersion = upperVerElement.ToString();
                     }
 
-                    if (rootDom.TryGetProperty("lower", out JsonElement lowerVerElement))
-                    {
-                        lowerVersion = lowerVerElement.ToString();
-                    }
-
                     // return clone, otherwise this JsonElement will be out of scope to the caller once JsonDocument is disposed
                     metadataElement = innerItemsElement.Clone();
                 }
             }
             catch (Exception e)
             {
-                errRecord = new ErrorRecord(e, "FindSearchQueryServiceFailure", ErrorCategory.InvalidResult, this);
+                errRecord = new ErrorRecord(e, "MetadataElementRetrievalFailure", ErrorCategory.InvalidResult, this);
             }
 
             return metadataElement;
@@ -908,7 +902,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     Console.WriteLine($"outer items count: {outerItemsArrayCount}");
 
                     string upperVersion = String.Empty;
-                    string lowerVersion = String.Empty;
 
                     // this will be a list of the inner most items elements (i.e containing the package metadata metadata)
                     List<JsonElement> innerItemsElements = new List<JsonElement>();
@@ -940,7 +933,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         }
                         else if (currentItem.TryGetProperty(idLinkName, out JsonElement idLinkElement))
                         {
-                            JsonElement innerItemElementFromId = GetMetadataElementForIdLinkElement(idLinkElement, packageName, out lowerVersion, out upperVersion, out errRecord);
+                            JsonElement innerItemElementFromId = GetMetadataElementForIdLinkElement(idLinkElement, packageName, out upperVersion, out errRecord);
                             if (errRecord != null)
                             {
                                 continue;

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -1049,7 +1049,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             catch (Exception e)
             {
-                errRecord = new ErrorRecord(e, "MetadataElementForItemsElementRetrievalFailure", ErrorCategory.InvalidResult, this);
+                errRecord = new ErrorRecord(
+                    exception: e,
+                    "MetadataElementForItemsElementRetrievalFailure",
+                    ErrorCategory.InvalidResult,
+                    this);
             }
 
             return innerItemsList.ToArray();
@@ -1076,7 +1080,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     JsonElement rootDom = pkgVersionEntry.RootElement;
                     if (!rootDom.TryGetProperty(itemsName, out JsonElement itemsElement) || itemsElement.GetArrayLength() == 0)
                     {
-                        errRecord = new ErrorRecord(new ArgumentException($"Response does not contain '{itemsName}' element for package with name '{packageName}' from repository '{Repository.Name}'."), "GetResponsesFromRegistrationsResourceFailure", ErrorCategory.InvalidResult, this);
+                        errRecord = new ErrorRecord(
+                            new ArgumentException($"Response does not contain '{itemsName}' element for package with name '{packageName}' from repository '{Repository.Name}'."),
+                            "GetResponsesFromRegistrationsResourceFailure",
+                            ErrorCategory.InvalidResult,
+                            this);
+
                         return Utils.EmptyStrArray;
                     }
 
@@ -1124,7 +1133,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     {
                         if (!item.TryGetProperty(property, out JsonElement metadataElement))
                         {
-                            errRecord = new ErrorRecord(new ArgumentException($"Response does not contain inner '{property}' element for package '{packageName}' from repository '{Repository.Name}'."), "GetResponsesFromRegistrationsResourceFailure", ErrorCategory.InvalidResult, this);
+                            errRecord = new ErrorRecord(
+                                new ArgumentException($"Response does not contain inner '{property}' element for package '{packageName}' from repository '{Repository.Name}'."),
+                                "GetResponsesFromRegistrationsResourceFailure",
+                                ErrorCategory.InvalidResult,
+                                this);
+
                             continue;
                         }
 
@@ -1153,7 +1167,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             catch (Exception e)
             {
-                errRecord = new ErrorRecord(e, "GetResponsesFromRegistrationsResourceFailure", ErrorCategory.InvalidResult, this);
+                errRecord = new ErrorRecord(
+                    exception: e,
+                    "GetResponsesFromRegistrationsResourceFailure",
+                    ErrorCategory.InvalidResult,
+                    this);
+
                 return Utils.EmptyStrArray;
             }
 
@@ -1250,7 +1269,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     JsonElement firstResponseDom = firstResponseJson.RootElement;
                     if (!firstResponseDom.TryGetProperty(versionName, out JsonElement firstVersionElement))
                     {
-                        errRecord = new ErrorRecord(new JsonParsingException($"Response did not contain '{versionName}' element"), "FirstVersionFirstSearchFailure", ErrorCategory.InvalidResult, this);
+                        errRecord = new ErrorRecord(
+                            new JsonParsingException($"Response did not contain '{versionName}' element"),
+                            "FirstVersionFirstSearchFailure",
+                            ErrorCategory.InvalidResult,
+                            this);
+
                         return latestVersionFirst;
                     }
                     
@@ -1258,7 +1282,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     string firstVersion = firstVersionElement.ToString();
                     if (!NuGetVersion.TryParse(firstVersion, out firstPkgVersion))
                     {
-                        errRecord = new ErrorRecord(new JsonParsingException($"First version '{firstVersion}' could not be parsed into NuGetVersion."), "FirstVersionFirstSearchFailure", ErrorCategory.InvalidResult, this);
+                        errRecord = new ErrorRecord(
+                            new JsonParsingException($"First version '{firstVersion}' could not be parsed into NuGetVersion."),
+                            "FirstVersionFirstSearchFailure",
+                            ErrorCategory.InvalidResult,
+                            this);
+
                         return latestVersionFirst;
                     }
                 }
@@ -1268,7 +1297,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     JsonElement lastResponseDom = lastResponseJson.RootElement;
                     if (!lastResponseDom.TryGetProperty(versionName, out JsonElement lastVersionElement))
                     {
-                        errRecord = new ErrorRecord(new JsonParsingException($"Response did not contain '{versionName}' element"), "LatestVersionFirstSearchFailure", ErrorCategory.InvalidResult, this);
+                        errRecord = new ErrorRecord(
+                            new JsonParsingException($"Response did not contain '{versionName}' element"),
+                            "LatestVersionFirstSearchFailure",
+                            ErrorCategory.InvalidResult,
+                            this);
+
                         return latestVersionFirst;
                     }
                     
@@ -1276,7 +1310,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     string lastVersion = lastVersionElement.ToString();
                     if (!NuGetVersion.TryParse(lastVersion, out lastPkgVersion))
                     {
-                        errRecord = new ErrorRecord(new JsonParsingException($"Last version '{lastVersion}' could not be parsed into NuGetVersion."), "LatestVersionFirstSearchFailure", ErrorCategory.InvalidResult, this);
+                        errRecord = new ErrorRecord(
+                            new JsonParsingException($"Last version '{lastVersion}' could not be parsed into NuGetVersion."),
+                            "LatestVersionFirstSearchFailure",
+                            ErrorCategory.InvalidResult,
+                            this);
+
                         return latestVersionFirst;
                     }
                 }

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -75,6 +75,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindAll(bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
+            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindAll()");
             errRecord = new ErrorRecord(
                 new InvalidOperationException($"Find all is not supported for the V3 server protocol repository '{Repository.Name}'"),
                 "FindAllFailure", 
@@ -113,6 +114,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindCommandOrDscResource(string[] tags, bool includePrerelease, bool isSearchingForCommands, out ErrorRecord errRecord)
         {
+            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindCommandOrDscResource()");
             errRecord = new ErrorRecord(
                 new InvalidOperationException($"Find by CommandName or DSCResource is not supported for the V3 server protocol repository '{Repository.Name}'"), 
                 "FindCommandOrDscResourceFailure", 
@@ -970,6 +972,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private JsonElement[] GetMetadataElementFromIdLinkElement(JsonElement idLinkElement, string packageName, out string upperVersion, out ErrorRecord errRecord)
         {
+            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::GetMetadataElementFromIdLinkElement()");
             upperVersion = String.Empty;
             JsonElement[] innerItems = new JsonElement[]{};
             List<JsonElement> innerItemsList = new List<JsonElement>();
@@ -1009,8 +1012,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     {
                         upperVersion = upperVerElement.ToString();
                     }
-
-                    // TODO: add ELSE condition and write debug statement saying upper property not present, so package versions may not be in descending order.
+                    else
+                    {
+                        _cmdletPassedIn.WriteDebug($"Package with name '{packageName}' did not have 'upper' property so package versions may not be in descending order.");
+                    }
 
                     foreach(JsonElement entry in innerItemsElement.EnumerateArray())
                     {
@@ -1036,6 +1041,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private JsonElement[] GetMetadataElementFromItemsElement(JsonElement itemsElement, string packageName, out ErrorRecord errRecord)
         {
+            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::GetMetadataElementFromItemsElement()");
             errRecord = null;
             List<JsonElement> innerItemsList = new List<JsonElement>();
 
@@ -1067,6 +1073,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private string[] GetMetadataElementsFromResponse(string response, string property, string packageName, out string upperVersion, out ErrorRecord errRecord)
         {
+            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::GetMetadataElementsFromResponse()");
             errRecord = null;
             upperVersion = String.Empty;
             List<string> versionedPkgResponses = new List<string>();
@@ -1110,7 +1117,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             {
                                 upperVersion = upperVersionElement.ToString();
                             }
-                            // TODO: add ELSE condition, write debug statement saying upper property not present, so package versions may not be in descending order.
+                            else
+                            {
+                                _cmdletPassedIn.WriteDebug($"Package with name '{packageName}' did not have 'upper' property so package versions may not be in descending order.");
+                            }
 
                             innerItemsElements.AddRange(innerItemsFromItemsElement);
                         }
@@ -1125,7 +1135,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                             innerItemsElements.AddRange(innerItemsFromIdElement);
                         }
-                        // TODO: add ELSE statement if neither of these cases are true with a Debug statement.
+                        else
+                        {
+                            _cmdletPassedIn.WriteDebug($"Metadata for package with name '{packageName}' did not have inner 'items' or '@Id' properties.");
+                        }
                     }
 
                     // Loop through inner "items" entries we collected, and get the specific entry for each package version
@@ -1161,7 +1174,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                             versionedPkgResponses.Add(metadataElement.ToString());
                         }
-                        // TODO: add else statement with Debug statement
+                        else
+                        {
+                            _cmdletPassedIn.WriteDebug($"Metadata for package with name '{packageName}' was not of value kind type string or object.");
+                        }
                     }
                 }
             }

--- a/test/InstallPSResourceTests/InstallPSResourceV3Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV3Server.Tests.ps1
@@ -67,7 +67,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
 
     It "Should not install resource given nonexistant name" {
         Install-PSResource -Name "NonExistantModule" -Repository $NuGetGalleryName -TrustRepository -ErrorVariable err -ErrorAction SilentlyContinue
-        $pkg = Get-InstalledPSResource "NonExistantModule"
+        $pkg = Get-InstalledPSResource "NonExistantModule" -ErrorAction SilentlyContinue
         $pkg.Name | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
@@ -112,7 +112,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
         {}
         $Error[0].FullyQualifiedErrorId | Should -be "IncorrectVersionFormat,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
 
-        $res = Get-InstalledPSResource $testModuleName
+        $res = Get-InstalledPSResource $testModuleName -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
     }
 

--- a/test/InstallPSResourceTests/InstallPSResourceV3Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV3Server.Tests.ps1
@@ -411,4 +411,18 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'ManualValidatio
 
         Set-PSResourceRepository PoshTestGallery -Trusted
     }
+
+    It "Install package from NuGetGallery that has outer and inner 'items' elements only and has outer items element array length greater than 1" {
+        $res = Install-PSResource -Name "Microsoft.Extensions.DependencyInjection" -Repository $NuGetGalleryName -TrustRepository -PassThru -ErrorVariable err -ErrorAction SilentlyContinue
+        $err | Should -HaveCount 0
+
+        $res.Name | Should -Be "Microsoft.Extensions.DependencyInjection"
+    }
+
+    It "Install package from NuGetGallery that has outer 'items', '@id' and inner 'items' elements" {
+        $res = Install-PSResource -Name "MsgReader" -Repository $NuGetGalleryName -TrustRepository -PassThru -ErrorVariable err -ErrorAction SilentlyContinue
+        $err | Should -HaveCount 0
+
+        $res.Name | Should -Be "MsgReader"
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
We've seen that for JFrog repository the V3 catalog and queries used for search returns a response that has an outer "items" property > "@Id" element > inner "items" element. We've found this is also true for some NuGet.org packages. Instead of special casing JFrog we try to see which approach a package's response follows instead for the V3 server protocol.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1345 #1344 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
