### PR TITLE
Bugfix for V2 server Tag based search with Prerelease returning extra packages

### DIFF
--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -152,7 +152,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Find method which allows for searching for packages with tag from a repository and returns latest version for each.
         /// Examples: Search -Tag "JSON" -Repository PSGallery
         /// API call:
-        /// - Include prerelease: http://www.powershellgallery.com/api/v2/Search()?$filter=IsAbsoluteLatestVersion&searchTerm=tag:JSON&includePrerelease=true
+        /// - Include prerelease: https://www.powershellgallery.com/api/v2/Search()?includePrerelease=true&$filter=IsAbsoluteLatestVersion and substringof('PSModule', Tags) eq true and substringof('CrescendoBuilt', Tags) eq true&$orderby=Id desc&$inlinecount=allpages&$skip=0&$top=6000
         /// </summary>
         public override FindResults FindTags(string[] tags, bool includePrerelease, ResourceType _type, out ErrorRecord errRecord)
         {

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -69,7 +69,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindAll(bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindAll()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindAll()");
             errRecord = null;
             List<string> responses = new List<string>();
 
@@ -156,7 +156,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindTags(string[] tags, bool includePrerelease, ResourceType _type, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindTags()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindTags()");
             errRecord = null;
             List<string> responses = new List<string>();
 
@@ -249,7 +249,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindCommandOrDscResource(string[] tags, bool includePrerelease, bool isSearchingForCommands, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindCommandOrDscResource()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindCommandOrDscResource()");
             List<string> responses = new List<string>();
             int skip = 0;
 
@@ -309,7 +309,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindName(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindName()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindName()");
             // Make sure to include quotations around the package name
             var prerelease = includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion";
 
@@ -352,7 +352,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindNameWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindNameWithTag()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindNameWithTag()");
             // Make sure to include quotations around the package name
             var prerelease = includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion";
 
@@ -403,7 +403,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindNameGlobbing(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindNameGlobbing()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindNameGlobbing()");
             List<string> responses = new List<string>();
             int skip = 0;
 
@@ -456,7 +456,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindNameGlobbingWithTag()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindNameGlobbingWithTag()");
             List<string> responses = new List<string>();
             int skip = 0;
 
@@ -511,7 +511,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindVersionGlobbing()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindVersionGlobbing()");
             List<string> responses = new List<string>();
             int skip = 0;
 
@@ -565,7 +565,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindVersion(string packageName, string version, ResourceType type, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindVersion()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindVersion()");
             // https://www.powershellgallery.com/api/v2/FindPackagesById()?id='blah'&includePrerelease=false&$filter= NormalizedVersion eq '1.1.0' and substringof('PSModule', Tags) eq true
             // Quotations around package name and version do not matter, same metadata gets returned.
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
@@ -607,7 +607,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindVersionWithTag()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindVersionWithTag()");
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
             string idFilterPart = $" and Id eq '{packageName}'";
             string typeFilterPart = GetTypeFilterForRequest(type);
@@ -656,7 +656,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override Stream InstallName(string packageName, bool includePrerelease, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::InstallName()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::InstallName()");
             var requestUrlV2 = $"{Repository.Uri}/package/{packageName}";
 
             var response = HttpRequestCallForContent(requestUrlV2, out errRecord);
@@ -675,7 +675,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::InstallVersion()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::InstallVersion()");
             var requestUrlV2 = $"{Repository.Uri}/package/{packageName}/{version}";
             var response = HttpRequestCallForContent(requestUrlV2, out errRecord);
             var responseStream = response.ReadAsStreamAsync().Result;
@@ -688,7 +688,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private string HttpRequestCall(string requestUrlV2, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::HttpRequestCall()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::HttpRequestCall()");
             errRecord = null;
             string response = string.Empty;
 
@@ -745,7 +745,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private HttpContent HttpRequestCallForContent(string requestUrlV2, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::HttpRequestCallForContent()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::HttpRequestCallForContent()");
             errRecord = null;
             HttpContent content = null;
 
@@ -798,7 +798,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private string FindAllFromTypeEndPoint(bool includePrerelease, bool isSearchingModule, int skip, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindAllFromTypeEndPoint()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindAllFromTypeEndPoint()");
             string typeEndpoint = isSearchingModule ? String.Empty : "/items/psscript";
             string paginationParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=6000";
             var prereleaseFilter = includePrerelease ? "IsAbsoluteLatestVersion&includePrerelease=true" : "IsLatestVersion";
@@ -812,7 +812,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private string FindTagFromEndpoint(string[] tags, bool includePrerelease, bool isSearchingModule, int skip, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindTagFromEndpoint()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindTagFromEndpoint()");
             // scenarios with type + tags:
             // type: None -> search both endpoints
             // type: M -> just search Module endpoint
@@ -821,7 +821,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // type: Command -> just search Modules
             string typeEndpoint = isSearchingModule ? String.Empty : "/items/psscript";
             string paginationParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=6000";
-            var prereleaseFilter = includePrerelease ? "$filter=IsAbsoluteLatestVersion&includePrerelease=true" : "$filter=IsLatestVersion";
+            var prereleaseFilter = includePrerelease ? "includePrerelease=true&$filter=IsAbsoluteLatestVersion" : "$filter=IsLatestVersion";
             string typeFilterPart = isSearchingModule ?  $" and substringof('PSModule', Tags) eq true" : $" and substringof('PSScript', Tags) eq true";
 
             string tagFilterPart = String.Empty;
@@ -840,7 +840,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private string FindCommandOrDscResource(string[] tags, bool includePrerelease, bool isSearchingForCommands, int skip, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindCommandOrDscResource()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindCommandOrDscResource()");
             // can only find from Modules endpoint
             string paginationParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=6000";
             var prereleaseFilter = includePrerelease ? "$filter=IsAbsoluteLatestVersion&includePrerelease=true" : "$filter=IsLatestVersion";
@@ -867,7 +867,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private string FindNameGlobbing(string packageName, ResourceType type, bool includePrerelease, int skip, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindNameGlobbing()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindNameGlobbing()");
             // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and startswith(Id, 'PowerShell') and IsLatestVersion (stable)
             // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and IsAbsoluteLatestVersion&includePrerelease=true
 
@@ -935,7 +935,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private string FindNameGlobbingWithTag(string packageName, string[] tags, ResourceType type, bool includePrerelease, int skip, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindNameGlobbingWithTag()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindNameGlobbingWithTag()");
             // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and startswith(Id, 'PowerShell') and IsLatestVersion (stable)
             // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and IsAbsoluteLatestVersion&includePrerelease=true
 
@@ -1009,7 +1009,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private string FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, int skip, bool getOnlyLatest, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindVersionGlobbing()");
+            _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindVersionGlobbing()");
             //https://www.powershellgallery.com/api/v2//FindPackagesById()?id='blah'&includePrerelease=false&$filter= NormalizedVersion gt '1.0.0' and NormalizedVersion lt '2.2.5' and substringof('PSModule', Tags) eq true
             //https://www.powershellgallery.com/api/v2//FindPackagesById()?id='PowerShellGet'&includePrerelease=false&$filter= NormalizedVersion gt '1.1.1' and NormalizedVersion lt '2.2.5'
             // NormalizedVersion doesn't include trailing zeroes

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -316,29 +316,29 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
-    It "find all resources with specified tag given Tag property" {
-        # FindTag()
-        $foundTestModule = $False
-        $foundTestScript = $False
-        $tagToFind = "Tag2"
-        $res = Find-PSResource -Tag $tagToFind -Repository $PSGalleryName
-        foreach ($item in $res) {
-            $item.Tags -contains $tagToFind | Should -Be $True
+    # It "find all resources with specified tag given Tag property" {
+    #     # FindTag()
+    #     $foundTestModule = $False
+    #     $foundTestScript = $False
+    #     $tagToFind = "Tag2"
+    #     $res = Find-PSResource -Tag $tagToFind -Repository $PSGalleryName
+    #     foreach ($item in $res) {
+    #         $item.Tags -contains $tagToFind | Should -Be $True
 
-            if ($item.Name -eq $testModuleName)
-            {
-                $foundTestModule = $True
-            }
+    #         if ($item.Name -eq $testModuleName)
+    #         {
+    #             $foundTestModule = $True
+    #         }
 
-            if ($item.Name -eq $testScriptName)
-            {
-                $foundTestScript = $True
-            }
-        }
+    #         if ($item.Name -eq $testScriptName)
+    #         {
+    #             $foundTestScript = $True
+    #         }
+    #     }
 
-        $foundTestModule | Should -Be $True
-        $foundTestScript | Should -Be $True
-    }
+    #     $foundTestModule | Should -Be $True
+    #     $foundTestScript | Should -Be $True
+    # }
 
     It "find all resources with specified tag given Tag property, with and without Prerelease property" {
         $tagToFind = "MyPSTag"

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -316,29 +316,38 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
-    # It "find all resources with specified tag given Tag property" {
-    #     # FindTag()
-    #     $foundTestModule = $False
-    #     $foundTestScript = $False
-    #     $tagToFind = "Tag2"
-    #     $res = Find-PSResource -Tag $tagToFind -Repository $PSGalleryName
-    #     foreach ($item in $res) {
-    #         $item.Tags -contains $tagToFind | Should -Be $True
+    It "find all resources with specified tag given Tag property" {
+        # FindTag()
+        $foundTestModule = $False
+        $foundTestScript = $False
+        $tagToFind = "Tag2"
+        $res = Find-PSResource -Tag $tagToFind -Repository $PSGalleryName
+        foreach ($item in $res) {
+            $item.Tags -contains $tagToFind | Should -Be $True
 
-    #         if ($item.Name -eq $testModuleName)
-    #         {
-    #             $foundTestModule = $True
-    #         }
+            if ($item.Name -eq $testModuleName)
+            {
+                $foundTestModule = $True
+            }
 
-    #         if ($item.Name -eq $testScriptName)
-    #         {
-    #             $foundTestScript = $True
-    #         }
-    #     }
+            if ($item.Name -eq $testScriptName)
+            {
+                $foundTestScript = $True
+            }
+        }
 
-    #     $foundTestModule | Should -Be $True
-    #     $foundTestScript | Should -Be $True
-    # }
+        $foundTestModule | Should -Be $True
+        $foundTestScript | Should -Be $True
+    }
+
+    It "find all resources with specified tag given Tag property, with and without Prerelease property" {
+        $tagToFind = "MyPSTag"
+        $res = Find-PSResource -Tag $tagToFind -Repository $PSGalleryName
+        $res | Should -HaveCount 1
+
+        $res = Find-PSResource -Tag $tagToFind -Repository $PSGalleryName -Prerelease
+        $res | Should -HaveCount 2
+    }
 
     It "find resource given CommandName" {
         $res = Find-PSResource -CommandName $commandName -Repository $PSGalleryName


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->
`Find-PSResource -Tag "CrescendoBuilt" -Prerelease -Repository PSGallery` should return 22 packages, not 12,005 (which at the time of issue creation is the total number of packages on PSGallery.

`Find-PSResource -Tag "CrescendoBuilt" -Repository PSGallery` returns correct number of packages
# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
