### PR TITLE
Add internal for setting caller as compat cmdlet

### DIFF
--- a/src/code/InternalHooks.cs
+++ b/src/code/InternalHooks.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Reflection;
+
+namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
+{
+    public class InternalHooks
+    {
+        internal static bool InvokedFromCompat;
+
+        public static void SetTestHook(string property, object value)
+        {
+            var fieldInfo = typeof(InternalHooks).GetField(property, BindingFlags.Static | BindingFlags.NonPublic);
+            fieldInfo?.SetValue(null, value);
+        }
+    }
+}

--- a/src/code/ServerFactory.cs
+++ b/src/code/ServerFactory.cs
@@ -24,9 +24,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private static string _psVersion;
         private static string _psResourceGetVersion;
         private static string _distributionChannel;
-        private static string _psGetCompat = InternalHooks.InvokedFromCompat ? "true" : "false";
 
-        internal static string UserAgentString => $"PSResourceGet/{_psResourceGetVersion} PowerShell/{_psVersion} DistributionChannel/{_distributionChannel} PowerShellGetCompat/{_psGetCompat}";
+        internal static string UserAgentString()
+        {
+            string psGetCompat = InternalHooks.InvokedFromCompat ? "true" : "false";
+            return $"PSResourceGet/{_psResourceGetVersion} PowerShell/{_psVersion} DistributionChannel/{_distributionChannel} PowerShellGetCompat/{psGetCompat}";
+        }
     }
 
     internal class ServerFactory
@@ -35,7 +38,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         {
             PSRepositoryInfo.APIVersion repoApiVersion = repository.ApiVersion;
             ServerApiCall currentServer = null;
-            string userAgentString = UserAgentInfo.UserAgentString;
+            string userAgentString = UserAgentInfo.UserAgentString();
 
             switch (repoApiVersion)
             {

--- a/src/code/ServerFactory.cs
+++ b/src/code/ServerFactory.cs
@@ -24,8 +24,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private static string _psVersion;
         private static string _psResourceGetVersion;
         private static string _distributionChannel;
+        private static string _psGetCompat = InternalHooks.InvokedFromCompat ? "true" : "false";
 
-        internal static string UserAgentString => $"PSResourceGet/{_psResourceGetVersion} PowerShell/{_psVersion} DistributionChannel/{_distributionChannel}";
+        internal static string UserAgentString => $"PSResourceGet/{_psResourceGetVersion} PowerShell/{_psVersion} DistributionChannel/{_distributionChannel} PowerShellGetCompat/{_psGetCompat}";
     }
 
     internal class ServerFactory


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add a way for compat module to set that it was called from it. This makes sure we get telemetry for in application insights as a user agent string.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
