### PR TITLE
ACR: Ensure versions returned are sorted and can be correctly compared if number of trailing zeroes differ

### DIFF
--- a/src/code/ACRServerAPICalls.cs
+++ b/src/code/ACRServerAPICalls.cs
@@ -154,9 +154,9 @@ namespace Microsoft.PowerShell.PSResourceGet
             List<JToken> allVersionsList = foundTags["tags"].ToList();
 
             SortedDictionary<NuGet.Versioning.SemanticVersion, string> sortedQualifyingPkgs = GetPackagesWithRequiredVersion(allVersionsList, VersionType.VersionRange, VersionRange.All, specificVersion: null, packageName, includePrerelease, out errRecord);
-            foreach(KeyValuePair<NuGet.Versioning.SemanticVersion, string> s in sortedQualifyingPkgs.Reverse())
+            foreach(KeyValuePair<NuGet.Versioning.SemanticVersion, string> pkgVersionTag in sortedQualifyingPkgs.Reverse())
             {
-                string exactTagVersion = s.Value.ToString();
+                string exactTagVersion = pkgVersionTag.Value.ToString();
                 Hashtable metadata = GetACRMetadata(Registry, packageNameLowercase, exactTagVersion, acrAccessToken, out errRecord);
                 if (errRecord != null || metadata.Count == 0)
                 {
@@ -260,9 +260,9 @@ namespace Microsoft.PowerShell.PSResourceGet
             List<Hashtable> latestVersionResponse = new List<Hashtable>();
             List<JToken> allVersionsList = foundTags["tags"].ToList();
             SortedDictionary<NuGet.Versioning.SemanticVersion, string> sortedQualifyingPkgs = GetPackagesWithRequiredVersion(allVersionsList, VersionType.VersionRange, versionRange, specificVersion: null, packageName, includePrerelease, out errRecord);
-            foreach(KeyValuePair<NuGet.Versioning.SemanticVersion, string> s in sortedQualifyingPkgs.Reverse())
+            foreach(KeyValuePair<NuGet.Versioning.SemanticVersion, string> pkgVersionTag in sortedQualifyingPkgs.Reverse())
             {
-                string exactTagVersion = s.Value.ToString();
+                string exactTagVersion = pkgVersionTag.Value.ToString();
                 Hashtable metadata = GetACRMetadata(Registry, packageName.ToLower(), exactTagVersion, acrAccessToken, out errRecord);
                 if (errRecord != null || metadata.Count == 0)
                 {
@@ -320,9 +320,9 @@ namespace Microsoft.PowerShell.PSResourceGet
             List<JToken> allVersionsList = foundTags["tags"].ToList();
 
             SortedDictionary<NuGet.Versioning.SemanticVersion, string> sortedQualifyingPkgs = GetPackagesWithRequiredVersion(allVersionsList, VersionType.SpecificVersion, VersionRange.All, requiredVersion, packageName, includePrereleaseVersions, out errRecord);
-            foreach(KeyValuePair<NuGet.Versioning.SemanticVersion, string> s in sortedQualifyingPkgs.Reverse())
+            foreach(KeyValuePair<NuGet.Versioning.SemanticVersion, string> pkgVersionTag in sortedQualifyingPkgs.Reverse())
             {
-                string exactTagVersion = s.Value.ToString();
+                string exactTagVersion = pkgVersionTag.Value.ToString();
                 Hashtable metadata = GetACRMetadata(Registry, packageNameLowercase, exactTagVersion, acrAccessToken, out errRecord);
                 if (errRecord != null || metadata.Count == 0)
                 {

--- a/src/code/ACRServerAPICalls.cs
+++ b/src/code/ACRServerAPICalls.cs
@@ -154,7 +154,9 @@ namespace Microsoft.PowerShell.PSResourceGet
             List<JToken> allVersionsList = foundTags["tags"].ToList();
 
             SortedDictionary<NuGet.Versioning.SemanticVersion, string> sortedQualifyingPkgs = GetPackagesWithRequiredVersion(allVersionsList, VersionType.VersionRange, VersionRange.All, specificVersion: null, packageName, includePrerelease, out errRecord);
-            foreach(KeyValuePair<NuGet.Versioning.SemanticVersion, string> pkgVersionTag in sortedQualifyingPkgs.Reverse())
+            var pkgsInDescendingOrder = sortedQualifyingPkgs.Reverse();
+
+            foreach(var pkgVersionTag in pkgsInDescendingOrder)
             {
                 string exactTagVersion = pkgVersionTag.Value.ToString();
                 Hashtable metadata = GetACRMetadata(Registry, packageNameLowercase, exactTagVersion, acrAccessToken, out errRecord);
@@ -260,7 +262,9 @@ namespace Microsoft.PowerShell.PSResourceGet
             List<Hashtable> latestVersionResponse = new List<Hashtable>();
             List<JToken> allVersionsList = foundTags["tags"].ToList();
             SortedDictionary<NuGet.Versioning.SemanticVersion, string> sortedQualifyingPkgs = GetPackagesWithRequiredVersion(allVersionsList, VersionType.VersionRange, versionRange, specificVersion: null, packageName, includePrerelease, out errRecord);
-            foreach(KeyValuePair<NuGet.Versioning.SemanticVersion, string> pkgVersionTag in sortedQualifyingPkgs.Reverse())
+            var pkgsInDescendingOrder = sortedQualifyingPkgs.Reverse();
+
+            foreach(var pkgVersionTag in pkgsInDescendingOrder)
             {
                 string exactTagVersion = pkgVersionTag.Value.ToString();
                 Hashtable metadata = GetACRMetadata(Registry, packageName.ToLower(), exactTagVersion, acrAccessToken, out errRecord);
@@ -320,7 +324,9 @@ namespace Microsoft.PowerShell.PSResourceGet
             List<JToken> allVersionsList = foundTags["tags"].ToList();
 
             SortedDictionary<NuGet.Versioning.SemanticVersion, string> sortedQualifyingPkgs = GetPackagesWithRequiredVersion(allVersionsList, VersionType.SpecificVersion, VersionRange.All, requiredVersion, packageName, includePrereleaseVersions, out errRecord);
-            foreach(KeyValuePair<NuGet.Versioning.SemanticVersion, string> pkgVersionTag in sortedQualifyingPkgs.Reverse())
+            var pkgsInDescendingOrder = sortedQualifyingPkgs.Reverse();
+
+            foreach(var pkgVersionTag in pkgsInDescendingOrder)
             {
                 string exactTagVersion = pkgVersionTag.Value.ToString();
                 Hashtable metadata = GetACRMetadata(Registry, packageNameLowercase, exactTagVersion, acrAccessToken, out errRecord);
@@ -1710,8 +1716,9 @@ namespace Microsoft.PowerShell.PSResourceGet
                     {
                         if (pkgVersion.ToNormalizedString() == specificVersion.ToNormalizedString())
                         {
-                            NuGet.Versioning.SemanticVersion semanticVersionOfPkg = new SemanticVersion(pkgVersion.Major, pkgVersion.Minor, pkgVersion.Patch, pkgVersion.IsPrerelease ? pkgVersion.Release: String.Empty);
-                            sortedPkgs.Add(semanticVersionOfPkg, pkgVersionElement.ToString());
+                            // NuGet.Versioning.SemanticVersion semanticVersionOfPkg = new SemanticVersion(pkgVersion.Major, pkgVersion.Minor, pkgVersion.Patch, pkgVersion.IsPrerelease ? pkgVersion.Release: String.Empty);
+                            // sortedPkgs.Add(semanticVersionOfPkg, pkgVersionElement.ToString());
+                            sortedPkgs.Add(pkgVersion, pkgVersionElement.ToString());
                             break;
                         }
                     }
@@ -1719,8 +1726,9 @@ namespace Microsoft.PowerShell.PSResourceGet
                     {
                         if (versionRange.Satisfies(pkgVersion) && (!pkgVersion.IsPrerelease || includePrerelease))
                         {
-                            NuGet.Versioning.SemanticVersion semanticVersionOfPkg = new SemanticVersion(pkgVersion.Major, pkgVersion.Minor, pkgVersion.Patch, pkgVersion.IsPrerelease ? pkgVersion.Release: String.Empty);
-                            sortedPkgs.Add(semanticVersionOfPkg, pkgVersionElement.ToString());
+                            // NuGet.Versioning.SemanticVersion semanticVersionOfPkg = new SemanticVersion(pkgVersion.Major, pkgVersion.Minor, pkgVersion.Patch, pkgVersion.IsPrerelease ? pkgVersion.Release: String.Empty);
+                            // sortedPkgs.Add(semanticVersionOfPkg, pkgVersionElement.ToString());
+                            sortedPkgs.Add(pkgVersion, pkgVersionElement.ToString());
                         }
                     }
 

--- a/src/code/ACRServerAPICalls.cs
+++ b/src/code/ACRServerAPICalls.cs
@@ -1612,7 +1612,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             List<Hashtable> latestVersionResponse = new List<Hashtable>();
             List<JToken> allVersionsList = foundTags["tags"].ToList();
 
-            SortedDictionary<NuGet.Versioning.SemanticVersion, string> sortedQualifyingPkgs = GetPackagesWithRequiredVersion(allVersionsList, versionType, versionRange, requiredVersion, packageNameLowercase, includePrerelease, getOnlyLatest, out errRecord);
+            SortedDictionary<NuGet.Versioning.SemanticVersion, string> sortedQualifyingPkgs = GetPackagesWithRequiredVersion(allVersionsList, versionType, versionRange, requiredVersion, packageNameLowercase, includePrerelease, out errRecord);
             if (errRecord != null)
             {
                 return emptyHashResponses;
@@ -1630,12 +1630,17 @@ namespace Microsoft.PowerShell.PSResourceGet
                 }
 
                 latestVersionResponse.Add(metadata);
+                if (getOnlyLatest)
+                {
+                    // getOnlyLatest will be true for FindName(), as only the latest criteria satisfying version should be returned
+                    break;
+                }
             }   
 
             return latestVersionResponse.ToArray();
         }
 
-        private SortedDictionary<NuGet.Versioning.SemanticVersion, string> GetPackagesWithRequiredVersion(List<JToken> allPkgVersions, VersionType versionType, VersionRange versionRange, NuGetVersion specificVersion, string packageName, bool includePrerelease, bool getOnlyLatest, out ErrorRecord errRecord)
+        private SortedDictionary<NuGet.Versioning.SemanticVersion, string> GetPackagesWithRequiredVersion(List<JToken> allPkgVersions, VersionType versionType, VersionRange versionRange, NuGetVersion specificVersion, string packageName, bool includePrerelease, out ErrorRecord errRecord)
         {
             errRecord = null;
             // we need NuGetVersion to sort versions by order, and string pkgVersionString (which is the exact tag from the server) to call GetACRMetadata() later with exact version tag.
@@ -1688,11 +1693,6 @@ namespace Microsoft.PowerShell.PSResourceGet
                         {
                             // accounts for FindVersionGlobbing() and FindName() scenario
                             sortedPkgs.Add(pkgVersion, pkgVersionString);
-                            if (getOnlyLatest)
-                            {
-                                // getOnlyLatest will be true for FindName(), as only the latest criteria satisfying version should be returned
-                                break;
-                            }
                         }
                     }
                 }

--- a/src/code/ACRServerAPICalls.cs
+++ b/src/code/ACRServerAPICalls.cs
@@ -154,11 +154,6 @@ namespace Microsoft.PowerShell.PSResourceGet
             List<JToken> allVersionsList = foundTags["tags"].ToList();
 
             SortedDictionary<NuGet.Versioning.SemanticVersion, string> sortedQualifyingPkgs = GetPackagesWithRequiredVersion(allVersionsList, VersionType.VersionRange, VersionRange.All, specificVersion: null, packageName, includePrerelease, out errRecord);
-            if (sortedQualifyingPkgs.Count == 0)
-            {
-                Console.WriteLine("Empty");
-            }
-
             foreach(KeyValuePair<NuGet.Versioning.SemanticVersion, string> s in sortedQualifyingPkgs.Reverse())
             {
                 string exactTagVersion = s.Value.ToString();
@@ -265,11 +260,6 @@ namespace Microsoft.PowerShell.PSResourceGet
             List<Hashtable> latestVersionResponse = new List<Hashtable>();
             List<JToken> allVersionsList = foundTags["tags"].ToList();
             SortedDictionary<NuGet.Versioning.SemanticVersion, string> sortedQualifyingPkgs = GetPackagesWithRequiredVersion(allVersionsList, VersionType.VersionRange, versionRange, specificVersion: null, packageName, includePrerelease, out errRecord);
-            if (sortedQualifyingPkgs.Count == 0)
-            {
-                Console.WriteLine("Empty");
-            }
-
             foreach(KeyValuePair<NuGet.Versioning.SemanticVersion, string> s in sortedQualifyingPkgs.Reverse())
             {
                 string exactTagVersion = s.Value.ToString();
@@ -330,11 +320,6 @@ namespace Microsoft.PowerShell.PSResourceGet
             List<JToken> allVersionsList = foundTags["tags"].ToList();
 
             SortedDictionary<NuGet.Versioning.SemanticVersion, string> sortedQualifyingPkgs = GetPackagesWithRequiredVersion(allVersionsList, VersionType.SpecificVersion, VersionRange.All, requiredVersion, packageName, includePrereleaseVersions, out errRecord);
-            if (sortedQualifyingPkgs.Count == 0)
-            {
-                Console.WriteLine("Empty");
-            }
-
             foreach(KeyValuePair<NuGet.Versioning.SemanticVersion, string> s in sortedQualifyingPkgs.Reverse())
             {
                 string exactTagVersion = s.Value.ToString();

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -827,6 +827,8 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             {
                 Hashtable metadata = new Hashtable(StringComparer.InvariantCultureIgnoreCase);
                 JsonElement rootDom = packageMetadata.RootElement;
+                metadata["IsPrerelease"] = false;
+                metadata["Prerelease"] = String.Empty;
 
                 // Version
                 // For scripts (i.e with "Version" property) the version can contain prerelease label

--- a/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
@@ -84,7 +84,7 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         # FindName()
         $res = Find-PSResource -Name $testModuleName -Repository $ACRRepoName -Prerelease
         $res.Name | Should -Be $testModuleName
-        $resPrerelease.Version | Should -Be "5.0.0"
+        $resPrerelease.Version | Should -Be "5.2.5"
         $resPrerelease.Prerelease | Should -Be "alpha001"
     }
 
@@ -95,7 +95,7 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $res.Version | Should -Be "5.0.0"
 
         $resPrerelease = Find-PSResource -Name $testModuleName -Prerelease -Repository $ACRRepoName
-        $resPrerelease.Version | Should -Be "5.0.0"
+        $resPrerelease.Version | Should -Be "5.2.5"
         $resPrerelease.Prerelease | Should -Be "alpha001"
     }
 

--- a/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
@@ -80,7 +80,6 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $res.Count | Should -BeGreaterOrEqual 1
     }
 
-    <# TODO: prerelease handling not yet implemented in ACR Server Protocol
     It "Find resource given specific Name, Version null but allowing Prerelease" {
         # FindName()
         $res = Find-PSResource -Name $testModuleName -Repository $ACRRepoName -Prerelease
@@ -105,7 +104,6 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $resWithPrerelease = Find-PSResource -Name $testModuleName -Version "*" -Repository $ACRRepoName -Prerelease
         $resWithPrerelease.Count | Should -BeGreaterOrEqual $resWithoutPrerelease.Count
     }
-    #>
 
     It "Should not find resource if Name, Version and Tag property are not all satisfied (single tag)" {
         # FindVersionWithTag()

--- a/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
@@ -84,8 +84,8 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         # FindName()
         $res = Find-PSResource -Name $testModuleName -Repository $ACRRepoName -Prerelease
         $res.Name | Should -Be $testModuleName
-        $resPrerelease.Version | Should -Be "5.2.5"
-        $resPrerelease.Prerelease | Should -Be "alpha001"
+        $res.Version | Should -Be "5.2.5"
+        $res.Prerelease | Should -Be "alpha001"
     }
 
     It "Find resource with latest (including prerelease) version given Prerelease parameter" {
@@ -157,11 +157,29 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $res.Version | Should -Be "2.0.0"
     }
 
+    It "Should find script given Name and Prerelease" {
+        # latest version is a prerelease version
+        $res = Find-PSResource -Name $testScript -Prerelease -Repository $ACRRepoName
+        $res | Should -Not -BeNullOrEmpty
+        $res.Name | Should -BeExactly $testScript
+        $res.Version | Should -Be "3.5.0"
+        $res.Prerelease | Should -Be "alpha"
+    }
+
     It "Should find script given Name and Version" {
         # FindVersion()
         $res = Find-PSResource -Name $testScript -Version "1.0.0" -Repository $ACRRepoName
         $res | Should -Not -BeNullOrEmpty
         $res.Name | Should -BeExactly $testScript
         $res.Version | Should -Be "1.0.0"
+    }
+
+    It "Should find script given Name, Version and Prerelease" {
+        # latest version is a prerelease version
+        $res = Find-PSResource -Name $testScript -Version "3.5.0-alpha" -Prerelease -Repository $ACRRepoName
+        $res | Should -Not -BeNullOrEmpty
+        $res.Name | Should -BeExactly $testScript
+        $res.Version | Should -Be "3.5.0"
+        $res.Prerelease | Should -Be "alpha"
     }
 }

--- a/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
@@ -84,7 +84,8 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         # FindName()
         $res = Find-PSResource -Name $testModuleName -Repository $ACRRepoName -Prerelease
         $res.Name | Should -Be $testModuleName
-        $res.Version | Should -Be "5.0.0-alpha001"
+        $resPrerelease.Version | Should -Be "5.0.0"
+        $resPrerelease.Prerelease | Should -Be "alpha001"
     }
 
     It "Find resource with latest (including prerelease) version given Prerelease parameter" {

--- a/test/InstallPSResourceTests/InstallPSResourceACRServer.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceACRServer.Tests.ps1
@@ -130,7 +130,6 @@ Describe 'Test Install-PSResource for ACR scenarios' -tags 'CI' {
         $pkg.Version | Should -Be "5.0.0"
     }
 
-    <# TODO: enable when prerelease functionality is implemented
     It "Install resource with latest (including prerelease) version given Prerelease parameter" {
         Install-PSResource -Name $testModuleName -Prerelease -Repository $ACRRepoName -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
@@ -138,7 +137,6 @@ Describe 'Test Install-PSResource for ACR scenarios' -tags 'CI' {
         $pkg.Version | Should -Be "5.2.5"
         $pkg.Prerelease | Should -Be "alpha001"
     }
-    #>
 
     It "Install resource via InputObject by piping from Find-PSresource" {
         Find-PSResource -Name $testModuleName -Repository $ACRRepoName | Install-PSResource -TrustRepository

--- a/test/PublishPSResourceTests/PublishPSResourceACRServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceACRServer.Tests.ps1
@@ -373,7 +373,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
 
     It "Should publish a script without lines in between comment blocks locally" {
         $scriptName = "ScriptWithoutEmptyLinesBetweenCommentBlocks"
-        $scriptVersion = "1.0.0"
+        $scriptVersion = "1.0"
         $scriptPath = (Join-Path -Path $script:testScriptsFolderPath -ChildPath "$scriptName.ps1")
 
         Publish-PSResource -Path $scriptPath -Repository $ACRRepoName
@@ -386,7 +386,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
 
     It "Should publish a script without lines in help block locally" {
         $scriptName = "ScriptWithoutEmptyLinesInMetadata"
-        $scriptVersion = "1.0.0"
+        $scriptVersion = "1.0"
         $scriptPath = (Join-Path -Path $script:testScriptsFolderPath -ChildPath "$scriptName.ps1")
 
         Publish-PSResource -Path $scriptPath -Repository $ACRRepoName

--- a/test/PublishPSResourceTests/PublishPSResourceACRServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceACRServer.Tests.ps1
@@ -371,7 +371,6 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $results[0].Version | Should -Be $scriptVersion
     }
 
-    <# This test does not work currently due to a bug if the last digit is 0. Link to issue: https://github.com/PowerShell/PSResourceGet/issues/1582
     It "Should publish a script without lines in between comment blocks locally" {
         $scriptName = "ScriptWithoutEmptyLinesBetweenCommentBlocks"
         $scriptVersion = "1.0.0"
@@ -384,9 +383,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $results[0].Name | Should -Be $scriptName
         $results[0].Version | Should -Be $scriptVersion
     }
-    #>
 
-    <# This test does not work currently due to a bug if the last digit is 0. Link to issue: https://github.com/PowerShell/PSResourceGet/issues/1582
     It "Should publish a script without lines in help block locally" {
         $scriptName = "ScriptWithoutEmptyLinesInMetadata"
         $scriptVersion = "1.0.0"
@@ -399,7 +396,6 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $results[0].Name | Should -Be $scriptName
         $results[0].Version | Should -Be $scriptVersion
     }
-    #>
 
     It "Should publish a script with ExternalModuleDependencies that are not published" {
         $scriptName = "ScriptWithExternalDependencies"


### PR DESCRIPTION
Versions stored in ACR are not present in numerical order, instead they use chronological order of when the repository tag (i.e version in our context) is published. This PR sorts tags (i.e versions) returned in FindACRImageTags().

The tag is a string, but we use it for version and version can be a NuGetVersion that may have different number of trailing 0's but the normalized version would be the same. So if a version "1.0.0" is published, the user input of version "1.0" or "1.0.0.0" should also match it but previously did not. This PR fixes this by finding the exact tag (i.e version) from the server and using that when we call GetACRMetadata().

Also add support for prerelease versions.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1581 #1582 #1584
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
