### PR TITLE
Add method to extract nupkg to directory

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -1175,13 +1175,19 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     foreach (ZipArchiveEntry entry in archive.Entries)
                     {
+                        // Sanitize the filename to remove any potentially harmful characters
+                        string sanitizedFileName = Path.GetFileName(entry.FullName);
+
+                        // Create a new entry in the archive
+                        ZipArchiveEntry sanitizedEntry = archive.CreateEntry(sanitizedFileName);
+
                         // If a file has one or more parent directories.
-                        if (entry.FullName.Contains(Path.DirectorySeparatorChar) || entry.FullName.Contains(Path.AltDirectorySeparatorChar))
+                        if (sanitizedEntry.FullName.Contains(Path.DirectorySeparatorChar) || sanitizedEntry.FullName.Contains(Path.AltDirectorySeparatorChar))
                         {
                             // Create the parent directories if they do not already exist
                             var lastPathSeparatorIdx = entry.FullName.Contains(Path.DirectorySeparatorChar) ?
-                                entry.FullName.LastIndexOf(Path.DirectorySeparatorChar) : entry.FullName.LastIndexOf(Path.AltDirectorySeparatorChar);
-                            var parentDirs = entry.FullName.Substring(0, lastPathSeparatorIdx);
+                                sanitizedEntry.FullName.LastIndexOf(Path.DirectorySeparatorChar) : sanitizedEntry.FullName.LastIndexOf(Path.AltDirectorySeparatorChar);
+                            var parentDirs = sanitizedEntry.FullName.Substring(0, lastPathSeparatorIdx);
                             var destinationDirectory = Path.Combine(extractPath, parentDirs);
                             if (!Directory.Exists(destinationDirectory))
                             {
@@ -1190,9 +1196,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         }
 
                         // Gets the full path to ensure that relative segments are removed.
-                        string destinationPath = Path.GetFullPath(Path.Combine(extractPath, entry.FullName));
+                        string destinationPath = Path.GetFullPath(Path.Combine(extractPath, sanitizedEntry.FullName));
 
-                        entry.ExtractToFile(destinationPath, overwrite:true);
+                        sanitizedEntry.ExtractToFile(destinationPath, overwrite:true);
                     }
                 }
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Some repositories (namely GitHub Packages) add an extra `_rels\rels` file to the .nupkgs. `System.IO.Compression.ZipFile.ExtractToDirectory` does not have an `overwrite` parameter for net472, so this method was throwing an exception every time it came across the second `_rels\rels`.    

This PR opens the .nupkg and runs `ExtractToFile` (which does have an `overwrite` parameter) on each item so that no exception gets thrown.  Note that anything under `_rels` by default gets thrown out by PSResourceGet, so overwriting this file is not an issue.  There should be no other duplicate files.  

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1433

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
