### PR TITLE
Bug fix for Import-PSGetRepository in Windows PS

### DIFF
--- a/src/Microsoft.PowerShell.PSResourceGet.psm1
+++ b/src/Microsoft.PowerShell.PSResourceGet.psm1
@@ -25,13 +25,14 @@ function Import-PSGetRepository {
     Microsoft.PowerShell.Utility\Write-Verbose ('Found {0} registered PowerShellGet repositories.' -f $PSGetRepositories.Count)
 
     if ($PSGetRepositories.Count) {
-        $repos = $PSGetRepositories.Values |
+        $repos = @( $PSGetRepositories.Values |
             Microsoft.PowerShell.Core\Where-Object {$_.PackageManagementProvider -eq 'NuGet'-and $_.Name -ne 'PSGallery'} |
             Microsoft.PowerShell.Utility\Select-Object Name, Trusted, SourceLocation
+        )
 
         Microsoft.PowerShell.Utility\Write-Verbose ('Selected {0} NuGet repositories.' -f $repos.Count)
 
-        if ($repos -ne $null) {
+        if ($repos.Count) {
             $repos | Microsoft.PowerShell.Core\ForEach-Object {
                 try {
                     $message = 'Registering {0} at {1} -Trusted:${2} -Force:${3}.' -f $_.Name,

--- a/src/Microsoft.PowerShell.PSResourceGet.psm1
+++ b/src/Microsoft.PowerShell.PSResourceGet.psm1
@@ -31,7 +31,7 @@ function Import-PSGetRepository {
 
         Microsoft.PowerShell.Utility\Write-Verbose ('Selected {0} NuGet repositories.' -f $repos.Count)
 
-        if ($repos.Count) {
+        if ($repos -ne $null) {
             $repos | Microsoft.PowerShell.Core\ForEach-Object {
                 try {
                     $message = 'Registering {0} at {1} -Trusted:${2} -Force:${3}.' -f $_.Name,

--- a/src/Microsoft.PowerShell.PSResourceGet.psm1
+++ b/src/Microsoft.PowerShell.PSResourceGet.psm1
@@ -25,7 +25,8 @@ function Import-PSGetRepository {
     Microsoft.PowerShell.Utility\Write-Verbose ('Found {0} registered PowerShellGet repositories.' -f $PSGetRepositories.Count)
 
     if ($PSGetRepositories.Count) {
-        $repos = @( $PSGetRepositories.Values |
+        $repos = @(
+            $PSGetRepositories.Values |
             Microsoft.PowerShell.Core\Where-Object {$_.PackageManagementProvider -eq 'NuGet'-and $_.Name -ne 'PSGallery'} |
             Microsoft.PowerShell.Utility\Select-Object Name, Trusted, SourceLocation
         )


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Bug fix for `Import-PSGetRepository` in Windows PowerShell not actually porting PowerShellGet v2 repositories to PSResourceGet.  `.count` property does not work on the object returned in Windows PS (however it does in PS 6+).  Simple change to check if the `$repos` returned is empty or not checks to see whether repositories need to be transferred over. 


<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1442 

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
