### PR TITLE
ACR package name should be lowercase when creating ACR urls

### DIFF
--- a/src/code/ACRServerAPICalls.cs
+++ b/src/code/ACRServerAPICalls.cs
@@ -1106,8 +1106,8 @@ namespace Microsoft.PowerShell.PSResourceGet
         {
             errRecord = null;
             // Push the nupkg to the appropriate repository
-            var fullNupkgFile = System.IO.Path.Combine(outputNupkgDir, pkgName + "." + pkgVersion.ToNormalizedString() + ".nupkg");
-
+            string fullNupkgFile = System.IO.Path.Combine(outputNupkgDir, pkgName + "." + pkgVersion.ToNormalizedString() + ".nupkg");
+            string pkgNameLower = pkgName.ToLower();
             string accessToken = string.Empty;
             string tenantID = string.Empty;
 
@@ -1136,7 +1136,8 @@ namespace Microsoft.PowerShell.PSResourceGet
 
             /* Uploading .nupkg */
             _cmdletPassedIn.WriteVerbose("Start uploading blob");
-            var moduleLocation = GetStartUploadBlobLocation(registry, pkgName, acrAccessToken).Result;
+            // Note:  ACR registries will only accept a name that is all lowercase.
+            var moduleLocation = GetStartUploadBlobLocation(registry, pkgNameLower, acrAccessToken).Result;
 
             _cmdletPassedIn.WriteVerbose("Computing digest for .nupkg file");
             bool nupkgDigestCreated = CreateDigest(fullNupkgFile, out string nupkgDigest, out ErrorRecord nupkgDigestError);
@@ -1159,7 +1160,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             }
             using (FileStream configStream = new FileStream(emptyFilePath, FileMode.Create)){ }
             _cmdletPassedIn.WriteVerbose("Start uploading an empty file");
-            var emptyLocation = GetStartUploadBlobLocation(registry, pkgName, acrAccessToken).Result;
+            var emptyLocation = GetStartUploadBlobLocation(registry, pkgNameLower, acrAccessToken).Result;
             _cmdletPassedIn.WriteVerbose("Computing digest for empty file");
             bool emptyDigestCreated = CreateDigest(emptyFilePath, out string emptyDigest, out ErrorRecord emptyDigestError);
             if (!emptyDigestCreated)
@@ -1200,7 +1201,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             File.WriteAllText(configFilePath, fileContent);
 
             _cmdletPassedIn.WriteVerbose("Create the manifest layer");
-            bool manifestCreated = CreateManifest(registry, pkgName, pkgVersion.OriginalVersion, configFilePath, true, acrAccessToken).Result;
+            bool manifestCreated = CreateManifest(registry, pkgNameLower, pkgVersion.OriginalVersion, configFilePath, true, acrAccessToken).Result;
 
             if (manifestCreated)
             {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
ACR only accepts packages with lowercase names.  When uploading blobs to ACR server, the package name should be lowercase (ie ACR will read the package name as being lowercase).  The annotations (metadata) will keep the original casing of the package.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
