### PR TITLE
Update V2 logic for count property

### DIFF
--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -820,7 +820,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
         private static PSRepositoryInfo.APIVersion GetRepoAPIVersion(Uri repoUri)
         {
-            if (repoUri.AbsoluteUri.EndsWith("api/v2", StringComparison.OrdinalIgnoreCase))
+            if (repoUri.AbsoluteUri.EndsWith("/v2", StringComparison.OrdinalIgnoreCase))
             {
                 // Scenario: V2 server protocol repositories (i.e PSGallery)
                 return PSRepositoryInfo.APIVersion.v2;

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -1159,6 +1159,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
    
                 if (!countSearchSucceeded)
                 {
+                             // Note: not all V2 servers may have the 'count' property implemented or valid (i.e CloudSmith server), in this case try to get 'd:Id' property.
                     elemList = doc.GetElementsByTagName("d:Id");
                     if (elemList.Count > 0)
                     {

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -1156,6 +1156,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         countSearchSucceeded = int.TryParse(node.InnerText, out count);
                     }
                 }
+   
                 if (!countSearchSucceeded)
                 {
                     elemList = doc.GetElementsByTagName("d:Id");


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

For v2 server protocol we use 'count' property to detect if package exists or not. But in case, a server does not implement the 'count' property we should try the 'd:Id' property. This is the case for the CloudSmith server.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1364 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
