### PR TITLE
Bug fix for deduping dependencies in Find-PSResource

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -632,7 +632,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         {
             ErrorRecord errRecord = null;
             List<PSResourceInfo> parentPkgs = new List<PSResourceInfo>();
-            HashSet<string> pkgsFound = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string,string> pkgsFound = new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase);
             string tagsAsString = String.Empty;
 
             _cmdletPassedIn.WriteDebug("In FindHelper::SearchByNames()");
@@ -677,7 +677,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             if (foundPkg.Type == _type || _type == ResourceType.None)
                             {
                                 parentPkgs.Add(foundPkg);
-                                pkgsFound.Add(String.Format("{0}{1}", foundPkg.Name, foundPkg.Version.ToString()));
+                                pkgsFound.Add(foundPkg.Name, foundPkg.Version.ToString());
                                 _cmdletPassedIn.WriteDebug($"Found package '{foundPkg.Name}' version '{foundPkg.Version}'");
                                 yield return foundPkg;
                             }
@@ -729,7 +729,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                             PSResourceInfo foundPkg = currentResult.returnedObject;
                             parentPkgs.Add(foundPkg);
-                            pkgsFound.Add(String.Format("{0}{1}", foundPkg.Name, foundPkg.Version.ToString()));
+                            pkgsFound.Add(foundPkg.Name, foundPkg.Version.ToString());
                             yield return foundPkg;
                         }
                     }
@@ -778,7 +778,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         PSResourceInfo foundPkg = currentResult.returnedObject;
                         parentPkgs.Add(foundPkg);
-                        pkgsFound.Add(String.Format("{0}{1}", foundPkg.Name, foundPkg.Version.ToString()));
+                        pkgsFound.Add(foundPkg.Name, foundPkg.Version.ToString());
                         yield return foundPkg;
                     }
                 }
@@ -839,7 +839,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         PSResourceInfo foundPkg = currentResult.returnedObject;
                         parentPkgs.Add(foundPkg);
-                        pkgsFound.Add(String.Format("{0}{1}", foundPkg.Name, foundPkg.Version.ToString()));
+                        pkgsFound.Add(foundPkg.Name, foundPkg.Version.ToString());
                         yield return foundPkg;
                     }
                 }
@@ -915,7 +915,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                    && _versionRange.Satisfies(version))
                             {
                                 parentPkgs.Add(foundPkg);
-                                pkgsFound.Add(String.Format("{0}{1}", foundPkg.Name, foundPkg.Version.ToString()));
+                                pkgsFound.Add(foundPkg.Name, foundPkg.Version.ToString());
 
                                 yield return foundPkg;
                             }
@@ -971,7 +971,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             ResponseUtil currentResponseUtil,
             PSResourceInfo currentPkg,
             PSRepositoryInfo repository,
-            HashSet<string> foundPkgs)
+            Dictionary<string,string> foundPkgs)
         {
             if (currentPkg.Dependencies.Length > 0)
             {
@@ -1009,9 +1009,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         }
 
                         depPkg = currentResult.returnedObject;
-                        string pkgHashKey = String.Format("{0}{1}", depPkg.Name, depPkg.Version.ToString());
 
-                        if (!foundPkgs.Contains(pkgHashKey))
+                        if (!foundPkgs.ContainsKey(depPkg.Name))
                         {
                             foreach (PSResourceInfo depRes in FindDependencyPackages(currentServer, currentResponseUtil, depPkg, repository, foundPkgs))
                             {
@@ -1079,9 +1078,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             continue;
                         }
                         
-                        string pkgHashKey = String.Format("{0}{1}", depPkg.Name, depPkg.Version.ToString());
-
-                        if (!foundPkgs.Contains(pkgHashKey))
+                        if (!foundPkgs.ContainsKey(depPkg.Name))
                         {
                             foreach (PSResourceInfo depRes in FindDependencyPackages(currentServer, currentResponseUtil, depPkg, repository, foundPkgs))
                             {
@@ -1092,10 +1089,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
             }
 
-            string currentPkgHashKey = String.Format("{0}{1}", currentPkg.Name, currentPkg.Version.ToString());
-
-            if (!foundPkgs.Contains(currentPkgHashKey))
+            if (!foundPkgs.ContainsKey(currentPkg.Name))
             {
+                foundPkgs.Add(currentPkg.Name, currentPkg.Version.ToString());
                 yield return currentPkg;
             }
         }

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -591,12 +591,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             _cmdletPassedIn.WriteWarning("Installing dependencies is not currently supported for V3 server protocol repositories. The package will be installed without installing dependencies.");
                         }
 
-                        HashSet<string> myHash = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        Dictionary<string,string> depDictionary = new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase);
                         // Get the dependencies from the installed package.
                         if (parentPkgObj.Dependencies.Length > 0)
                         {
                             bool depFindFailed = false;
-                            foreach (PSResourceInfo depPkg in findHelper.FindDependencyPackages(currentServer, currentResponseUtil, parentPkgObj, repository, myHash))
+                            foreach (PSResourceInfo depPkg in findHelper.FindDependencyPackages(currentServer, currentResponseUtil, parentPkgObj, repository, depDictionary))
                             {
                                 if (depPkg == null)
                                 {

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -6,7 +6,7 @@ Import-Module $modPath -Force -Verbose
 
 $psmodulePaths = $env:PSModulePath -split ';'
 Write-Verbose -Verbose "Current module search paths: $psmodulePaths"
-<#
+
 Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
 
     BeforeAll{
@@ -398,7 +398,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $err.Count | Should -Be 0
     }
 }
-#>
+
 Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'ManualValidationOnly' {
 
     BeforeAll{
@@ -412,9 +412,9 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'ManualValidat
     }
 
     It "find resource given CommandName" {
-        #$res = Find-PSResource -Name $testModuleName -Repository $PSGalleryName -Type Module
+        $res = Find-PSResource -Name $testModuleName -Repository $PSGalleryName -Type Module
 
-        #$res.Name | Should -Be $testModuleName
+        $res.Name | Should -Be $testModuleName
     }
 
     It "find should not duplicate dependencies found" {

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -6,7 +6,7 @@ Import-Module $modPath -Force -Verbose
 
 $psmodulePaths = $env:PSModulePath -split ';'
 Write-Verbose -Verbose "Current module search paths: $psmodulePaths"
-
+<#
 Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
 
     BeforeAll{
@@ -398,7 +398,7 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $err.Count | Should -Be 0
     }
 }
-
+#>
 Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'ManualValidationOnly' {
 
     BeforeAll{
@@ -410,9 +410,31 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'ManualValidat
     AfterAll {
         Get-RevertPSResourceRepositoryFile
     }
-    It "find resource given CommandName" {
-        $res = Find-PSResource -Name $testModuleName -Repository $PSGalleryName -Type Module
 
-        $res.Name | Should -Be $testModuleName
+    It "find resource given CommandName" {
+        #$res = Find-PSResource -Name $testModuleName -Repository $PSGalleryName -Type Module
+
+        #$res.Name | Should -Be $testModuleName
+    }
+
+    It "find should not duplicate dependencies found" {
+        $res = Find-PSResource -Name "Az" -IncludeDependencies -Repository $PSGalleryName
+        $res | Should -Not -BeNullOrEmpty
+
+        $foundPkgs = [System.Collections.Generic.HashSet[String]]::new()
+        $duplicatePkgsFound = $false
+        foreach ($item in $res)
+        {
+            if ($foundPkgs.Contains($item.Name))
+            {
+                write-host "this pkg already found"
+                $duplicatePkgsFound = $true
+                break
+            }
+
+            $foundPkgs.Add($item.Name)
+        }
+
+        $duplicatePkgsFound | Should -BeFalse
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
`Find-PSResource` should not display duplicate package dependencies when returning packages found.

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1372 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
