### PR TITLE
ACR Integration: Update SecretManagement credential use with ACR repos

### DIFF
--- a/src/code/ACRServerAPICalls.cs
+++ b/src/code/ACRServerAPICalls.cs
@@ -146,10 +146,8 @@ namespace Microsoft.PowerShell.PSResourceGet
 
                 _cmdletPassedIn.WriteVerbose("Access token retrieved.");
 
-                tenantID = Utils.GetSecretInfoFromSecretManagement(
-                    Repository.Name,
-                    repositoryCredentialInfo,
-                    _cmdletPassedIn);
+                tenantID = repositoryCredentialInfo.SecretName;
+                _cmdletPassedIn.WriteVerbose($"Tenant ID: {tenantID}");
             }
 
             // Call asynchronous network methods in a try/catch block to handle exceptions.
@@ -284,10 +282,8 @@ namespace Microsoft.PowerShell.PSResourceGet
 
                 _cmdletPassedIn.WriteVerbose("Access token retrieved.");
 
-                tenantID = Utils.GetSecretInfoFromSecretManagement(
-                    Repository.Name,
-                    repositoryCredentialInfo,
-                    _cmdletPassedIn);
+                tenantID = repositoryCredentialInfo.SecretName;
+                _cmdletPassedIn.WriteVerbose($"Tenant ID: {tenantID}");
             }
 
             // Call asynchronous network methods in a try/catch block to handle exceptions.
@@ -405,10 +401,8 @@ namespace Microsoft.PowerShell.PSResourceGet
 
                 callingCmdlet.WriteVerbose("Access token retrieved.");
 
-                tenantID = Utils.GetSecretInfoFromSecretManagement(
-                    repo.Name,
-                    repositoryCredentialInfo,
-                    callingCmdlet);
+                tenantID = repositoryCredentialInfo.SecretName;
+                callingCmdlet.WriteVerbose($"Tenant ID: {tenantID}");
             }
 
             // Call asynchronous network methods in a try/catch block to handle exceptions.
@@ -534,10 +528,8 @@ namespace Microsoft.PowerShell.PSResourceGet
 
                 callingCmdlet.WriteVerbose("Access token retrieved.");
 
-                tenantID = Utils.GetSecretInfoFromSecretManagement(
-                    repo.Name,
-                    repositoryCredentialInfo,
-                    callingCmdlet);
+                tenantID = repositoryCredentialInfo.SecretName;
+                callingCmdlet.WriteVerbose($"Tenant ID: {tenantID}");
             }
 
             // Call asynchronous network methods in a try/catch block to handle exceptions.
@@ -860,10 +852,8 @@ namespace Microsoft.PowerShell.PSResourceGet
 
                 _cmdletPassedIn.WriteVerbose("Access token retrieved.");
 
-                tenantID = Utils.GetSecretInfoFromSecretManagement(
-                    repository.Name,
-                    repositoryCredentialInfo,
-                    _cmdletPassedIn);
+                tenantID = repositoryCredentialInfo.SecretName;
+                _cmdletPassedIn.WriteVerbose($"Tenant ID: {tenantID}");
             }
 
             // Call asynchronous network methods in a try/catch block to handle exceptions.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
"Username" for PSCredentialInfo object is now expected to be the tenant ID for the ACR registry. 

This allows for simplifying how ACR persistent credentials are set up and later retrieved. 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
