### PR TITLE
Provide more intuitive error message when JFrog feed is inactive

### DIFF
--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -1476,10 +1476,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 // scenario where the feed is not active anymore, i.e confirmed for JFrogArtifactory. The default error message is not intuitive.
                 errRecord = new ErrorRecord(
-                exception: new Exception($"JSON response from repository {Repository.Name} could not be parsed, likely due to the feed being inactive or invalid, with inner exception: {e.Message}"), 
-                "FindVersionGlobbingFailure",
-                ErrorCategory.InvalidResult, 
-                this);
+                    exception: new Exception($"JSON response from repository {Repository.Name} could not be parsed, likely due to the feed being inactive or invalid, with inner exception: {e.Message}"), 
+                    "FindVersionGlobbingFailure",
+                    ErrorCategory.InvalidResult, 
+                    this);
             }
             catch (Exception e)
             {

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -1472,25 +1472,22 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     entries = responseEntries.ToArray();
                 }
             }
+            catch (JsonException e)
+            {
+                // scenario where the feed is not active anymore, i.e confirmed for JFrogArtifactory. The default error message is not intuitive.
+                errRecord = new ErrorRecord(
+                exception: new Exception($"JSON response from repository {Repository.Name} could not be parsed, likely due to the feed being inactive or invalid, with inner exception: {e.Message}"), 
+                "FindVersionGlobbingFailure",
+                ErrorCategory.InvalidResult, 
+                this);
+            }
             catch (Exception e)
             {
-                if (e.Message.Contains("'<' is an invalid start of a value"))
-                {
-                    // scenario where the feed is not active anymore, i.e confirmed for JFrogArtifactory. The default error message is not intuitive.
-                    errRecord = new ErrorRecord(
-                    exception: new Exception($"JSON response from repository {Repository.Name} could not be parsed due to the feed being inactive or invalid, with inner exception: {e.Message}"), 
-                    "FindVersionGlobbingFailure",
+                errRecord = new ErrorRecord(
+                    exception: e, 
+                    "GetResponsesFromRegistrationsResourceFailure", 
                     ErrorCategory.InvalidResult, 
                     this);
-                }
-                else
-                {
-                    errRecord = new ErrorRecord(
-                        exception: e, 
-                        "GetResponsesFromRegistrationsResourceFailure", 
-                        ErrorCategory.InvalidResult, 
-                        this);
-                }
             }
 
             return entries;

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -1474,11 +1474,23 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             catch (Exception e)
             {
-                errRecord = new ErrorRecord(
-                    exception: e, 
-                    "GetResponsesFromRegistrationsResourceFailure", 
+                if (e.Message.Contains("'<' is an invalid start of a value"))
+                {
+                    // scenario where the feed is not active anymore, i.e confirmed for JFrogArtifactory. The default error message is not intuitive.
+                    errRecord = new ErrorRecord(
+                    exception: new Exception($"JSON response from repository {Repository.Name} could not be parsed due to the feed being inactive or invalid, with inner exception: {e.Message}"), 
+                    "FindVersionGlobbingFailure",
                     ErrorCategory.InvalidResult, 
                     this);
+                }
+                else
+                {
+                    errRecord = new ErrorRecord(
+                        exception: e, 
+                        "GetResponsesFromRegistrationsResourceFailure", 
+                        ErrorCategory.InvalidResult, 
+                        this);
+                }
             }
 
             return entries;

--- a/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
@@ -389,15 +389,13 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
                repository = $PSGalleryName
             }
 
-             test_module2 = @{
+            test_module2 = @{
                version = "[1.0.0,3.0.0)"
                repository = $PSGalleryName
                prerelease = "true"
             }
 
-             TestModule99 = @{
-                repository = $PSGalleryName
-            }
+            TestModule99 = @{}
           }
 
           Install-PSResource -RequiredResource $rrHash -TrustRepository

--- a/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
@@ -389,13 +389,15 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
                repository = $PSGalleryName
             }
 
-            test_module2 = @{
+             test_module2 = @{
                version = "[1.0.0,3.0.0)"
                repository = $PSGalleryName
                prerelease = "true"
             }
 
-            TestModule99 = @{}
+             TestModule99 = @{
+                repository = $PSGalleryName
+            }
           }
 
           Install-PSResource -RequiredResource $rrHash -TrustRepository


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1424
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
