### PR TITLE
Make delete more robust (fix #1662)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ srcOld/code/obj
 out
 test/**/obj
 test/**/bin
+# Project file created by VSCode
+/*.sln

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ srcOld/code/obj
 out
 test/**/obj
 test/**/bin
-# Project file created by VSCode
-/*.sln

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -467,7 +467,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         // Delete the directory path before replacing it with the new module.
                         // If deletion fails (usually due to binary file in use), then attempt restore so that the currently
                         // installed module is not corrupted.
-                        _cmdletPassedIn.WriteVerbose($"Attempting to delete with restore on failure.'{finalModuleVersionDir}'");
+                        _cmdletPassedIn.WriteVerbose($"Attempting to delete with restore on failure. '{finalModuleVersionDir}'");
                         Utils.DeleteDirectoryWithRestore(finalModuleVersionDir);
                     }
 

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1540,6 +1540,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         /// </Summary>
         public static void DeleteDirectory(string dirPath)
         {
+            // Delete files first
             foreach (var dirFilePath in Directory.GetFiles(dirPath))
             {
                 // Remove read only file attribute if present
@@ -1570,12 +1571,12 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     }
                 }
             }
-
+            // Delete child directories
             foreach (var dirSubPath in Directory.GetDirectories(dirPath))
             {
                 DeleteDirectory(dirSubPath);
             }
-
+            // Delete parent directory
             Directory.Delete(dirPath);
         }
 

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         #region String fields
 
         public static readonly string[] EmptyStrArray = Array.Empty<string>();
-        public static readonly char[] WhitespaceSeparator = new char[]{' '};
+        public static readonly char[] WhitespaceSeparator = new char[] { ' ' };
         public const string PSDataFileExt = ".psd1";
         public const string PSScriptFileExt = ".ps1";
         private const string ConvertJsonToHashtableScript = @"
@@ -142,7 +142,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             if (list == null) { return null; }
 
             var strArray = new string[list.Count];
-            for (int i=0; i < list.Count; i++)
+            for (int i = 0; i < list.Count; i++)
             {
                 strArray[i] = list[i] as string;
             }
@@ -163,7 +163,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             {
                 isContainWildcard = true;
                 errorMsgs = errorMsgsList.ToArray();
-                return new string[] {"*"};
+                return new string[] { "*" };
             }
 
             isContainWildcard = false;
@@ -181,8 +181,8 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     if (String.Equals(name, "*", StringComparison.InvariantCultureIgnoreCase))
                     {
                         isContainWildcard = true;
-                        errorMsgs = new string[] {};
-                        return new string[] {"*"};
+                        errorMsgs = new string[] { };
+                        return new string[] { "*" };
                     }
 
                     if (name.Contains("?") || name.Contains("["))
@@ -277,7 +277,8 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     // eg: 2.8.8.* should translate to the version range "[2.1.3.0,2.1.3.99999]"
                     modifiedVersion = $"[{versionSplit[0]}.{versionSplit[1]}.{versionSplit[2]}.0,{versionSplit[0]}.{versionSplit[1]}.{versionSplit[2]}.999999]";
                 }
-                else {
+                else
+                {
                     error = "Argument for -Version parameter is not in the proper format";
                     return false;
                 }
@@ -471,15 +472,15 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
             try
             {
-                if (!string.IsNullOrEmpty((string) credentialInfoCandidate.Properties[PSCredentialInfo.VaultNameAttribute]?.Value)
-                    && !string.IsNullOrEmpty((string) credentialInfoCandidate.Properties[PSCredentialInfo.SecretNameAttribute]?.Value))
+                if (!string.IsNullOrEmpty((string)credentialInfoCandidate.Properties[PSCredentialInfo.VaultNameAttribute]?.Value)
+                    && !string.IsNullOrEmpty((string)credentialInfoCandidate.Properties[PSCredentialInfo.SecretNameAttribute]?.Value))
                 {
                     PSCredential credential = null;
                     if (credentialInfoCandidate.Properties[PSCredentialInfo.CredentialAttribute] != null)
                     {
                         try
                         {
-                            credential = (PSCredential) credentialInfoCandidate.Properties[PSCredentialInfo.CredentialAttribute].Value;
+                            credential = (PSCredential)credentialInfoCandidate.Properties[PSCredentialInfo.CredentialAttribute].Value;
                         }
                         catch (Exception e)
                         {
@@ -494,8 +495,8 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     }
 
                     repoCredentialInfo = new PSCredentialInfo(
-                        (string) credentialInfoCandidate.Properties[PSCredentialInfo.VaultNameAttribute].Value,
-                        (string) credentialInfoCandidate.Properties[PSCredentialInfo.SecretNameAttribute].Value,
+                        (string)credentialInfoCandidate.Properties[PSCredentialInfo.VaultNameAttribute].Value,
+                        (string)credentialInfoCandidate.Properties[PSCredentialInfo.SecretNameAttribute].Value,
                         credential
                     );
 
@@ -713,7 +714,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 string password = new NetworkCredential(string.Empty, secretSecureString).Password;
                 return password;
             }
-            else if(secretValue is PSCredential psCredSecret)
+            else if (secretValue is PSCredential psCredSecret)
             {
                 string password = new NetworkCredential(string.Empty, psCredSecret.Password).Password;
                 return password;
@@ -1122,7 +1123,8 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 // paths are the same for both Linux and macOS
                 localUserDir = Path.Combine(GetHomeOrCreateTempHome(), ".local", "share", "powershell");
                 // Create the default data directory if it doesn't exist.
-                if (!Directory.Exists(localUserDir)) {
+                if (!Directory.Exists(localUserDir))
+                {
                     Directory.CreateDirectory(localUserDir);
                 }
 
@@ -1249,7 +1251,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     result = psObject.BaseObject;
                 }
 
-                dataFileInfo = (Hashtable) result;
+                dataFileInfo = (Hashtable)result;
                 error = null;
                 return true;
             }
@@ -1371,10 +1373,10 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             validatedModuleSpecs = Array.Empty<ModuleSpecification>();
             List<ModuleSpecification> moduleSpecsList = new List<ModuleSpecification>();
 
-            foreach(Hashtable moduleSpec in moduleSpecHashtables)
+            foreach (Hashtable moduleSpec in moduleSpecHashtables)
             {
                 // ModuleSpecification(string) constructor for creating a ModuleSpecification when only ModuleName is provided.
-                if (!moduleSpec.ContainsKey("ModuleName") || String.IsNullOrEmpty((string) moduleSpec["ModuleName"]))
+                if (!moduleSpec.ContainsKey("ModuleName") || String.IsNullOrEmpty((string)moduleSpec["ModuleName"]))
                 {
                     errorList.Add(new ErrorRecord(
                         new ArgumentException($"RequiredModules Hashtable entry {moduleSpec.ToString()} is missing a key 'ModuleName' and associated value, which is required for each module specification entry"),
@@ -1386,7 +1388,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 }
 
                 // At this point it must contain ModuleName key.
-                string moduleSpecName = (string) moduleSpec["ModuleName"];
+                string moduleSpecName = (string)moduleSpec["ModuleName"];
                 ModuleSpecification currentModuleSpec = null;
                 if (!moduleSpec.ContainsKey("MaximumVersion") && !moduleSpec.ContainsKey("ModuleVersion") && !moduleSpec.ContainsKey("RequiredVersion"))
                 {
@@ -1412,10 +1414,10 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 else
                 {
                     // ModuleSpecification(Hashtable) constructor for when ModuleName + {Required,Maximum,Module}Version value is also provided.
-                    string moduleSpecMaxVersion = moduleSpec.ContainsKey("MaximumVersion") ? (string) moduleSpec["MaximumVersion"] : String.Empty;
-                    string moduleSpecModuleVersion = moduleSpec.ContainsKey("ModuleVersion") ? (string) moduleSpec["ModuleVersion"] : String.Empty;
-                    string moduleSpecRequiredVersion = moduleSpec.ContainsKey("RequiredVersion") ? (string) moduleSpec["RequiredVersion"] : String.Empty;
-                    Guid moduleSpecGuid = moduleSpec.ContainsKey("Guid") ? (Guid) moduleSpec["Guid"] : Guid.Empty;
+                    string moduleSpecMaxVersion = moduleSpec.ContainsKey("MaximumVersion") ? (string)moduleSpec["MaximumVersion"] : String.Empty;
+                    string moduleSpecModuleVersion = moduleSpec.ContainsKey("ModuleVersion") ? (string)moduleSpec["ModuleVersion"] : String.Empty;
+                    string moduleSpecRequiredVersion = moduleSpec.ContainsKey("RequiredVersion") ? (string)moduleSpec["RequiredVersion"] : String.Empty;
+                    Guid moduleSpecGuid = moduleSpec.ContainsKey("Guid") ? (Guid)moduleSpec["Guid"] : Guid.Empty;
 
                     if (String.IsNullOrEmpty(moduleSpecMaxVersion) && String.IsNullOrEmpty(moduleSpecModuleVersion) && String.IsNullOrEmpty(moduleSpecRequiredVersion))
                     {
@@ -1548,19 +1550,23 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 // Delete file
                 int maxAttempts = 5;
                 int msDelay = 5;
-                for (int i = 0; i < maxAttempts; ++i)
+                for (int attempt = 1; i <= maxAttempts; ++i)
                 {
-                    try {
+                    try
+                    {
                         File.Delete(dirFilePath);
                         break;
                     }
-                    catch (IOException)
+                    catch (Exception ex)
                     {
-                        Thread.Sleep(msDelay);
-                    }
-                    catch (UnauthorizedAccessException)
-                    {
-                        Thread.Sleep(msDelay);
+                        if (attempt < maxAttempts && (ex is IOException || ex is UnauthorizedAccessException))
+                        {
+                            Thread.Sleep(msDelay);
+                        }
+                        else
+                        {
+                            throw;
+                        }
                     }
                 }
             }

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1548,7 +1548,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 {
                     File.SetAttributes(dirFilePath, File.GetAttributes(dirFilePath) & ~FileAttributes.ReadOnly);
                 }
-                // Delete file
+                // Delete file, try multiple times before throwing ( #1662 )
                 int maxAttempts = 5;
                 int msDelay = 5;
                 for (int attempt = 1; attempt <= maxAttempts; ++attempt)

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1556,7 +1556,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 try
                 {
                     Directory.Delete(dirPath,true);
-                    break;
+                    return;
                 }
                 catch (Exception ex)
                 {

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1550,7 +1550,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 // Delete file
                 int maxAttempts = 5;
                 int msDelay = 5;
-                for (int attempt = 1; i <= maxAttempts; ++i)
+                for (int attempt = 1; attempt <= maxAttempts; ++attempt)
                 {
                     try
                     {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Make delete more robust by trying multiple times before failing, to fix #1662.

## PR Context

In #1662 I experienced that PSResourceGet would fail to install modules because antimalware realtime scanners added file handles on files inside `%TEMP%` that were to be deleted.

I read here <https://stackoverflow.com/a/329502/9874541> that trying multiple times is a common approach for scenarios like these.

I then tried adapting the existing code to try multiple times on the step that sometimes failed.

I tried the code by building both `net472` and `netstandard2.0`, and I could no longer reproduce #1662.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
