### PR TITLE
Bugfix - Test if InstalledScriptInfos folder exists and create if needed

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -488,12 +488,21 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             else
             {
-                var scriptXML = pkgInfo.Name + "_InstalledScriptInfo.xml";
+                string scriptInfoFolderPath = Path.Combine(installPath, "InstalledScriptInfos");
+                string scriptXML = pkgInfo.Name + "_InstalledScriptInfo.xml";
+                string scriptXmlFilePath = Path.Combine(scriptInfoFolderPath, scriptXML);
                 if (!_savePkg)
                 {
+                    // Need to ensure "InstalledScriptInfos directory exists
+                    if (!Directory.Exists(Path.Combine(installPath, "InstalledScriptInfos")))
+                    {
+                        _cmdletPassedIn.WriteVerbose($"Created '{scriptInfoFolderPath}' path for scripts");
+                        Directory.CreateDirectory(scriptInfoFolderPath);
+                    }
+
                     // Need to delete old xml files because there can only be 1 per script
-                    _cmdletPassedIn.WriteVerbose(string.Format("Checking if path '{0}' exists: ", File.Exists(Path.Combine(installPath, "InstalledScriptInfos", scriptXML))));
-                    if (File.Exists(Path.Combine(installPath, "InstalledScriptInfos", scriptXML)))
+                    _cmdletPassedIn.WriteVerbose(string.Format("Checking if path '{0}' exists: '{1}'", scriptXmlFilePath, File.Exists(scriptXmlFilePath)));
+                    if (File.Exists(scriptXmlFilePath))
                     {
                         _cmdletPassedIn.WriteVerbose("Deleting script metadata XML");
                         File.Delete(Path.Combine(installPath, "InstalledScriptInfos", scriptXML));

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -506,7 +506,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (File.Exists(scriptXmlFilePath))
                     {
                         _cmdletPassedIn.WriteVerbose("Deleting script metadata XML");
-                        File.Delete(Path.Combine(installPath, "InstalledScriptInfos", scriptXML));
+                        File.Delete(Path.Combine(scriptInfoFolderPath, scriptXML));
+
                     }
 
                     _cmdletPassedIn.WriteVerbose(string.Format("Moving '{0}' to '{1}'", Path.Combine(dirNameVersion, scriptXML), Path.Combine(installPath, "InstalledScriptInfos", scriptXML)));

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -494,7 +494,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (!_savePkg)
                 {
                     // Need to ensure "InstalledScriptInfos directory exists
-                    if (!Directory.Exists(Path.Combine(installPath, "InstalledScriptInfos")))
+                    if (!Directory.Exists(scriptInfoFolderPath))
+
                     {
                         _cmdletPassedIn.WriteVerbose($"Created '{scriptInfoFolderPath}' path for scripts");
                         Directory.CreateDirectory(scriptInfoFolderPath);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->
Install-PSResource code was not checking if the InstalledScriptInfos folder existed, would try to use that path regardless and throw an uncaught error. This PR makes a fix to ensure the folder exists.

Fixes #1540 
# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
