### PR TITLE
Fix 'name' bug with v2 JFrog Artifactory

### DIFF
--- a/src/code/V2ResponseUtil.cs
+++ b/src/code/V2ResponseUtil.cs
@@ -75,12 +75,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             XmlDocument doc = new XmlDocument();
             doc.LoadXml(httpResponse);
 
-            XmlNodeList elemList = doc.GetElementsByTagName("m:properties");
-            
-            XmlNode[] nodes = new XmlNode[elemList.Count]; 
-            for (int i = 0; i < elemList.Count; i++) 
+            XmlNodeList entryNode = doc.GetElementsByTagName("entry");
+
+            XmlNode[] nodes = new XmlNode[entryNode.Count];
+            for (int i = 0; i < entryNode.Count; i++) 
             {
-                nodes[i] = elemList[i]; 
+                nodes[i] = entryNode[i];
             }
 
             return nodes;

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -41,6 +41,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public FindResponseType v2FindResponseType = FindResponseType.ResponseString;
         private bool _isADORepo;
         private bool _isJFrogRepo;
+        private bool _isPSGalleryRepo;
 
         #endregion
 
@@ -60,6 +61,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             var repoURL = repository.Uri.ToString().ToLower();
             _isADORepo = repoURL.Contains("pkgs.dev.azure.com") || repoURL.Contains("pkgs.visualstudio.com");
             _isJFrogRepo = repoURL.Contains("jfrog");
+            _isPSGalleryRepo = repoURL.Contains("powershellgallery.com/api/v2");
         }
 
         #endregion
@@ -806,7 +808,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private string FindAllFromTypeEndPoint(bool includePrerelease, bool isSearchingModule, int skip, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindAllFromTypeEndPoint()");
-            string typeEndpoint = isSearchingModule ? String.Empty : "/items/psscript";
+            string typeEndpoint = _isPSGalleryRepo && !isSearchingModule ? "/items/psscript" : String.Empty;
             string paginationParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=6000";
             var prereleaseFilter = includePrerelease ? "IsAbsoluteLatestVersion&includePrerelease=true" : "IsLatestVersion";
 
@@ -826,7 +828,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // type: S -> just search Scripts end point
             // type: DSCResource -> just search Modules
             // type: Command -> just search Modules
-            string typeEndpoint = isSearchingModule ? String.Empty : "/items/psscript";
+            string typeEndpoint = _isPSGalleryRepo && !isSearchingModule ? "/items/psscript" : String.Empty;
             string paginationParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=6000";
             var prereleaseFilter = includePrerelease ? "includePrerelease=true&$filter=IsAbsoluteLatestVersion" : "$filter=IsLatestVersion";
             string typeFilterPart = isSearchingModule ?  $" and substringof('PSModule', Tags) eq true" : $" and substringof('PSScript', Tags) eq true";


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fixes bug where `Find-PSResource` using v2 Jfrog Artifactory is not returning the 'name' property of a module. 

Previously, all package properties were pulled from the xml node `m:properties`, however `title`, listed as a child node under `m:properties`, can sometimes be empty.  There is another `title` node that is a child of `entry` and as far as I can tell this node seems to always contain the  name of the package.  

Instead of pulling `m:properties` from the xml response, `entry` (which is the parent of `m:properties`) is now being used as the parent node from which all package metadata is parsed.  This allows us to pull all of the information that was previously being retrieved from `m:properties`, but also get the extra `title` node mentioned above.

## PR Context

Resolves #1534 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
