### PR TITLE
Update buildtools reference to container registry tests

### DIFF
--- a/buildtools.psm1
+++ b/buildtools.psm1
@@ -134,9 +134,9 @@ function Invoke-ModuleTestsACR {
     )
 
     $acrTestFiles = @(
-        "FindPSResourceTests/FindPSResourceACRServer.Tests.ps1",
-        "InstallPSResourceTests/InstallPSResourceACRServer.Tests.ps1",
-        "PublishPSResourceTests/PublishPSResourceACRServer.Tests.ps1"
+        "FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1",
+        "InstallPSResourceTests/InstallPSResourceContainerRegistryServer.Tests.ps1",
+        "PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1"
     )
 
     Invoke-ModuleTests -Type $Type -TestFilePath $acrTestFiles


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update the `Invoke-ModuleTestsACR` method in `buildtools.psm1` to reference the new names for container registry tests.

## PR Context
Right now container registry (formerly `ACR`) CI tests are not being run because the referenced file names are incorrect.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
