### PR TITLE
Add prerelease string when NormalizedVersion doesn't exist (but prelease string does)

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -803,6 +803,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             pkgToInstall.RepositorySourceLocation = repository.Uri.ToString();
             pkgToInstall.AdditionalMetadata.TryGetValue("NormalizedVersion", out string pkgVersion);
             if (pkgVersion == null) {
+                // Not all NuGet providers (e.g. Artifactory, possibly others) send NormalizedVersion in NuGet package responses.
+                // If they don't, we need to manually construct the combined version+prerelease from pkgToInstall.Version and the prerelease string.
                 pkgVersion = pkgToInstall.Version.ToString();
                 if (!String.IsNullOrEmpty(pkgToInstall.Prerelease)) {
                     pkgVersion += $"-{pkgToInstall.Prerelease}";

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -804,6 +804,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             pkgToInstall.AdditionalMetadata.TryGetValue("NormalizedVersion", out string pkgVersion);
             if (pkgVersion == null) {
                 pkgVersion = pkgToInstall.Version.ToString();
+                if (!String.IsNullOrEmpty(pkgToInstall.Prerelease)) {
+                    pkgVersion += $"-{pkgToInstall.Prerelease}";
+                }
             }
             // Check to see if the pkg is already installed (ie the pkg is installed and the version satisfies the version range provided via param)
             if (!_reinstall)


### PR DESCRIPTION
# PR Summary

This PR conditionally adds the package prerelease string to the to-be-installed package version name (passed to `InstallVersion()`) inside `InstallHelper.BeginPackageInstall()`

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Currently, the version string is backfilled with the package's raw Version field if `NormalizedVersion` was not returned by the package management service. This causes a difference in behavior:
* For sources that provide `NormalizedVersion`, the prerelease string is included in `NormalizedVersion` and is included in `pkgVersion` as a result.
* For sources that don't provide it, `System.Version` does not include prerelease info and as-such the prerelease string is not included in `pkgVersion`.

This PR reconciles the second case to include prerelease strings, aligning it with the first.

Fixes #1680.

### Concerns

I don't have visibility into `NormalizedVersion` behavior on other package management services (only Artifactory and PSGallery), so I'm not 100% sure if `pkgToInstall.Prerelease` is the correct field to rely on.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
