### PR TITLE
Bugfix script parse whitespace

### DIFF
--- a/src/code/PSScriptFileInfo.cs
+++ b/src/code/PSScriptFileInfo.cs
@@ -127,7 +127,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             {
                 string line = fileContents[i];
                 
-                if (line.StartsWith("<#PSScriptInfo"))
+                if (line.Trim().StartsWith("<#PSScriptInfo"))
                 {
                     int j = i + 1; // start at the next line
                     // keep grabbing lines until we get to closing #>
@@ -135,7 +135,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     {
                         string blockLine = fileContents[j];
                         psScriptInfoCommentContent.Add(blockLine);
-                        if (blockLine.StartsWith("#>"))
+                        if (blockLine.Trim().StartsWith("#>"))
                         {
 
                             reachedPSScriptInfoCommentEnd = true;
@@ -157,7 +157,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                         return false;
                     }
                 }
-                else if (line.StartsWith("<#"))
+                else if (line.Trim().StartsWith("<#"))
                 {
                     // The next comment block must be the help comment block (containing description)
                     // keep grabbing lines until we get to closing #>
@@ -166,7 +166,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     {
                         string blockLine = fileContents[j];
 
-                        if (blockLine.StartsWith("#>"))
+                        if (blockLine.Trim().StartsWith("#>"))
                         {
                             reachedHelpInfoCommentEnd = true;
                             i = j + 1;

--- a/test/PSScriptFileInfoTests/TestPSScriptFile.Tests.ps1
+++ b/test/PSScriptFileInfoTests/TestPSScriptFile.Tests.ps1
@@ -88,4 +88,11 @@ Describe "Test Test-PSScriptFileInfo" -tags 'CI' {
 
         Test-PSScriptFileInfo $scriptFilePath | Should -Be $true
     }
+
+    It "determine script with whitespace before closing comment is valid" {
+        $scriptName = "ScriptWithWhitespaceBeforeClosingComment.ps1"
+        $scriptFilePath = Join-Path $script:testScriptsFolderPath -ChildPath $scriptName
+
+        Test-PSScriptFileInfo $scriptFilePath | Should -Be $true
+    }
 }

--- a/test/testFiles/testScripts/ScriptWithWhitespaceBeforeClosingComment.ps1
+++ b/test/testFiles/testScripts/ScriptWithWhitespaceBeforeClosingComment.ps1
@@ -1,0 +1,42 @@
+
+<#PSScriptInfo
+
+.VERSION 1.0
+
+.GUID 3951be04-bd06-4337-8dc3-a620bf539fbd
+
+.AUTHOR annavied
+
+.COMPANYNAME
+
+.COPYRIGHT
+
+.TAGS
+
+.LICENSEURI
+
+.PROJECTURI
+
+.ICONURI
+
+.EXTERNALMODULEDEPENDENCIES 
+
+.REQUIREDSCRIPTS
+
+.EXTERNALSCRIPTDEPENDENCIES
+
+.RELEASENOTES
+
+
+.PRIVATEDATA
+
+#>
+
+<# 
+
+.DESCRIPTION 
+ this is a test for a script that will be published remotely 
+
+ #> 
+Param()
+


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->
Bugfix for trimming whitespace from script comment starting and ending lines. Errors are written when these lines are not present, so fix detection for them by ignoring whitespace.
# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1455 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
