### PR TITLE
Add User-Agent string to identity psresourceget in telemetry

### DIFF
--- a/src/code/ACRServerAPICalls.cs
+++ b/src/code/ACRServerAPICalls.cs
@@ -596,7 +596,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             var contentHeaders = new Collection<KeyValuePair<string, string>> { new KeyValuePair<string, string>("Content-Type", "application/x-www-form-urlencoded") };
             string exchangeUrl = string.Format(acrOAuthExchangeUrlTemplate, registry);
             var results = GetHttpResponseJObjectUsingContentHeaders(exchangeUrl, HttpMethod.Post, content, contentHeaders, out errRecord);
-            
+
             if (results != null && results["refresh_token"] != null)
             {
                 return results["refresh_token"].ToString();
@@ -613,7 +613,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             var results = GetHttpResponseJObjectUsingContentHeaders(tokenUrl, HttpMethod.Post, content, contentHeaders, out errRecord);
 
             if (results != null && results["access_token"] != null)
-            { 
+            {
                 return results["access_token"].ToString();
             }
 
@@ -706,7 +706,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             if (exception != null)
             {
                 errRecord = new ErrorRecord(exception, "FindNameFailure", ErrorCategory.InvalidResult, this);
-                
+
                 return requiredVersionResponse;
             }
 
@@ -749,7 +749,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             if (layers == null || layers[0] == null)
             {
                 exception = new InvalidOrEmptyResponse($"Response does not contain 'layers' element in manifest for package '{packageName}' in '{Repository.Name}'.");
-                  
+
                 return emptyTuple;
             }
 
@@ -757,14 +757,14 @@ namespace Microsoft.PowerShell.PSResourceGet
             if (annotations == null)
             {
                 exception = new InvalidOrEmptyResponse($"Response does not contain 'annotations' element in manifest for package '{packageName}' in '{Repository.Name}'.");
-                    
+
                 return emptyTuple;
             }
 
             if (annotations["metadata"] == null)
             {
                 exception = new InvalidOrEmptyResponse($"Response does not contain 'metadata' element in manifest for package '{packageName}' in '{Repository.Name}'.");
-                    
+
                 return emptyTuple;
             }
 
@@ -774,7 +774,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             if (metadataPkgTitleJToken == null)
             {
                 exception = new InvalidOrEmptyResponse($"Response does not contain 'org.opencontainers.image.title' element for package '{packageName}' in '{Repository.Name}'.");
-                  
+
                 return emptyTuple;
             }
 
@@ -782,7 +782,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             if (string.IsNullOrWhiteSpace(metadataPkgName))
             {
                 exception = new InvalidOrEmptyResponse($"Response element 'org.opencontainers.image.title' is empty for package '{packageName}' in '{Repository.Name}'.");
-                   
+
                 return emptyTuple;
             }
 
@@ -929,6 +929,7 @@ namespace Microsoft.PowerShell.PSResourceGet
                     }
                 }
 
+                request.Headers.Add("User-Agent", "PowerShellResourceGet/1.1.0");
                 return SendRequestAsync(request).GetAwaiter().GetResult();
             }
             catch (ResourceNotFoundException e)
@@ -1002,6 +1003,12 @@ namespace Microsoft.PowerShell.PSResourceGet
                     }
                 }
             }
+
+            // Add User-Agent string for the request
+            if (!s_client.DefaultRequestHeaders.Contains("User-Agent"))
+            {
+                s_client.DefaultRequestHeaders.Add("User-Agent", "PowerShellResourceGet/1.1.0");
+            }
         }
 
         private static async Task<HttpContent> SendContentRequestAsync(HttpRequestMessage message)
@@ -1022,6 +1029,12 @@ namespace Microsoft.PowerShell.PSResourceGet
         {
             try
             {
+                // Add User-Agent string for the request
+                if (!message.Headers.Contains("User-Agent"))
+                {
+                    message.Headers.Add("User-Agent", "PowerShellResourceGet/1.1.0");
+                }
+
                 HttpResponseMessage response = await s_client.SendAsync(message);
 
                 switch (response.StatusCode)
@@ -1211,9 +1224,9 @@ namespace Microsoft.PowerShell.PSResourceGet
         }
 
         private string CreateJsonContent(
-            string nupkgDigest, 
-            string configDigest, 
-            long nupkgFileSize, 
+            string nupkgDigest,
+            string configDigest,
+            long nupkgFileSize,
             string fileName,
             string packageName,
             string jsonString)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add User-Agent header to ACR calls so we can get telemetry for usage
## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
