### PR TITLE
ACR - Update `PSRepositoryInfo.APIVersion` to replace `acr` with `ContainerRegistry`

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -956,7 +956,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // After retrieving all packages find their dependencies
             if (_includeDependencies)
             {
-                if (currentServer.Repository.ApiVersion == PSRepositoryInfo.APIVersion.v3)
+                if (currentServer.Repository.ApiVersion == PSRepositoryInfo.APIVersion.V3)
                 {
                     _cmdletPassedIn.WriteWarning("Installing dependencies is not currently supported for V3 server protocol repositories. The package will be installed without installing dependencies.");
                     yield break;

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -315,7 +315,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
 
                 repositoryNamesToSearch.Add(repoName);
-                if ((currentRepository.ApiVersion == PSRepositoryInfo.APIVersion.v3) && (!installDepsForRepo))
+                if ((currentRepository.ApiVersion == PSRepositoryInfo.APIVersion.V3) && (!installDepsForRepo))
                 {
                     _cmdletPassedIn.WriteWarning("Installing dependencies is not currently supported for V3 server protocol repositories. The package will be installed without installing dependencies.");
                     installDepsForRepo = true;
@@ -598,7 +598,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                     if (!skipDependencyCheck)
                     {
-                        if (currentServer.Repository.ApiVersion == PSRepositoryInfo.APIVersion.v3)
+                        if (currentServer.Repository.ApiVersion == PSRepositoryInfo.APIVersion.V3)
                         {
                             _cmdletPassedIn.WriteWarning("Installing dependencies is not currently supported for V3 server protocol repositories. The package will be installed without installing dependencies.");
                         }

--- a/src/code/PSRepositoryInfo.cs
+++ b/src/code/PSRepositoryInfo.cs
@@ -15,12 +15,12 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
         public enum APIVersion
         {
-            unknown,
-            v2,
-            v3,
-            local,
-            nugetServer,
-            acr
+            Unknown,
+            V2,
+            V3,
+            Local,
+            NugetServer,
+            ContainerRegistry
         }
 
         #endregion

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -494,7 +494,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 string repositoryUri = repository.Uri.AbsoluteUri;
 
-                if (repository.ApiVersion == PSRepositoryInfo.APIVersion.acr)
+                if (repository.ApiVersion == PSRepositoryInfo.APIVersion.ContainerRegistry)
                 {
                     ACRServerAPICalls acrServer = new ACRServerAPICalls(repository, this, _networkCredential, userAgentString);
 

--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -339,11 +339,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (repo.ContainsKey("ApiVersion") && 
                 (repo["ApiVersion"] == null || String.IsNullOrEmpty(repo["ApiVersion"].ToString()) ||
-                !(repo["ApiVersion"].ToString().Equals("local") || repo["ApiVersion"].ToString().Equals("v2") || 
-                repo["ApiVersion"].ToString().Equals("v3") || repo["ApiVersion"].ToString().Equals("nugetServer") || repo["ApiVersion"].ToString().Equals("unknown"))))
+                !(repo["ApiVersion"].ToString().Equals("Local", StringComparison.OrdinalIgnoreCase) || repo["ApiVersion"].ToString().Equals("V2", StringComparison.OrdinalIgnoreCase) || 
+                repo["ApiVersion"].ToString().Equals("V3", StringComparison.OrdinalIgnoreCase) || repo["ApiVersion"].ToString().Equals("NugetServer", StringComparison.OrdinalIgnoreCase) || 
+                repo["ApiVersion"].ToString().Equals("Unknown", StringComparison.OrdinalIgnoreCase))))
             {
                 WriteError(new ErrorRecord(
-                    new PSInvalidOperationException("Repository ApiVersion must be either 'local', 'v2', 'v3', 'nugetServer' or 'unknown'"),
+                    new PSInvalidOperationException("Repository ApiVersion must be either 'Local', 'V2', 'V3', 'NugetServer', 'ContainRegistry' or 'Unknown'"),
                     "IncorrectApiVersionForRepositoriesParameterSetRegistration",
                     ErrorCategory.InvalidArgument,
                     this));

--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -422,7 +422,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 }
                 else
                 {
-                    resolvedAPIVersion = (PSRepositoryInfo.APIVersion)Enum.Parse(typeof(PSRepositoryInfo.APIVersion), node.Attribute("APIVersion").Value);
+                    resolvedAPIVersion = (PSRepositoryInfo.APIVersion)Enum.Parse(typeof(PSRepositoryInfo.APIVersion), node.Attribute("APIVersion").Value, ignoreCase: true);
                 }
 
 
@@ -529,7 +529,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                         Int32.Parse(node.Attribute("Priority").Value),
                         Boolean.Parse(node.Attribute("Trusted").Value),
                         repoCredentialInfo,
-                        (PSRepositoryInfo.APIVersion)Enum.Parse(typeof(PSRepositoryInfo.APIVersion), node.Attribute("APIVersion").Value)));
+                        (PSRepositoryInfo.APIVersion)Enum.Parse(typeof(PSRepositoryInfo.APIVersion), node.Attribute("APIVersion").Value, ignoreCase: true)));
 
                 // Remove item from file
                 node.Remove();
@@ -659,7 +659,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                         Int32.Parse(repo.Attribute("Priority").Value),
                         Boolean.Parse(repo.Attribute("Trusted").Value),
                         thisCredentialInfo,
-                        (PSRepositoryInfo.APIVersion)Enum.Parse(typeof(PSRepositoryInfo.APIVersion), repo.Attribute("APIVersion").Value));
+                        (PSRepositoryInfo.APIVersion)Enum.Parse(typeof(PSRepositoryInfo.APIVersion), repo.Attribute("APIVersion").Value, ignoreCase: true));
 
                     foundRepos.Add(currentRepoItem);
                 }

--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -7,8 +7,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
-using System.Security.Cryptography;
-using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using static Microsoft.PowerShell.PSResourceGet.UtilClasses.PSRepositoryInfo;
@@ -63,7 +61,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
                 // Add PSGallery to the newly created store
                 Uri psGalleryUri = new Uri(PSGalleryRepoUri);
-                Add(PSGalleryRepoName, psGalleryUri, DefaultPriority, DefaultTrusted, repoCredentialInfo: null, PSRepositoryInfo.APIVersion.v2, force: false);
+                Add(PSGalleryRepoName, psGalleryUri, DefaultPriority, DefaultTrusted, repoCredentialInfo: null, PSRepositoryInfo.APIVersion.V2, force: false);
             }
 
             // Open file (which should exist now), if cannot/is corrupted then throw error
@@ -416,7 +414,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 }
 
                 // Update APIVersion if necessary
-                PSRepositoryInfo.APIVersion resolvedAPIVersion = PSRepositoryInfo.APIVersion.unknown;
+                PSRepositoryInfo.APIVersion resolvedAPIVersion = PSRepositoryInfo.APIVersion.Unknown;
                 if (apiVersion != null)
                 {
                     resolvedAPIVersion = (PSRepositoryInfo.APIVersion)apiVersion;
@@ -765,7 +763,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                             Int32.Parse(node.Attribute("Priority").Value),
                             Boolean.Parse(node.Attribute("Trusted").Value),
                             thisCredentialInfo,
-                            (PSRepositoryInfo.APIVersion)Enum.Parse(typeof(PSRepositoryInfo.APIVersion), node.Attribute("APIVersion").Value));
+                            (PSRepositoryInfo.APIVersion)Enum.Parse(typeof(PSRepositoryInfo.APIVersion), node.Attribute("APIVersion").Value, ignoreCase: true));
 
                         foundRepos.Add(currentRepoItem);
                     }
@@ -823,30 +821,30 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             if (repoUri.AbsoluteUri.EndsWith("/v2", StringComparison.OrdinalIgnoreCase))
             {
                 // Scenario: V2 server protocol repositories (i.e PSGallery)
-                return PSRepositoryInfo.APIVersion.v2;
+                return PSRepositoryInfo.APIVersion.V2;
             }
             else if (repoUri.AbsoluteUri.EndsWith("/index.json", StringComparison.OrdinalIgnoreCase))
             {
                 // Scenario: V3 server protocol repositories (i.e NuGet.org, Azure Artifacts (ADO), Artifactory, Github Packages, MyGet.org)
-                return PSRepositoryInfo.APIVersion.v3;
+                return PSRepositoryInfo.APIVersion.V3;
             }
             else if (repoUri.AbsoluteUri.EndsWith("/nuget", StringComparison.OrdinalIgnoreCase))
             {
                 // Scenario: ASP.Net application feed created with NuGet.Server to host packages
-                return PSRepositoryInfo.APIVersion.nugetServer;
+                return PSRepositoryInfo.APIVersion.NugetServer;
             }
             else if (repoUri.Scheme.Equals(Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase) || repoUri.Scheme.Equals("temp", StringComparison.OrdinalIgnoreCase))
             {
                 // repositories with Uri Scheme "temp" may have PSPath Uri's like: "Temp:\repo" and we should consider them as local repositories.
-                return PSRepositoryInfo.APIVersion.local;
+                return PSRepositoryInfo.APIVersion.Local;
             }
             else if (repoUri.AbsoluteUri.EndsWith(".azurecr.io") || repoUri.AbsoluteUri.EndsWith(".azurecr.io/"))
             {
-                return PSRepositoryInfo.APIVersion.acr;
+                return PSRepositoryInfo.APIVersion.ContainerRegistry;
             }
             else
             {
-                return PSRepositoryInfo.APIVersion.unknown;
+                return PSRepositoryInfo.APIVersion.Unknown;
             }
         }
 

--- a/src/code/ResponseUtilFactory.cs
+++ b/src/code/ResponseUtilFactory.cs
@@ -14,27 +14,27 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             switch (repoApiVersion)
             {
-                case PSRepositoryInfo.APIVersion.v2:
+                case PSRepositoryInfo.APIVersion.V2:
                     currentResponseUtil = new V2ResponseUtil(repository);
                     break;
 
-                case PSRepositoryInfo.APIVersion.v3:
+                case PSRepositoryInfo.APIVersion.V3:
                     currentResponseUtil = new V3ResponseUtil(repository);
                     break;
 
-                case PSRepositoryInfo.APIVersion.local:
+                case PSRepositoryInfo.APIVersion.Local:
                     currentResponseUtil = new LocalResponseUtil(repository);
                     break;
 
-                case PSRepositoryInfo.APIVersion.nugetServer:
+                case PSRepositoryInfo.APIVersion.NugetServer:
                     currentResponseUtil = new NuGetServerResponseUtil(repository);
                     break;
 
-                case PSRepositoryInfo.APIVersion.acr:
+                case PSRepositoryInfo.APIVersion.ContainerRegistry:
                     currentResponseUtil = new ACRResponseUtil(repository);
                     break;
 
-                case PSRepositoryInfo.APIVersion.unknown:
+                case PSRepositoryInfo.APIVersion.Unknown:
                     break;
             }
 

--- a/src/code/ServerFactory.cs
+++ b/src/code/ServerFactory.cs
@@ -43,27 +43,27 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             switch (repoApiVersion)
             {
-                case PSRepositoryInfo.APIVersion.v2:
+                case PSRepositoryInfo.APIVersion.V2:
                     currentServer = new V2ServerAPICalls(repository, cmdletPassedIn, networkCredential, userAgentString);
                     break;
 
-                case PSRepositoryInfo.APIVersion.v3:
+                case PSRepositoryInfo.APIVersion.V3:
                     currentServer = new V3ServerAPICalls(repository, cmdletPassedIn, networkCredential, userAgentString);
                     break;
 
-                case PSRepositoryInfo.APIVersion.local:
+                case PSRepositoryInfo.APIVersion.Local:
                     currentServer = new LocalServerAPICalls(repository, cmdletPassedIn, networkCredential);
                     break;
 
-                case PSRepositoryInfo.APIVersion.nugetServer:
+                case PSRepositoryInfo.APIVersion.NugetServer:
                     currentServer = new NuGetServerAPICalls(repository, cmdletPassedIn, networkCredential, userAgentString);
                     break;
 
-                case PSRepositoryInfo.APIVersion.acr:
+                case PSRepositoryInfo.APIVersion.ContainerRegistry:
                     currentServer = new ACRServerAPICalls(repository, cmdletPassedIn, networkCredential, userAgentString);
                     break;
 
-                case PSRepositoryInfo.APIVersion.unknown:
+                case PSRepositoryInfo.APIVersion.Unknown:
                     break;
             }
 

--- a/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceACRServer.Tests.ps1
@@ -18,12 +18,12 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         if ($usingAzAuth)
         {
             Write-Verbose -Verbose "Using Az module for authentication"
-            Register-PSResourceRepository -Name $ACRRepoName -ApiVersion 'acr' -Uri $ACRRepoUri -Verbose
+            Register-PSResourceRepository -Name $ACRRepoName -ApiVersion 'ContainerRegistry' -Uri $ACRRepoUri -Verbose
         }
         else
         {
             $psCredInfo = New-Object Microsoft.PowerShell.PSResourceGet.UtilClasses.PSCredentialInfo ("SecretStore", "$env:TENANTID")
-            Register-PSResourceRepository -Name $ACRRepoName -ApiVersion 'acr' -Uri $ACRRepoUri -CredentialInfo $psCredInfo -Verbose
+            Register-PSResourceRepository -Name $ACRRepoName -ApiVersion 'ContainerRegistry' -Uri $ACRRepoUri -CredentialInfo $psCredInfo -Verbose
         }
     }
 

--- a/test/InstallPSResourceTests/InstallPSResourceACRServer.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceACRServer.Tests.ps1
@@ -13,10 +13,13 @@ Describe 'Test Install-PSResource for ACR scenarios' -tags 'CI' {
         $testScriptName = "testscript"
         $ACRRepoName = "ACRRepo"
         $ACRRepoUri = "https://psresourcegettest.azurecr.io/"
+
+        Write-Verbose -Verbose "**********************"
         Get-NewPSResourceRepositoryFile
 
         $usingAzAuth = $env:USINGAZAUTH -eq 'true'
-
+        $repos = Get-PSResourceRepository
+        Write-Host $repos.Name 
         if ($usingAzAuth)
         {
             Register-PSResourceRepository -Name $ACRRepoName -ApiVersion 'ContainerRegistry' -Uri $ACRRepoUri -Verbose

--- a/test/InstallPSResourceTests/InstallPSResourceACRServer.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceACRServer.Tests.ps1
@@ -13,13 +13,10 @@ Describe 'Test Install-PSResource for ACR scenarios' -tags 'CI' {
         $testScriptName = "testscript"
         $ACRRepoName = "ACRRepo"
         $ACRRepoUri = "https://psresourcegettest.azurecr.io/"
-
-        Write-Verbose -Verbose "**********************"
         Get-NewPSResourceRepositoryFile
 
         $usingAzAuth = $env:USINGAZAUTH -eq 'true'
-        $repos = Get-PSResourceRepository
-        Write-Host $repos.Name 
+
         if ($usingAzAuth)
         {
             Register-PSResourceRepository -Name $ACRRepoName -ApiVersion 'ContainerRegistry' -Uri $ACRRepoUri -Verbose

--- a/test/InstallPSResourceTests/InstallPSResourceACRServer.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceACRServer.Tests.ps1
@@ -19,12 +19,12 @@ Describe 'Test Install-PSResource for ACR scenarios' -tags 'CI' {
 
         if ($usingAzAuth)
         {
-            Register-PSResourceRepository -Name $ACRRepoName -ApiVersion 'acr' -Uri $ACRRepoUri -Verbose
+            Register-PSResourceRepository -Name $ACRRepoName -ApiVersion 'ContainerRegistry' -Uri $ACRRepoUri -Verbose
         }
         else
         {
             $psCredInfo = New-Object Microsoft.PowerShell.PSResourceGet.UtilClasses.PSCredentialInfo ("SecretStore", "$env:TENANTID")
-            Register-PSResourceRepository -Name $ACRRepoName -ApiVersion 'acr' -Uri $ACRRepoUri -CredentialInfo $psCredInfo -Verbose
+            Register-PSResourceRepository -Name $ACRRepoName -ApiVersion 'ContainerRegistry' -Uri $ACRRepoUri -CredentialInfo $psCredInfo -Verbose
         }
     }
 

--- a/test/PublishPSResourceTests/PublishPSResourceACRServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceACRServer.Tests.ps1
@@ -53,12 +53,12 @@ Describe "Test Publish-PSResource" -tags 'CI' {
 
         if ($usingAzAuth)
         {
-            Register-PSResourceRepository -Name $ACRRepoName -ApiVersion 'acr' -Uri $ACRRepoUri -Verbose
+            Register-PSResourceRepository -Name $ACRRepoName -ApiVersion 'ContainerRegistry' -Uri $ACRRepoUri -Verbose
         }
         else
         {
             $psCredInfo = New-Object Microsoft.PowerShell.PSResourceGet.UtilClasses.PSCredentialInfo ("SecretStore", "$env:TENANTID")
-            Register-PSResourceRepository -Name $ACRRepoName -ApiVersion 'acr' -Uri $ACRRepoUri -CredentialInfo $psCredInfo -Verbose
+            Register-PSResourceRepository -Name $ACRRepoName -ApiVersion 'ContainerRegistry' -Uri $ACRRepoUri -CredentialInfo $psCredInfo -Verbose
         }
 
         # Create module

--- a/test/ResourceRepositoryTests/RegisterPSResourceRepository.Tests.ps1
+++ b/test/ResourceRepositoryTests/RegisterPSResourceRepository.Tests.ps1
@@ -411,7 +411,7 @@ Describe "Test Register-PSResourceRepository" -tags 'CI' {
         $res = Get-PSResourceRepository -Name $ContainerRegistryName
 
         $res.Name | Should -Be $ContainerRegistryName
-        $res.Uri.LocalPath | Should -Contain $ContainerRegistryUri
+        $res.Uri.AbsoluteUri | Should -Contain $ContainerRegistryUri
         $res.ApiVersion | Should -Be 'ContainerRegistry'
     }
 }

--- a/test/ResourceRepositoryTests/RegisterPSResourceRepository.Tests.ps1
+++ b/test/ResourceRepositoryTests/RegisterPSResourceRepository.Tests.ps1
@@ -406,7 +406,7 @@ Describe "Test Register-PSResourceRepository" -tags 'CI' {
 
     It "should register container registry repository with correct ApiVersion" {
         $ContainerRegistryName = "ACRRepo"
-        $ContainerRegistryUri = "https://psresourcegettest.azurecr.io"
+        $ContainerRegistryUri = "https://psresourcegettest.azurecr.io/"
         Register-PSResourceRepository -Name $ContainerRegistryName -Uri $ContainerRegistryUri
         $res = Get-PSResourceRepository -Name $ContainerRegistryName
 

--- a/test/ResourceRepositoryTests/RegisterPSResourceRepository.Tests.ps1
+++ b/test/ResourceRepositoryTests/RegisterPSResourceRepository.Tests.ps1
@@ -403,4 +403,15 @@ Describe "Test Register-PSResourceRepository" -tags 'CI' {
         $res.Uri.LocalPath | Should -Contain $tmpDir1Path
         $res.ApiVersion | Should -Be 'v2'
     }
+
+    It "should register container registry repository with correct ApiVersion" {
+        $ContainerRegistryName = "ACRRepo"
+        $ContainerRegistryUri = "https://psresourcegettest.azurecr.io"
+        Register-PSResourceRepository -Name $ContainerRegistryName -Uri $ContainerRegistryUri
+        $res = Get-PSResourceRepository -Name $ContainerRegistryName
+
+        $res.Name | Should -Be $ContainerRegistryName
+        $res.Uri.LocalPath | Should -Contain $ContainerRegistryUri
+        $res.ApiVersion | Should -Be 'ContainerRegistry'
+    }
 }


### PR DESCRIPTION


<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR changes the enum type `PSRepositoryInfo.APIVersion` from `acr` to `ContainerRegistry`.
It also changes the values to be pascal case, which is more conventional for enums.

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1579 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
