### PR TITLE
Add protection against empty response from server

### DIFF
--- a/src/code/NuGetServerAPICalls.cs
+++ b/src/code/NuGetServerAPICalls.cs
@@ -143,9 +143,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override FindResults FindCommandOrDscResource(string[] tags, bool includePrerelease, bool isSearchingForCommands, out ErrorRecord errRecord)
         {
             errRecord = new ErrorRecord(
-                new InvalidOperationException($"Find by CommandName or DSCResource is not supported for the repository '{Repository.Name}'"), 
-                "FindCommandOrDscResourceFailure", 
-                ErrorCategory.InvalidOperation, 
+                new InvalidOperationException($"Find by CommandName or DSCResource is not supported for the repository '{Repository.Name}'"),
+                "FindCommandOrDscResourceFailure",
+                ErrorCategory.InvalidOperation,
                 this);
 
             return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: FindResponseType);
@@ -437,25 +437,25 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             catch (HttpRequestException e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "HttpRequestFallFailure", 
-                    ErrorCategory.ConnectionError, 
+                    exception: e,
+                    "HttpRequestFallFailure",
+                    ErrorCategory.ConnectionError,
                     this);
             }
             catch (ArgumentNullException e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "HttpRequestFallFailure", 
+                    exception: e,
+                    "HttpRequestFallFailure",
                     ErrorCategory.ConnectionError,
                     this);
             }
             catch (InvalidOperationException e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "HttpRequestFallFailure", 
-                    ErrorCategory.ConnectionError, 
+                    exception: e,
+                    "HttpRequestFallFailure",
+                    ErrorCategory.ConnectionError,
                     this);
             }
 
@@ -486,25 +486,25 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             catch (HttpRequestException e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "HttpRequestFailure", 
-                    ErrorCategory.ConnectionError , 
+                    exception: e,
+                    "HttpRequestFailure",
+                    ErrorCategory.ConnectionError ,
                     this);
             }
             catch (ArgumentNullException e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "HttpRequestFailure", 
-                    ErrorCategory.InvalidData, 
+                    exception: e,
+                    "HttpRequestFailure",
+                    ErrorCategory.InvalidData,
                     this);
             }
             catch (InvalidOperationException e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "HttpRequestFailure", 
-                    ErrorCategory.InvalidOperation, 
+                    exception: e,
+                    "HttpRequestFailure",
+                    ErrorCategory.InvalidOperation,
                     this);
             }
 
@@ -571,9 +571,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (names.Length == 0)
             {
                 errRecord = new ErrorRecord(
-                    new ArgumentException("-Name '*' for NuGet.Server hosted feed repository is not supported"), 
-                    "FindNameGlobbingFailure", 
-                    ErrorCategory.InvalidArgument, 
+                    new ArgumentException("-Name '*' for NuGet.Server hosted feed repository is not supported"),
+                    "FindNameGlobbingFailure",
+                    ErrorCategory.InvalidArgument,
                     this);
 
                 return string.Empty;
@@ -607,9 +607,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             else
             {
                 errRecord = new ErrorRecord(
-                    new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."), 
-                    "FindNameGlobbingFailure", 
-                    ErrorCategory.InvalidArgument, 
+                    new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."),
+                    "FindNameGlobbingFailure",
+                    ErrorCategory.InvalidArgument,
                     this);
 
                 return string.Empty;
@@ -638,9 +638,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (names.Length == 0)
             {
                 errRecord = new ErrorRecord(
-                    new ArgumentException("-Name '*' for NuGet.Server hosted feed repository  is not supported"), 
-                    "FindNameGlobbingFailure", 
-                    ErrorCategory.InvalidArgument, 
+                    new ArgumentException("-Name '*' for NuGet.Server hosted feed repository  is not supported"),
+                    "FindNameGlobbingFailure",
+                    ErrorCategory.InvalidArgument,
                     this);
 
                 return string.Empty;
@@ -674,9 +674,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             else
             {
                 errRecord = new ErrorRecord(
-                    new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."), 
-                    "FindNameGlobbing", 
-                    ErrorCategory.InvalidArgument, 
+                    new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."),
+                    "FindNameGlobbing",
+                    ErrorCategory.InvalidArgument,
                     this);
 
                 return string.Empty;
@@ -786,16 +786,26 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Name: no wildcard support.
         /// Examples: Install "PowerShellGet"
         /// Implementation Note:   {repoUri}/Packages(Id='test_local_mod')/Download
-        ///                        if prerelease, call into InstallVersion instead. 
+        ///                        if prerelease, call into InstallVersion instead.
         /// </summary>
         private Stream InstallName(string packageName, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::InstallName()");
             var requestUrl = $"{Repository.Uri}/Packages/(Id='{packageName}')/Download";
             var response = HttpRequestCallForContent(requestUrl, out errRecord);
-            var responseStream = response.ReadAsStreamAsync().Result;
 
-            return responseStream;
+            if (response is null)
+            {
+                errRecord = new ErrorRecord(
+                    new Exception($"No content was returned by repository '{Repository.Name}'"),
+                    "InstallFailureContentNullNuGetServer",
+                    ErrorCategory.InvalidResult,
+                    this);
+
+                return null;
+            }
+
+            return response.ReadAsStreamAsync().Result;
         }
 
         /// <summary>
@@ -805,15 +815,25 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Install "PowerShellGet" -Version "3.0.0.0"
         ///           Install "PowerShellGet" -Version "3.0.0-beta16"
         /// API Call: {repoUri}/Packages(Id='Castle.Core',Version='5.1.1')/Download
-        /// </summary>    
+        /// </summary>
         private Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::InstallVersion()");
             var requestUrl = $"{Repository.Uri}/Packages(Id='{packageName}',Version='{version}')/Download";
             var response = HttpRequestCallForContent(requestUrl, out errRecord);
-            var responseStream = response.ReadAsStreamAsync().Result;
 
-            return responseStream;
+            if (response is null)
+            {
+                errRecord = new ErrorRecord(
+                    new Exception($"No content was returned by repository '{Repository.Name}'"),
+                    "InstallFailureContentNullNuGetServer",
+                    ErrorCategory.InvalidResult,
+                    this);
+
+                return null;
+            }
+
+            return response.ReadAsStreamAsync().Result;
         }
 
         /// <summary>
@@ -835,9 +855,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             catch (XmlException e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "GetCountFromResponse", 
-                    ErrorCategory.InvalidData, 
+                    exception: e,
+                    "GetCountFromResponse",
+                    ErrorCategory.InvalidData,
                     this);
             }
             if (errRecord != null)
@@ -892,7 +912,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 HttpResponseMessage response = await s_client.SendAsync(message);
                 response.EnsureSuccessStatusCode();
-                
+
                 return response.Content;
             }
             catch (HttpRequestException e)

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -240,9 +240,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (responses.Count == 0)
             {
                 errRecord = new ErrorRecord(
-                    new ResourceNotFoundException($"Package with Tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), 
-                    "PackageWithSpecifiedTagsNotFound", 
-                    ErrorCategory.ObjectNotFound, 
+                    new ResourceNotFoundException($"Package with Tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."),
+                    "PackageWithSpecifiedTagsNotFound",
+                    ErrorCategory.ObjectNotFound,
                     this);
             }
 
@@ -294,9 +294,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 string parameterForErrorMsg = isSearchingForCommands ? "Command" : "DSC Resource";
                 errRecord = new ErrorRecord(
-                    new ResourceNotFoundException($"Package with {parameterForErrorMsg} '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), 
-                    "PackageWithSpecifiedCmdOrDSCNotFound", 
-                    ErrorCategory.InvalidResult, 
+                    new ResourceNotFoundException($"Package with {parameterForErrorMsg} '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."),
+                    "PackageWithSpecifiedCmdOrDSCNotFound",
+                    ErrorCategory.InvalidResult,
                     this);
             }
 
@@ -330,21 +330,21 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
 
             int count = GetCountFromResponse(response, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
 
             if (count == 0)
             {
                 errRecord = new ErrorRecord(
-                    new ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}'."), 
-                    "PackageNotFound", 
-                    ErrorCategory.ObjectNotFound, 
+                    new ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}'."),
+                    "PackageNotFound",
+                    ErrorCategory.ObjectNotFound,
                     this);
                 response = string.Empty;
             }
@@ -382,21 +382,21 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
 
             int count = GetCountFromResponse(response, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
 
             if (count == 0)
             {
                 errRecord = new ErrorRecord(
                     new ResourceNotFoundException($"Package with name '{packageName}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."),
-                    "PackageNotFound", 
-                    ErrorCategory.ObjectNotFound, 
+                    "PackageNotFound",
+                    ErrorCategory.ObjectNotFound,
                     this);
                 response = string.Empty;
             }
@@ -436,7 +436,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // If count is 0, early out as this means no packages matching search criteria were found. We want to set the responses array to empty and not set ErrorRecord (as is a globbing scenario).
             if (initialCount == 0)
             {
-                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);   
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
 
             int count = (int)Math.Ceiling((double)(initialCount / 100));
@@ -488,7 +488,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (initialCount == 0)
             {
-                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);   
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
 
             int count = (int)Math.Ceiling((double)(initialCount / 100));
@@ -540,7 +540,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (initialCount == 0)
             {
-                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);   
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
 
             responses.Add(initialResponse);
@@ -589,7 +589,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
 
             int count = GetCountFromResponse(response, out errRecord);
@@ -597,15 +597,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
 
             if (count == 0)
             {
                 errRecord = new ErrorRecord(
-                    new ResourceNotFoundException($"Package with name '{packageName}', version '{version}' could not be found in repository '{Repository.Name}'."), 
-                    "PackageNotFound", 
-                    ErrorCategory.ObjectNotFound, 
+                    new ResourceNotFoundException($"Package with name '{packageName}', version '{version}' could not be found in repository '{Repository.Name}'."),
+                    "PackageNotFound",
+                    ErrorCategory.ObjectNotFound,
                     this);
                 response = string.Empty;
             }
@@ -638,7 +638,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
 
             int count = GetCountFromResponse(response, out errRecord);
@@ -646,19 +646,19 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (errRecord != null)
             {
-                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);                
+                return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
 
             if (count == 0)
             {
                 errRecord = new ErrorRecord(
-                    new ResourceNotFoundException($"Package with name '{packageName}', version '{version}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), 
-                    "PackageNotFound", 
-                    ErrorCategory.ObjectNotFound, 
+                    new ResourceNotFoundException($"Package with name '{packageName}', version '{version}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."),
+                    "PackageNotFound",
+                    ErrorCategory.ObjectNotFound,
                     this);
                 response = string.Empty;
             }
-            
+
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
         }
 
@@ -709,33 +709,33 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             catch (ResourceNotFoundException e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "ResourceNotFound", 
-                    ErrorCategory.InvalidResult, 
+                    exception: e,
+                    "ResourceNotFound",
+                    ErrorCategory.InvalidResult,
                     this);
             }
             catch (UnauthorizedException e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "UnauthorizedRequest", 
-                    ErrorCategory.InvalidResult, 
+                    exception: e,
+                    "UnauthorizedRequest",
+                    ErrorCategory.InvalidResult,
                     this);
             }
             catch (HttpRequestException e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "HttpRequestCallFailure", 
-                    ErrorCategory.ConnectionError, 
+                    exception: e,
+                    "HttpRequestCallFailure",
+                    ErrorCategory.ConnectionError,
                     this);
             }
             catch (Exception e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "HttpRequestCallFailure", 
-                    ErrorCategory.ConnectionError, 
+                    exception: e,
+                    "HttpRequestCallFailure",
+                    ErrorCategory.ConnectionError,
                     this);
             }
 
@@ -766,25 +766,25 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             catch (HttpRequestException e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "HttpRequestFailure", 
-                    ErrorCategory.ConnectionError, 
+                    exception: e,
+                    "HttpRequestFailure",
+                    ErrorCategory.ConnectionError,
                     this);
             }
             catch (ArgumentNullException e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "HttpRequestFailure", 
-                    ErrorCategory.InvalidData, 
+                    exception: e,
+                    "HttpRequestFailure",
+                    ErrorCategory.InvalidData,
                     this);
             }
             catch (InvalidOperationException e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "HttpRequestFailure", 
-                    ErrorCategory.InvalidOperation, 
+                    exception: e,
+                    "HttpRequestFailure",
+                    ErrorCategory.InvalidOperation,
                     this);
             }
 
@@ -792,7 +792,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 _cmdletPassedIn.WriteDebug("Response is empty");
             }
-            
+
             return content;
         }
 
@@ -838,7 +838,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             var requestUrlV2 = $"{Repository.Uri}{typeEndpoint}/Search()?{prereleaseFilter}{typeFilterPart}{tagFilterPart}{paginationParam}";
-            
+
             return HttpRequestCall(requestUrlV2: requestUrlV2, out errRecord);
         }
 
@@ -865,7 +865,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             var requestUrlV2 = $"{Repository.Uri}/Search()?{prereleaseFilter}&searchTerm='{tagSearchTermPart}'{paginationParam}";
-            
+
             return HttpRequestCall(requestUrlV2, out errRecord);
         }
 
@@ -887,9 +887,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (names.Length == 0)
             {
                 errRecord = new ErrorRecord(
-                    new ArgumentException("-Name '*' for V2 server protocol repositories is not supported"), 
-                    "FindNameGlobbingFailure", 
-                    ErrorCategory.InvalidArgument, 
+                    new ArgumentException("-Name '*' for V2 server protocol repositories is not supported"),
+                    "FindNameGlobbingFailure",
+                    ErrorCategory.InvalidArgument,
                     this);
 
                 return string.Empty;
@@ -923,9 +923,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             else
             {
                 errRecord = new ErrorRecord(
-                    new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."), 
-                    "FindNameGlobbingFailure", 
-                    ErrorCategory.InvalidArgument, 
+                    new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."),
+                    "FindNameGlobbingFailure",
+                    ErrorCategory.InvalidArgument,
                     this);
 
                 return string.Empty;
@@ -933,7 +933,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             string typeFilterPart = GetTypeFilterForRequest(type);
             var requestUrlV2 = $"{Repository.Uri}/Search()?$filter={nameFilter}{typeFilterPart} and {prerelease}{extraParam}";
-            
+
             return HttpRequestCall(requestUrlV2, out errRecord);
         }
 
@@ -955,9 +955,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (names.Length == 0)
             {
                 errRecord = new ErrorRecord(
-                    new ArgumentException("-Name '*' for V2 server protocol repositories is not supported"), 
-                    "FindNameGlobbingFailure", 
-                    ErrorCategory.InvalidArgument, 
+                    new ArgumentException("-Name '*' for V2 server protocol repositories is not supported"),
+                    "FindNameGlobbingFailure",
+                    ErrorCategory.InvalidArgument,
                     this);
 
                 return string.Empty;
@@ -991,9 +991,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             else
             {
                 errRecord = new ErrorRecord(
-                    new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."), 
-                    "FindNameGlobbing", 
-                    ErrorCategory.InvalidArgument, 
+                    new ArgumentException("-Name with wildcards is only supported for scenarios similar to the following examples: PowerShell*, *ShellGet, *Shell*."),
+                    "FindNameGlobbing",
+                    ErrorCategory.InvalidArgument,
                     this);
 
                 return string.Empty;
@@ -1007,7 +1007,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             string typeFilterPart = GetTypeFilterForRequest(type);
             var requestUrlV2 = $"{Repository.Uri}/Search()?$filter={nameFilter}{tagFilterPart}{typeFilterPart} and {prerelease}{extraParam}";
-            
+
             return HttpRequestCall(requestUrlV2, out errRecord);
         }
 
@@ -1059,7 +1059,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // because we want to retrieve all the prerelease versions for the upper end of the range
                 // and PSGallery views prerelease as higher than its stable.
                 // eg 3.0.0-prerelease > 3.0.0
-                // If looking for versions within '[1.9.9,1.9.9]' including prerelease values, this will change it to search for '[1.9.9,1.9.99]' 
+                // If looking for versions within '[1.9.9,1.9.9]' including prerelease values, this will change it to search for '[1.9.9,1.9.99]'
                 // and find any pkg versions that are 1.9.9-prerelease.
                 string maxString = includePrerelease ? $"{versionRange.MaxVersion.Major}.{versionRange.MaxVersion.Minor}.{versionRange.MaxVersion.Patch.ToString() + "9"}" :
                                  $"{versionRange.MaxVersion.ToNormalizedString()}";
@@ -1067,7 +1067,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     maxPart = String.Format(format, operation, $"'{maxVersion.ToNormalizedString()}'");
                 }
-                else { 
+                else {
                     maxPart = String.Format(format, operation, $"'{versionRange.MaxVersion.ToNormalizedString()}'");
                 }
             }
@@ -1113,7 +1113,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             filterQuery = filterQuery.EndsWith("=") ? string.Empty : filterQuery;
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$orderby=NormalizedVersion desc&{paginationParam}{filterQuery}";
-            
+
             return HttpRequestCall(requestUrlV2, out errRecord);
         }
 
@@ -1146,13 +1146,24 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             var response = HttpRequestCallForContent(requestUrlV2, out errRecord);
-            var responseStream = response.ReadAsStreamAsync().Result;
+
             if (errRecord != null)
             {
                 return new MemoryStream();
             }
 
-            return responseStream;
+            if (response is null)
+            {
+                errRecord = new ErrorRecord(
+                    new Exception($"No content was returned by repository '{Repository.Name}'"),
+                    "InstallFailureContentNullv2",
+                    ErrorCategory.InvalidResult,
+                    this);
+
+                return null;
+            }
+
+            return response.ReadAsStreamAsync().Result;
         }
 
         private string GetTypeFilterForRequest(ResourceType type) {
@@ -1205,7 +1216,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         countSearchSucceeded = int.TryParse(node.InnerText, out count);
                     }
                 }
-   
+
                 if (!countSearchSucceeded)
                 {
                              // Note: not all V2 servers may have the 'count' property implemented or valid (i.e CloudSmith server), in this case try to get 'd:Id' property.
@@ -1217,16 +1228,16 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     }
                     else
                     {
-                        _cmdletPassedIn.WriteDebug($"Property 'count' and 'd:Id' could not be found in response. This may indicate that the package could not be found"); 
+                        _cmdletPassedIn.WriteDebug($"Property 'count' and 'd:Id' could not be found in response. This may indicate that the package could not be found");
                     }
                 }
             }
             catch (XmlException e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "GetCountFromResponse", 
-                    ErrorCategory.InvalidData, 
+                    exception: e,
+                    "GetCountFromResponse",
+                    ErrorCategory.InvalidData,
                     this);
             }
 

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -778,9 +778,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return null;
             }
 
-            pkgStream = content.ReadAsStreamAsync().Result;
-
-            return pkgStream;
+            return content.ReadAsStreamAsync().Result;
         }
 
         /// <summary>

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -78,8 +78,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindAll()");
             errRecord = new ErrorRecord(
                 new InvalidOperationException($"Find all is not supported for the V3 server protocol repository '{Repository.Name}'"),
-                "FindAllFailure", 
-                ErrorCategory.InvalidOperation, 
+                "FindAllFailure",
+                ErrorCategory.InvalidOperation,
                 this);
 
             return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -116,9 +116,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         {
             _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindCommandOrDscResource()");
             errRecord = new ErrorRecord(
-                new InvalidOperationException($"Find by CommandName or DSCResource is not supported for the V3 server protocol repository '{Repository.Name}'"), 
-                "FindCommandOrDscResourceFailure", 
-                ErrorCategory.InvalidOperation, 
+                new InvalidOperationException($"Find by CommandName or DSCResource is not supported for the V3 server protocol repository '{Repository.Name}'"),
+                "FindCommandOrDscResourceFailure",
+                ErrorCategory.InvalidOperation,
                 this);
 
             return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -162,9 +162,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             else
             {
                 errRecord = new ErrorRecord(
-                    new InvalidOperationException($"Find with Name containing wildcards is not supported for the V3 server protocol repository '{Repository.Name}'"), 
-                    "FindNameGlobbingFailure", 
-                    ErrorCategory.InvalidOperation, 
+                    new InvalidOperationException($"Find with Name containing wildcards is not supported for the V3 server protocol repository '{Repository.Name}'"),
+                    "FindNameGlobbingFailure",
+                    ErrorCategory.InvalidOperation,
                     this);
 
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -185,9 +185,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             else
             {
                 errRecord = new ErrorRecord(
-                    new InvalidOperationException($"Find with Name containing wildcards is not supported for the V3 server protocol repository '{Repository.Name}'"), 
-                    "FindNameGlobbingWithTagFailure", 
-                    ErrorCategory.InvalidOperation, 
+                    new InvalidOperationException($"Find with Name containing wildcards is not supported for the V3 server protocol repository '{Repository.Name}'"),
+                    "FindNameGlobbingWithTagFailure",
+                    ErrorCategory.InvalidOperation,
                     this);
 
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -222,9 +222,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         if (!rootDom.TryGetProperty(versionName, out JsonElement pkgVersionElement))
                         {
                             errRecord = new ErrorRecord(
-                                new InvalidOrEmptyResponse($"Response does not contain '{versionName}' element."), 
-                                "FindVersionGlobbingFailure", 
-                                ErrorCategory.InvalidData, 
+                                new InvalidOrEmptyResponse($"Response does not contain '{versionName}' element."),
+                                "FindVersionGlobbingFailure",
+                                ErrorCategory.InvalidData,
                                 this);
 
                             return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -243,9 +243,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 catch (Exception e)
                 {
                     errRecord = new ErrorRecord(
-                        exception: e, 
+                        exception: e,
                         "FindVersionGlobbingFailure",
-                        ErrorCategory.InvalidResult, 
+                        ErrorCategory.InvalidResult,
                         this);
 
                     return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -327,8 +327,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 errRecord = new ErrorRecord(
                     new ArgumentException("-Name '*' for V3 server protocol repositories is not supported"),
-                    "FindNameGlobbingFromNuGetRepoFailure", 
-                    ErrorCategory.InvalidArgument, 
+                    "FindNameGlobbingFromNuGetRepoFailure",
+                    ErrorCategory.InvalidArgument,
                     this);
 
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -384,9 +384,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (!pkgEntry.TryGetProperty(tagsName, out JsonElement tagsItem))
                     {
                         errRecord = new ErrorRecord(
-                            new JsonParsingException("FindNameGlobbing(): Tags element could not be found in response."), 
-                            "GetEntriesFromSearchQueryResourceFailure", 
-                            ErrorCategory.InvalidResult, 
+                            new JsonParsingException("FindNameGlobbing(): Tags element could not be found in response."),
+                            "GetEntriesFromSearchQueryResourceFailure",
+                            ErrorCategory.InvalidResult,
                             this);
 
                         return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -415,8 +415,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     errRecord = new ErrorRecord(
                         exception: e,
-                        "GetEntriesFromSearchQueryResourceFailure", 
-                        ErrorCategory.InvalidResult, 
+                        "GetEntriesFromSearchQueryResourceFailure",
+                        ErrorCategory.InvalidResult,
                         this);
 
                     break;
@@ -444,9 +444,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (tagPkgEntries.Count == 0)
             {
                 errRecord = new ErrorRecord(
-                    new ResourceNotFoundException($"Package with Tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), 
-                    "PackageWithSpecifiedTagsNotFound", 
-                    ErrorCategory.ObjectNotFound, 
+                    new ResourceNotFoundException($"Package with Tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."),
+                    "PackageWithSpecifiedTagsNotFound",
+                    ErrorCategory.ObjectNotFound,
                     this);
 
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -485,9 +485,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         if (!rootDom.TryGetProperty(versionName, out JsonElement pkgVersionElement))
                         {
                             errRecord = new ErrorRecord(
-                                new InvalidOrEmptyResponse($"Response does not contain '{versionName}' element for search with Name '{packageName}' in '{Repository.Name}'."), 
-                                "FindNameFailure", 
-                                ErrorCategory.InvalidResult, 
+                                new InvalidOrEmptyResponse($"Response does not contain '{versionName}' element for search with Name '{packageName}' in '{Repository.Name}'."),
+                                "FindNameFailure",
+                                ErrorCategory.InvalidResult,
                                 this);
 
                             return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -495,9 +495,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         if (!rootDom.TryGetProperty(tagsName, out JsonElement tagsItem))
                         {
                             errRecord = new ErrorRecord(
-                                new InvalidOrEmptyResponse($"Response does not contain '{tagsName}' element for search with Name '{packageName}' in '{Repository.Name}'."), 
-                                "FindNameFailure", 
-                                ErrorCategory.InvalidResult, 
+                                new InvalidOrEmptyResponse($"Response does not contain '{tagsName}' element for search with Name '{packageName}' in '{Repository.Name}'."),
+                                "FindNameFailure",
+                                ErrorCategory.InvalidResult,
                                 this);
 
                             return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -520,9 +520,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 catch (Exception e)
                 {
                     errRecord = new ErrorRecord(
-                        exception: e, 
-                        "FindNameFailure", 
-                        ErrorCategory.InvalidResult, 
+                        exception: e,
+                        "FindNameFailure",
+                        ErrorCategory.InvalidResult,
                         this);
 
                     return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -532,9 +532,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (String.IsNullOrEmpty(latestVersionResponse))
             {
                 errRecord = new ErrorRecord(
-                    new ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}'."), 
-                    "PackageNotFound", 
-                    ErrorCategory.ObjectNotFound, 
+                    new ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}'."),
+                    "PackageNotFound",
+                    ErrorCategory.ObjectNotFound,
                     this);
 
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -546,9 +546,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (errRecord == null)
                 {
                     errRecord = new ErrorRecord(
-                        new ResourceNotFoundException($"Package with name '{packageName}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), 
-                        "PackageNotFound", 
-                        ErrorCategory.ObjectNotFound, 
+                        new ResourceNotFoundException($"Package with name '{packageName}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."),
+                        "PackageNotFound",
+                        ErrorCategory.ObjectNotFound,
                         this);
                 }
 
@@ -567,9 +567,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (!NuGetVersion.TryParse(version, out NuGetVersion requiredVersion))
             {
                 errRecord = new ErrorRecord(
-                    new ArgumentException($"Version {version} to be found is not a valid NuGet version."), 
-                    "FindNameFailure", 
-                    ErrorCategory.InvalidArgument, 
+                    new ArgumentException($"Version {version} to be found is not a valid NuGet version."),
+                    "FindNameFailure",
+                    ErrorCategory.InvalidArgument,
                     this);
 
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -595,9 +595,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         if (!rootDom.TryGetProperty(versionName, out JsonElement pkgVersionElement))
                         {
                             errRecord = new ErrorRecord(
-                                new InvalidOrEmptyResponse($"Response does not contain '{versionName}' element for search with name '{packageName}' and version '{version}' in repository '{Repository.Name}'."), 
-                                "FindVersionFailure", 
-                                ErrorCategory.InvalidResult, 
+                                new InvalidOrEmptyResponse($"Response does not contain '{versionName}' element for search with name '{packageName}' and version '{version}' in repository '{Repository.Name}'."),
+                                "FindVersionFailure",
+                                ErrorCategory.InvalidResult,
                                 this);
 
                             return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -605,9 +605,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         if (!rootDom.TryGetProperty(tagsName, out JsonElement tagsItem))
                         {
                             errRecord = new ErrorRecord(
-                                new InvalidOrEmptyResponse($"Response does not contain '{tagsName}' element for search with name '{packageName}' and version '{version}' in repository '{Repository.Name}'."), 
-                                "FindVersionFailure", 
-                                ErrorCategory.InvalidResult, 
+                                new InvalidOrEmptyResponse($"Response does not contain '{tagsName}' element for search with name '{packageName}' and version '{version}' in repository '{Repository.Name}'."),
+                                "FindVersionFailure",
+                                ErrorCategory.InvalidResult,
                                 this);
 
                             return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -627,9 +627,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 catch (Exception e)
                 {
                     errRecord = new ErrorRecord(
-                        exception: e, 
-                        "FindVersionFailure", 
-                        ErrorCategory.InvalidResult, 
+                        exception: e,
+                        "FindVersionFailure",
+                        ErrorCategory.InvalidResult,
                         this);
 
                     return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -639,9 +639,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (String.IsNullOrEmpty(latestVersionResponse))
             {
                 errRecord = new ErrorRecord(
-                    new ResourceNotFoundException($"Package with name '{packageName}', version '{version}' could not be found in repository '{Repository.Name}'."), 
-                    "PackageNotFound", 
-                    ErrorCategory.ObjectNotFound, 
+                    new ResourceNotFoundException($"Package with name '{packageName}', version '{version}' could not be found in repository '{Repository.Name}'."),
+                    "PackageNotFound",
+                    ErrorCategory.ObjectNotFound,
                     this);
 
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -652,9 +652,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (errRecord == null)
                 {
                     errRecord = new ErrorRecord(
-                        new ResourceNotFoundException($"FindVersion(): Package with name '{packageName}', version '{version}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."), 
-                        "PackageNotFound", 
-                        ErrorCategory.ObjectNotFound, 
+                        new ResourceNotFoundException($"FindVersion(): Package with name '{packageName}', version '{version}' and tags '{String.Join(", ", tags)}' could not be found in repository '{Repository.Name}'."),
+                        "PackageNotFound",
+                        ErrorCategory.ObjectNotFound,
                         this);
                 }
 
@@ -722,9 +722,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (versionedResponses.Length == 0)
             {
                 errRecord = new ErrorRecord(
-                    new Exception($"Package with name '{packageName}' and version '{version}' could not be found in repository '{Repository.Name}'"), 
-                    "InstallFailure", 
-                    ErrorCategory.InvalidResult, 
+                    new Exception($"Package with name '{packageName}' and version '{version}' could not be found in repository '{Repository.Name}'"),
+                    "InstallFailure",
+                    ErrorCategory.InvalidResult,
                     this);
 
                 return null;
@@ -753,9 +753,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (String.IsNullOrEmpty(pkgContentUrl))
             {
                 errRecord = new ErrorRecord(
-                    new Exception($"Package with name '{packageName}' and version '{version}' could not be found in repository '{Repository.Name}'"), 
-                    "InstallFailure", 
-                    ErrorCategory.InvalidResult, 
+                    new Exception($"Package with name '{packageName}' and version '{version}' could not be found in repository '{Repository.Name}'"),
+                    "InstallFailure",
+                    ErrorCategory.InvalidResult,
                     this);
 
                 return null;
@@ -764,6 +764,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             var content = HttpRequestCallForContent(pkgContentUrl, out errRecord);
             if (errRecord != null)
             {
+                return null;
+            }
+
+            if (content is null)
+            {
+                errRecord = new ErrorRecord(
+                    new Exception($"No content was returned by repository '{Repository.Name}'"),
+                    "InstallFailureContentNullv3",
+                    ErrorCategory.InvalidResult,
+                    this);
+
                 return null;
             }
 
@@ -865,8 +876,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (!resource.TryGetProperty("@type", out JsonElement typeElement))
                     {
                         errRecord = new ErrorRecord(
-                            new JsonParsingException($"@type element not found for resource in service index for repository '{Repository.Name}'"), "GetResourcesFromServiceIndexFailure", 
-                            ErrorCategory.InvalidResult, 
+                            new JsonParsingException($"@type element not found for resource in service index for repository '{Repository.Name}'"), "GetResourcesFromServiceIndexFailure",
+                            ErrorCategory.InvalidResult,
                             this);
 
                         return new Dictionary<string, string>();
@@ -875,9 +886,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (!resource.TryGetProperty("@id", out JsonElement idElement))
                     {
                         errRecord = new ErrorRecord(
-                            new JsonParsingException($"@id element not found for resource in service index for repository '{Repository.Name}'"), 
-                            "GetResourcesFromServiceIndexFailure", 
-                            ErrorCategory.InvalidResult, 
+                            new JsonParsingException($"@id element not found for resource in service index for repository '{Repository.Name}'"),
+                            "GetResourcesFromServiceIndexFailure",
+                            ErrorCategory.InvalidResult,
                             this);
 
                         return new Dictionary<string, string>();
@@ -892,9 +903,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 catch (Exception e)
                 {
                     errRecord = new ErrorRecord(
-                        new Exception($"Exception parsing service index JSON for respository '{Repository.Name}' with error: {e.Message}"), 
-                        "GetResourcesFromServiceIndexFailure", 
-                        ErrorCategory.InvalidResult, 
+                        new Exception($"Exception parsing service index JSON for respository '{Repository.Name}' with error: {e.Message}"),
+                        "GetResourcesFromServiceIndexFailure",
+                        ErrorCategory.InvalidResult,
                         this);
 
                     return new Dictionary<string, string>();
@@ -946,9 +957,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             else
             {
                 errRecord = new ErrorRecord(
-                    new ResourceNotFoundException($"RegistrationBaseUrl resource could not be found for repository '{Repository.Name}'"), 
-                    "FindRegistrationsBaseUrlFailure", 
-                    ErrorCategory.InvalidResult, 
+                    new ResourceNotFoundException($"RegistrationBaseUrl resource could not be found for repository '{Repository.Name}'"),
+                    "FindRegistrationsBaseUrlFailure",
+                    ErrorCategory.InvalidResult,
                     this);
             }
 
@@ -984,9 +995,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             else
             {
                 errRecord = new ErrorRecord(
-                    new ResourceNotFoundException($"SearchQueryService resource could not be found for Repository '{Repository.Name}'"), 
-                    "FindSearchQueryServiceFailure", 
-                    ErrorCategory.InvalidResult, 
+                    new ResourceNotFoundException($"SearchQueryService resource could not be found for Repository '{Repository.Name}'"),
+                    "FindSearchQueryServiceFailure",
+                    ErrorCategory.InvalidResult,
                     this);
             }
 
@@ -1010,9 +1021,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 if (errRecord.Exception is ResourceNotFoundException) {
                     errRecord = new ErrorRecord(
-                        new ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}'.", errRecord.Exception), 
-                        "PackageNotFound", 
-                        ErrorCategory.ObjectNotFound, 
+                        new ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}'.", errRecord.Exception),
+                        "PackageNotFound",
+                        ErrorCategory.ObjectNotFound,
                         this);
                 }
 
@@ -1027,9 +1038,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (!rootDom.TryGetProperty(itemsName, out JsonElement innerItemsElement))
                     {
                         errRecord = new ErrorRecord(
-                            new ResourceNotFoundException($"'{itemsName}' element for package with name '{packageName}' could not be found in JFrog repository '{Repository.Name}'"), 
-                            "GetElementForJFrogRepoFailure", 
-                            ErrorCategory.InvalidResult, 
+                            new ResourceNotFoundException($"'{itemsName}' element for package with name '{packageName}' could not be found in JFrog repository '{Repository.Name}'"),
+                            "GetElementForJFrogRepoFailure",
+                            ErrorCategory.InvalidResult,
                             this);
 
                         return innerItems;
@@ -1054,9 +1065,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             catch (Exception e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "MetadataElementForIdElementRetrievalFailure", 
-                    ErrorCategory.InvalidResult, 
+                    exception: e,
+                    "MetadataElementForIdElementRetrievalFailure",
+                    ErrorCategory.InvalidResult,
                     this);
             }
 
@@ -1221,7 +1232,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             return versionedPkgResponses.ToArray();
         }
-        
+
         /// <summary>
         /// Helper method iterates through the entries in the registrationsUrl for a specific package and all its versions.
         /// This contains an inner items element (containing the package metadata) and the packageContent element (containing URI through which the .nupkg can be downloaded)
@@ -1242,9 +1253,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (errRecord.Exception is ResourceNotFoundException)
                 {
                     errRecord = new ErrorRecord(
-                        new ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}'.", errRecord.Exception), 
-                        "PackageNotFound", 
-                        ErrorCategory.ObjectNotFound, 
+                        new ResourceNotFoundException($"Package with name '{packageName}' could not be found in repository '{Repository.Name}'.", errRecord.Exception),
+                        "PackageNotFound",
+                        ErrorCategory.ObjectNotFound,
                         this);
                 }
 
@@ -1320,7 +1331,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         return latestVersionFirst;
                     }
-                    
+
 
                     string firstVersion = firstVersionElement.ToString();
                     if (!NuGetVersion.TryParse(firstVersion, out firstPkgVersion))
@@ -1348,7 +1359,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         return latestVersionFirst;
                     }
-                    
+
 
                     string lastVersion = lastVersionElement.ToString();
                     if (!NuGetVersion.TryParse(lastVersion, out lastPkgVersion))
@@ -1371,9 +1382,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             catch (Exception e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "LatestVersionFirstSearchFailure", 
-                    ErrorCategory.InvalidResult, 
+                    exception: e,
+                    "LatestVersionFirstSearchFailure",
+                    ErrorCategory.InvalidResult,
                     this);
 
                 return true;
@@ -1440,11 +1451,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             catch (Exception e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "GetResponsesFromRegistrationsResourceFailure", 
-                    ErrorCategory.InvalidResult, 
+                    exception: e,
+                    "GetResponsesFromRegistrationsResourceFailure",
+                    ErrorCategory.InvalidResult,
                     this);
-                    
+
                 return false;
             }
 
@@ -1503,17 +1514,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 // scenario where the feed is not active anymore, i.e confirmed for JFrogArtifactory. The default error message is not intuitive.
                 errRecord = new ErrorRecord(
-                    exception: new Exception($"JSON response from repository {Repository.Name} could not be parsed, likely due to the feed being inactive or invalid, with inner exception: {e.Message}"), 
+                    exception: new Exception($"JSON response from repository {Repository.Name} could not be parsed, likely due to the feed being inactive or invalid, with inner exception: {e.Message}"),
                     "FindVersionGlobbingFailure",
-                    ErrorCategory.InvalidResult, 
+                    ErrorCategory.InvalidResult,
                     this);
             }
             catch (Exception e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "GetResponsesFromRegistrationsResourceFailure", 
-                    ErrorCategory.InvalidResult, 
+                    exception: e,
+                    "GetResponsesFromRegistrationsResourceFailure",
+                    ErrorCategory.InvalidResult,
                     this);
             }
 
@@ -1539,33 +1550,33 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             catch (ResourceNotFoundException e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "ResourceNotFound", 
-                    ErrorCategory.InvalidResult, 
+                    exception: e,
+                    "ResourceNotFound",
+                    ErrorCategory.InvalidResult,
                     this);
             }
             catch (UnauthorizedException e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "UnauthorizedRequest", 
-                    ErrorCategory.InvalidResult, 
+                    exception: e,
+                    "UnauthorizedRequest",
+                    ErrorCategory.InvalidResult,
                     this);
             }
             catch (HttpRequestException e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "HttpRequestCallFailure", 
-                    ErrorCategory.InvalidResult, 
+                    exception: e,
+                    "HttpRequestCallFailure",
+                    ErrorCategory.InvalidResult,
                     this);
             }
             catch (Exception e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "HttpRequestCallFailure", 
-                    ErrorCategory.InvalidResult, 
+                    exception: e,
+                    "HttpRequestCallFailure",
+                    ErrorCategory.InvalidResult,
                     this);
             }
 
@@ -1590,9 +1601,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             catch (Exception e)
             {
                 errRecord = new ErrorRecord(
-                    exception: e, 
-                    "HttpRequestCallForContentFailure", 
-                    ErrorCategory.InvalidResult, 
+                    exception: e,
+                    "HttpRequestCallForContentFailure",
+                    ErrorCategory.InvalidResult,
                     this);
             }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

There are cases where the response from the server can be null. Add protection against it to avoid `Object reference to null` exceptions.

## PR Context

Fixes #1493 

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
