### PR TITLE
Bug fix for Update-PSResource not updating from correct repository

### DIFF
--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -321,6 +321,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 latestInstalledIsPrerelease = true;
             }
 
+            // Update from the repository where the package was previously installed from.
+            // If user explicitly specifies a repository to update from, use that instead.
+            if (Repository == null)
+            {
+                Repository = new String[] { installedPackages.First().Value.Repository };
+
+                WriteDebug($"Updating from repository '{string.Join(", ", Repository)}");
+            }
+
             // Find all packages selected for updating in provided repositories.
             var repositoryPackages = new Dictionary<string, PSResourceInfo>(StringComparer.InvariantCultureIgnoreCase);
             foreach (var foundResource in _findHelper.FindByResourceName(

--- a/test/UpdatePSResourceTests/UpdatePSResourceLocalTests.ps1
+++ b/test/UpdatePSResourceTests/UpdatePSResourceLocalTests.ps1
@@ -10,6 +10,7 @@ Describe 'Test Update-PSResource for local repositories' -tags 'CI' {
 
     BeforeAll {
         $localRepo = "psgettestlocal"
+        $localRepo2 = "psgettestlocal2"
         $moduleName = "test_local_mod"
         $moduleName2 = "test_local_mod2"
         Get-NewPSResourceRepositoryFile
@@ -20,6 +21,9 @@ Describe 'Test Update-PSResource for local repositories' -tags 'CI' {
         Get-ModuleResourcePublishedToLocalRepoTestDrive $moduleName $localRepo "5.0.0"
         Get-ModuleResourcePublishedToLocalRepoTestDrive $moduleName2 $localRepo "1.0.0"
         Get-ModuleResourcePublishedToLocalRepoTestDrive $moduleName2 $localRepo "5.0.0"
+
+        Get-ModuleResourcePublishedToLocalRepoTestDrive $moduleName $localRepo2 "1.0.0"
+        Get-ModuleResourcePublishedToLocalRepoTestDrive $moduleName $localRepo2 "5.0.0"
     }
 
     AfterEach {
@@ -46,6 +50,31 @@ Describe 'Test Update-PSResource for local repositories' -tags 'CI' {
         }
 
         $isPkgUpdated | Should -Be $true
+    }
+
+    It "Update resource from the repository which package was previously from" {
+        Install-PSResource -Name $moduleName -Version "1.0.0" -Repository $localRepo2 -TrustRepository
+
+        Update-PSResource -Name $moduleName -TrustRepository
+        $res = Get-InstalledPSResource -Name $moduleName
+
+        $isPkgUpdated = $false
+        $isCorrectRepo = $false
+        foreach ($pkg in $res)
+        {
+            if ([System.Version]$pkg.Version -gt [System.Version]"1.0.0")
+            {
+                $isPkgUpdated = $true
+
+                if ($pkg.Repository -eq $localRepo2)
+                {
+                    $isCorrectRepo = $true
+                }
+            }
+        }
+
+        $isPkgUpdated | Should -Be $true
+        $isCorrectRepo | Should -Be $true
     }
 
     It "Update resources installed given Name (with wildcard) parameter" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR fixes a bug with `Update-PSResource` where it was not installing from the repository which the previous installation for the lower version had been installed from.  `Update` now looks at the `Repository` property after retrieving installed version and installs from that repository.  The `-Repository` parameter still takes precedence, so if a user passes in a value there, that will be the repository `update` uses.
 
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1521 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
