### PR TITLE
ACR Integration:  Find-PSResource methods and response class

### DIFF
--- a/src/code/ACRResponseUtil.cs
+++ b/src/code/ACRResponseUtil.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text.Json;
-using System.Xml;
 
 namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 {

--- a/src/code/ACRServerAPICalls.cs
+++ b/src/code/ACRServerAPICalls.cs
@@ -413,6 +413,7 @@ namespace Microsoft.PowerShell.PSResourceGet
                             if (!includePrerelease && pkgVersion.IsPrerelease == true)
                             {
                                 _cmdletPassedIn.WriteDebug($"Prerelease version '{pkgVersion}' found, but not included.");
+                                continue;
                             }
 
                             latestVersionResponse.Add(new Hashtable() { { packageName, packageVersionStr } });

--- a/src/code/ACRServerAPICalls.cs
+++ b/src/code/ACRServerAPICalls.cs
@@ -146,10 +146,8 @@ namespace Microsoft.PowerShell.PSResourceGet
 
                 _cmdletPassedIn.WriteVerbose("Access token retrieved.");
 
-                tenantID = Utils.GetSecretInfoFromSecretManagement(
-                    Repository.Name,
-                    repositoryCredentialInfo,
-                    _cmdletPassedIn);
+                tenantID = repositoryCredentialInfo.SecretName;
+                _cmdletPassedIn.WriteVerbose($"Tenant ID: {tenantID}");
             }
 
             // Call asynchronous network methods in a try/catch block to handle exceptions.
@@ -284,10 +282,8 @@ namespace Microsoft.PowerShell.PSResourceGet
 
                 _cmdletPassedIn.WriteVerbose("Access token retrieved.");
 
-                tenantID = Utils.GetSecretInfoFromSecretManagement(
-                    Repository.Name,
-                    repositoryCredentialInfo,
-                    _cmdletPassedIn);
+                tenantID = repositoryCredentialInfo.SecretName;
+                _cmdletPassedIn.WriteVerbose($"Tenant ID: {tenantID}");
             }
 
             // Call asynchronous network methods in a try/catch block to handle exceptions.
@@ -405,10 +401,8 @@ namespace Microsoft.PowerShell.PSResourceGet
 
                 callingCmdlet.WriteVerbose("Access token retrieved.");
 
-                tenantID = Utils.GetSecretInfoFromSecretManagement(
-                    repo.Name,
-                    repositoryCredentialInfo,
-                    callingCmdlet);
+                tenantID = repositoryCredentialInfo.SecretName;
+                callingCmdlet.WriteVerbose($"Tenant ID: {tenantID}");
             }
 
             // Call asynchronous network methods in a try/catch block to handle exceptions.
@@ -534,10 +528,8 @@ namespace Microsoft.PowerShell.PSResourceGet
 
                 callingCmdlet.WriteVerbose("Access token retrieved.");
 
-                tenantID = Utils.GetSecretInfoFromSecretManagement(
-                    repo.Name,
-                    repositoryCredentialInfo,
-                    callingCmdlet);
+                tenantID = repositoryCredentialInfo.SecretName;
+                callingCmdlet.WriteVerbose($"Tenant ID: {tenantID}");
             }
 
             // Call asynchronous network methods in a try/catch block to handle exceptions.
@@ -860,10 +852,8 @@ namespace Microsoft.PowerShell.PSResourceGet
 
                 _cmdletPassedIn.WriteVerbose("Access token retrieved.");
 
-                tenantID = Utils.GetSecretInfoFromSecretManagement(
-                    repository.Name,
-                    repositoryCredentialInfo,
-                    _cmdletPassedIn);
+                tenantID = repositoryCredentialInfo.SecretName;
+                _cmdletPassedIn.WriteVerbose($"Tenant ID: {tenantID}");
             }
 
             // Call asynchronous network methods in a try/catch block to handle exceptions.

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -779,7 +779,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             pkgToInstall.RepositorySourceLocation = repository.Uri.ToString();
             pkgToInstall.AdditionalMetadata.TryGetValue("NormalizedVersion", out string pkgVersion);
-
+            if (pkgVersion == null) {
+                pkgVersion = pkgToInstall.Version.ToString();
+            }
             // Check to see if the pkg is already installed (ie the pkg is installed and the version satisfies the version range provided via param)
             if (!_reinstall)
             {

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -12,8 +12,6 @@ using System.Xml;
 using Microsoft.PowerShell.Commands;
 
 using Dbg = System.Diagnostics.Debug;
-using System.IdentityModel.Protocols.WSTrust;
-using NuGet.Protocol.Core.Types;
 
 namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 {

--- a/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
@@ -41,17 +41,6 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $res | Should -BeNullOrEmpty
     }
 
-<#  TODO: wildcard name NOT IMPLEMENTED YET
-    It "find resource(s) given wildcard Name" {
-        # FindNameGlobbing
-        $wildcardName = "test_local_m*"
-        $res = Find-PSResource -Name $wildcardName -Repository $ACRRepoName -ErrorVariable err -ErrorAction SilentlyContinue
-        $res | Should -BeNullOrEmpty
-        $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameGlobbingFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
-        $res | Should -BeNullOrEmpty
-    }
-#>
     $testCases2 = @{Version="[5.0.0.0]";           ExpectedVersions=@("5.0.0");                              Reason="validate version, exact match"},
                   @{Version="5.0.0.0";             ExpectedVersions=@("5.0.0");                              Reason="validate version, exact match without bracket syntax"},
                   @{Version="[1.0.0.0, 5.0.0.0]";  ExpectedVersions=@("1.0.0", "3.0.0", "5.0.0");            Reason="validate version, exact range inclusive"},

--- a/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
@@ -1,0 +1,152 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+$modPath = "$psscriptroot/../PSGetTestUtils.psm1"
+Import-Module $modPath -Force -Verbose
+
+Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
+
+    BeforeAll{
+        $testModuleName = "hello-world"
+        $ACRRepoName = "PSGetTestingFeed"
+        $ACRRepoUri = "https://psgetregistry.azurecr.io"
+        Get-NewPSResourceRepositoryFile
+        Register-PSResourceRepository -Name $ACRRepoName -Uri $ACRepoUri -ApiVersion "ACR"
+    }
+
+    AfterAll {
+        Get-RevertPSResourceRepositoryFile
+    }
+
+    # Passing
+    It "find resource given specific Name, Version null" {
+        # FindName()
+        $res = Find-PSResource -Name $testModuleName -Repository $ACRRepoName
+        $res.Name | Should -Be $testModuleName
+        $res.Version | Should -Be "3.0.0"
+    }
+
+    # TODO: Failing needs better error handling
+    It "should not find resource given nonexistant Name" {
+        # FindName()
+        $res = Find-PSResource -Name NonExistantModule -Repository $ACRRepoName -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -BeNullOrEmpty
+        $err.Count | Should -BeGreaterThan 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $res | Should -BeNullOrEmpty
+    }
+
+<#  TODO: wildcard name NOT IMPLEMENTED YET
+    It "find resource(s) given wildcard Name" {
+        # FindNameGlobbing
+        $wildcardName = "test_local_m*"
+        $res = Find-PSResource -Name $wildcardName -Repository $ACRRepoName -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -BeNullOrEmpty
+        $err.Count | Should -BeGreaterThan 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindNameGlobbingFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $res | Should -BeNullOrEmpty
+    }
+#>
+    # Passing
+    $testCases2 = @{Version="[5.0.0.0]";           ExpectedVersions=@("5.0.0");                              Reason="validate version, exact match"},
+                  @{Version="5.0.0.0";             ExpectedVersions=@("5.0.0");                              Reason="validate version, exact match without bracket syntax"},
+                  @{Version="[1.0.0.0, 5.0.0.0]";  ExpectedVersions=@("1.0.0", "3.0.0", "5.0.0");            Reason="validate version, exact range inclusive"},
+                  @{Version="(1.0.0.0, 5.0.0.0)";  ExpectedVersions=@("3.0.0");                              Reason="validate version, exact range exclusive"},
+                  @{Version="(1.0.0.0,)";          ExpectedVersions=@("3.0.0", "5.0.0");                     Reason="validate version, minimum version exclusive"},
+                  @{Version="[1.0.0.0,)";          ExpectedVersions=@("1.0.0", "3.0.0", "5.0.0");            Reason="validate version, minimum version inclusive"},
+                  @{Version="(,3.0.0.0)";          ExpectedVersions=@("1.0.0");                              Reason="validate version, maximum version exclusive"},
+                  @{Version="(,3.0.0.0]";          ExpectedVersions=@("1.0.0", "3.0.0");                     Reason="validate version, maximum version inclusive"},
+                  @{Version="[1.0.0.0, 5.0.0.0)";  ExpectedVersions=@("1.0.0", "3.0.0");                     Reason="validate version, mixed inclusive minimum and exclusive maximum version"}
+                  @{Version="(1.0.0.0, 5.0.0.0]";  ExpectedVersions=@("3.0.0", "5.0.0");                     Reason="validate version, mixed exclusive minimum and inclusive maximum version"}
+
+    It "find resource when given Name to <Reason> <Version>" -TestCases $testCases2{
+        # FindVersionGlobbing()
+        param($Version, $ExpectedVersions)
+        $res = Find-PSResource -Name $testModuleName -Version $Version -Repository $ACRRepoName
+        $res | Should -Not -BeNullOrEmpty
+        foreach ($item in $res) {
+            $item.Name | Should -Be $testModuleName
+            $ExpectedVersions | Should -Contain $item.Version
+        }
+    }
+
+    # Passing
+    It "find all versions of resource when given specific Name, Version not null --> '*'" {
+        # FindVersionGlobbing()
+        $res = Find-PSResource -Name $testModuleName -Version "*" -Repository $ACRRepoName
+        $res | Should -Not -BeNullOrEmpty
+        $res | ForEach-Object {
+            $_.Name | Should -Be $testModuleName
+        }
+
+        $res.Count | Should -BeGreaterOrEqual 1
+    }
+
+    # Passing
+    It "find resource with latest (including prerelease) version given Prerelease parameter" {
+        # FindName()
+        # test_local_mod resource's latest version is a prerelease version, before that it has a non-prerelease version
+        $res = Find-PSResource -Name $testModuleName -Repository $ACRRepoName
+        $res.Version | Should -Be "5.0.0"
+
+        $resPrerelease = Find-PSResource -Name $testModuleName -Prerelease -Repository $ACRRepoName
+        $resPrerelease.Version | Should -Be "5.2.5"
+        $resPrerelease.Prerelease | Should -Be "alpha001"
+    }
+
+    # TODO: Failing
+    It "find resources, including Prerelease version resources, when given Prerelease parameter" {
+        # FindVersionGlobbing()
+        $resWithoutPrerelease = Find-PSResource -Name $testModuleName -Version "*" -Repository $ACRRepoName
+        $resWithPrerelease = Find-PSResource -Name $testModuleName -Version "*" -Repository $ACRRepoName -Prerelease
+        $resWithPrerelease.Count | Should -BeGreaterOrEqual $resWithoutPrerelease.Count
+    }
+
+    # Passing
+    It "should not find resource if Name, Version and Tag property are not all satisfied (single tag)" {
+        # FindVersionWithTag()
+        $requiredTag = "windows" # tag "windows" is not present for test_local_mod package
+        $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $ACRRepoName -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -BeNullOrEmpty
+        $err.Count | Should -BeGreaterThan 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionWithTagFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
+
+    # Passing
+    It "should not find resources given Tag property" {
+        # FindTag()
+        $tagToFind = "Tag2"
+        $res = Find-PSResource -Tag $tagToFind -Repository $ACRRepoName -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -BeNullOrEmpty
+        $err.Count | Should -BeGreaterThan 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindTagsFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
+
+    # Passing
+    It "should not find resource given CommandName" {
+        # FindCommandOrDSCResource()
+        $res = Find-PSResource -CommandName "command" -Repository $ACRRepoName -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -BeNullOrEmpty
+        $err.Count | Should -BeGreaterThan 0
+        write-Host $($err[0].FullyQualifiedErrorId)
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindCommandOrDscResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
+
+    # Passing
+    It "should not find resource given DscResourceName" {
+        # FindCommandOrDSCResource()
+        $res = Find-PSResource -DscResourceName "dscResource" -Repository $ACRRepoName -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -BeNullOrEmpty
+        $err.Count | Should -BeGreaterThan 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindCommandOrDscResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
+
+    # Passing
+    It "should not find all resources given Name '*'" {
+        # FindAll()
+        $res = Find-PSResource -Name "*" -Repository $ACRRepoName -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -BeNullOrEmpty
+        $err.Count | Should -BeGreaterThan 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindAllFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
+}

--- a/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
@@ -1,6 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+<#
+# These tests are working with manual validation but there is currently no automated testing for ACR repositories. 
+
 $modPath = "$psscriptroot/../PSGetTestUtils.psm1"
 Import-Module $modPath -Force -Verbose
 
@@ -135,3 +138,5 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $err[0].FullyQualifiedErrorId | Should -BeExactly "FindAllFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 }
+
+#>

--- a/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
@@ -26,13 +26,13 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $res.Version | Should -Be "3.0.0"
     }
 
-    # TODO: Failing needs better error handling
+    # Passing
     It "should not find resource given nonexistant Name" {
         # FindName()
         $res = Find-PSResource -Name NonExistantModule -Repository $ACRRepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "ACRPackageNotFoundFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
         $res | Should -BeNullOrEmpty
     }
 

--- a/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
 
     BeforeAll{
         $testModuleName = "hello-world"
-        $ACRRepoName = "PSGetTestingFeed"
+        $ACRRepoName = "ACRRepo"
         $ACRRepoUri = "https://psgetregistry.azurecr.io"
         Get-NewPSResourceRepositoryFile
         Register-PSResourceRepository -Name $ACRRepoName -Uri $ACRepoUri -ApiVersion "ACR"
@@ -18,16 +18,21 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         Get-RevertPSResourceRepositoryFile
     }
 
-    # Passing
-    It "find resource given specific Name, Version null" {
+    It "Find resource given specific Name, Version null" {
         # FindName()
         $res = Find-PSResource -Name $testModuleName -Repository $ACRRepoName
         $res.Name | Should -Be $testModuleName
-        $res.Version | Should -Be "3.0.0"
+        $res.Version | Should -Be "5.0.0"
     }
 
-    # Passing
-    It "should not find resource given nonexistant Name" {
+    It "Find resource given specific Name, Version null" {
+        # FindName()
+        $res = Find-PSResource -Name $testModuleName -Repository $ACRRepoName -Prerelease
+        $res.Name | Should -Be $testModuleName
+        $res.Version | Should -Be "5.0.0-alpha001"
+    }
+
+    It "Should not find resource given nonexistant Name" {
         # FindName()
         $res = Find-PSResource -Name NonExistantModule -Repository $ACRRepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
@@ -47,7 +52,6 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $res | Should -BeNullOrEmpty
     }
 #>
-    # Passing
     $testCases2 = @{Version="[5.0.0.0]";           ExpectedVersions=@("5.0.0");                              Reason="validate version, exact match"},
                   @{Version="5.0.0.0";             ExpectedVersions=@("5.0.0");                              Reason="validate version, exact match without bracket syntax"},
                   @{Version="[1.0.0.0, 5.0.0.0]";  ExpectedVersions=@("1.0.0", "3.0.0", "5.0.0");            Reason="validate version, exact range inclusive"},
@@ -59,7 +63,7 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
                   @{Version="[1.0.0.0, 5.0.0.0)";  ExpectedVersions=@("1.0.0", "3.0.0");                     Reason="validate version, mixed inclusive minimum and exclusive maximum version"}
                   @{Version="(1.0.0.0, 5.0.0.0]";  ExpectedVersions=@("3.0.0", "5.0.0");                     Reason="validate version, mixed exclusive minimum and inclusive maximum version"}
 
-    It "find resource when given Name to <Reason> <Version>" -TestCases $testCases2{
+    It "Find resource when given Name to <Reason> <Version>" -TestCases $testCases2{
         # FindVersionGlobbing()
         param($Version, $ExpectedVersions)
         $res = Find-PSResource -Name $testModuleName -Version $Version -Repository $ACRRepoName
@@ -70,8 +74,7 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         }
     }
 
-    # Passing
-    It "find all versions of resource when given specific Name, Version not null --> '*'" {
+    It "Find all versions of resource when given specific Name, Version not null --> '*'" {
         # FindVersionGlobbing()
         $res = Find-PSResource -Name $testModuleName -Version "*" -Repository $ACRRepoName
         $res | Should -Not -BeNullOrEmpty
@@ -82,28 +85,25 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $res.Count | Should -BeGreaterOrEqual 1
     }
 
-    # Passing
-    It "find resource with latest (including prerelease) version given Prerelease parameter" {
+    It "Find resource with latest (including prerelease) version given Prerelease parameter" {
         # FindName()
         # test_local_mod resource's latest version is a prerelease version, before that it has a non-prerelease version
         $res = Find-PSResource -Name $testModuleName -Repository $ACRRepoName
         $res.Version | Should -Be "5.0.0"
 
         $resPrerelease = Find-PSResource -Name $testModuleName -Prerelease -Repository $ACRRepoName
-        $resPrerelease.Version | Should -Be "5.2.5"
+        $resPrerelease.Version | Should -Be "5.0.0"
         $resPrerelease.Prerelease | Should -Be "alpha001"
     }
 
-    # TODO: Failing
-    It "find resources, including Prerelease version resources, when given Prerelease parameter" {
+    It "Find resources, including Prerelease version resources, when given Prerelease parameter" {
         # FindVersionGlobbing()
         $resWithoutPrerelease = Find-PSResource -Name $testModuleName -Version "*" -Repository $ACRRepoName
         $resWithPrerelease = Find-PSResource -Name $testModuleName -Version "*" -Repository $ACRRepoName -Prerelease
         $resWithPrerelease.Count | Should -BeGreaterOrEqual $resWithoutPrerelease.Count
     }
 
-    # Passing
-    It "should not find resource if Name, Version and Tag property are not all satisfied (single tag)" {
+    It "Should not find resource if Name, Version and Tag property are not all satisfied (single tag)" {
         # FindVersionWithTag()
         $requiredTag = "windows" # tag "windows" is not present for test_local_mod package
         $res = Find-PSResource -Name $testModuleName -Version "5.0.0.0" -Tag $requiredTag -Repository $ACRRepoName -ErrorVariable err -ErrorAction SilentlyContinue
@@ -112,8 +112,7 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $err[0].FullyQualifiedErrorId | Should -BeExactly "FindVersionWithTagFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
-    # Passing
-    It "should not find resources given Tag property" {
+    It "Should not find resources given Tag property" {
         # FindTag()
         $tagToFind = "Tag2"
         $res = Find-PSResource -Tag $tagToFind -Repository $ACRRepoName -ErrorVariable err -ErrorAction SilentlyContinue
@@ -122,8 +121,7 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $err[0].FullyQualifiedErrorId | Should -BeExactly "FindTagsFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
-    # Passing
-    It "should not find resource given CommandName" {
+    It "Should not find resource given CommandName" {
         # FindCommandOrDSCResource()
         $res = Find-PSResource -CommandName "command" -Repository $ACRRepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
@@ -132,8 +130,7 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $err[0].FullyQualifiedErrorId | Should -BeExactly "FindCommandOrDscResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
-    # Passing
-    It "should not find resource given DscResourceName" {
+    It "Should not find resource given DscResourceName" {
         # FindCommandOrDSCResource()
         $res = Find-PSResource -DscResourceName "dscResource" -Repository $ACRRepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
@@ -141,8 +138,7 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $err[0].FullyQualifiedErrorId | Should -BeExactly "FindCommandOrDscResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
-    # Passing
-    It "should not find all resources given Name '*'" {
+    It "Should not find all resources given Name '*'" {
         # FindAll()
         $res = Find-PSResource -Name "*" -Repository $ACRRepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR includes the implementation of Find-PSResource (including all supported parameters, ie version, etc).
It also includes the implementation of the response class and converting response into PSResourceInfo objects.  

This PR also includes tests for Find-PSResource calling ACR repositories.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
