### PR TITLE
V2/Server: Prevent NRE when NormalizedVersion is missing

### DIFF
--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -571,7 +571,11 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 };
 
                 var additionalMetadataHashtable = new Dictionary<string, string>();
-                additionalMetadataHashtable.Add("NormalizedVersion", metadata["NormalizedVersion"].ToString());
+
+                // Only add NormalizedVersion to additionalMetadata if server response included it
+                if (metadata.ContainsKey("NormalizedVersion")) {
+                    additionalMetadataHashtable.Add("NormalizedVersion", metadata["NormalizedVersion"].ToString());
+                }
 
                 var includes = new ResourceIncludes(resourceHashtable);
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR conditionalizes adding `NormalizedVersion` to the `additionalMetadata` property on V2 server responses. This should resolve #1486.

## PR Context

Services like Artifactory do not present a `NormalizedVersion` property in their metadata when querying via the NuGet v2 API. This causes `PSResourceInfo.TryConvertFromXml()` to NRE.

The change in this PR skips trying to add this property to `AdditionalMetadata` if the server did not present a `NormalizedVersion` property.

This naturally means `AdditionalMetadata` is not guaranteed to include this field on responses from v2 Server feeds, but I don't see any documentation indicating this is guaranteed.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
