### PR TITLE
Add -ApiVersion to Register-PSResourceRepository

### DIFF
--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -337,9 +337,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return null;
             }
 
-            if (!repo.ContainsKey("ApiVersion") || repo["ApiVersion"] == null || String.IsNullOrEmpty(repo["ApiVersion"].ToString()) ||
-               !(repo["ApiVersion"].ToString().Equals("local") || repo["ApiVersion"].ToString().Equals("v2") || repo["ApiVersion"].ToString().Equals("v3") 
-               || repo["ApiVersion"].ToString().Equals("nugetServer") || repo["ApiVersion"].ToString().Equals("unknown")))
+            if (repo.ContainsKey("ApiVersion") && 
+                (repo["ApiVersion"] == null || String.IsNullOrEmpty(repo["ApiVersion"].ToString()) ||
+                !(repo["ApiVersion"].ToString().Equals("local") || repo["ApiVersion"].ToString().Equals("v2") || 
+                repo["ApiVersion"].ToString().Equals("v3") || repo["ApiVersion"].ToString().Equals("nugetServer") || repo["ApiVersion"].ToString().Equals("unknown"))))
             {
                 WriteError(new ErrorRecord(
                     new PSInvalidOperationException("Repository ApiVersion must be either 'local', 'v2', 'v3', 'nugetServer' or 'unknown'"),

--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -339,7 +339,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (!repo.ContainsKey("ApiVersion") || repo["ApiVersion"] == null || String.IsNullOrEmpty(repo["ApiVersion"].ToString()) ||
                !(repo["ApiVersion"].ToString().Equals("local") || repo["ApiVersion"].ToString().Equals("v2") || repo["ApiVersion"].ToString().Equals("v3") 
-               || repo["ApiVersion"].ToString().Equals("nugetServer") || repo["ApiVersion"].ToString().Equals("unknown"))
+               || repo["ApiVersion"].ToString().Equals("nugetServer") || repo["ApiVersion"].ToString().Equals("unknown")))
             {
                 WriteError(new ErrorRecord(
                     new PSInvalidOperationException("Repository ApiVersion must be either 'local', 'v2', 'v3', 'nugetServer' or 'unknown'"),

--- a/test/ResourceRepositoryTests/RegisterPSResourceRepository.Tests.ps1
+++ b/test/ResourceRepositoryTests/RegisterPSResourceRepository.Tests.ps1
@@ -400,7 +400,7 @@ Describe "Test Register-PSResourceRepository" -tags 'CI' {
         $res = Get-PSResourceRepository -Name $TestRepoName1
 
         $res.Name | Should -Be $TestRepoName1
-        $res.Uri.LocalPath | Should -Contain $relativeCurrentPath
+        $res.Uri.LocalPath | Should -Contain $tmpDir1Path
         $res.ApiVersion | Should -Be 'v2'
     }
 }

--- a/test/ResourceRepositoryTests/RegisterPSResourceRepository.Tests.ps1
+++ b/test/ResourceRepositoryTests/RegisterPSResourceRepository.Tests.ps1
@@ -394,4 +394,13 @@ Describe "Test Register-PSResourceRepository" -tags 'CI' {
         $res.Uri.LocalPath | Should -Be "\"
         $res.ApiVersion | Should -Be "local"
     }
+
+    It "should register repository with explicitly provided ApiVersion" {
+        Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -ApiVersion 'v2'
+        $res = Get-PSResourceRepository -Name $TestRepoName1
+
+        $res.Name | Should -Be $TestRepoName1
+        $res.Uri.LocalPath | Should -Contain $relativeCurrentPath
+        $res.ApiVersion | Should -Be 'v2'
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR adds the parameter `ApiVersion` to `Register-PSResourceRepository`.  


## PR Context
Needed for PR #1425 
Also resolves #1417 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
