### PR TITLE
Added support for AWS CodeArtifact

### DIFF
--- a/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
@@ -11,6 +11,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
 
     BeforeAll{
         $AWSCodeArtifactGalleryName = Get-AWSCodeArtifactGalleryName
+        $AWSCodeArtifactGalleryLocation = Get-AWSCodeArtifactGalleryLocation
         $NuGetGalleryName = Get-NuGetGalleryName
         $testModuleName = "test_module"
         Get-NewPSResourceRepositoryFile

--- a/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
@@ -272,7 +272,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
     }
 
     It "should support AWS CodeArtifact with find all resources given Name '*'" {
-            Register-PSResourceRepository -Name $AWSCodeArtifactGalleryName -Uri $AWSCodeArtifactGalleryLocation
+        Register-PSResourceRepository -Name $AWSCodeArtifactGalleryName -Uri $AWSCodeArtifactGalleryLocation
         $res = Find-PSResource -Name "*" -Repository $AWSCodeArtifactGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         Unregister-PSResourceRepository -Name $AWSCodeArtifactGalleryName
         $res | Should -BeNullOrEmpty

--- a/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
@@ -272,7 +272,9 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
     }
 
     It "should support AWS CodeArtifact with find all resources given Name '*'" {
+                Register-PSResourceRepository -Name $AWSCodeArtifactGalleryName -Uri $AWSCodeArtifactGalleryLocation
         $res = Find-PSResource -Name "*" -Repository $AWSCodeArtifactGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
+        Unregister-PSResourceRepository -Name $AWSCodeArtifactGalleryName
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
         # The `HttpRequestCallFailure` error indicates the cmdlet moved past the fast-fail for `-Name '*'` not supported

--- a/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
@@ -10,6 +10,7 @@ Write-Verbose -Verbose "Current module search paths: $psmodulePaths"
 Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
 
     BeforeAll{
+        $AWSCodeArtifactGalleryName = Get-AWSCodeArtifactGalleryName
         $NuGetGalleryName = Get-NuGetGalleryName
         $testModuleName = "test_module"
         Get-NewPSResourceRepositoryFile
@@ -269,13 +270,21 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
         $err[0].FullyQualifiedErrorId | Should -BeExactly "FindAllFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
+    It "should support AWS CodeArtifact with find all resources given Name '*'" {
+        $res = Find-PSResource -Name "*" -Repository $AWSCodeArtifactGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
+        $res | Should -BeNullOrEmpty
+        $err.Count | Should -BeGreaterThan 0
+        # The `HttpRequestCallFailure` error indicates the cmdlet moved past the fast-fail for `-Name '*'` not supported
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "HttpRequestCallFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+    }
+
     It "should not find an unlisted module" {
         $res = Find-PSResource -Name "PMTestDependency1" -Repository $NuGetGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
-    
+
     # "carb*" is intentionally chosen as a sequence that will trigger pagination (ie more than 100 results),
     # but is not too time consuming.
     # There are currently between 236 packages that should be returned

--- a/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV3Server.Tests.ps1
@@ -272,7 +272,7 @@ Describe 'Test HTTP Find-PSResource for V3 Server Protocol' -tags 'CI' {
     }
 
     It "should support AWS CodeArtifact with find all resources given Name '*'" {
-                Register-PSResourceRepository -Name $AWSCodeArtifactGalleryName -Uri $AWSCodeArtifactGalleryLocation
+            Register-PSResourceRepository -Name $AWSCodeArtifactGalleryName -Uri $AWSCodeArtifactGalleryLocation
         $res = Find-PSResource -Name "*" -Repository $AWSCodeArtifactGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
         Unregister-PSResourceRepository -Name $AWSCodeArtifactGalleryName
         $res | Should -BeNullOrEmpty

--- a/test/PSGetTestUtils.psm1
+++ b/test/PSGetTestUtils.psm1
@@ -22,6 +22,11 @@ $script:PSGalleryLocation = 'https://www.powershellgallery.com/api/v2'
 $script:NuGetGalleryName = 'NuGetGallery'
 $script:NuGetGalleryLocation = 'https://api.nuget.org/v3/index.json'
 
+# This is not a valid Code Artifact endpoint. However, this will allow a unit test to move
+# past the NuGet v3 fast fail in the FindAll() method.
+$script:AWSCodeArtifactName = 'AWSCodeArtifact'
+$script:AWSCodeArtifactLocation = 'https://cadomainname-awsaccountid.d.codeartifact.region.amazonaws.com/nuget/carepositoryname/v3/index.json'
+
 if($script:IsInbox)
 {
     $script:ProgramFilesPSPath = Microsoft.PowerShell.Management\Join-Path -Path $env:ProgramFiles -ChildPath "WindowsPowerShell"
@@ -133,6 +138,14 @@ function Get-TempPath {
 
 function Get-PSGetLocalAppDataPath {
     return $script:PSGetAppLocalPath
+}
+
+function Get-AWSCodeArtifactGalleryName {
+    return $script:AWSCodeArtifactName
+}
+
+function Get-AWSCodeArtifactGalleryLocation {
+    return $script:AWSCodeArtifactLocation
 }
 
 function Get-NuGetGalleryName


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Adds support for AWS CodeArtifact NuGet v3 repositories. Resolves https://github.com/PowerShell/PSResourceGet/issues/1650.

## PR Context

AWS CodeArtifact supports NuGet v3 feeds. This adds the features supported by AWS CodeArtifact to the PSResourceGet module.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.

**Testing

This is both. I've added a unit test to ensure the fast-fail code path is not hit. I have also used this interactively. Examples below against a repository in my AWS account.

```powershell
# Showing the resource repository
# NOTE: My AWS AccountId has been changed...
PS>Get-PSResourceRepository -Name AWSCodeArtifact | Select-Object -Property Name, Uri

Name            Uri
----            ---
AWSCodeArtifact https://psrepo-123456789012.d.codeartifact.us-west-2.amazonaws.com/nuget/psrepo/v3/index.json

# Showing `-Name '*'` works
PS>Find-PSResource -Credential $credential -Repository 'AWSCodeArtifact' -Name '*' | Select-Object -Property Name, Repository

Name                   Repository
----                   ----------
AWS.Tools.CodeArtifact AWSCodeArtifact
AWS.Tools.Common       AWSCodeArtifact
AWS.Tools.EC2          AWSCodeArtifact
AWS.Tools.S3           AWSCodeArtifact
Convert                AWSCodeArtifact
FastPing               AWSCodeArtifact
FileSystemHelpers      AWSCodeArtifact

# Showing `-Name 'Prefix*'` works
PS>Find-PSResource -Credential $credential -Repository 'AWSCodeArtifact' -Name 'AWS.Tools.*' | Select-Object -Property Name, Repository

Name                   Repository
----                   ----------
AWS.Tools.CodeArtifact AWSCodeArtifact
AWS.Tools.Common       AWSCodeArtifact
AWS.Tools.EC2          AWSCodeArtifact
AWS.Tools.S3           AWSCodeArtifact
```
