### PR TITLE
Add test for save script using `Save-PSResource` without `-IncludeXml`

### DIFF
--- a/test/SavePSResourceTests/SavePSResourceV2Tests.ps1
+++ b/test/SavePSResourceTests/SavePSResourceV2Tests.ps1
@@ -175,6 +175,9 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
 
     It "Save script without using -IncludeXML" {
         Save-PSResource -Name $testScriptName -Repository $PSGalleryName -Path $SaveDir -TrustRepository | Should -Not -Throw
+
+        $SavedScriptFile = [System.IO.Path]::Combine($SaveDir,('{0}.ps1' -f $testScriptName))
+        [System.IO.File]::Exists($SavedScriptFile) | Should -BeTrue
     }
 
     It "Save script using -IncludeXML" {

--- a/test/SavePSResourceTests/SavePSResourceV2Tests.ps1
+++ b/test/SavePSResourceTests/SavePSResourceV2Tests.ps1
@@ -125,7 +125,7 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
         $pkgDirVersion.Name | Should -Be "5.2.5"
     }
 
-   It "Save a module with a dependency" {
+    It "Save a module with a dependency" {
         Save-PSResource -Name "TestModuleWithDependencyE" -Version "1.0.0.0" -Repository $PSGalleryName -Path $SaveDir -TrustRepository
         $pkgDirs = Get-ChildItem -Path $SaveDir | Where-Object { $_.Name -eq "TestModuleWithDependencyE" -or $_.Name -eq "TestModuleWithDependencyC" -or $_.Name -eq "TestModuleWithDependencyB" -or $_.Name -eq "TestModuleWithDependencyD"}
         $pkgDirs.Count | Should -BeGreaterThan 1
@@ -148,7 +148,7 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
         Find-PSResource -Name $testModuleName -Version "5.2.5-alpha001" -Repository $PSGalleryName | Save-PSResource -Path $SaveDir -TrustRepository -Verbose
         $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
-        (Get-ChildItem -Path $pkgDir.FullName) | Should -HaveCount 1   
+        (Get-ChildItem -Path $pkgDir.FullName) | Should -HaveCount 1
     }
 
     It "Save module as a nupkg" {
@@ -171,6 +171,10 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
         $res = Save-PSResource -Name $testModuleName -Version "1.0.0" -Repository $PSGalleryName -Path $SaveDir -PassThru -TrustRepository
         $res.Name | Should -Be $testModuleName
         $res.Version | Should -Be "1.0.0.0"
+    }
+
+    It "Save script without using -IncludeXML" {
+        Save-PSResource -Name $testScriptName -Repository $PSGalleryName -Path $SaveDir -TrustRepository | Should -Not -Throw
     }
 
     It "Save script using -IncludeXML" {

--- a/test/SavePSResourceTests/SavePSResourceV2Tests.ps1
+++ b/test/SavePSResourceTests/SavePSResourceV2Tests.ps1
@@ -178,9 +178,9 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
     }
 
     It "Save script using -IncludeXML" {
-        Save-PSResource -Name $testScriptName -Repository $PSGalleryName -Path $SaveDir -TrustRepository
+        Save-PSResource -Name $testScriptName -Repository $PSGalleryName -Path $SaveDir -TrustRepository -IncludeXml
 
-        $scriptXML = $testScriptNamen + "_InstalledScriptInfo.xml"
+        $scriptXML = $testScriptName + "_InstalledScriptInfo.xml"
         $savedScriptFile = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "test_script.ps1"
         $savedScriptXML = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $scriptXML
         $savedScriptFile | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add test for #1609

Which probably broke when fixing #1335

## PR Context

Add test "Save script without using -IncludeXML" for saving script using `Save-PSResource` without `-IncludeXml`.

Also fix typo and missing `-IncludeXml` in existing test "Save script using -IncludeXML".

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
