### PR TITLE
Fix requiring 'tags' in server response

### DIFF
--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -492,7 +492,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                             return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
                         }
-                        if (!rootDom.TryGetProperty(tagsName, out JsonElement tagsItem))
+                        if (!rootDom.TryGetProperty(tagsName, out JsonElement tagsItem) && tags.Length != 0)
                         {
                             errRecord = new ErrorRecord(
                                 new InvalidOrEmptyResponse($"Response does not contain '{tagsName}' element for search with Name '{packageName}' in '{Repository.Name}'."),
@@ -602,7 +602,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                             return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
                         }
-                        if (!rootDom.TryGetProperty(tagsName, out JsonElement tagsItem))
+                        if (!rootDom.TryGetProperty(tagsName, out JsonElement tagsItem) && tags.Length != 0)
                         {
                             errRecord = new ErrorRecord(
                                 new InvalidOrEmptyResponse($"Response does not contain '{tagsName}' element for search with name '{packageName}' and version '{version}' in repository '{Repository.Name}'."),


### PR DESCRIPTION
FindNameHelper and FindVersionHelper now properly allow a server response that has no 'tags' element. This fixes Install-PSResource not working, and fixes Find-PSResource not working in the case of the user not using the `-Tag` parameter. Using Find-PSResource with `-Tag` still properly errors out if the server does not respond with tags.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
When the server response doesn't contain tags, the find helpers now only give an error if the user passed in `-Tag {tags to find}`, if the user is searching for a tag then it's necessary for the response to contain tags. But when -Tag is not used then the lack of 'tags' in the server response is now ignored and the code continues as expected. The rest of the code already handles no tags correctly.

This PR does not contain updated tests, someone responded in issue #1621 that this should be fine. Updated tests should just involve duplicating one or more existing tests around finding and installing packages but removing the 'tags' element in the server responses to verify the old code fails the test and new code passes.

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1621

Tags are optional in the NuGet API as shown [here](https://learn.microsoft.com/en-us/nuget/api/search-query-service-resource#search-result). Before this fix, when using Find-PSResource against a server that does not return 'tags' would give an error saying the server response does not contain the 'tags' element, this occurred even in the case of the user not using the `-Tag` parameter to search for a tag. This behavior is seen on a local Gitea server where it does not include tags in the response for unknown reasons, but that is supposed to be allowed in the NuGet API. Also note that PowerShellGet was tested on the same server and it finds packages fine despite the server not returning the 'tags' element.

Without this fix, using PSResourceGet is unusable with Gitea for finding and installing packages with `Find-PSResource` and `Install-PSResource` because they both use the code that requires the 'tags' element and error out.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
