### PR TITLE
Add 10 minute timeout to HTTPClient

### DIFF
--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -20,7 +20,6 @@ using Microsoft.PowerShell.PSResourceGet.Cmdlets;
 using System.Text;
 using System.Security.Cryptography;
 using System.Text.Json;
-using System.Runtime.InteropServices.WindowsRuntime;
 
 namespace Microsoft.PowerShell.PSResourceGet
 {

--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -63,6 +63,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             };
 
             _sessionClient = new HttpClient(handler);
+            _sessionClient.Timeout = TimeSpan.FromMinutes(10);
             _sessionClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", userAgentString);
         }
 

--- a/src/code/NuGetServerAPICalls.cs
+++ b/src/code/NuGetServerAPICalls.cs
@@ -40,6 +40,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             };
 
             _sessionClient = new HttpClient(handler);
+            _sessionClient.Timeout = TimeSpan.FromMinutes(10);
             _sessionClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", userAgentString);
         }
 

--- a/src/code/ServerApiCall.cs
+++ b/src/code/ServerApiCall.cs
@@ -31,6 +31,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             };
 
             _sessionClient = new HttpClient(handler);
+            _sessionClient.Timeout = TimeSpan.FromMinutes(10);
         }
 
         #endregion

--- a/src/code/ServerApiCall.cs
+++ b/src/code/ServerApiCall.cs
@@ -8,6 +8,7 @@ using NuGet.Versioning;
 using System.Net;
 using System.Runtime.ExceptionServices;
 using System.Management.Automation;
+using System;
 
 namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 {

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -57,6 +57,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             };
 
             _sessionClient = new HttpClient(handler);
+            _sessionClient.Timeout = TimeSpan.FromMinutes(10);
             _sessionClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", userAgentString);
             var repoURL = repository.Uri.ToString().ToLower();
             _isADORepo = repoURL.Contains("pkgs.dev.azure.com") || repoURL.Contains("pkgs.visualstudio.com");

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -57,6 +57,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             };
 
             _sessionClient = new HttpClient(handler);
+            _sessionClient.Timeout = TimeSpan.FromMinutes(10);
             _sessionClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", userAgentString);
 
             _isNuGetRepo = String.Equals(Repository.Uri.AbsoluteUri, nugetRepoUri, StringComparison.InvariantCultureIgnoreCase);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Add a 10 minute timeout to HTTPClient.
Remove duplicate HttpClient object in ContainerRegistryServerAPICalls class.
 
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1060 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
