### PR TITLE
enable isJFrogRepo flag for domains containing `artifactory`

### DIFF
--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             _sessionClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", userAgentString);
             var repoURL = repository.Uri.ToString().ToLower();
             _isADORepo = repoURL.Contains("pkgs.dev.azure.com") || repoURL.Contains("pkgs.visualstudio.com");
-            _isJFrogRepo = repoURL.Contains("jfrog");
+            _isJFrogRepo = repoURL.Contains("jfrog") || repoURL.Contains("artifactory");
             _isPSGalleryRepo = repoURL.Contains("powershellgallery.com/api/v2");
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

This PR updates the conditions where `V2ServerAPICalls._isJFrogRepo` is enabled to include repos where `artifactory` is in the URL

This PR should resolve #1530.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

JFrog hosted Artifactory instances all fall under the `jfrog.io` domain, but selfhosted Artifactory instances are not necessarily beholden to this requirement. Moreover, the Artifactory product-line (as I understand it) predates JFrog's rearchitecture into the "JFrog Platform" (including component services like Artifactory), so older installations may not make the distinction between "JFrog" and "Artifactory"

This PR would entail a behavioral change for any selfhosted Artifactory instances that fall under this scenario. However, any behavioral changes gated behind that flag were most-likely intended for Artifactory, so this is probably a good thing.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
