### PR TITLE
Refactor V2/NuGetServerAPICalls to use object-oriented query/filter builder

### DIFF
--- a/src/code/Microsoft.PowerShell.PSResourceGet.csproj
+++ b/src/code/Microsoft.PowerShell.PSResourceGet.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="System.Text.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Azure.Identity" Version="1.11.0" />
+    <Reference Include="System.Web" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/code/NuGetServerAPICalls.cs
+++ b/src/code/NuGetServerAPICalls.cs
@@ -172,10 +172,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             });
             var filterBuilder = queryBuilder.FilterBuilder;
 
-            filterBuilder.AddCriteria(includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion");
+            filterBuilder.AddCriterion(includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion");
 
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
-            filterBuilder.AddCriteria($"Id eq '{packageName}'");
+            filterBuilder.AddCriterion($"Id eq '{packageName}'");
             var requestUrl = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
             string response = HttpRequestCall(requestUrl, out errRecord);
 
@@ -201,13 +201,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             var filterBuilder = queryBuilder.FilterBuilder;
             
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
-            filterBuilder.AddCriteria($"Id eq '{packageName}'");
+            filterBuilder.AddCriterion($"Id eq '{packageName}'");
 
-            filterBuilder.AddCriteria(includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion");
+            filterBuilder.AddCriterion(includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion");
 
             foreach (string tag in tags)
             {
-                filterBuilder.AddCriteria($"substringof('{tag}', Tags) eq true");
+                filterBuilder.AddCriterion($"substringof('{tag}', Tags) eq true");
             }
 
             var requestUrl = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
@@ -378,8 +378,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             var filterBuilder = queryBuilder.FilterBuilder;
 
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
-            filterBuilder.AddCriteria($"Id eq '{packageName}'");
-            filterBuilder.AddCriteria($"NormalizedVersion eq '{packageName}'");
+            filterBuilder.AddCriterion($"Id eq '{packageName}'");
+            filterBuilder.AddCriterion($"NormalizedVersion eq '{packageName}'");
 
             var requestUrl = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
             string response = HttpRequestCall(requestUrl, out errRecord);
@@ -403,12 +403,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             var filterBuilder = queryBuilder.FilterBuilder;
 
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
-            filterBuilder.AddCriteria($"Id eq '{packageName}'");
-            filterBuilder.AddCriteria($"NormalizedVersion eq '{packageName}'");
+            filterBuilder.AddCriterion($"Id eq '{packageName}'");
+            filterBuilder.AddCriterion($"NormalizedVersion eq '{packageName}'");
 
             foreach (string tag in tags)
             {
-                filterBuilder.AddCriteria($"substringof('{tag}', Tags) eq true");
+                filterBuilder.AddCriterion($"substringof('{tag}', Tags) eq true");
             }
 
             var requestUrl = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
@@ -565,9 +565,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriteria("IsAbsoluteLatestVersion");
+                filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
             } else {
-                filterBuilder.AddCriteria("IsLatestVersion");
+                filterBuilder.AddCriterion("IsLatestVersion");
             }
             
             var requestUrl = $"{Repository.Uri}/Search()?{queryBuilder.BuildQueryString()}";
@@ -593,14 +593,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriteria("IsAbsoluteLatestVersion");
+                filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
             } else {
-                filterBuilder.AddCriteria("IsLatestVersion");
+                filterBuilder.AddCriterion("IsLatestVersion");
             }
 
             foreach (string tag in tags)
             {
-                filterBuilder.AddCriteria($"substringof('{tag}', Tags) eq true");
+                filterBuilder.AddCriterion($"substringof('{tag}', Tags) eq true");
             }
 
             var requestUrl = $"{Repository.Uri}/Search()?{queryBuilder.BuildQueryString()}";
@@ -628,9 +628,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriteria("IsAbsoluteLatestVersion");
+                filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
             } else {
-                filterBuilder.AddCriteria("IsLatestVersion");
+                filterBuilder.AddCriterion("IsLatestVersion");
             }
 
 
@@ -651,17 +651,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (packageName.StartsWith("*") && packageName.EndsWith("*"))
                 {
                     // *get*
-                    filterBuilder.AddCriteria($"substringof('{names[0]}', Id)");
+                    filterBuilder.AddCriterion($"substringof('{names[0]}', Id)");
                 }
                 else if (packageName.EndsWith("*"))
                 {
                     // PowerShell*
-                    filterBuilder.AddCriteria($"startswith(Id, '{names[0]}')");
+                    filterBuilder.AddCriterion($"startswith(Id, '{names[0]}')");
                 }
                 else
                 {
                     // *ShellGet
-                    filterBuilder.AddCriteria($"endswith(Id, '{names[0]}')");
+                    filterBuilder.AddCriterion($"endswith(Id, '{names[0]}')");
                 }
             }
             else if (names.Length == 2 && !packageName.StartsWith("*") && !packageName.EndsWith("*"))
@@ -670,7 +670,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // pow*get -> only support this
                 // pow*get*
                 // *pow*get
-                filterBuilder.AddCriteria($"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')");
+                filterBuilder.AddCriterion($"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')");
             }
             else
             {
@@ -707,10 +707,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             var filterBuilder = queryBuilder.FilterBuilder;
 
             if (includePrerelease) {
-                filterBuilder.AddCriteria("IsAbsoluteLatestVersion");
+                filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
             } else {
-                filterBuilder.AddCriteria("IsLatestVersion");
+                filterBuilder.AddCriterion("IsLatestVersion");
             }
 
             var names = packageName.Split(new char[] {'*'}, StringSplitOptions.RemoveEmptyEntries);
@@ -730,17 +730,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (packageName.StartsWith("*") && packageName.EndsWith("*"))
                 {
                     // *get*
-                    filterBuilder.AddCriteria($"substringof('{names[0]}', Id)");
+                    filterBuilder.AddCriterion($"substringof('{names[0]}', Id)");
                 }
                 else if (packageName.EndsWith("*"))
                 {
                     // PowerShell*
-                    filterBuilder.AddCriteria($"startswith(Id, '{names[0]}')");
+                    filterBuilder.AddCriterion($"startswith(Id, '{names[0]}')");
                 }
                 else
                 {
                     // *ShellGet
-                    filterBuilder.AddCriteria($"endswith(Id, '{names[0]}')");
+                    filterBuilder.AddCriterion($"endswith(Id, '{names[0]}')");
                 }
             }
             else if (names.Length == 2 && !packageName.StartsWith("*") && !packageName.EndsWith("*"))
@@ -749,7 +749,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // pow*get -> only support this
                 // pow*get*
                 // *pow*get
-                filterBuilder.AddCriteria($"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')");
+                filterBuilder.AddCriterion($"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')");
             }
             else
             {
@@ -764,7 +764,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             foreach (string tag in tags)
             {
-                filterBuilder.AddCriteria($"substringof('{tag}', Tags) eq true");
+                filterBuilder.AddCriterion($"substringof('{tag}', Tags) eq true");
             }
 
             var requestUrl = $"{Repository.Uri}/Search()?{queryBuilder.BuildQueryString()}";
@@ -832,19 +832,19 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string versionFilterParts = String.Empty;
             if (!String.IsNullOrEmpty(minPart))
             {
-                filterBuilder.AddCriteria(minPart);
+                filterBuilder.AddCriterion(minPart);
             }
             if (!String.IsNullOrEmpty(maxPart))
             {
-                filterBuilder.AddCriteria(maxPart);
+                filterBuilder.AddCriterion(maxPart);
             }
 
             if (!includePrerelease) {
-                filterBuilder.AddCriteria("IsPrerelease eq false");
+                filterBuilder.AddCriterion("IsPrerelease eq false");
             }
 
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
-            filterBuilder.AddCriteria($"Id eq '{packageName}'");
+            filterBuilder.AddCriterion($"Id eq '{packageName}'");
 
             var requestUrl = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
 

--- a/src/code/NuGetServerAPICalls.cs
+++ b/src/code/NuGetServerAPICalls.cs
@@ -163,14 +163,20 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override FindResults FindName(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindName()");
-            // Make sure to include quotations around the package name
-            var prerelease = includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion";
-
             // This should return the latest stable version or the latest prerelease version (respectively)
             // https://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'&$filter=IsLatestVersion and substringof('PSModule', Tags) eq true
+
+            // Make sure to include quotations around the package name
+            var queryBuilder = new NuGetV2QueryBuilder(new Dictionary<string, string>{
+                { "id", $"'{packageName}'" },
+            });
+            var filterBuilder = queryBuilder.FilterBuilder;
+
+            filterBuilder.AddCriteria(includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion");
+
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
-            string idFilterPart = $" and Id eq '{packageName}'";
-            var requestUrl = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter={prerelease}{idFilterPart}";
+            filterBuilder.AddCriteria($"Id eq '{packageName}'");
+            var requestUrl = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
             string response = HttpRequestCall(requestUrl, out errRecord);
 
             return new FindResults(stringResponse: new string[]{ response }, hashtableResponse: emptyHashResponses, responseType: FindResponseType);
@@ -185,20 +191,26 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override FindResults FindNameWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindNameWithTag()");
-            // Make sure to include quotations around the package name
-            var prerelease = includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion";
 
             // This should return the latest stable version or the latest prerelease version (respectively)
             // https://www.powershellgallery.com/api/v2/FindPackagesById()?id='PowerShellGet'&$filter=IsLatestVersion and substringof('PSModule', Tags) eq true
+            
+            var queryBuilder = new NuGetV2QueryBuilder(new Dictionary<string, string>{
+                { "id", $"'{packageName}'" },
+            });
+            var filterBuilder = queryBuilder.FilterBuilder;
+            
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
-            string idFilterPart = $" and Id eq '{packageName}'";
-            string tagFilterPart = String.Empty;
+            filterBuilder.AddCriteria($"Id eq '{packageName}'");
+
+            filterBuilder.AddCriteria(includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion");
+
             foreach (string tag in tags)
             {
-                tagFilterPart += $" and substringof('{tag}', Tags) eq true";
+                filterBuilder.AddCriteria($"substringof('{tag}', Tags) eq true");
             }
 
-            var requestUrl = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter={prerelease}{idFilterPart}{tagFilterPart}";
+            var requestUrl = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
             string response = HttpRequestCall(requestUrl, out errRecord);
 
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: FindResponseType);
@@ -359,9 +371,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindVersion()");
             // https://www.powershellgallery.com/api/v2/FindPackagesById()?id='blah'&includePrerelease=false&$filter= NormalizedVersion eq '1.1.0' and substringof('PSModule', Tags) eq true
             // Quotations around package name and version do not matter, same metadata gets returned.
+
+            var queryBuilder = new NuGetV2QueryBuilder(new Dictionary<string, string>{
+                { "id", $"'{packageName}'" },
+            });
+            var filterBuilder = queryBuilder.FilterBuilder;
+
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
-            string idFilterPart = $" and Id eq '{packageName}'";
-            var requestUrl = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter= NormalizedVersion eq '{version}'{idFilterPart}";
+            filterBuilder.AddCriteria($"Id eq '{packageName}'");
+            filterBuilder.AddCriteria($"NormalizedVersion eq '{packageName}'");
+
+            var requestUrl = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
             string response = HttpRequestCall(requestUrl, out errRecord);
 
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: FindResponseType);
@@ -376,15 +396,22 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override FindResults FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindVersionWithTag()");
+
+            var queryBuilder = new NuGetV2QueryBuilder(new Dictionary<string, string>{
+                { "id", $"'{packageName}'" },
+            });
+            var filterBuilder = queryBuilder.FilterBuilder;
+
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
-            string idFilterPart = $" and Id eq '{packageName}'";
-            string tagFilterPart = String.Empty;
+            filterBuilder.AddCriteria($"Id eq '{packageName}'");
+            filterBuilder.AddCriteria($"NormalizedVersion eq '{packageName}'");
+
             foreach (string tag in tags)
             {
-                tagFilterPart += $" and substringof('{tag}', Tags) eq true";
+                filterBuilder.AddCriteria($"substringof('{tag}', Tags) eq true");
             }
 
-            var requestUrl = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$filter= NormalizedVersion eq '{version}'{idFilterPart}{tagFilterPart}";
+            var requestUrl = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
             string response = HttpRequestCall(requestUrl, out errRecord);
 
             return new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: FindResponseType);
@@ -526,9 +553,24 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private string FindAllFromEndPoint(bool includePrerelease, int skip, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindAllFromEndPoint()");
-            string paginationParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=6000";
-            var prereleaseFilter = includePrerelease ? "IsAbsoluteLatestVersion&includePrerelease=true" : "IsLatestVersion";
-            var requestUrl = $"{Repository.Uri}/Search()?$filter={prereleaseFilter}{paginationParam}";
+
+            var queryBuilder = new NuGetV2QueryBuilder(new Dictionary<string, string> {
+                { "$inlinecount", "allpages" },
+                { "$skip", skip.ToString() },
+                { "$top", "6000" },
+                { "$orderBy", "Id desc" },
+            });
+
+            var filterBuilder = queryBuilder.FilterBuilder;
+
+            if (includePrerelease) {
+                queryBuilder.AdditionalParameters["includePrerelease"] = "true";
+                filterBuilder.AddCriteria("IsAbsoluteLatestVersion");
+            } else {
+                filterBuilder.AddCriteria("IsLatestVersion");
+            }
+            
+            var requestUrl = $"{Repository.Uri}/Search()?{queryBuilder.BuildQueryString()}";
 
             return HttpRequestCall(requestUrl, out errRecord);
         }
@@ -539,16 +581,29 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private string FindTagFromEndpoint(string[] tags, bool includePrerelease, int skip, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindTagFromEndpoint()");
-            string paginationParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=6000";
-            var prereleaseFilter = includePrerelease ? "$filter=IsAbsoluteLatestVersion&includePrerelease=true" : "$filter=IsLatestVersion";
 
-            string tagFilterPart = String.Empty;
-            foreach (string tag in tags)
-            {
-                tagFilterPart += $" and substringof('{tag}', Tags) eq true";
+            var queryBuilder = new NuGetV2QueryBuilder(new Dictionary<string, string> {
+                { "$inlinecount", "allpages" },
+                { "$skip", skip.ToString() },
+                { "$top", "6000" },
+                { "$orderBy", "Id desc" },
+            });
+
+            var filterBuilder = queryBuilder.FilterBuilder;
+
+            if (includePrerelease) {
+                queryBuilder.AdditionalParameters["includePrerelease"] = "true";
+                filterBuilder.AddCriteria("IsAbsoluteLatestVersion");
+            } else {
+                filterBuilder.AddCriteria("IsLatestVersion");
             }
 
-            var requestUrl = $"{Repository.Uri}/Search()?{prereleaseFilter}{tagFilterPart}{paginationParam}";
+            foreach (string tag in tags)
+            {
+                filterBuilder.AddCriteria($"substringof('{tag}', Tags) eq true");
+            }
+
+            var requestUrl = $"{Repository.Uri}/Search()?{queryBuilder.BuildQueryString()}";
 
             return HttpRequestCall(requestUrl, out errRecord);
         }
@@ -562,9 +617,22 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and startswith(Id, 'PowerShell') and IsLatestVersion (stable)
             // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and IsAbsoluteLatestVersion&includePrerelease=true
 
-            string extraParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=100";
-            var prerelease = includePrerelease ? "IsAbsoluteLatestVersion&includePrerelease=true" : "IsLatestVersion";
-            string nameFilter;
+            var queryBuilder = new NuGetV2QueryBuilder(new Dictionary<string, string> {
+                { "$inlinecount", "allpages" },
+                { "$skip", skip.ToString() },
+                { "$top", "100" },
+                { "$orderBy", "NormalizedVersion desc" },
+            });
+
+            var filterBuilder = queryBuilder.FilterBuilder;
+
+            if (includePrerelease) {
+                queryBuilder.AdditionalParameters["includePrerelease"] = "true";
+                filterBuilder.AddCriteria("IsAbsoluteLatestVersion");
+            } else {
+                filterBuilder.AddCriteria("IsLatestVersion");
+            }
+
 
             var names = packageName.Split(new char[] {'*'}, StringSplitOptions.RemoveEmptyEntries);
 
@@ -583,17 +651,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (packageName.StartsWith("*") && packageName.EndsWith("*"))
                 {
                     // *get*
-                    nameFilter = $"substringof('{names[0]}', Id)";
+                    filterBuilder.AddCriteria($"substringof('{names[0]}', Id)");
                 }
                 else if (packageName.EndsWith("*"))
                 {
                     // PowerShell*
-                    nameFilter = $"startswith(Id, '{names[0]}')";
+                    filterBuilder.AddCriteria($"startswith(Id, '{names[0]}')");
                 }
                 else
                 {
                     // *ShellGet
-                    nameFilter = $"endswith(Id, '{names[0]}')";
+                    filterBuilder.AddCriteria($"endswith(Id, '{names[0]}')");
                 }
             }
             else if (names.Length == 2 && !packageName.StartsWith("*") && !packageName.EndsWith("*"))
@@ -602,7 +670,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // pow*get -> only support this
                 // pow*get*
                 // *pow*get
-                nameFilter = $"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')";
+                filterBuilder.AddCriteria($"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')");
             }
             else
             {
@@ -615,7 +683,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return string.Empty;
             }
 
-            var requestUrl = $"{Repository.Uri}/Search()?$filter={nameFilter} and {prerelease}{extraParam}";
+            var requestUrl = $"{Repository.Uri}/Search()?{queryBuilder.BuildQueryString()}";
 
             return HttpRequestCall(requestUrl, out errRecord);
         }
@@ -629,9 +697,21 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and startswith(Id, 'PowerShell') and IsLatestVersion (stable)
             // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and IsAbsoluteLatestVersion&includePrerelease=true
 
-            string extraParam = $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=100";
-            var prerelease = includePrerelease ? "IsAbsoluteLatestVersion&includePrerelease=true" : "IsLatestVersion";
-            string nameFilter;
+            var queryBuilder = new NuGetV2QueryBuilder(new Dictionary<string, string> {
+                { "$inlinecount", "allpages" },
+                { "$skip", skip.ToString() },
+                { "$top", "100" },
+                { "$orderBy", "Id desc" },
+            });
+
+            var filterBuilder = queryBuilder.FilterBuilder;
+
+            if (includePrerelease) {
+                filterBuilder.AddCriteria("IsAbsoluteLatestVersion");
+                queryBuilder.AdditionalParameters["includePrerelease"] = "true";
+            } else {
+                filterBuilder.AddCriteria("IsLatestVersion");
+            }
 
             var names = packageName.Split(new char[] {'*'}, StringSplitOptions.RemoveEmptyEntries);
 
@@ -650,17 +730,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (packageName.StartsWith("*") && packageName.EndsWith("*"))
                 {
                     // *get*
-                    nameFilter = $"substringof('{names[0]}', Id)";
+                    filterBuilder.AddCriteria($"substringof('{names[0]}', Id)");
                 }
                 else if (packageName.EndsWith("*"))
                 {
                     // PowerShell*
-                    nameFilter = $"startswith(Id, '{names[0]}')";
+                    filterBuilder.AddCriteria($"startswith(Id, '{names[0]}')");
                 }
                 else
                 {
                     // *ShellGet
-                    nameFilter = $"endswith(Id, '{names[0]}')";
+                    filterBuilder.AddCriteria($"endswith(Id, '{names[0]}')");
                 }
             }
             else if (names.Length == 2 && !packageName.StartsWith("*") && !packageName.EndsWith("*"))
@@ -669,7 +749,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // pow*get -> only support this
                 // pow*get*
                 // *pow*get
-                nameFilter = $"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')";
+                filterBuilder.AddCriteria($"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')");
             }
             else
             {
@@ -682,13 +762,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return string.Empty;
             }
 
-            string tagFilterPart = String.Empty;
             foreach (string tag in tags)
             {
-                tagFilterPart += $" and substringof('{tag}', Tags) eq true";
+                filterBuilder.AddCriteria($"substringof('{tag}', Tags) eq true");
             }
 
-            var requestUrl = $"{Repository.Uri}/Search()?$filter={nameFilter}{tagFilterPart} and {prerelease}{extraParam}";
+            var requestUrl = $"{Repository.Uri}/Search()?{queryBuilder.BuildQueryString()}";
 
             return HttpRequestCall(requestUrl, out errRecord);
         }
@@ -706,6 +785,16 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // will need to filter additionally, if IncludePrerelease=false, by default we get stable + prerelease both back
             // Current bug: Find PSGet -Version "2.0.*" -> https://www.powershellgallery.com/api/v2//FindPackagesById()?id='PowerShellGet'&includePrerelease=false&$filter= Version gt '2.0.*' and Version lt '2.1'
             // Make sure to include quotations around the package name
+
+            var queryBuilder = new NuGetV2QueryBuilder(new Dictionary<string, string> {
+                { "id", $"'{packageName}'" },
+                { "$inlinecount", "allpages" },
+                { "$skip", skip.ToString() },
+                { "$top", getOnlyLatest ? "1" : "100" },
+                { "$orderBy", "NormalizedVersion desc" },
+            });
+
+            var filterBuilder = queryBuilder.FilterBuilder;
 
             //and IsPrerelease eq false
             // ex:
@@ -741,42 +830,23 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             string versionFilterParts = String.Empty;
-            if (!String.IsNullOrEmpty(minPart) && !String.IsNullOrEmpty(maxPart))
+            if (!String.IsNullOrEmpty(minPart))
             {
-                versionFilterParts += minPart + " and " + maxPart;
+                filterBuilder.AddCriteria(minPart);
             }
-            else if (!String.IsNullOrEmpty(minPart))
+            if (!String.IsNullOrEmpty(maxPart))
             {
-                versionFilterParts += minPart;
-            }
-            else if (!String.IsNullOrEmpty(maxPart))
-            {
-                versionFilterParts += maxPart;
+                filterBuilder.AddCriteria(maxPart);
             }
 
-            string filterQuery = "&$filter=";
-            filterQuery += includePrerelease ? string.Empty : "IsPrerelease eq false";
+            if (!includePrerelease) {
+                filterBuilder.AddCriteria("IsPrerelease eq false");
+            }
 
-            string andOperator = " and ";
-            string joiningOperator = filterQuery.EndsWith("=") ? String.Empty : andOperator;
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
-            string idFilterPart = $"{joiningOperator}Id eq '{packageName}'";
-            filterQuery += idFilterPart;
+            filterBuilder.AddCriteria($"Id eq '{packageName}'");
 
-            if (!String.IsNullOrEmpty(versionFilterParts))
-            {
-                // Check if includePrerelease is true, if it is we want to add "$filter"
-                // Single case where version is "*" (or "[,]") and includePrerelease is true, then we do not want to add "$filter" to the requestUrl.
-
-                // Note: could be null/empty if Version was "*" -> [,]
-                filterQuery +=  $"{andOperator}{versionFilterParts}";
-            }
-
-            string topParam = getOnlyLatest ? "$top=1" : "$top=100"; // only need 1 package if interested in latest
-            string paginationParam = $"$inlinecount=allpages&$skip={skip}&{topParam}";
-
-            filterQuery = filterQuery.EndsWith("=") ? string.Empty : filterQuery;
-            var requestUrl = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$orderby=NormalizedVersion desc&{paginationParam}{filterQuery}";
+            var requestUrl = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
 
             return HttpRequestCall(requestUrl, out errRecord);
         }

--- a/src/code/V2QueryBuilder.cs
+++ b/src/code/V2QueryBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/code/V2QueryBuilder.cs
+++ b/src/code/V2QueryBuilder.cs
@@ -19,6 +19,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         internal bool ShouldEmitEmptyFilter = false;
 
+        internal string SearchTerm;
+
         internal NuGetV2QueryBuilder()
         {
 
@@ -39,6 +41,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (FilterBuilder.CriteriaCount > 0 || ShouldEmitEmptyFilter)
             {
                 QueryParameters["$filter"] = FilterBuilder.BuildFilterString();
+            }
+
+            if (SearchTerm != null) {
+                QueryParameters["searchTerm"] = SearchTerm;
             }
 
             foreach (var parameter in AdditionalParameters)

--- a/src/code/V2QueryBuilder.cs
+++ b/src/code/V2QueryBuilder.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Configuration.Assemblies;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Web;
+
+namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
+{
+    internal class NuGetV2QueryBuilder
+    {
+
+        internal Dictionary<string, string> AdditionalParameters { get; private set; }
+
+        internal NuGetV2FilterBuilder FilterBuilder { get; private set; }
+
+        internal bool ShouldEmitEmptyFilter = false;
+
+        internal NuGetV2QueryBuilder()
+        {
+
+            FilterBuilder = new NuGetV2FilterBuilder();
+            AdditionalParameters = new Dictionary<string, string> { };
+        }
+
+        internal NuGetV2QueryBuilder(Dictionary<string, string> parameters) : this()
+        {
+            AdditionalParameters = new Dictionary<string, string>(parameters);
+        }
+        internal string BuildQueryString()
+        {
+
+            var QueryParameters = HttpUtility.ParseQueryString("");
+
+
+            if (FilterBuilder.CriteriaCount > 0 || ShouldEmitEmptyFilter)
+            {
+                QueryParameters["$filter"] = FilterBuilder.BuildFilterString();
+            }
+
+            foreach (var parameter in AdditionalParameters)
+            {
+                QueryParameters[parameter.Key] = parameter.Value;
+            }
+
+            return QueryParameters.ToString();
+
+        }
+
+    }
+
+    internal class NuGetV2FilterBuilder
+    {
+
+        internal NuGetV2FilterBuilder()
+        {
+
+        }
+
+        private HashSet<String> FilterCriteria = new HashSet<String>();
+
+        /// <summary>
+        ///     Convert the builder's provided set of filter criteria into an OData-compatible <c>filter</c> string.
+        /// </summary>
+        /// <remarks>
+        ///     Criteria order is not guaranteed.
+        /// 
+        ///     Filter criteria are individually parenthesized, then combined with the <c>and</c> operator.
+        /// </remarks>
+        /// <returns>
+        ///     Filter criteria combined into a single string.
+        /// </returns>
+        /// <example>
+        ///     The following example will emit one of the two values:
+        ///     <list type="bullet">
+        ///         <item>
+        ///             <description><c>(IsPrerelease eq false) and (Id eq 'Microsoft.PowerShell.PSResourceGet')</c></description>
+        ///         </item>
+        ///         <item>
+        ///             <description><c>(Id eq 'Microsoft.PowerShell.PSResourceGet') and (IsPrerelease eq false)</c></description>
+        ///         </item>
+        ///     </list>
+        /// </example>
+        public string BuildFilterString()
+        {
+
+            if (FilterCriteria.Count == 0)
+            {
+                return "";
+            }
+
+            // Figure out the expected size of our filter string, based on:
+            int ExpectedSize = FilterCriteria.Select(x => x.Length).Sum() // The length of the filter criteria themselves.
+                + 7 * (FilterCriteria.Count - 1) // The length of the combining string, ") and (", interpolated between the filters.
+                + 2; // The two outer parentheses.
+
+            // Allocate a StringBuilder with our calculated capacity. 
+            // This helps right-size memory allocation and reduces performance impact from resizing the builder's internal capacity.
+            StringBuilder sb = new StringBuilder(ExpectedSize);
+
+            // StringBuilder.AppendJoin() is not available in .NET 4.8.1/.NET Standard 2,
+            // so we have to make do with repeated calls to Append().
+
+            sb.Append("(");
+
+            int CriteriaAdded = 0;
+
+            foreach (string filter in FilterCriteria)
+            {
+                sb.Append(filter);
+                CriteriaAdded++;
+                if (CriteriaAdded < FilterCriteria.Count)
+                {
+                    sb.Append(") and (");
+                }
+                else
+                {
+                    sb.Append(")");
+                }
+            }
+
+            return sb.ToString();
+
+        }
+
+        public bool AddCriteria(string criteria)
+        {
+            if (string.IsNullOrEmpty(criteria))
+            {
+                throw new ArgumentException("Criteria cannot be null or empty.", nameof(criteria));
+            }
+            else
+            {
+                return FilterCriteria.Add(criteria);
+            }
+        }
+
+        public bool RemoveCriteria(string criteria) => FilterCriteria.Remove(criteria);
+
+        public int CriteriaCount => FilterCriteria.Count;
+
+    }
+}

--- a/src/code/V2QueryBuilder.cs
+++ b/src/code/V2QueryBuilder.cs
@@ -89,6 +89,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         ///             <description><c>(Id eq 'Microsoft.PowerShell.PSResourceGet') and (IsPrerelease eq false)</c></description>
         ///         </item>
         ///     </list>
+        ///     <code>
+        ///     var filter = new NuGetV2FilterBuilder();
+        ///     filter.AddCriteria("IsPrerelease eq false");
+        ///     filter.AddCriteria("Id eq 'Microsoft.PowerShell.PSResourceGet'");
+        ///     return filter.BuildFilterString();
+        ///     </code>
         /// </example>
         public string BuildFilterString()
         {

--- a/src/code/V2QueryBuilder.cs
+++ b/src/code/V2QueryBuilder.cs
@@ -18,12 +18,30 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         internal Dictionary<string, string> AdditionalParameters { get; private set; }
 
+        /// <summary>
+        ///     The filter to use when querying the NuGet API (query parameter <c>$filter</c>), if needed.
+        /// </summary>
+        /// <remarks>
+        ///     If no criteria are added with <seealso cref="NuGetV2FilterBuilder.AddCriterion(string)"/>, the built query string will not contain a <c>$filter</c> parameter unless <seealso cref="ShouldEmitEmptyFilter"/> is true.
+        /// </remarks>
         internal NuGetV2FilterBuilder FilterBuilder { get; private set; }
-
+        
+        /// <summary>
+        ///     Indicates whether an empty <c>$filter</c> parameter should be emitted if <seealso cref="FilterBuilder"/> contains no criteria.
+        /// </summary>
         internal bool ShouldEmitEmptyFilter = false;
 
+        /// <summary>
+        ///     The search term to pass to NuGet (<c>searchTerm</c> parameter), if needed.
+        /// </summary>
+        /// <remarks>
+        ///     No additional quote-encapsulation is performed on the string. A <seealso cref="null"/> string will cause the parameter to be omitted.
+        /// </remarks>
         internal string SearchTerm;
 
+        /// <summary>
+        ///     Construct a new <seealso cref="NuGetV2QueryBuilder"/> with no additional query parameters.
+        /// </summary>
         internal NuGetV2QueryBuilder()
         {
 
@@ -31,10 +49,26 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             AdditionalParameters = new Dictionary<string, string> { };
         }
 
+        /// <summary>
+        ///     Construct a new <seealso cref="NuGetV2QueryBuilder"/> with a user-specified collection of query parameters.
+        /// </summary>
+        /// <param name="parameters">
+        ///     The set of additional parameters to provide.
+        /// </param>
         internal NuGetV2QueryBuilder(Dictionary<string, string> parameters) : this()
         {
             AdditionalParameters = new Dictionary<string, string>(parameters);
         }
+
+        /// <summary>
+        ///     Serialize the instance to an HTTP-compatible query string.
+        /// </summary>
+        /// <remarks>
+        ///     Query key-value pairs from <seealso cref="AdditionalParameters"/> will take precedence.
+        /// </remarks>
+        /// <returns>
+        ///     A <seealso cref="string"/> containing URL-encoded query parameters separated by <c><![CDATA[&]]></c>. No <c>?</c> is prefixed at the beginning of the string.
+        /// </returns>
         internal string BuildQueryString()
         {
 
@@ -61,9 +95,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
     }
 
+    /// <summary>
+    ///     Helper class for building NuGet v2 (OData) filter strings based on a set of criteria
+    /// </summary>
     internal class NuGetV2FilterBuilder
     {
 
+        /// <summary>
+        ///     Construct a new <seealso cref="NuGetV2FilterBuilder"/> with an empty set of criteria.
+        /// </summary>
         internal NuGetV2FilterBuilder()
         {
 
@@ -137,19 +177,46 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         }
 
-        public bool AddCriteria(string criteria)
+        /// <summary>
+        ///     Add a given OData-compatible criterion to the object's internal criteria set.
+        /// </summary>
+        /// <param name="criterion">
+        ///     The criterion to add, e.g. <c>IsLatestVersion</c> or <c>Id eq 'Foo'</c>.
+        /// </param>
+        /// <returns>
+        ///     A boolean indicating whether the criterion was added to the set. <cref>false</cref> indicates the criteria set already contains the given string.
+        /// </returns>
+        /// <remarks>
+        ///     This method encapsulates over <seealso cref="HashSet{string}.Add(string)"/>. Similar comparison and equality semantics apply.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        ///     The provided criterion string was null or empty.
+        /// </exception>
+        public bool AddCriterion(string criterion)
         {
-            if (string.IsNullOrEmpty(criteria))
+            if (string.IsNullOrEmpty(criterion))
             {
-                throw new ArgumentException("Criteria cannot be null or empty.", nameof(criteria));
+                throw new ArgumentException("Criteria cannot be null or empty.", nameof(criterion));
             }
             else
             {
-                return FilterCriteria.Add(criteria);
+                return FilterCriteria.Add(criterion);
             }
         }
 
-        public bool RemoveCriteria(string criteria) => FilterCriteria.Remove(criteria);
+        /// <summary>
+        ///     Remove a criterion from the instance's internal criteria set.
+        /// </summary>
+        /// <param name="criterion">
+        ///     The criteria to remove.
+        /// </param>
+        /// <returns>
+        ///     <cref>true</cref> if the criterion was removed, <cref>false</cref> if it was not found.
+        /// </returns>
+        /// <remarks>
+        ///     This method encapsulates over <seealso cref="HashSet{string}.Remove(string)"/>. Similar comparison and equality semantics apply.
+        /// </remarks>
+        public bool RemoveCriterion(string criterion) => FilterCriteria.Remove(criterion);
 
         public int CriteriaCount => FilterCriteria.Count;
 

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -891,7 +891,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             // JFrog/Artifactory requires an empty search term to enumerate all packages in the feed
             if (_isJFrogRepo) {
-                queryBuilder.SearchTerm = "";
+                queryBuilder.SearchTerm = "''";
             }
 
             if (includePrerelease) {
@@ -931,7 +931,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             // JFrog/Artifactory requires an empty search term to enumerate all packages in the feed
             if (_isJFrogRepo) {
-                queryBuilder.SearchTerm = "";
+                queryBuilder.SearchTerm = "''";
             }
 
             if (includePrerelease) {
@@ -982,10 +982,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // can only find from Modules endpoint
             var tagPrefix = isSearchingForCommands ? "PSCommand_" : "PSDscResource_";
 
-            queryBuilder.SearchTerm = string.Join(
+            queryBuilder.SearchTerm = "'" + string.Join(
                 " ",
                 tags.Select(tag => $"tag:{tagPrefix}{tag}")
-            );
+            ) + "'";
                 
 
             var requestUrlV2 = $"{Repository.Uri}/Search()?{queryBuilder.BuildQueryString()}";

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -902,9 +902,24 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and startswith(Id, 'PowerShell') and IsLatestVersion (stable)
             // https://www.powershellgallery.com/api/v2/Search()?$filter=endswith(Id, 'Get') and IsAbsoluteLatestVersion&includePrerelease=true
 
-            string extraParam = _isPSGalleryRepo ? $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=100" : $"&$inlinecount=allpages&$skip={skip}&$top=100";
-            var prerelease = includePrerelease ? "IsAbsoluteLatestVersion&includePrerelease=true" : "IsLatestVersion";
-            string nameFilter;
+            var queryBuilder = new NuGetV2QueryBuilder(new Dictionary<string, string>{
+                { "$inlinecount", "allpages" },
+                { "$skip", skip.ToString()},
+                { "$top", "100"}
+            });
+            var filterBuilder = queryBuilder.FilterBuilder;
+
+            if (_isPSGalleryRepo) {
+                queryBuilder.AdditionalParameters["$orderby"] = "Id desc";
+            }
+
+            if (includePrerelease) {
+                queryBuilder.AdditionalParameters["includePrerelease"] = "true";
+                filterBuilder.AddCriteria("IsAbsoluteLatestVersion");
+            } else {
+                filterBuilder.AddCriteria("IsLatestVersion");
+            }
+
 
             var names = packageName.Split(new char[] {'*'}, StringSplitOptions.RemoveEmptyEntries);
 
@@ -923,17 +938,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (packageName.StartsWith("*") && packageName.EndsWith("*"))
                 {
                     // *get*
-                    nameFilter = $"substringof('{names[0]}', Id)";
+                    filterBuilder.AddCriteria($"substringof('{names[0]}', Id)");
                 }
                 else if (packageName.EndsWith("*"))
                 {
                     // PowerShell*
-                    nameFilter = $"startswith(Id, '{names[0]}')";
+                    filterBuilder.AddCriteria($"startswith(Id, '{names[0]}')");
                 }
                 else
                 {
                     // *ShellGet
-                    nameFilter = $"endswith(Id, '{names[0]}')";
+                    filterBuilder.AddCriteria($"endswith(Id, '{names[0]}')");
                 }
             }
             else if (names.Length == 2 && !packageName.StartsWith("*") && !packageName.EndsWith("*"))
@@ -942,7 +957,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // pow*get -> only support this
                 // pow*get*
                 // *pow*get
-                nameFilter = $"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')";
+                filterBuilder.AddCriteria($"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')");
             }
             else
             {
@@ -965,8 +980,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 return string.Empty;
             }
-            string typeFilterPart = GetTypeFilterForRequest(type);
-            var requestUrlV2 = $"{Repository.Uri}/Search()?$filter={nameFilter}{typeFilterPart} and {prerelease}{extraParam}";
+            filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+            var requestUrlV2 = $"{Repository.Uri}/Search()?{queryBuilder.BuildQueryString()}";
 
             return HttpRequestCall(requestUrlV2, out errRecord);
         }

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -351,12 +351,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // If it's a JFrog repository do not include the Id filter portion since JFrog uses 'Title' instead of 'Id',
             // however filtering on 'and Title eq '<packageName>' returns "Response status code does not indicate success: 500".
             if (!_isJFrogRepo) {
-                filterBuilder.AddCriteria($"Id eq '{packageName}'");
+                filterBuilder.AddCriterion($"Id eq '{packageName}'");
             }
 
-            filterBuilder.AddCriteria(includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion");
+            filterBuilder.AddCriterion(includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion");
             if (type != ResourceType.None) {
-                filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+                filterBuilder.AddCriterion(GetTypeFilterForRequest(type));
             }
             
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
@@ -409,17 +409,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // If it's a JFrog repository do not include the Id filter portion since JFrog uses 'Title' instead of 'Id',
             // however filtering on 'and Title eq '<packageName>' returns "Response status code does not indicate success: 500".
             if (!_isJFrogRepo) {
-                filterBuilder.AddCriteria($"Id eq '{packageName}'");
+                filterBuilder.AddCriterion($"Id eq '{packageName}'");
             }
 
-            filterBuilder.AddCriteria(includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion");
+            filterBuilder.AddCriterion(includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion");
             if (type != ResourceType.None) {
-                filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+                filterBuilder.AddCriterion(GetTypeFilterForRequest(type));
             }
 
             foreach (string tag in tags)
             {
-                filterBuilder.AddCriteria($"substringof('{tag}', Tags) eq true");
+                filterBuilder.AddCriterion($"substringof('{tag}', Tags) eq true");
             }
 
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
@@ -635,12 +635,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // If it's a JFrog repository do not include the Id filter portion since JFrog uses 'Title' instead of 'Id',
             // however filtering on 'and Title eq '<packageName>' returns "Response status code does not indicate success: 500".
             if (!_isJFrogRepo) {
-                filterBuilder.AddCriteria($"Id eq '{packageName}'");
+                filterBuilder.AddCriterion($"Id eq '{packageName}'");
             }
             
-            filterBuilder.AddCriteria($"NormalizedVersion eq '{version}'");
+            filterBuilder.AddCriterion($"NormalizedVersion eq '{version}'");
             if (type != ResourceType.None) {
-                filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+                filterBuilder.AddCriterion(GetTypeFilterForRequest(type));
             }
 
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
@@ -691,17 +691,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // If it's a JFrog repository do not include the Id filter portion since JFrog uses 'Title' instead of 'Id',
             // however filtering on 'and Title eq '<packageName>' returns "Response status code does not indicate success: 500".
             if (!_isJFrogRepo) {
-                filterBuilder.AddCriteria($"Id eq '{packageName}'");
+                filterBuilder.AddCriterion($"Id eq '{packageName}'");
             }
             
-            filterBuilder.AddCriteria($"NormalizedVersion eq '{version}'");
+            filterBuilder.AddCriterion($"NormalizedVersion eq '{version}'");
             if (type != ResourceType.None) {
-                filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+                filterBuilder.AddCriterion(GetTypeFilterForRequest(type));
             }
 
             foreach (string tag in tags)
             {
-                filterBuilder.AddCriteria($"substringof('{tag}', Tags) eq true");
+                filterBuilder.AddCriterion($"substringof('{tag}', Tags) eq true");
             }
 
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
@@ -896,9 +896,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriteria("IsAbsoluteLatestVersion");
+                filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
             } else {
-                filterBuilder.AddCriteria("IsLatestVersion");
+                filterBuilder.AddCriterion("IsLatestVersion");
             }
             var requestUrlV2 = $"{Repository.Uri}{typeEndpoint}/Search()?$filter={queryBuilder.BuildQueryString()}";
             return HttpRequestCall(requestUrlV2, out errRecord);
@@ -936,16 +936,16 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriteria("IsAbsoluteLatestVersion");
+                filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
             } else {
-                filterBuilder.AddCriteria("IsLatestVersion");
+                filterBuilder.AddCriterion("IsLatestVersion");
             }
 
-            filterBuilder.AddCriteria($"substringof('PS{(isSearchingModule ? "Module" : "Script")}', Tags) eq true");
+            filterBuilder.AddCriterion($"substringof('PS{(isSearchingModule ? "Module" : "Script")}', Tags) eq true");
             
             foreach (string tag in tags)
             {
-                filterBuilder.AddCriteria($"substringof('{tag}', Tags) eq true");
+                filterBuilder.AddCriterion($"substringof('{tag}', Tags) eq true");
             }
 
             var requestUrlV2 = $"{Repository.Uri}{typeEndpoint}/Search()?{queryBuilder.BuildQueryString()}";
@@ -973,9 +973,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriteria("IsAbsoluteLatestVersion");
+                filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
             } else {
-                filterBuilder.AddCriteria("IsLatestVersion");
+                filterBuilder.AddCriterion("IsLatestVersion");
             }
 
 
@@ -1015,9 +1015,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriteria("IsAbsoluteLatestVersion");
+                filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
             } else {
-                filterBuilder.AddCriteria("IsLatestVersion");
+                filterBuilder.AddCriterion("IsLatestVersion");
             }
 
 
@@ -1038,17 +1038,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (packageName.StartsWith("*") && packageName.EndsWith("*"))
                 {
                     // *get*
-                    filterBuilder.AddCriteria($"substringof('{names[0]}', Id)");
+                    filterBuilder.AddCriterion($"substringof('{names[0]}', Id)");
                 }
                 else if (packageName.EndsWith("*"))
                 {
                     // PowerShell*
-                    filterBuilder.AddCriteria($"startswith(Id, '{names[0]}')");
+                    filterBuilder.AddCriterion($"startswith(Id, '{names[0]}')");
                 }
                 else
                 {
                     // *ShellGet
-                    filterBuilder.AddCriteria($"endswith(Id, '{names[0]}')");
+                    filterBuilder.AddCriterion($"endswith(Id, '{names[0]}')");
                 }
             }
             else if (names.Length == 2 && !packageName.StartsWith("*") && !packageName.EndsWith("*"))
@@ -1057,7 +1057,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // pow*get -> only support this
                 // pow*get*
                 // *pow*get
-                filterBuilder.AddCriteria($"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')");
+                filterBuilder.AddCriterion($"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')");
             }
             else
             {
@@ -1081,7 +1081,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return string.Empty;
             }
             if (type != ResourceType.None) {
-                filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+                filterBuilder.AddCriterion(GetTypeFilterForRequest(type));
             }
             var requestUrlV2 = $"{Repository.Uri}/Search()?{queryBuilder.BuildQueryString()}";
 
@@ -1110,9 +1110,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriteria("IsAbsoluteLatestVersion");
+                filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
             } else {
-                filterBuilder.AddCriteria("IsLatestVersion");
+                filterBuilder.AddCriterion("IsLatestVersion");
             }
 
 
@@ -1142,17 +1142,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 if (packageName.StartsWith("*") && packageName.EndsWith("*"))
                 {
-                    filterBuilder.AddCriteria($"substringof('{names[0]}', Id)");
+                    filterBuilder.AddCriterion($"substringof('{names[0]}', Id)");
                 }
                 else if (packageName.EndsWith("*"))
                 {
                     // PowerShell*
-                    filterBuilder.AddCriteria($"startswith(Id, '{names[0]}')");
+                    filterBuilder.AddCriterion($"startswith(Id, '{names[0]}')");
                 }
                 else
                 {
                     // *ShellGet
-                    filterBuilder.AddCriteria($"endswith(Id, '{names[0]}')");
+                    filterBuilder.AddCriterion($"endswith(Id, '{names[0]}')");
                 }
             }
             else if (names.Length == 2 && !packageName.StartsWith("*") && !packageName.EndsWith("*"))
@@ -1161,7 +1161,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // pow*get -> only support this
                 // pow*get*
                 // *pow*get
-                filterBuilder.AddCriteria($"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')");
+                filterBuilder.AddCriterion($"startswith(Id, '{names[0]}') and endswith(Id, '{names[1]}')");
             }
             else
             {
@@ -1177,11 +1177,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string tagFilterPart = String.Empty;
             foreach (string tag in tags)
             {
-                filterBuilder.AddCriteria($"substringof('{tag}', Tags) eq true");
+                filterBuilder.AddCriterion($"substringof('{tag}', Tags) eq true");
             }
 
             if (type != ResourceType.None) {
-                filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+                filterBuilder.AddCriterion(GetTypeFilterForRequest(type));
             }
             var requestUrlV2 = $"{Repository.Uri}/Search()?{queryBuilder.BuildQueryString()}";
 
@@ -1261,14 +1261,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string versionFilterParts = String.Empty;
             if (!String.IsNullOrEmpty(minPart))
             {
-                filterBuilder.AddCriteria(minPart);
+                filterBuilder.AddCriterion(minPart);
             }
             if (!String.IsNullOrEmpty(maxPart))
             {
-                filterBuilder.AddCriteria(maxPart);
+                filterBuilder.AddCriterion(maxPart);
             }
             if (!includePrerelease) {
-                filterBuilder.AddCriteria("IsPrerelease eq false");
+                filterBuilder.AddCriterion("IsPrerelease eq false");
             }
             
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
@@ -1276,11 +1276,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // If it's a JFrog repository do not include the Id filter portion since JFrog uses 'Title' instead of 'Id',
             // however filtering on 'and Title eq '<packageName>' returns "Response status code does not indicate success: 500".
             if (!_isJFrogRepo) {
-                filterBuilder.AddCriteria($"Id eq '{packageName}'");
+                filterBuilder.AddCriterion($"Id eq '{packageName}'");
             }
 
             if (type == ResourceType.Script) {
-                filterBuilder.AddCriteria($"substringof('PS{type.ToString()}', Tags) eq true");
+                filterBuilder.AddCriterion($"substringof('PS{type.ToString()}', Tags) eq true");
             }
             
 

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -355,9 +355,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             filterBuilder.AddCriteria(includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion");
-            filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+            if (type != ResourceType.None) {
+                filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+            }
             
-            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById(){queryBuilder.BuildQueryString()}";
+            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             if (errRecord != null)
             {
@@ -411,7 +413,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             filterBuilder.AddCriteria(includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion");
-            filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+            if (type != ResourceType.None) {
+                filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+            }
 
             foreach (string tag in tags)
             {
@@ -635,7 +639,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             
             filterBuilder.AddCriteria($"NormalizedVersion eq '{version}'");
-            filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+            if (type != ResourceType.None) {
+                filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+            }
 
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
             string response = HttpRequestCall(requestUrlV2, out errRecord);
@@ -689,7 +695,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             
             filterBuilder.AddCriteria($"NormalizedVersion eq '{version}'");
-            filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+            if (type != ResourceType.None) {
+                filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+            }
 
             foreach (string tag in tags)
             {
@@ -1072,7 +1080,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 return string.Empty;
             }
-            filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+            if (type != ResourceType.None) {
+                filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+            }
             var requestUrlV2 = $"{Repository.Uri}/Search()?{queryBuilder.BuildQueryString()}";
 
             return HttpRequestCall(requestUrlV2, out errRecord);
@@ -1170,7 +1180,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 filterBuilder.AddCriteria($"substringof('{tag}', Tags) eq true");
             }
 
-            filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+            if (type != ResourceType.None) {
+                filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+            }
             var requestUrlV2 = $"{Repository.Uri}/Search()?{queryBuilder.BuildQueryString()}";
 
             return HttpRequestCall(requestUrlV2, out errRecord);

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -881,7 +881,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             var queryBuilder = new NuGetV2QueryBuilder(new Dictionary<string, string>{
                 { "$inlinecount", "allpages" },
                 { "$skip", skip.ToString()},
-                { "$top", "100"}
+                { "$top", "6000"}
             });
             var filterBuilder = queryBuilder.FilterBuilder;
 

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -602,11 +602,22 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // Quotations around package name and version do not matter, same metadata gets returned.
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
 
+            var queryBuilder = new NuGetV2QueryBuilder(new Dictionary<string, string>{
+                { "$inlinecount", "allpages" },
+                { "id", $"'{packageName}'" },
+            });
+            var filterBuilder = queryBuilder.FilterBuilder;
+
             // If it's a JFrog repository do not include the Id filter portion since JFrog uses 'Title' instead of 'Id',
             // however filtering on 'and Title eq '<packageName>' returns "Response status code does not indicate success: 500".
-            string idFilterPart = _isJFrogRepo ? "" : $" and Id eq '{packageName}'";
-            string typeFilterPart = GetTypeFilterForRequest(type);
-            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$inlinecount=allpages&$filter= NormalizedVersion eq '{version}'{idFilterPart}{typeFilterPart}";
+            if (!_isJFrogRepo) {
+                filterBuilder.AddCriteria($"Id eq '{packageName}'");
+            }
+            
+            filterBuilder.AddCriteria($"NormalizedVersion eq '{version}'");
+            filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+
+            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             if (errRecord != null)
             {
@@ -643,19 +654,29 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override FindResults FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindVersionWithTag()");
+
+            var queryBuilder = new NuGetV2QueryBuilder(new Dictionary<string, string>{
+                { "$inlinecount", "allpages" },
+                { "id", $"'{packageName}'" },
+            });
+            var filterBuilder = queryBuilder.FilterBuilder;
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
 
             // If it's a JFrog repository do not include the Id filter portion since JFrog uses 'Title' instead of 'Id',
             // however filtering on 'and Title eq '<packageName>' returns "Response status code does not indicate success: 500".
-            string idFilterPart = _isJFrogRepo ? "" : $" and Id eq '{packageName}'";
-            string typeFilterPart = GetTypeFilterForRequest(type);
-            string tagFilterPart = String.Empty;
+            if (!_isJFrogRepo) {
+                filterBuilder.AddCriteria($"Id eq '{packageName}'");
+            }
+            
+            filterBuilder.AddCriteria($"NormalizedVersion eq '{version}'");
+            filterBuilder.AddCriteria(GetTypeFilterForRequest(type));
+
             foreach (string tag in tags)
             {
-                tagFilterPart += $" and substringof('{tag}', Tags) eq true";
+                filterBuilder.AddCriteria($"substringof('{tag}', Tags) eq true");
             }
 
-            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?id='{packageName}'&$inlinecount=allpages&$filter= NormalizedVersion eq '{version}'{idFilterPart}{typeFilterPart}{tagFilterPart}";
+            var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             if (errRecord != null)
             {
@@ -828,12 +849,30 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         {
             _cmdletPassedIn.WriteDebug("In V2ServerAPICalls::FindAllFromTypeEndPoint()");
             string typeEndpoint = _isPSGalleryRepo && !isSearchingModule ? "/items/psscript" : String.Empty;
-            string paginationParam = _isPSGalleryRepo ? $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=6000" : $"&$inlinecount=allpages&$skip={skip}&$top=6000";
-            // JFrog/Artifactory requires an empty search term to enumerate all packages in the feed
-            string searchTerm = _isJFrogRepo ? "&searchTerm=''" : "";
-            var prereleaseFilter = includePrerelease ? "IsAbsoluteLatestVersion&includePrerelease=true" : "IsLatestVersion";
 
-            var requestUrlV2 = $"{Repository.Uri}{typeEndpoint}/Search()?$filter={prereleaseFilter}{searchTerm}{paginationParam}";
+            var queryBuilder = new NuGetV2QueryBuilder(new Dictionary<string, string>{
+                { "$inlinecount", "allpages" },
+                { "$skip", skip.ToString()},
+                { "$top", "100"}
+            });
+            var filterBuilder = queryBuilder.FilterBuilder;
+
+            if (_isPSGalleryRepo) {
+                queryBuilder.AdditionalParameters["$orderby"] = "Id desc";
+            }
+
+            // JFrog/Artifactory requires an empty search term to enumerate all packages in the feed
+            if (_isJFrogRepo) {
+                queryBuilder.SearchTerm = "";
+            }
+
+            if (includePrerelease) {
+                queryBuilder.AdditionalParameters["includePrerelease"] = "true";
+                filterBuilder.AddCriteria("IsAbsoluteLatestVersion");
+            } else {
+                filterBuilder.AddCriteria("IsLatestVersion");
+            }
+            var requestUrlV2 = $"{Repository.Uri}{typeEndpoint}/Search()?$filter={queryBuilder.BuildQueryString()}";
             return HttpRequestCall(requestUrlV2, out errRecord);
         }
 
@@ -850,19 +889,38 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // type: DSCResource -> just search Modules
             // type: Command -> just search Modules
             string typeEndpoint = _isPSGalleryRepo && !isSearchingModule ? "/items/psscript" : String.Empty;
-            string paginationParam = _isPSGalleryRepo ? $"&$orderby=Id desc&$inlinecount=allpages&$skip={skip}&$top=6000" : $"&$inlinecount=allpages&$skip={skip}&$top=6000";
-            // JFrog/Artifactory requires an empty search term to enumerate all packages in the feed
-            string searchTerm = _isJFrogRepo ? "&searchTerm=''" : "";
-            var prereleaseFilter = includePrerelease ? "includePrerelease=true&$filter=IsAbsoluteLatestVersion" : "$filter=IsLatestVersion";
-            string typeFilterPart = isSearchingModule ?  $" and substringof('PSModule', Tags) eq true" : $" and substringof('PSScript', Tags) eq true";
 
-            string tagFilterPart = String.Empty;
-            foreach (string tag in tags)
-            {
-                tagFilterPart += $" and substringof('{tag}', Tags) eq true";
+            var queryBuilder = new NuGetV2QueryBuilder(new Dictionary<string, string>{
+                { "$inlinecount", "allpages" },
+                { "$skip", skip.ToString()},
+                { "$top", "6000"}
+            });
+            var filterBuilder = queryBuilder.FilterBuilder;
+
+            if (_isPSGalleryRepo) {
+                queryBuilder.AdditionalParameters["$orderby"] = "Id desc";
             }
 
-            var requestUrlV2 = $"{Repository.Uri}{typeEndpoint}/Search()?{prereleaseFilter}{searchTerm}{typeFilterPart}{tagFilterPart}{paginationParam}";
+            // JFrog/Artifactory requires an empty search term to enumerate all packages in the feed
+            if (_isJFrogRepo) {
+                queryBuilder.SearchTerm = "";
+            }
+
+            if (includePrerelease) {
+                queryBuilder.AdditionalParameters["includePrerelease"] = "true";
+                filterBuilder.AddCriteria("IsAbsoluteLatestVersion");
+            } else {
+                filterBuilder.AddCriteria("IsLatestVersion");
+            }
+
+            filterBuilder.AddCriteria($"substringof('PS{(isSearchingModule ? "Module" : "Script")}', Tags) eq true");
+            
+            foreach (string tag in tags)
+            {
+                filterBuilder.AddCriteria($"substringof('{tag}', Tags) eq true");
+            }
+
+            var requestUrlV2 = $"{Repository.Uri}{typeEndpoint}/Search()?{queryBuilder.BuildQueryString()}";
 
             return HttpRequestCall(requestUrlV2: requestUrlV2, out errRecord);
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
This PR replaces the existing NuGet v2 API call-building mechanism based on string manipulation (as used in members of `V2ServerAPICalls` and `NuGetServerAPICalls`) with a separate pair of classes (`NuGetV2QueryBuilder` and `NuGetV2FilterBuilder`) that construct a query-string by aggregating user-supplied criteria.

Resolves #1643.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

The current implementation of V2 API calling classes builds API call URLs (including parameters) by directly performing string-manipulation on the URL itself. This has several drawbacks:
* **Performance**: In the CLR, strings are immutable. Calling `+=` on a string means a completely new string is created (with the suffix appended), and the prior string remains in memory until GC. 
  * `NuGetV2FilterBuilder` uses `StringBuilder` to avoid costly reallocation of large strings.
* **Sanitization**: OData filters, being URL query parameters, must be URL-encoded to prevent unexpected behavior. Operating on the URL directly means each relevant method has to URL-encode, which adds boilerplate or security risks if methods mis-encode.
  * `NuGetV2QueryBuilder` uses a derivative of `System.Collections.Specialized.NameValueCollection` to automatically URL-encode any configured parameters.
  * This does not include user input sanitization at the OData level - see below.
* **Flexibility**: Different NuGet server implementations have different API call requirements, as seen by the quirk flag system used today. Different combinations of these quirk flags have caused manual combination of filter clauses to misbehave (#1633) when a clause previously expected to be "always present" is no longer present.
  * `NuGetV2FilterBuilder` joins filter clauses together after the full set is available, so there's no duplicated/inappropriately-placed joining operators.

There are some specific limitations in the current implementation:
* I had to add a project reference to `System.Web` to build against TFM `net472`, as we need `System.Web.HttpUtility`. To my knowledge, System.Web should be in the GAC on .NET 4.5 and above, and PowerShell 7 already has System.Web.HttpUtility.dll linked as-is.  
  I'm not an expert in MSBuild, however, so if there's a better way to ensure `HttpUtility` is available I'm all ears.
* `NuGetV2FilterBuilder` doesn't ensure that filter clauses are properly escaping OData-relevant syntax (parentheses, quotes, etc.). 
  I wanted to focus namely on the aggregation of clauses versus the clauses themselves in the first pass - now that we have purpose-built classes for these, it would be significantly easier to expose an interface for filter clauses (`INuGetV2FilterCriterion`?) with some inheritance for unary-/binary-operator criteria.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
