### PR TITLE
ACR Integration: Populate metadata into PSResourceInfo object

### DIFF
--- a/src/code/ACRServerAPICalls.cs
+++ b/src/code/ACRServerAPICalls.cs
@@ -1251,9 +1251,9 @@ namespace Microsoft.PowerShell.PSResourceGet
             jsonWriter.WritePropertyName("annotations");
             jsonWriter.WriteStartObject();
             jsonWriter.WritePropertyName("org.opencontainers.image.title");
-            jsonWriter.WriteValue(fileName);
-            jsonWriter.WritePropertyName("packageName");
             jsonWriter.WriteValue(packageName);
+            jsonWriter.WritePropertyName("org.opencontainers.image.description");
+            jsonWriter.WriteValue(fileName);
             jsonWriter.WritePropertyName("metadata");
             jsonWriter.WriteValue(jsonString);
             jsonWriter.WriteEndObject();

--- a/src/code/ACRServerAPICalls.cs
+++ b/src/code/ACRServerAPICalls.cs
@@ -173,32 +173,13 @@ namespace Microsoft.PowerShell.PSResourceGet
                 return new FindResults(stringResponse: new string[] { }, hashtableResponse: emptyHashResponses, responseType: acrFindResponseType);
             }
 
-            /* response returned looks something like:
-             *   "registry": "myregistry.azurecr.io"
-             *   "imageName": "hello-world"
-             *   "tags": [
-             *     {
-             *       ""name"": ""1.0.0"",
-             *       ""digest"": ""sha256:92c7f9c92844bbbb5d0a101b22f7c2a7949e40f8ea90c8b3bc396879d95e899a"",
-             *       ""createdTime"": ""2023-12-23T18:06:48.9975733Z"",
-             *       ""lastUpdateTime"": ""2023-12-23T18:06:48.9975733Z"",
-             *       ""signed"": false,
-             *       ""changeableAttributes"": {
-             *         ""deleteEnabled"": true,
-             *         ""writeEnabled"": true,
-             *         ""readEnabled"": true,
-             *         ""listEnabled"": true
-             *       }
-             *     }]
-             */
             List<Hashtable> latestVersionResponse = new List<Hashtable>();
             List<JToken> allVersionsList = foundTags["tags"].ToList();
             allVersionsList.Reverse();
 
-            foreach (var packageVersion in allVersionsList)
+            foreach (var pkgVersionTagInfo in allVersionsList)
             {
-                var packageVersionStr = packageVersion.ToString();
-                using (JsonDocument pkgVersionEntry = JsonDocument.Parse(packageVersionStr))
+                using (JsonDocument pkgVersionEntry = JsonDocument.Parse(pkgVersionTagInfo.ToString()))
                 {
                     JsonElement rootDom = pkgVersionEntry.RootElement;
                     if (!rootDom.TryGetProperty("name", out JsonElement pkgVersionElement))
@@ -218,7 +199,7 @@ namespace Microsoft.PowerShell.PSResourceGet
                         if (!pkgVersion.IsPrerelease || includePrerelease)
                         {
                             // Versions are always in descending order i.e 5.0.0, 3.0.0, 1.0.0 so grabbing the first match suffices
-                            latestVersionResponse.Add(new Hashtable() { { packageName, packageVersionStr } });
+                            latestVersionResponse.Add(GetACRMetadata(registry, packageName, pkgVersion, acrAccessToken, out errRecord));
 
                             break;
                         }
@@ -339,26 +320,9 @@ namespace Microsoft.PowerShell.PSResourceGet
                 return new FindResults(stringResponse: new string[] { }, hashtableResponse: emptyHashResponses, responseType: acrFindResponseType);
             }
 
-            /* response returned looks something like:
-             *   "registry": "myregistry.azurecr.io"
-             *   "imageName": "hello-world"
-             *   "tags": [
-             *     {
-             *       ""name"": ""1.0.0"",
-             *       ""digest"": ""sha256:92c7f9c92844bbbb5d0a101b22f7c2a7949e40f8ea90c8b3bc396879d95e899a"",
-             *       ""createdTime"": ""2023-12-23T18:06:48.9975733Z"",
-             *       ""lastUpdateTime"": ""2023-12-23T18:06:48.9975733Z"",
-             *       ""signed"": false,
-             *       ""changeableAttributes"": {
-             *         ""deleteEnabled"": true,
-             *         ""writeEnabled"": true,
-             *         ""readEnabled"": true,
-             *         ""listEnabled"": true
-             *       }
-             *     }]
-             */
             List<Hashtable> latestVersionResponse = new List<Hashtable>();
             List<JToken> allVersionsList = foundTags["tags"].ToList();
+            allVersionsList.Reverse();
             foreach (var packageVersion in allVersionsList)
             {
                 var packageVersionStr = packageVersion.ToString();
@@ -387,7 +351,7 @@ namespace Microsoft.PowerShell.PSResourceGet
                                 continue;
                             }
 
-                            latestVersionResponse.Add(new Hashtable() { { packageName, packageVersionStr } });
+                            latestVersionResponse.Add(GetACRMetadata(registry, packageName, pkgVersion, acrAccessToken, out errRecord));
                         }
                     }
                 }
@@ -453,59 +417,12 @@ namespace Microsoft.PowerShell.PSResourceGet
             }
 
             _cmdletPassedIn.WriteVerbose("Getting tags");
-            var foundTags = FindAcrImageTags(registry, packageName, requiredVersion.ToString(), acrAccessToken, out errRecord);
-            if (errRecord != null || foundTags == null)
+            List<Hashtable> results = new List<Hashtable>
             {
-                return new FindResults(stringResponse: new string[] { }, hashtableResponse: emptyHashResponses, responseType: acrFindResponseType);
-            }
+                GetACRMetadata(registry, packageName, requiredVersion, acrAccessToken, out errRecord)
+            };
 
-            /* response returned looks something like:
-             *   "registry": "myregistry.azurecr.io"
-             *   "imageName": "hello-world"
-             *   "tags": [
-             *     {
-             *       ""name"": ""1.0.0"",
-             *       ""digest"": ""sha256:92c7f9c92844bbbb5d0a101b22f7c2a7949e40f8ea90c8b3bc396879d95e899a"",
-             *       ""createdTime"": ""2023-12-23T18:06:48.9975733Z"",
-             *       ""lastUpdateTime"": ""2023-12-23T18:06:48.9975733Z"",
-             *       ""signed"": false,
-             *       ""changeableAttributes"": {
-             *         ""deleteEnabled"": true,
-             *         ""writeEnabled"": true,
-             *         ""readEnabled"": true,
-             *         ""listEnabled"": true
-             *       }
-             *     }]
-             */
-            List<Hashtable> requiredVersionResponse = new List<Hashtable>();
-
-            var packageVersionStr = foundTags["tag"].ToString();
-            using (JsonDocument pkgVersionEntry = JsonDocument.Parse(packageVersionStr))
-            {
-                JsonElement rootDom = pkgVersionEntry.RootElement;
-                if (!rootDom.TryGetProperty("name", out JsonElement pkgVersionElement))
-                {
-                    errRecord = new ErrorRecord(
-                        new InvalidOrEmptyResponse($"Response does not contain version element ('name') for package '{packageName}' in '{Repository.Name}'."),
-                        "FindNameFailure",
-                        ErrorCategory.InvalidResult,
-                        this);
-
-                    return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: acrFindResponseType);
-                }
-
-                if (NuGetVersion.TryParse(pkgVersionElement.ToString(), out NuGetVersion pkgVersion))
-                {
-                    _cmdletPassedIn.WriteDebug($"'{packageName}' version parsed as '{pkgVersion}'");
-
-                    if (pkgVersion == requiredVersion)
-                    {
-                        requiredVersionResponse.Add(new Hashtable() { { packageName, packageVersionStr } });
-                    }
-                }
-            }
-
-            return new FindResults(stringResponse: new string[] { }, hashtableResponse: requiredVersionResponse.ToArray(), responseType: acrFindResponseType);
+            return new FindResults(stringResponse: new string[] { }, hashtableResponse: results.ToArray(), responseType: acrFindResponseType);
         }
 
         /// <summary>
@@ -709,6 +626,24 @@ namespace Microsoft.PowerShell.PSResourceGet
 
         internal JObject FindAcrImageTags(string registry, string repositoryName, string version, string acrAccessToken, out ErrorRecord errRecord)
         {
+            /* response returned looks something like:
+             *   "registry": "myregistry.azurecr.io"
+             *   "imageName": "hello-world"
+             *   "tags": [
+             *     {
+             *       ""name"": ""1.0.0"",
+             *       ""digest"": ""sha256:92c7f9c92844bbbb5d0a101b22f7c2a7949e40f8ea90c8b3bc396879d95e899a"",
+             *       ""createdTime"": ""2023-12-23T18:06:48.9975733Z"",
+             *       ""lastUpdateTime"": ""2023-12-23T18:06:48.9975733Z"",
+             *       ""signed"": false,
+             *       ""changeableAttributes"": {
+             *         ""deleteEnabled"": true,
+             *         ""writeEnabled"": true,
+             *         ""readEnabled"": true,
+             *         ""listEnabled"": true
+             *       }
+             *     }]
+             */
             try
             {
                 string resolvedVersion = string.Equals(version, "*", StringComparison.OrdinalIgnoreCase) ? null : $"/{version}";
@@ -719,6 +654,146 @@ namespace Microsoft.PowerShell.PSResourceGet
             catch (HttpRequestException e)
             {
                 throw new HttpRequestException("Error finding ACR artifact: " + e.Message);
+            }
+        }
+
+        internal Hashtable GetACRMetadata(string registry, string packageName, NuGetVersion requiredVersion, string acrAccessToken, out ErrorRecord errRecord)
+        {
+            Hashtable requiredVersionResponse = new Hashtable();
+
+            var foundTags = FindAcrManifest(registry, packageName, requiredVersion.ToNormalizedString(), acrAccessToken, out errRecord);
+            if (errRecord != null || foundTags == null)
+            {
+                return requiredVersionResponse;
+            }
+
+            /*   Response returned looks something like:
+             *    {
+             *     "schemaVersion": 2,
+             *     "config": {
+             *       "mediaType": "application/vnd.unknown.config.v1+json",
+             *       "digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+             *       "size": 0
+             *     },
+             *     "layers": [
+             *       {
+             *         "mediaType": "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip'",
+             *         "digest": "sha256:7c55c7b66cb075628660d8249cc4866f16e34741c246a42ed97fb23ccd4ea956",
+             *         "size": 3533,
+             *         "annotations": {
+             *           "org.opencontainers.image.title": "test_module.1.0.0.nupkg",
+             *           "metadata": "{\"GUID\":\"45219bf4-10a4-4242-92d6-9bfcf79878fd\",\"FunctionsToExport\":[],\"CompanyName\":\"Anam\",\"CmdletsToExport\":[],\"VariablesToExport\":\"*\",\"Author\":\"Anam Navied\",\"ModuleVersion\":\"1.0.0\",\"Copyright\":\"(c) Anam Navied. All rights reserved.\",\"PrivateData\":{\"PSData\":{\"Tags\":[\"Test\",\"CommandsAndResource\",\"Tag2\"]}},\"RequiredModules\":[],\"Description\":\"This is a test module, for PSGallery team internal testing. Do not take a dependency on this package. This version contains tags for the package.\",\"AliasesToExport\":[]}"
+             *         }
+             *       }
+             *     ]
+             *   }
+             */
+
+            var layers = foundTags["layers"];
+            if (layers == null || layers[0] == null)
+            {
+                errRecord = new ErrorRecord(
+                    new InvalidOrEmptyResponse($"Response does not contain 'layers' element in manifest for package '{packageName}' in '{Repository.Name}'."),
+                    "FindNameFailure",
+                    ErrorCategory.InvalidResult,
+                    this);
+
+                return requiredVersionResponse;
+            }
+
+            var annotations = layers[0]["annotations"];
+            if (annotations == null)
+            {
+                errRecord = new ErrorRecord(
+                    new InvalidOrEmptyResponse($"Response does not contain 'annotations' element in manifest for package '{packageName}' in '{Repository.Name}'."),
+                    "FindNameFailure",
+                    ErrorCategory.InvalidResult,
+                    this);
+
+                return requiredVersionResponse;
+            }
+
+            if (annotations["metadata"] == null)
+            {
+                errRecord = new ErrorRecord(
+                    new InvalidOrEmptyResponse($"Response does not contain 'metadata' element in manifest for package '{packageName}' in '{Repository.Name}'."),
+                    "FindNameFailure",
+                    ErrorCategory.InvalidResult,
+                    this);
+
+                return requiredVersionResponse;
+            }
+
+            var metadata = annotations["metadata"].ToString();
+
+
+            var metadataPkgNameJToken = annotations["packageName"];
+            if (metadataPkgNameJToken == null)
+            {
+                errRecord = new ErrorRecord(
+                    new InvalidOrEmptyResponse($"Response does not contain 'packageName' element for package '{packageName}' in '{Repository.Name}'."),
+                    "FindNameFailure",
+                    ErrorCategory.InvalidResult,
+                    this);
+
+                return requiredVersionResponse;
+            }
+
+            string metadataPkgName = metadataPkgNameJToken.ToString();
+            if (string.IsNullOrWhiteSpace(metadataPkgName))
+            {
+                errRecord = new ErrorRecord(
+                    new InvalidOrEmptyResponse($"Response element 'packageName' is empty for package '{packageName}' in '{Repository.Name}'."),
+                    "FindNameFailure",
+                    ErrorCategory.InvalidResult,
+                    this);
+
+                return requiredVersionResponse;
+            }
+
+
+            using (JsonDocument metadataJSONDoc = JsonDocument.Parse(metadata))
+            {
+                JsonElement rootDom = metadataJSONDoc.RootElement;
+                if (!rootDom.TryGetProperty("ModuleVersion", out JsonElement pkgVersionElement) &&
+                     !rootDom.TryGetProperty("Version", out pkgVersionElement))
+                {
+                    errRecord = new ErrorRecord(
+                        new InvalidOrEmptyResponse($"Response does not contain 'ModuleVersion' or 'Version' property in metadata for package '{packageName}' in '{Repository.Name}'."),
+                        "FindNameFailure",
+                        ErrorCategory.InvalidResult,
+                        this);
+
+                    return requiredVersionResponse;
+                }
+
+                if (NuGetVersion.TryParse(pkgVersionElement.ToString(), out NuGetVersion pkgVersion))
+                {
+                    _cmdletPassedIn.WriteDebug($"'{packageName}' version parsed as '{pkgVersion}'");
+
+                    if (pkgVersion == requiredVersion)
+                    {
+                        requiredVersionResponse.Add(metadataPkgName, metadata);
+                    }
+                }
+            }
+
+            return requiredVersionResponse;
+        }
+
+        internal JObject FindAcrManifest(string registry, string packageName, string version, string acrAccessToken, out ErrorRecord errRecord)
+        {
+            try
+            {
+                var createManifestUrl = string.Format(acrManifestUrlTemplate, registry, packageName, version);
+                _cmdletPassedIn.WriteDebug($"GET manifest url:  {createManifestUrl}");
+
+                var defaultHeaders = GetDefaultHeaders(acrAccessToken);
+                return GetHttpResponseJObjectUsingDefaultHeaders(createManifestUrl, HttpMethod.Get, defaultHeaders, out errRecord);
+            }
+            catch (HttpRequestException e)
+            {
+                throw new HttpRequestException("Error finding ACR manifest: " + e.Message);
             }
         }
 
@@ -1113,7 +1188,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             FileInfo nupkgFile = new FileInfo(fullNupkgFile);
             var fileSize = nupkgFile.Length;
             var fileName = System.IO.Path.GetFileName(fullNupkgFile);
-            string fileContent = CreateJsonContent(nupkgDigest, configDigest, fileSize, fileName, jsonString);
+            string fileContent = CreateJsonContent(nupkgDigest, configDigest, fileSize, fileName, pkgName, jsonString);
             File.WriteAllText(configFilePath, fileContent);
 
             _cmdletPassedIn.WriteVerbose("Create the manifest layer");
@@ -1130,7 +1205,8 @@ namespace Microsoft.PowerShell.PSResourceGet
             string nupkgDigest, 
             string configDigest, 
             long nupkgFileSize, 
-            string fileName, 
+            string fileName,
+            string packageName,
             string jsonString)
         {
             StringBuilder stringBuilder = new StringBuilder();
@@ -1168,6 +1244,8 @@ namespace Microsoft.PowerShell.PSResourceGet
             jsonWriter.WriteStartObject();
             jsonWriter.WritePropertyName("org.opencontainers.image.title");
             jsonWriter.WriteValue(fileName);
+            jsonWriter.WritePropertyName("packageName");
+            jsonWriter.WriteValue(packageName);
             jsonWriter.WritePropertyName("metadata");
             jsonWriter.WriteValue(jsonString);
             jsonWriter.WriteEndObject();


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR takes the metadata json string stored in `annotations` and populates it into PSResourceInfo object.
eg:
![image](https://github.com/PowerShell/PSResourceGet/assets/25858831/533f98c7-86f1-4f20-8dbe-e59a6cbec2f5)

A small change was made to `Publish-PSResource` as well-- it now pushes `org.opencontainers.image.title` (the package name) and `org.opencontainers.image.description` (the full .nupkg name) to `annotations`.  See [documentation on naming conventions](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc4/annotations.md#pre-defined-annotation-keys). 

![image](https://github.com/PowerShell/PSResourceGet/assets/25858831/e8d4145b-e144-46e4-b43a-d7d576399d21)

Note: the only way to retrieve `annotations` is to make a call to pull the manifest (ie GET request for a specific tag will not return layers, therefore will not return `annotations`).  See: [manifest response](https://learn.microsoft.com/en-us/rest/api/containerregistry/manifests/get?view=rest-containerregistry-2019-08-15&tabs=HTTP) vs [tag response](https://learn.microsoft.com/en-us/rest/api/containerregistry/tag/get-list?view=rest-containerregistry-2019-08-15&tabs=HTTP)

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
