### PR TITLE
Install-PSResource -RequiredResource with empty inner hashtable value bugfix

### DIFF
--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -428,7 +428,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             WriteDebug("In InstallPSResource::RequiredResourceHelper()");
             InstallPkgParams pkgParams = new InstallPkgParams();
             PSCredential pkgCredential = Credential;
-            string pkgVersion = String.Empty;
             
             foreach (DictionaryEntry entry in reqResourceHash)
             {
@@ -436,6 +435,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // inclding the scenario where only package name is specified
                 // i.e Install-PSResource -RequiredResource @ { MyPackage = @{} }
                 string pkgName = entry.Key.ToString();
+                string pkgVersion = String.Empty;
                 if (!(entry.Value is Hashtable pkgInstallInfo))
                 {
                     var requiredReourceHashtableInputFormatError = new ErrorRecord(

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -444,7 +444,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         ErrorCategory.InvalidArgument,
                         this);
 
-                    WriteError(requiredReourceHashtableInputFormatError);
+                    WriteError(requiredResourceHashtableInputFormatError);
                     return;
                 }
 

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -426,11 +426,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private void RequiredResourceHelper(Hashtable reqResourceHash)
         {
             WriteDebug("In InstallPSResource::RequiredResourceHelper()");
-            InstallPkgParams pkgParams = new InstallPkgParams();
-            PSCredential pkgCredential = Credential;
-            
             foreach (DictionaryEntry entry in reqResourceHash)
             {
+                InstallPkgParams pkgParams = new InstallPkgParams();
+                PSCredential pkgCredential = Credential;
+
                 // Set package name which will be key for the inner hashtable and is present for all scenarios,
                 // inclding the scenario where only package name is specified
                 // i.e Install-PSResource -RequiredResource @ { MyPackage = @{} }

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -245,6 +245,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private const string InputObjectParameterSet = "InputObjectParameterSet";
         private const string RequiredResourceFileParameterSet = "RequiredResourceFileParameterSet";
         private const string RequiredResourceParameterSet = "RequiredResourceParameterSet";
+        private const string CredentialKey = "credential";
         List<string> _pathsToInstallPkg;
         private string _requiredResourceFile;
         private string _requiredResourceJson;
@@ -435,6 +436,19 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // including the scenario where only package name is specified
                 // i.e Install-PSResource -RequiredResource @ { MyPackage = @{} }
                 string pkgName = entry.Key.ToString();
+                // check if pkgName is empty or whitespace
+                if (String.IsNullOrEmpty(pkgName.Trim()))
+                {
+                    var pkgNameEmptyOrWhitespaceError = new ErrorRecord(
+                        new ArgumentException($"The package name '{pkgName}' provided cannot be an empty string or whitespace."),
+                        "pkgNameEmptyOrWhitespaceError", 
+                        ErrorCategory.InvalidArgument,
+                        this);
+
+                    WriteError(pkgNameEmptyOrWhitespaceError);
+                    return;
+                }
+
                 string pkgVersion = String.Empty;
                 if (!(entry.Value is Hashtable pkgInstallInfo))
                 {
@@ -456,7 +470,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                     foreach (string paramName in pkgParamNames)
                     {
-                        if (string.Equals(paramName, "credential", StringComparison.InvariantCultureIgnoreCase))
+                        if (string.Equals(paramName, CredentialKey, StringComparison.InvariantCultureIgnoreCase))
                         {
                             WriteVerbose("Credential specified for required resource");
                             pkgCredential = pkgInstallInfo[paramName] as PSCredential;

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -438,7 +438,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 string pkgName = entry.Key.ToString();
                 if (!(entry.Value is Hashtable pkgInstallInfo))
                 {
-                    // possible invalid input: TODO err handle
+                    var requiredReourceHashtableInputFormatError = new ErrorRecord(
+                        new ArgumentException($"The RequiredResource input with name {pkgName} does not have a valid value, the value must be a hashtable."),
+                        "RequiredReourceHashtableInputFormatError", 
+                        ErrorCategory.InvalidArgument,
+                        this);
+
+                    WriteError(requiredReourceHashtableInputFormatError);
                     return;
                 }
 
@@ -456,10 +462,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             pkgCredential = pkgInstallInfo[paramName] as PSCredential;
                         }
 
-                        pkgParams.SetProperty(paramName, pkgInstallInfo[paramName] as string, out ErrorRecord IncorrectVersionFormat);
-                        if (IncorrectVersionFormat != null)
+                        // for all parameters found, we try to add it to the InstallPkgParams object if it is valid.
+                        pkgParams.SetProperty(paramName, pkgInstallInfo[paramName] as string, out ErrorRecord ParameterParsingError);
+                        if (ParameterParsingError != null)
                         {
-                            ThrowTerminatingError(IncorrectVersionFormat);
+                            ThrowTerminatingError(ParameterParsingError);
                         }
                     }
                         

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -440,7 +440,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     var requiredResourceHashtableInputFormatError = new ErrorRecord(
                         new ArgumentException($"The RequiredResource input with name {pkgName} does not have a valid value, the value must be a hashtable."),
-                        "RequiredReourceHashtableInputFormatError", 
+                        "RequiredResourceHashtableInputFormatError", 
                         ErrorCategory.InvalidArgument,
                         this);
 

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -431,7 +431,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 InstallPkgParams pkgParams = new InstallPkgParams();
                 PSCredential pkgCredential = Credential;
 
-                // Set package name which will be key for the inner hashtable and is present for all scenarios,
+                // The package name which will be the key for the inner hashtable and is present for all scenarios,
                 // including the scenario where only package name is specified
                 // i.e Install-PSResource -RequiredResource @ { MyPackage = @{} }
                 string pkgName = entry.Key.ToString();

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -438,7 +438,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 string pkgVersion = String.Empty;
                 if (!(entry.Value is Hashtable pkgInstallInfo))
                 {
-                    var requiredReourceHashtableInputFormatError = new ErrorRecord(
+                    var requiredResourceHashtableInputFormatError = new ErrorRecord(
                         new ArgumentException($"The RequiredResource input with name {pkgName} does not have a valid value, the value must be a hashtable."),
                         "RequiredReourceHashtableInputFormatError", 
                         ErrorCategory.InvalidArgument,

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -442,7 +442,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     return;
                 }
 
-                // scenario where only package name and other parameters are provided:
+                // scenario where package name and other parameters are provided:
                 // Install-PSResource -RequiredResource @ { MyPackage = @{ version = '1.2.3', repository = 'PSGallery' } }
                 if (pkgInstallInfo.Count != 0)
                 {

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -432,7 +432,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 PSCredential pkgCredential = Credential;
 
                 // Set package name which will be key for the inner hashtable and is present for all scenarios,
-                // inclding the scenario where only package name is specified
+                // including the scenario where only package name is specified
                 // i.e Install-PSResource -RequiredResource @ { MyPackage = @{} }
                 string pkgName = entry.Key.ToString();
                 string pkgVersion = String.Empty;

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -439,7 +439,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (!(entry.Value is Hashtable pkgInstallInfo))
                 {
                     var requiredResourceHashtableInputFormatError = new ErrorRecord(
-                        new ArgumentException($"The RequiredResource input with name {pkgName} does not have a valid value, the value must be a hashtable."),
+                        new ArgumentException($"The RequiredResource input with name '{pkgName}' does not have a valid value, the value must be a hashtable."),
                         "RequiredResourceHashtableInputFormatError", 
                         ErrorCategory.InvalidArgument,
                         this);

--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -431,7 +431,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 InstallPkgParams pkgParams = new InstallPkgParams();
                 PSCredential pkgCredential = Credential;
 
-                // The package name which will be the key for the inner hashtable and is present for all scenarios,
+                // The package name will be the key for the inner hashtable and is present for all scenarios,
                 // including the scenario where only package name is specified
                 // i.e Install-PSResource -RequiredResource @ { MyPackage = @{} }
                 string pkgName = entry.Key.ToString();

--- a/src/code/InstallPkgParams.cs
+++ b/src/code/InstallPkgParams.cs
@@ -28,6 +28,15 @@ public class InstallPkgParams
     public void SetProperty(string propertyName, string propertyValue, out ErrorRecord ParameterParsingError)
     {
         ParameterParsingError = null;
+        if (String.IsNullOrEmpty(propertyName.Trim()))
+        {
+            ParameterParsingError = new ErrorRecord(
+                new ArgumentException("Argument for parameter cannot be null or whitespace."),
+                "EmptyOrWhitespaceParameterKey", 
+                ErrorCategory.InvalidArgument,
+                this);
+        }
+
         switch (propertyName.ToLower())
         {
             case "name":

--- a/src/code/InstallPkgParams.cs
+++ b/src/code/InstallPkgParams.cs
@@ -25,9 +25,9 @@ public class InstallPkgParams
 
     #region Private methods
 
-    public void SetProperty(string propertyName, string propertyValue, out ErrorRecord IncorrectVersionFormat)
+    public void SetProperty(string propertyName, string propertyValue, out ErrorRecord ParameterParsingError)
     {
-        IncorrectVersionFormat = null;
+        ParameterParsingError = null;
         switch (propertyName.ToLower())
         {
             case "name":
@@ -44,7 +44,7 @@ public class InstallPkgParams
                 }
                 else if (!Utils.TryParseVersionOrVersionRange(propertyValue, out versionTmp))
                 {
-                    IncorrectVersionFormat = new ErrorRecord(
+                    ParameterParsingError = new ErrorRecord(
                         new ArgumentException("Argument for Version parameter is not in the proper format."),
                         "IncorrectVersionFormat", 
                         ErrorCategory.InvalidArgument,
@@ -98,7 +98,11 @@ public class InstallPkgParams
                 break;
 
             default:
-                // TODO Anam write error
+                ParameterParsingError = new ErrorRecord(
+                    new ArgumentException($"The parameter '{propertyName}' provided is not a recognized or valid parameter. Allowed values include: Name, Version, Repository, AcceptLicense, Prerelease, Scope, Quiet, Reinstall, TrustRepository, NoClobber, and SkipDependencyCheck."),
+                    "IncorrectParameterError", 
+                    ErrorCategory.InvalidArgument,
+                    this);
                 break;
         }
     }

--- a/src/code/InstallPkgParams.cs
+++ b/src/code/InstallPkgParams.cs
@@ -98,7 +98,7 @@ public class InstallPkgParams
                 break;
 
             default:
-                // write error
+                // TODO Anam write error
                 break;
         }
     }

--- a/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
@@ -389,15 +389,13 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
                repository = $PSGalleryName
             }
 
-             test_module2 = @{
+            test_module2 = @{
                version = "[1.0.0,3.0.0)"
                repository = $PSGalleryName
                prerelease = "true"
             }
 
-             TestModule99 = @{
-                repository = $PSGalleryName
-            }
+            TestModule99 = @{}
           }
 
           Install-PSResource -RequiredResource $rrHash -TrustRepository


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
For examples of valid input for Install-PSResource's `-RequiredResource` cmdlet please reference the docs [here](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.psresourceget/install-psresource?view=powershellget-3.x#example-5)

Additionally parameters can be supplied via parameter splatting which is supported in powershell.

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1411 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
