### PR TITLE
Fix JFrog's NuGet Artifactory (v2 endpoint) bug

### DIFF
--- a/src/code/IServerAPICalls.cs
+++ b/src/code/IServerAPICalls.cs
@@ -83,7 +83,7 @@ public interface IServerAPICalls
     /// Name: no wildcard support.
     /// Examples: Install "PowerShellGet"
     /// </summary>
-    Stream InstallName(string packageName, bool includePrerelease, out ErrorRecord errRecord);
+    Stream InstallName(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord);
 
     /// <summary>
     /// Installs package with specific name and version.

--- a/src/code/IServerAPICalls.cs
+++ b/src/code/IServerAPICalls.cs
@@ -83,16 +83,7 @@ public interface IServerAPICalls
     /// Name: no wildcard support.
     /// Examples: Install "PowerShellGet"
     /// </summary>
-    Stream InstallName(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord);
-
-    /// <summary>
-    /// Installs package with specific name and version.
-    /// Name: no wildcard support.
-    /// Version: no wildcard support.
-    /// Examples: Install "PowerShellGet" -Version "3.0.0.0"
-    ///           Install "PowerShellGet" -Version "3.0.0-beta16"
-    /// </summary>    
-    Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord);
+    Stream InstallPackage(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord);
 
     #endregion
 }

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -843,7 +843,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 if (searchVersionType == VersionType.NoVersion && !_prerelease)
                 {
-                    responseStream = currentServer.InstallName(pkgName, _prerelease, out ErrorRecord installNameErrRecord);
+                    responseStream = currentServer.InstallName(pkgName, pkgVersion, _prerelease, out ErrorRecord installNameErrRecord);
                     if (installNameErrRecord != null)
                     {
                         errRecord = installNameErrRecord;

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -549,7 +549,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     // and value as a Hashtable of specific package info:
                     //     packageName, { version = "", isScript = "", isModule = "", pkg = "", etc. }
                     // Install parent package to the temp directory.
-                    Hashtable packagesHash = InstallPackage(
+                    Hashtable packagesHash = BeginPackageInstall(
                                                         searchVersionType: _versionType,
                                                         specificVersion: _nugetVersion,
                                                         versionRange: _versionRange,
@@ -617,7 +617,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                     }
                                 }
 
-                                packagesHash = InstallPackage(
+                                packagesHash = BeginPackageInstall(
                                             searchVersionType: VersionType.SpecificVersion,
                                             specificVersion: depVersion,
                                             versionRange: null,
@@ -683,7 +683,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Installs a single package to the temporary path.
         /// </summary>
-        private Hashtable InstallPackage(
+        private Hashtable BeginPackageInstall(
             VersionType searchVersionType,
             NuGetVersion specificVersion,
             VersionRange versionRange,
@@ -839,25 +839,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 // Download the package.
                 string pkgName = pkgToInstall.Name;
-                Stream responseStream;
-
-                if (searchVersionType == VersionType.NoVersion && !_prerelease)
+                Stream responseStream = currentServer.InstallPackage(pkgName, pkgVersion, _prerelease, out ErrorRecord installNameErrRecord);
+                if (installNameErrRecord != null)
                 {
-                    responseStream = currentServer.InstallName(pkgName, pkgVersion, _prerelease, out ErrorRecord installNameErrRecord);
-                    if (installNameErrRecord != null)
-                    {
-                        errRecord = installNameErrRecord;
-                        return packagesHash;
-                    }
-                }
-                else
-                {
-                    responseStream = currentServer.InstallVersion(pkgName, pkgVersion, out ErrorRecord installVersionErrRecord);
-                    if (installVersionErrRecord != null)
-                    {
-                        errRecord = installVersionErrRecord;
-                        return packagesHash;
-                    }
+                    errRecord = installNameErrRecord;
+                    return packagesHash;
                 }
 
                 bool installedToTempPathSuccessfully = _asNupkg ? TrySaveNupkgToTempPath(responseStream, tempInstallPath, pkgName, pkgVersion, pkgToInstall, packagesHash, out updatedPackagesHash, out errRecord) :

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -217,157 +217,28 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /**  INSTALL APIS **/
 
         /// <summary>
-        /// Installs specific package.
+        /// Installs a specific package.
         /// Name: no wildcard support.
         /// Examples: Install "PowerShellGet"
-        /// Implementation Note:   if not prerelease: https://www.powershellgallery.com/api/v2/package/powershellget (Returns latest stable)
-        ///                        if prerelease, call into InstallVersion instead.
+        ///           Install "PowerShellGet" -Version "3.0.0"
         /// </summary>
-        public override Stream InstallName(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord)
+        public override Stream InstallPackage(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In LocalServerApiCalls::InstallName()");
-            FileStream fs = null;
-            errRecord = null;
-            WildcardPattern pkgNamePattern = new WildcardPattern($"{packageName}.*", WildcardOptions.IgnoreCase);
-            NuGetVersion latestVersion = new NuGetVersion("0.0.0.0");
-            String latestVersionPath = String.Empty;
-
-            foreach (string path in Directory.GetFiles(Repository.Uri.LocalPath))
+            Stream results = new MemoryStream();
+            if (string.IsNullOrEmpty(packageVersion))
             {
-                string packageFullName = Path.GetFileName(path);
-
-                if (!String.IsNullOrEmpty(packageFullName) && pkgNamePattern.IsMatch(packageFullName))
-                {
-                    _cmdletPassedIn.WriteDebug($"'{packageName}' found in '{path}'");
-                    string[] packageWithoutName = packageFullName.ToLower().Split(new string[]{ $"{packageName.ToLower()}." }, StringSplitOptions.RemoveEmptyEntries);
-                    string packageVersionAndExtension = packageWithoutName[0];
-                    int extensionDot = packageVersionAndExtension.LastIndexOf('.');
-                    string version = packageVersionAndExtension.Substring(0, extensionDot);
-                    _cmdletPassedIn.WriteDebug($"Parsing version '{version}' of package '{packageName}'");
-                    NuGetVersion.TryParse(version, out NuGetVersion nugetVersion);
-
-                    if ((!nugetVersion.IsPrerelease || includePrerelease) && (nugetVersion > latestVersion))
-                    {
-                        latestVersion = nugetVersion;
-                        latestVersionPath = path;
-                    }
-                }
+                results = InstallName(packageName, includePrerelease, out errRecord);
+            }
+            else {
+                results = InstallVersion(packageName, packageVersion, out errRecord);
             }
 
-            if (String.IsNullOrEmpty(latestVersionPath))
-            {
-                errRecord = new ErrorRecord(
-                    new LocalResourceEmpty($"'{packageName}' is not present in repository"), 
-                    "InstallNameFailure", 
-                    ErrorCategory.ResourceUnavailable, 
-                    this);
-
-                return fs;
-            }
-
-            try
-            {
-                _cmdletPassedIn.WriteDebug($"Reading file '{latestVersionPath}'");
-                fs = new FileStream(latestVersionPath, FileMode.Open, FileAccess.Read);
-                if (fs == null)
-                {
-                    errRecord = new ErrorRecord(
-                        new LocalResourceEmpty("The contents of the package file for specified resource was empty or invalid"), 
-                        "InstallNameFailure", 
-                        ErrorCategory.ResourceUnavailable, 
-                        this);
-                }
-            }
-            catch (Exception e)
-            {
-                errRecord = new ErrorRecord(
-                    exception: e, 
-                    "InstallNameFailure", 
-                    ErrorCategory.ReadError, 
-                    this);
-            }
-
-            return fs;
-        }
-
-        /// <summary>
-        /// Installs package with specific name and version.
-        /// Name: no wildcard support.
-        /// Version: no wildcard support.
-        /// Examples: Install "PowerShellGet" -Version "3.0.0.0"
-        ///           Install "PowerShellGet" -Version "3.0.0-beta16"
-        /// API Call: https://www.powershellgallery.com/api/v2/package/Id/version (version can be prerelease)
-        /// </summary>
-        public override Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord)
-        {
-            _cmdletPassedIn.WriteDebug("In LocalServerApiCalls::InstallVersion()");
-            errRecord = null;
-            FileStream fs = null;
-
-            // if 4 digits and last is 0, create 3 digit equiv string
-            // 4 digit version (where last is 0) is always passed in.
-            NuGetVersion.TryParse(version, out NuGetVersion pkgVersion);
-            _cmdletPassedIn.WriteDebug($"Version parsed as '{pkgVersion}'");
-
-            if (pkgVersion.Revision == 0)
-            {
-                version = pkgVersion.ToNormalizedString();
-            }
-
-            WildcardPattern pkgNamePattern = new WildcardPattern($"{packageName}.{version}.nupkg*", WildcardOptions.IgnoreCase);
-            String pkgVersionPath = String.Empty;
-
-            foreach (string path in Directory.GetFiles(Repository.Uri.LocalPath))
-            {
-                string packageFullName = Path.GetFileName(path);
-
-                if (!String.IsNullOrEmpty(packageFullName) && pkgNamePattern.IsMatch(packageFullName))
-                {
-                    _cmdletPassedIn.WriteDebug($"Found match with '{path}'");
-                    pkgVersionPath = path;
-                }
-            }
-
-            if (String.IsNullOrEmpty(pkgVersionPath))
-            {
-                errRecord = new ErrorRecord(
-                    new LocalResourceEmpty($"'{packageName}' is not present in repository"), 
-                    "InstallNameFailure", 
-                    ErrorCategory.ResourceUnavailable, 
-                    this);
-
-                return fs;
-            }
-
-            try
-            {
-                _cmdletPassedIn.WriteDebug($"Reading file '{pkgVersionPath}'");
-                fs = new FileStream(pkgVersionPath, FileMode.Open, FileAccess.Read);
-
-                if (fs == null)
-                {
-                    errRecord = new ErrorRecord(
-                        new LocalResourceEmpty("The contents of the package file for specified resource was empty or invalid"), 
-                        "InstallNameFailure", 
-                        ErrorCategory.ResourceUnavailable, 
-                        this);
-                }
-            }
-            catch (Exception e)
-            {
-                errRecord = new ErrorRecord(
-                    exception: e, 
-                    "InstallVersionFailure", 
-                    ErrorCategory.ReadError, 
-                    this);
-            }
-
-            return fs;
+            return results;
         }
 
         #endregion
 
-        #region LocalRepo Specific Methods
+        #region Private Methods
 
         /// <summary>
         /// Helper method called by FindName() and FindNameWithTag()
@@ -590,6 +461,155 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             findResponse = new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: pkgsFound.ToArray(), responseType: _localServerFindResponseType);
 
             return findResponse;
+        }
+
+        /// <summary>
+        /// Installs specific package.
+        /// Name: no wildcard support.
+        /// Examples: Install "PowerShellGet"
+        /// Implementation Note:   if not prerelease: https://www.powershellgallery.com/api/v2/package/powershellget (Returns latest stable)
+        ///                        if prerelease, call into InstallVersion instead.
+        /// </summary>
+        private Stream InstallName(string packageName, bool includePrerelease, out ErrorRecord errRecord)
+        {
+            _cmdletPassedIn.WriteDebug("In LocalServerApiCalls::InstallName()");
+            FileStream fs = null;
+            errRecord = null;
+            WildcardPattern pkgNamePattern = new WildcardPattern($"{packageName}.*", WildcardOptions.IgnoreCase);
+            NuGetVersion latestVersion = new NuGetVersion("0.0.0.0");
+            String latestVersionPath = String.Empty;
+
+            foreach (string path in Directory.GetFiles(Repository.Uri.LocalPath))
+            {
+                string packageFullName = Path.GetFileName(path);
+
+                if (!String.IsNullOrEmpty(packageFullName) && pkgNamePattern.IsMatch(packageFullName))
+                {
+                    _cmdletPassedIn.WriteDebug($"'{packageName}' found in '{path}'");
+                    string[] packageWithoutName = packageFullName.ToLower().Split(new string[] { $"{packageName.ToLower()}." }, StringSplitOptions.RemoveEmptyEntries);
+                    string packageVersionAndExtension = packageWithoutName[0];
+                    int extensionDot = packageVersionAndExtension.LastIndexOf('.');
+                    string version = packageVersionAndExtension.Substring(0, extensionDot);
+                    _cmdletPassedIn.WriteDebug($"Parsing version '{version}' of package '{packageName}'");
+                    NuGetVersion.TryParse(version, out NuGetVersion nugetVersion);
+
+                    if ((!nugetVersion.IsPrerelease || includePrerelease) && (nugetVersion > latestVersion))
+                    {
+                        latestVersion = nugetVersion;
+                        latestVersionPath = path;
+                    }
+                }
+            }
+
+            if (String.IsNullOrEmpty(latestVersionPath))
+            {
+                errRecord = new ErrorRecord(
+                    new LocalResourceEmpty($"'{packageName}' is not present in repository"),
+                    "InstallNameFailure",
+                    ErrorCategory.ResourceUnavailable,
+                    this);
+
+                return fs;
+            }
+
+            try
+            {
+                _cmdletPassedIn.WriteDebug($"Reading file '{latestVersionPath}'");
+                fs = new FileStream(latestVersionPath, FileMode.Open, FileAccess.Read);
+                if (fs == null)
+                {
+                    errRecord = new ErrorRecord(
+                        new LocalResourceEmpty("The contents of the package file for specified resource was empty or invalid"),
+                        "InstallNameFailure",
+                        ErrorCategory.ResourceUnavailable,
+                        this);
+                }
+            }
+            catch (Exception e)
+            {
+                errRecord = new ErrorRecord(
+                    exception: e,
+                    "InstallNameFailure",
+                    ErrorCategory.ReadError,
+                    this);
+            }
+
+            return fs;
+        }
+
+        /// <summary>
+        /// Installs package with specific name and version.
+        /// Name: no wildcard support.
+        /// Version: no wildcard support.
+        /// Examples: Install "PowerShellGet" -Version "3.0.0.0"
+        ///           Install "PowerShellGet" -Version "3.0.0-beta16"
+        /// API Call: https://www.powershellgallery.com/api/v2/package/Id/version (version can be prerelease)
+        /// </summary>
+        private Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord)
+        {
+            _cmdletPassedIn.WriteDebug("In LocalServerApiCalls::InstallVersion()");
+            errRecord = null;
+            FileStream fs = null;
+
+            // if 4 digits and last is 0, create 3 digit equiv string
+            // 4 digit version (where last is 0) is always passed in.
+            NuGetVersion.TryParse(version, out NuGetVersion pkgVersion);
+            _cmdletPassedIn.WriteDebug($"Version parsed as '{pkgVersion}'");
+
+            if (pkgVersion.Revision == 0)
+            {
+                version = pkgVersion.ToNormalizedString();
+            }
+
+            WildcardPattern pkgNamePattern = new WildcardPattern($"{packageName}.{version}.nupkg*", WildcardOptions.IgnoreCase);
+            String pkgVersionPath = String.Empty;
+
+            foreach (string path in Directory.GetFiles(Repository.Uri.LocalPath))
+            {
+                string packageFullName = Path.GetFileName(path);
+
+                if (!String.IsNullOrEmpty(packageFullName) && pkgNamePattern.IsMatch(packageFullName))
+                {
+                    _cmdletPassedIn.WriteDebug($"Found match with '{path}'");
+                    pkgVersionPath = path;
+                }
+            }
+
+            if (String.IsNullOrEmpty(pkgVersionPath))
+            {
+                errRecord = new ErrorRecord(
+                    new LocalResourceEmpty($"'{packageName}' is not present in repository"),
+                    "InstallNameFailure",
+                    ErrorCategory.ResourceUnavailable,
+                    this);
+
+                return fs;
+            }
+
+            try
+            {
+                _cmdletPassedIn.WriteDebug($"Reading file '{pkgVersionPath}'");
+                fs = new FileStream(pkgVersionPath, FileMode.Open, FileAccess.Read);
+
+                if (fs == null)
+                {
+                    errRecord = new ErrorRecord(
+                        new LocalResourceEmpty("The contents of the package file for specified resource was empty or invalid"),
+                        "InstallNameFailure",
+                        ErrorCategory.ResourceUnavailable,
+                        this);
+                }
+            }
+            catch (Exception e)
+            {
+                errRecord = new ErrorRecord(
+                    exception: e,
+                    "InstallVersionFailure",
+                    ErrorCategory.ReadError,
+                    this);
+            }
+
+            return fs;
         }
 
         /// <summary>

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -223,7 +223,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Implementation Note:   if not prerelease: https://www.powershellgallery.com/api/v2/package/powershellget (Returns latest stable)
         ///                        if prerelease, call into InstallVersion instead.
         /// </summary>
-        public override Stream InstallName(string packageName, bool includePrerelease, out ErrorRecord errRecord)
+        public override Stream InstallName(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In LocalServerApiCalls::InstallName()");
             FileStream fs = null;

--- a/src/code/NuGetServerAPICalls.cs
+++ b/src/code/NuGetServerAPICalls.cs
@@ -399,7 +399,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Implementation Note:   {repoUri}/Packages(Id='test_local_mod')/Download
         ///                        if prerelease, call into InstallVersion instead. 
         /// </summary>
-        public override Stream InstallName(string packageName, bool includePrerelease, out ErrorRecord errRecord)
+        public override Stream InstallName(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::InstallName()");
             var requestUrl = $"{Repository.Uri}/Packages/(Id='{packageName}')/Download";

--- a/src/code/NuGetServerAPICalls.cs
+++ b/src/code/NuGetServerAPICalls.cs
@@ -393,38 +393,23 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /**  INSTALL APIS **/
 
         /// <summary>
-        /// Installs specific package.
+        /// Installs a specific package.
         /// Name: no wildcard support.
         /// Examples: Install "PowerShellGet"
-        /// Implementation Note:   {repoUri}/Packages(Id='test_local_mod')/Download
-        ///                        if prerelease, call into InstallVersion instead. 
+        ///           Install "PowerShellGet" -Version "3.0.0"
         /// </summary>
-        public override Stream InstallName(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord)
+        public override Stream InstallPackage(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::InstallName()");
-            var requestUrl = $"{Repository.Uri}/Packages/(Id='{packageName}')/Download";
-            var response = HttpRequestCallForContent(requestUrl, out errRecord);
-            var responseStream = response.ReadAsStreamAsync().Result;
+            Stream results = new MemoryStream();
+            if (string.IsNullOrEmpty(packageVersion))
+            {
+                results = InstallName(packageName, out errRecord);
+            }
+            else {
+                results = InstallVersion(packageName, packageVersion, out errRecord);
+            }
 
-            return responseStream;
-        }
-
-        /// <summary>
-        /// Installs package with specific name and version.
-        /// Name: no wildcard support.
-        /// Version: no wildcard support.
-        /// Examples: Install "PowerShellGet" -Version "3.0.0.0"
-        ///           Install "PowerShellGet" -Version "3.0.0-beta16"
-        /// API Call: {repoUri}/Packages(Id='Castle.Core',Version='5.1.1')/Download
-        /// </summary>    
-        public override Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord)
-        {
-            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::InstallVersion()");
-            var requestUrl = $"{Repository.Uri}/Packages(Id='{packageName}',Version='{version}')/Download";
-            var response = HttpRequestCallForContent(requestUrl, out errRecord);
-            var responseStream = response.ReadAsStreamAsync().Result;
-
-            return responseStream;
+            return results;
         }
 
         /// <summary>
@@ -788,6 +773,41 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             var requestUrl = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$orderby=NormalizedVersion desc&{paginationParam}{filterQuery}";
 
             return HttpRequestCall(requestUrl, out errRecord);
+        }
+
+        /// <summary>
+        /// Installs specific package.
+        /// Name: no wildcard support.
+        /// Examples: Install "PowerShellGet"
+        /// Implementation Note:   {repoUri}/Packages(Id='test_local_mod')/Download
+        ///                        if prerelease, call into InstallVersion instead. 
+        /// </summary>
+        private Stream InstallName(string packageName, out ErrorRecord errRecord)
+        {
+            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::InstallName()");
+            var requestUrl = $"{Repository.Uri}/Packages/(Id='{packageName}')/Download";
+            var response = HttpRequestCallForContent(requestUrl, out errRecord);
+            var responseStream = response.ReadAsStreamAsync().Result;
+
+            return responseStream;
+        }
+
+        /// <summary>
+        /// Installs package with specific name and version.
+        /// Name: no wildcard support.
+        /// Version: no wildcard support.
+        /// Examples: Install "PowerShellGet" -Version "3.0.0.0"
+        ///           Install "PowerShellGet" -Version "3.0.0-beta16"
+        /// API Call: {repoUri}/Packages(Id='Castle.Core',Version='5.1.1')/Download
+        /// </summary>    
+        private Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord)
+        {
+            _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::InstallVersion()");
+            var requestUrl = $"{Repository.Uri}/Packages(Id='{packageName}',Version='{version}')/Download";
+            var response = HttpRequestCallForContent(requestUrl, out errRecord);
+            var responseStream = response.ReadAsStreamAsync().Result;
+
+            return responseStream;
         }
 
         /// <summary>

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -498,8 +498,24 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
                     if (key.Equals("Title"))
                     {
-                        // For repositories such as JFrog's Artifactory, there is no "Id" property, just "Title" (which contains the Id)
-                        metadata["Id"] = value;
+                        // For repositories such as JFrog's Artifactory, there is no 'Id' property, just 'Title' (which contains the name of the pkg).
+                        // However, other repos, like PSGallery include the name of the pkg in the 'Id' property and leave 'Title' empty.
+
+                        // First check to see that both 'Title' and 'Id' exist in the child nodes. 
+                        // If both exist, take 'Id', otherwise just take 'Title'. 
+                        bool containsID = false;
+                        foreach (XmlElement childNode in childNodes)
+                        {
+                            if (childNode.LocalName == "Id")
+                            {
+                                containsID = true;
+                            }
+                        }
+
+                        if (!containsID)
+                        {
+                            metadata["Id"] = value;
+                        }
                     }
                     if (key.Equals("Version"))
                     {

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -496,6 +496,11 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     var key = child.LocalName;
                     var value = child.InnerText;
 
+                    if (key.Equals("Title"))
+                    {
+                        // For repositories such as JFrog's Artifactory, there is no "Id" property, just "Title" (which contains the Id)
+                        metadata["Id"] = value;
+                    }
                     if (key.Equals("Version"))
                     {
                         metadata[key] = ParseHttpVersion(value, out string prereleaseLabel);

--- a/src/code/ServerApiCall.cs
+++ b/src/code/ServerApiCall.cs
@@ -116,7 +116,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         ///                        if prerelease, the calling method should first call IFindPSResource.FindName(),
         ///                             then find the exact version to install, then call into install version
         /// </summary>
-        public abstract Stream InstallName(string packageName, bool includePrerelease, out ErrorRecord errRecord);
+        public abstract Stream InstallName(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord);
 
 
         /// <summary>

--- a/src/code/ServerApiCall.cs
+++ b/src/code/ServerApiCall.cs
@@ -112,21 +112,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Installs specific package.
         /// Name: no wildcard support.
         /// Examples: Install "PowerShellGet"
+        ///           Install "PowerShellGet" -Version "3.0.0"
+        ///           Install "PowerShellGet" -Version "3.0.0-beta24"
         /// Implementation Note:   if not prerelease: https://www.powershellgallery.com/api/v2/package/powershellget (Returns latest stable)
         ///                        if prerelease, the calling method should first call IFindPSResource.FindName(),
         ///                             then find the exact version to install, then call into install version
         /// </summary>
-        public abstract Stream InstallName(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord);
-
-
-        /// <summary>
-        /// Installs package with specific name and version.
-        /// Name: no wildcard support.
-        /// Version: no wildcard support.
-        /// Examples: Install "PowerShellGet" -Version "3.0.0.0"
-        ///           Install "PowerShellGet" -Version "3.0.0-beta16"
-        /// </summary>
-        public abstract Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord);
+        public abstract Stream InstallPackage(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord);
 
         #endregion
 

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -56,7 +56,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             _sessionClient = new HttpClient(handler);
             _sessionClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", userAgentString);
-            _isJFrogRepo = repository.Uri.ToString().ToLower().Contains("jfrog");
+            var repoURL = repository.Uri.ToString().ToLower();
+            _isJFrogRepo = repoURL.Contains("jfrog");
         }
 
         #endregion
@@ -671,7 +672,16 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override Stream InstallName(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::InstallName()");
-            var requestUrlV2 = _isJFrogRepo ? $"{Repository.Uri}/Download/{packageName}/{packageVersion}" : $"{Repository.Uri}/package/{packageName}";
+            var requestUrlV2 = string.Empty;
+
+            if (_isJFrogRepo)
+            {
+                requestUrlV2 = $"{Repository.Uri}/Download/{packageName}/{packageVersion}";
+            }
+            else {
+                requestUrlV2 = $"{Repository.Uri}/package/{packageName}";
+            }
+
             var response = HttpRequestCallForContent(requestUrlV2, out errRecord);
             if (errRecord != null)
             {
@@ -694,8 +704,16 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::InstallVersion()");
-            var downloadType = _isJFrogRepo ? "Download" : "package";
-            var requestUrlV2 = $"{Repository.Uri}/{downloadType}/{packageName}/{version}";
+            var requestUrlV2 = string.Empty;
+
+            if (_isJFrogRepo)
+            {
+                requestUrlV2 = $"{Repository.Uri}/Download/{packageName}/{version}";
+            }
+            else {
+                requestUrlV2 = $"{Repository.Uri}/package/{packageName}/{version}";
+            }
+
             var response = HttpRequestCallForContent(requestUrlV2, out errRecord);
             var responseStream = response.ReadAsStreamAsync().Result;
             if (errRecord != null)

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -1120,17 +1120,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private Stream InstallName(string packageName, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::InstallName()");
-            string requestUrlV2;
-
-            if (_isJFrogRepo)
-            {
-                requestUrlV2 = $"{Repository.Uri}/(Id='{packageName}')/Download";
-            }
-            else
-            {
-                requestUrlV2 = $"{Repository.Uri}/Packages/(Id='{packageName}')/Download";
-            }
-
+            var requestUrlV2 = $"{Repository.Uri}/package/{packageName}";
             var response = HttpRequestCallForContent(requestUrlV2, out errRecord);
             if (errRecord != null)
             {

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -668,12 +668,16 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Implementation Note:   if not prerelease: https://www.powershellgallery.com/api/v2/package/powershellget (Returns latest stable)
         ///                        if prerelease, call into InstallVersion instead.
         /// </summary>
-        public override Stream InstallName(string packageName, bool includePrerelease, out ErrorRecord errRecord)
+        public override Stream InstallName(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::InstallName()");
-            var requestUrlV2 = $"{Repository.Uri}/package/{packageName}";
-
+            var requestUrlV2 = _isJFrogRepo ? $"{Repository.Uri}/Download/{packageName}/{packageVersion}" : $"{Repository.Uri}/package/{packageName}";
             var response = HttpRequestCallForContent(requestUrlV2, out errRecord);
+            if (errRecord != null)
+            {
+                return new MemoryStream();
+            }
+
             var responseStream = response.ReadAsStreamAsync().Result;
 
             return responseStream;
@@ -690,9 +694,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::InstallVersion()");
-            var requestUrlV2 = $"{Repository.Uri}/package/{packageName}/{version}";
+            var downloadType = _isJFrogRepo ? "Download" : "package";
+            var requestUrlV2 = $"{Repository.Uri}/{downloadType}/{packageName}/{version}";
             var response = HttpRequestCallForContent(requestUrlV2, out errRecord);
             var responseStream = response.ReadAsStreamAsync().Result;
+            if (errRecord != null)
+            {
+                return new MemoryStream();
+            }
 
             return responseStream;
         }
@@ -795,7 +804,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     this);
             }
 
-            if (string.IsNullOrEmpty(content.ToString()))
+            if (content == null || string.IsNullOrEmpty(content.ToString()))
             {
                 _cmdletPassedIn.WriteDebug("Response is empty");
             }

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -292,6 +292,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override Stream InstallPackage(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord)
         {
             Stream results = new MemoryStream();
+            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::InstallPackage()");
             if (string.IsNullOrEmpty(packageVersion))
             {
                 results = InstallName(packageName, out errRecord);

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -284,38 +284,24 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /**  INSTALL APIS **/
 
         /// <summary>
-        /// Installs specific package.
+        /// Installs a specific package.
         /// Name: no wildcard support.
-        /// Examples: Install "Newtonsoft.json"
+        /// Examples: Install "PowerShellGet"
+        ///           Install "PowerShellGet" -Version "3.0.0"
         /// </summary>
-        public override Stream InstallName(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord)
+        public override Stream InstallPackage(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::InstallName()");
-            return InstallHelper(packageName, version: null, out errRecord);
-        }
-
-        /// <summary>
-        /// Installs package with specific name and version.
-        /// Name: no wildcard support.
-        /// Version: no wildcard support.
-        /// Examples: Install "Newtonsoft.json" -Version "1.0.0.0"
-        ///           Install "Newtonsoft.json" -Version "2.5.0-beta"
-        /// </summary>
-        public override Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord)
-        {
-            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::InstallVersion()");
-            if (!NuGetVersion.TryParse(version, out NuGetVersion requiredVersion))
+            Stream results = new MemoryStream();
+            if (string.IsNullOrEmpty(packageVersion))
             {
-                errRecord = new ErrorRecord(
-                    new ArgumentException($"Version {version} to be installed is not a valid NuGet version."), 
-                    "InstallVersionFailure", 
-                    ErrorCategory.InvalidArgument, 
-                    this);
-
-                return null;
+                results = InstallName(packageName, out errRecord);
+            }
+            else
+            {
+                results = InstallVersion(packageName, packageVersion, out errRecord);
             }
 
-            return InstallHelper(packageName, requiredVersion, out errRecord);
+            return results;
         }
 
         #endregion
@@ -670,6 +656,41 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             return new FindResults(stringResponse: new string[] { latestVersionResponse }, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
+        }
+
+        /// <summary>
+        /// Installs specific package.
+        /// Name: no wildcard support.
+        /// Examples: Install "Newtonsoft.json"
+        /// </summary>
+        private Stream InstallName(string packageName, out ErrorRecord errRecord)
+        {
+            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::InstallName()");
+            return InstallHelper(packageName, version: null, out errRecord);
+        }
+
+        /// <summary>
+        /// Installs package with specific name and version.
+        /// Name: no wildcard support.
+        /// Version: no wildcard support.
+        /// Examples: Install "Newtonsoft.json" -Version "1.0.0.0"
+        ///           Install "Newtonsoft.json" -Version "2.5.0-beta"
+        /// </summary>
+        private Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord)
+        {
+            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::InstallVersion()");
+            if (!NuGetVersion.TryParse(version, out NuGetVersion requiredVersion))
+            {
+                errRecord = new ErrorRecord(
+                    new ArgumentException($"Version {version} to be installed is not a valid NuGet version."),
+                    "InstallVersionFailure",
+                    ErrorCategory.InvalidArgument,
+                    this);
+
+                return null;
+            }
+
+            return InstallHelper(packageName, requiredVersion, out errRecord);
         }
 
         /// <summary>

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -288,7 +288,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Name: no wildcard support.
         /// Examples: Install "Newtonsoft.json"
         /// </summary>
-        public override Stream InstallName(string packageName, bool includePrerelease, out ErrorRecord errRecord)
+        public override Stream InstallName(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::InstallName()");
             return InstallHelper(packageName, version: null, out errRecord);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fixes a few bugs related to the v2 endpoint for JFrog's NuGet Artifactory repositories:

*  `Find` was not able to find a package in a repo.  It previously errored out saying package could not be found.  This was due to the request query being created adding the filter `"Id eq '<packageName>'"` (eg: `https://test.jfrog.io/artifactory/api/nuget/nuget/FindPackagesById()?id='<packageName>'&$filter=IsLatestVersion and Id eq '<packageName>'`), however the server have information for an 'Id' property.  What other repositories call `Id` Jfrog calls `Title`, however filtering on title returns a 405, so I've removed the filter altogether for JFrog repos.  The filter cannot be removed for other v2 repos such as the PSGallery because `FindPackagesById()?id='\<packageName>'` fuzzy matches, so it needs to be further filtered for exact matching.

* Because JFrog has no `Id` property, when the package is returned PSResourceGet could not find the name of the package and returned whitespace instead of the proper package name.  When parsing the response xml, PSResourceGet now looks for 'Title' as well as 'Id' for the package name.

* Exceptions thrown from `SendV2RequestForContentAsync` were not properly getting caught and would cause null pointer exceptions to later get thrown. These request call exceptions (specifically related to v2 installation) are now properly caught and thrown.

*  `string.IsNullOrEmpty(content.ToString()))` was not validating that content was not null before using `.ToString()` method.  Simple null check was added here.

* Previously requests to install a package from JFrog looked like: `https://test.jfrog.io/artifactory/api/nuget/nuget/package/<packageName>`. However, the proper request should look like: `https://test.jfrog.io/artifactory/api/nuget/nuget/Download/<packageName>/<packageVersion>`.  JFrog needs the package version to install a package, it won't just install the latest.  `InstallName` now takes a `packageVersion` parameter so that it can form the proper query. 

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Resolves #1416  

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
