### PR TITLE
Bug fix for deduping dependencies in Find-PSResource

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -634,7 +634,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         {
             ErrorRecord errRecord = null;
             List<PSResourceInfo> parentPkgs = new List<PSResourceInfo>();
-            //Dictionary<string, List<string>> pkgsFound = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
             string tagsAsString = String.Empty;
 
             _cmdletPassedIn.WriteDebug("In FindHelper::SearchByNames()");
@@ -679,8 +678,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             if (foundPkg.Type == _type || _type == ResourceType.None)
                             {
                                 parentPkgs.Add(foundPkg);
-                                TryAddToDependencyHash(foundPkg);
+                                TryAddToPackagesFoundHash(foundPkg);
                                 _cmdletPassedIn.WriteDebug($"Found package '{foundPkg.Name}' version '{foundPkg.Version}'");
+
                                 yield return foundPkg;
                             }
                         }
@@ -731,7 +731,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                             PSResourceInfo foundPkg = currentResult.returnedObject;
                             parentPkgs.Add(foundPkg);
-                            TryAddToDependencyHash(foundPkg);
+                            TryAddToPackagesFoundHash(foundPkg);
+
                             yield return foundPkg;
                         }
                     }
@@ -780,7 +781,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         PSResourceInfo foundPkg = currentResult.returnedObject;
                         parentPkgs.Add(foundPkg);
-                        TryAddToDependencyHash(foundPkg);
+                        TryAddToPackagesFoundHash(foundPkg);
+
                         yield return foundPkg;
                     }
                 }
@@ -841,7 +843,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         PSResourceInfo foundPkg = currentResult.returnedObject;
                         parentPkgs.Add(foundPkg);
-                        TryAddToDependencyHash(foundPkg);
+                        TryAddToPackagesFoundHash(foundPkg);
 
                         yield return foundPkg;
                     }
@@ -918,7 +920,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                    && _versionRange.Satisfies(version))
                             {
                                 parentPkgs.Add(foundPkg);
-                                TryAddToDependencyHash(foundPkg);
+                                TryAddToPackagesFoundHash(foundPkg);
 
                                 yield return foundPkg;
                             }
@@ -966,7 +968,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         }
 
 
-        private bool TryAddToDependencyHash(PSResourceInfo foundPkg)
+        private bool TryAddToPackagesFoundHash(PSResourceInfo foundPkg)
         {
             bool addedToHash = false;
             string foundPkgName = foundPkg.Name;
@@ -1122,7 +1124,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // if adding yield return
             if (!_packagesFound.ContainsKey(currentPkg.Name)) // todo: check version too
             {
-                TryAddToDependencyHash(currentPkg);
+                TryAddToPackagesFoundHash(currentPkg);
                 yield return currentPkg;
             }
         }

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -972,7 +972,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         {
             bool addedToHash = false;
             string foundPkgName = foundPkg.Name;
-            string foundPkgVersion = foundPkg.Version.ToString();
+            string foundPkgVersion = Utils.GetNormalizedVersionString(foundPkg.Version.ToString(), foundPkg.Prerelease);
 
             if (_packagesFound.ContainsKey(foundPkgName))
             {

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -990,6 +990,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 _packagesFound.Add(foundPkg.Name, new List<string> { foundPkgVersion });
                 addedToHash = true;
             }
+   
             _cmdletPassedIn.WriteDebug($"Found package '{foundPkg.Name}' version '{foundPkg.Version}'");
 
             return addedToHash;

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -34,6 +34,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private bool _includeDependencies = false;
         private bool _repositoryNameContainsWildcard = true;
         private NetworkCredential _networkCredential;
+        private Dictionary<string, List<string>> _packagesFound;
 
         #endregion
 
@@ -46,6 +47,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             _cancellationToken = cancellationToken;
             _cmdletPassedIn = cmdletPassedIn;
             _networkCredential = networkCredential;
+            _packagesFound = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
         }
 
         #endregion
@@ -404,7 +406,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         {
                             _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
                         }
-                        
+
                         continue;
                     }
 
@@ -632,7 +634,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         {
             ErrorRecord errRecord = null;
             List<PSResourceInfo> parentPkgs = new List<PSResourceInfo>();
-            HashSet<string> pkgsFound = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            //Dictionary<string, List<string>> pkgsFound = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
             string tagsAsString = String.Empty;
 
             _cmdletPassedIn.WriteDebug("In FindHelper::SearchByNames()");
@@ -677,7 +679,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             if (foundPkg.Type == _type || _type == ResourceType.None)
                             {
                                 parentPkgs.Add(foundPkg);
-                                pkgsFound.Add(String.Format("{0}{1}", foundPkg.Name, foundPkg.Version.ToString()));
+                                TryAddToDependencyHash(foundPkg);
                                 _cmdletPassedIn.WriteDebug($"Found package '{foundPkg.Name}' version '{foundPkg.Version}'");
                                 yield return foundPkg;
                             }
@@ -729,7 +731,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                             PSResourceInfo foundPkg = currentResult.returnedObject;
                             parentPkgs.Add(foundPkg);
-                            pkgsFound.Add(String.Format("{0}{1}", foundPkg.Name, foundPkg.Version.ToString()));
+                            TryAddToDependencyHash(foundPkg);
                             yield return foundPkg;
                         }
                     }
@@ -778,7 +780,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         PSResourceInfo foundPkg = currentResult.returnedObject;
                         parentPkgs.Add(foundPkg);
-                        pkgsFound.Add(String.Format("{0}{1}", foundPkg.Name, foundPkg.Version.ToString()));
+                        TryAddToDependencyHash(foundPkg);
                         yield return foundPkg;
                     }
                 }
@@ -833,13 +835,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                 "FindVersionConvertToPSResourceFailure", 
                                 ErrorCategory.ObjectNotFound, 
                                 this));
-                            
+
                             continue;
                         }
 
                         PSResourceInfo foundPkg = currentResult.returnedObject;
                         parentPkgs.Add(foundPkg);
-                        pkgsFound.Add(String.Format("{0}{1}", foundPkg.Name, foundPkg.Version.ToString()));
+                        TryAddToDependencyHash(foundPkg);
+
                         yield return foundPkg;
                     }
                 }
@@ -915,7 +918,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                    && _versionRange.Satisfies(version))
                             {
                                 parentPkgs.Add(foundPkg);
-                                pkgsFound.Add(String.Format("{0}{1}", foundPkg.Name, foundPkg.Version.ToString()));
+                                TryAddToDependencyHash(foundPkg);
 
                                 yield return foundPkg;
                             }
@@ -936,7 +939,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 foreach (PSResourceInfo currentPkg in parentPkgs)
                 {
                     _cmdletPassedIn.WriteDebug($"Finding dependency packages for '{currentPkg.Name}'");
-                    foreach (PSResourceInfo pkgDep in FindDependencyPackages(currentServer, currentResponseUtil, currentPkg, repository, pkgsFound))
+                    foreach (PSResourceInfo pkgDep in FindDependencyPackages(currentServer, currentResponseUtil, currentPkg, repository))
                     {
                         yield return pkgDep;
                     }
@@ -962,6 +965,34 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             return pkgsToDiscover;
         }
 
+
+        private bool TryAddToDependencyHash(PSResourceInfo foundPkg)
+        {
+            bool addedToHash = false;
+            string foundPkgName = foundPkg.Name;
+            string foundPkgVersion = foundPkg.Version.ToString();
+
+            if (_packagesFound.ContainsKey(foundPkgName))
+            {
+                List<string> pkgVersions = _packagesFound[foundPkgName] as List<string>;
+
+                if (!pkgVersions.Contains(foundPkgVersion))
+                {
+                    pkgVersions.Add(foundPkgVersion);
+                    _packagesFound[foundPkgName] = pkgVersions;
+                    addedToHash = true;
+                }
+            }
+            else
+            {
+                _packagesFound.Add(foundPkg.Name, new List<string> { foundPkgVersion });
+                addedToHash = true;
+            }
+            _cmdletPassedIn.WriteDebug($"Found package '{foundPkg.Name}' version '{foundPkg.Version}'");
+
+            return addedToHash;
+        }
+
         #endregion
 
         #region Internal Client Search Methods
@@ -970,8 +1001,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             ServerApiCall currentServer,
             ResponseUtil currentResponseUtil,
             PSResourceInfo currentPkg,
-            PSRepositoryInfo repository,
-            HashSet<string> foundPkgs)
+            PSRepositoryInfo repository)
         {
             if (currentPkg.Dependencies.Length > 0)
             {
@@ -1009,11 +1039,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         }
 
                         depPkg = currentResult.returnedObject;
-                        string pkgHashKey = String.Format("{0}{1}", depPkg.Name, depPkg.Version.ToString());
 
-                        if (!foundPkgs.Contains(pkgHashKey))
+                        if (!_packagesFound.ContainsKey(depPkg.Name)) // todo: check version too
                         {
-                            foreach (PSResourceInfo depRes in FindDependencyPackages(currentServer, currentResponseUtil, depPkg, repository, foundPkgs))
+                            foreach (PSResourceInfo depRes in FindDependencyPackages(currentServer, currentResponseUtil, depPkg, repository))
                             {
                                 yield return depRes;
                             }
@@ -1066,7 +1095,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             if (foundDep.IsPrerelease) {
                                 depVersionStr += $"-{foundDep.Prerelease}";
                             }
-                            
+
                             if (NuGetVersion.TryParse(depVersionStr, out NuGetVersion depVersion)
                                    && dep.VersionRange.Satisfies(depVersion))
                             {
@@ -1078,12 +1107,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         {
                             continue;
                         }
-                        
-                        string pkgHashKey = String.Format("{0}{1}", depPkg.Name, depPkg.Version.ToString());
 
-                        if (!foundPkgs.Contains(pkgHashKey))
+                        if (!_packagesFound.ContainsKey(depPkg.Name)) // todo: check version too
                         {
-                            foreach (PSResourceInfo depRes in FindDependencyPackages(currentServer, currentResponseUtil, depPkg, repository, foundPkgs))
+                            foreach (PSResourceInfo depRes in FindDependencyPackages(currentServer, currentResponseUtil, depPkg, repository))
                             {
                                 yield return depRes;
                             }
@@ -1092,9 +1119,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
             }
 
-            string currentPkgHashKey = String.Format("{0}{1}", currentPkg.Name, currentPkg.Version.ToString());
-
-            if (!foundPkgs.Contains(currentPkgHashKey))
+            // if adding yield return
+            if (!_packagesFound.ContainsKey(currentPkg.Name)) // todo: check version too
             {
                 yield return currentPkg;
             }

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -1042,11 +1042,23 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         depPkg = currentResult.returnedObject;
 
-                        if (!_packagesFound.ContainsKey(depPkg.Name)) // todo: check version too
+                        if (!_packagesFound.ContainsKey(depPkg.Name)) // todo version should be full version
                         {
                             foreach (PSResourceInfo depRes in FindDependencyPackages(currentServer, currentResponseUtil, depPkg, repository))
                             {
                                 yield return depRes;
+                            }
+                        }
+                        else
+                        {
+                            List<string> pkgVersions = _packagesFound[depPkg.Name] as List<string>;
+                            // _packagesFound has depPkg.name in it, but the version is not the same
+                            if (!pkgVersions.Contains(depPkg.Version.ToString()))
+                            {
+                                foreach (PSResourceInfo depRes in FindDependencyPackages(currentServer, currentResponseUtil, depPkg, repository))
+                                {
+                                    yield return depRes;
+                                }
                             }
                         }
                     }
@@ -1110,23 +1122,46 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             continue;
                         }
 
-                        if (!_packagesFound.ContainsKey(depPkg.Name)) // todo: check version too
+                        if (!_packagesFound.ContainsKey(depPkg.Name)) // todo version should be full version
                         {
                             foreach (PSResourceInfo depRes in FindDependencyPackages(currentServer, currentResponseUtil, depPkg, repository))
                             {
                                 yield return depRes;
                             }
                         }
+                        else {
+                            List<string> pkgVersions = _packagesFound[depPkg.Name] as List<string>;
+                            // _packagesFound has depPkg.name in it, but the version is not the same
+                            if (!pkgVersions.Contains(depPkg.Version.ToString()))
+                            {
+                                foreach (PSResourceInfo depRes in FindDependencyPackages(currentServer, currentResponseUtil, depPkg, repository))
+                                {
+                                    yield return depRes;
+                                }
+                            }
+                        }
                     }
                 }
             }
 
-            // if adding yield return
-            if (!_packagesFound.ContainsKey(currentPkg.Name)) // todo: check version too
+            if (!_packagesFound.ContainsKey(currentPkg.Name))  // todo version should be full version
             {
                 TryAddToPackagesFoundHash(currentPkg);
+
                 yield return currentPkg;
             }
+            else
+            {
+                List<string> pkgVersions = _packagesFound[currentPkg.Name] as List<string>;
+                // _packagesFound has currentPkg.name in it, but the version is not the same
+                if (!pkgVersions.Contains(currentPkg.Version.ToString()))
+                {
+                    TryAddToPackagesFoundHash(currentPkg);
+
+                    yield return currentPkg;
+                }
+            }
+
         }
 
         #endregion

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -1145,7 +1145,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
             }
 
-            if (!_packagesFound.ContainsKey(currentPkg.Name))  // todo version should be full version
+            if (!_packagesFound.ContainsKey(currentPkg.Name))
             {
                 TryAddToPackagesFoundHash(currentPkg);
 

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -1122,6 +1122,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // if adding yield return
             if (!_packagesFound.ContainsKey(currentPkg.Name)) // todo: check version too
             {
+                TryAddToDependencyHash(currentPkg);
                 yield return currentPkg;
             }
         }

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -678,7 +678,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             if (foundPkg.Type == _type || _type == ResourceType.None)
                             {
                                 parentPkgs.Add(foundPkg);
-                                TryAddToPackagesFoundHash(foundPkg);
+                                TryAddToPackagesFound(foundPkg);
                                 _cmdletPassedIn.WriteDebug($"Found package '{foundPkg.Name}' version '{foundPkg.Version}'");
 
                                 yield return foundPkg;
@@ -731,7 +731,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                             PSResourceInfo foundPkg = currentResult.returnedObject;
                             parentPkgs.Add(foundPkg);
-                            TryAddToPackagesFoundHash(foundPkg);
+                            TryAddToPackagesFound(foundPkg);
 
                             yield return foundPkg;
                         }
@@ -781,7 +781,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         PSResourceInfo foundPkg = currentResult.returnedObject;
                         parentPkgs.Add(foundPkg);
-                        TryAddToPackagesFoundHash(foundPkg);
+                        TryAddToPackagesFound(foundPkg);
 
                         yield return foundPkg;
                     }
@@ -843,7 +843,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         PSResourceInfo foundPkg = currentResult.returnedObject;
                         parentPkgs.Add(foundPkg);
-                        TryAddToPackagesFoundHash(foundPkg);
+                        TryAddToPackagesFound(foundPkg);
 
                         yield return foundPkg;
                     }
@@ -920,7 +920,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                    && _versionRange.Satisfies(version))
                             {
                                 parentPkgs.Add(foundPkg);
-                                TryAddToPackagesFoundHash(foundPkg);
+                                TryAddToPackagesFound(foundPkg);
 
                                 yield return foundPkg;
                             }
@@ -968,7 +968,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         }
 
 
-        private bool TryAddToPackagesFoundHash(PSResourceInfo foundPkg)
+        private bool TryAddToPackagesFound(PSResourceInfo foundPkg)
         {
             bool addedToHash = false;
             string foundPkgName = foundPkg.Name;
@@ -994,6 +994,19 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             _cmdletPassedIn.WriteDebug($"Found package '{foundPkg.Name}' version '{foundPkg.Version}'");
 
             return addedToHash;
+        }
+
+        private string FormatPkgVersionString(PSResourceInfo pkg)
+        {
+            string fullPkgVersion = pkg.Version.ToString();
+
+            if (!string.IsNullOrWhiteSpace(pkg.Prerelease))
+            {
+                fullPkgVersion += $"-{pkg.Prerelease}";
+            }
+            _cmdletPassedIn.WriteDebug($"Formatted full package version is: '{fullPkgVersion}'");
+
+            return fullPkgVersion;
         }
 
         #endregion
@@ -1043,7 +1056,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         depPkg = currentResult.returnedObject;
 
-                        if (!_packagesFound.ContainsKey(depPkg.Name)) // todo version should be full version
+                        if (!_packagesFound.ContainsKey(depPkg.Name))
                         {
                             foreach (PSResourceInfo depRes in FindDependencyPackages(currentServer, currentResponseUtil, depPkg, repository))
                             {
@@ -1054,7 +1067,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         {
                             List<string> pkgVersions = _packagesFound[depPkg.Name] as List<string>;
                             // _packagesFound has depPkg.name in it, but the version is not the same
-                            if (!pkgVersions.Contains(depPkg.Version.ToString()))
+                            if (!pkgVersions.Contains(FormatPkgVersionString(depPkg)))
                             {
                                 foreach (PSResourceInfo depRes in FindDependencyPackages(currentServer, currentResponseUtil, depPkg, repository))
                                 {
@@ -1133,7 +1146,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         else {
                             List<string> pkgVersions = _packagesFound[depPkg.Name] as List<string>;
                             // _packagesFound has depPkg.name in it, but the version is not the same
-                            if (!pkgVersions.Contains(depPkg.Version.ToString()))
+                            if (!pkgVersions.Contains(FormatPkgVersionString(depPkg)))
                             {
                                 foreach (PSResourceInfo depRes in FindDependencyPackages(currentServer, currentResponseUtil, depPkg, repository))
                                 {
@@ -1147,7 +1160,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (!_packagesFound.ContainsKey(currentPkg.Name))
             {
-                TryAddToPackagesFoundHash(currentPkg);
+                TryAddToPackagesFound(currentPkg);
 
                 yield return currentPkg;
             }
@@ -1155,9 +1168,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 List<string> pkgVersions = _packagesFound[currentPkg.Name] as List<string>;
                 // _packagesFound has currentPkg.name in it, but the version is not the same
-                if (!pkgVersions.Contains(currentPkg.Version.ToString()))
+                if (!pkgVersions.Contains(FormatPkgVersionString(currentPkg)))
                 {
-                    TryAddToPackagesFoundHash(currentPkg);
+                    TryAddToPackagesFound(currentPkg);
 
                     yield return currentPkg;
                 }

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -1123,7 +1123,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             continue;
                         }
 
-                        if (!_packagesFound.ContainsKey(depPkg.Name)) // todo version should be full version
+                        if (!_packagesFound.ContainsKey(depPkg.Name))
                         {
                             foreach (PSResourceInfo depRes in FindDependencyPackages(currentServer, currentResponseUtil, depPkg, repository))
                             {

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -591,12 +591,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             _cmdletPassedIn.WriteWarning("Installing dependencies is not currently supported for V3 server protocol repositories. The package will be installed without installing dependencies.");
                         }
 
-                        HashSet<string> myHash = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                         // Get the dependencies from the installed package.
                         if (parentPkgObj.Dependencies.Length > 0)
                         {
                             bool depFindFailed = false;
-                            foreach (PSResourceInfo depPkg in findHelper.FindDependencyPackages(currentServer, currentResponseUtil, parentPkgObj, repository, myHash))
+                            foreach (PSResourceInfo depPkg in findHelper.FindDependencyPackages(currentServer, currentResponseUtil, parentPkgObj, repository))
                             {
                                 if (depPkg == null)
                                 {

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -415,4 +415,25 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'ManualValidat
 
         $res.Name | Should -Be $testModuleName
     }
+
+    It "find should not duplicate dependencies found" {
+        $res = Find-PSResource -Name "Az" -IncludeDependencies -Repository $PSGalleryName
+        $res | Should -Not -BeNullOrEmpty
+
+        $foundPkgs = [System.Collections.Generic.HashSet[String]]::new()
+        $duplicatePkgsFound = $false
+        foreach ($item in $res)
+        {
+            if ($foundPkgs.Contains($item.Name))
+            {
+                write-host "this pkg already found"
+                $duplicatePkgsFound = $true
+                break
+            }
+
+            $foundPkgs.Add($item.Name)
+        }
+
+        $duplicatePkgsFound | Should -BeFalse
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Find-PSResource should not display duplicate package dependencies when returning packages found.

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1372 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
