### PR TITLE
Update the feed name used for testing

### DIFF
--- a/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceADOServer.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'Test HTTP Find-PSResource for ADO Server Protocol' -tags 'CI' {
     BeforeAll{
         $testModuleName = "test_local_mod"
         $ADORepoName = "PSGetTestingPublicFeed"
-        $ADORepoUri = "https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell-public-test/nuget/v3/index.json"
+        $ADORepoUri = "https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/psresourceget-public-test-ci/nuget/v3/index.json"
         Get-NewPSResourceRepositoryFile
         Register-PSResourceRepository -Name $ADORepoName -Uri $ADORepoUri
     }

--- a/test/FindPSResourceTests/FindPSResourceADOV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceADOV2Server.Tests.ps1
@@ -12,7 +12,7 @@ Describe 'Test HTTP Find-PSResource for ADO V2 Server Protocol' -tags 'CI' {
     BeforeAll{
         $testModuleName = "test_local_mod"
         $ADOV2RepoName = "PSGetTestingPublicFeed"
-        $ADOV2RepoUri = "https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell-public-test/nuget/v2"
+        $ADOV2RepoUri = "https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/psresourceget-public-test-ci/nuget/v2"
         Get-NewPSResourceRepositoryFile
         Register-PSResourceRepository -Name $ADOV2RepoName -Uri $ADOV2RepoUri
     }

--- a/test/InstallPSResourceTests/InstallPSResourceADOServer.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceADOServer.Tests.ps1
@@ -12,7 +12,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
         $testModuleName2 = "test_local_mod2"
         $testScriptName = "test_ado_script"
         $ADORepoName = "PSGetTestingPublicFeed"
-        $ADORepoUri = "https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell-public-test/nuget/v3/index.json"
+        $ADORepoUri = "https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/psresourceget-public-test-ci/nuget/v3/index.json"
         Get-NewPSResourceRepositoryFile
         Register-PSResourceRepository -Name $ADORepoName -Uri $ADORepoUri
     }
@@ -54,7 +54,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
 
     It "Install multiple resources by name" {
         $pkgNames = @($testModuleName, $testModuleName2)
-        Install-PSResource -Name $pkgNames -Repository $ADORepoName -TrustRepository  
+        Install-PSResource -Name $pkgNames -Repository $ADORepoName -TrustRepository
         $pkg = Get-InstalledPSResource $pkgNames
         $pkg.Name | Should -Be $pkgNames
     }
@@ -64,7 +64,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
         $pkg = Get-InstalledPSResource "NonExistantModule"
         $pkg | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
     }
 
     # Do some version testing, but Find-PSResource should be doing thorough testing
@@ -76,21 +76,21 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
     }
 
     It "Should install resource given name and exact version with bracket syntax" {
-        Install-PSResource -Name $testModuleName -Version "[1.0.0]" -Repository $ADORepoName -TrustRepository  
+        Install-PSResource -Name $testModuleName -Version "[1.0.0]" -Repository $ADORepoName -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName
         $pkg.Version | Should -Be "1.0.0"
     }
 
     It "Should install resource given name and exact range inclusive [1.0.0, 5.0.0]" {
-        Install-PSResource -Name $testModuleName -Version "[1.0.0, 5.0.0]" -Repository $ADORepoName -TrustRepository  
+        Install-PSResource -Name $testModuleName -Version "[1.0.0, 5.0.0]" -Repository $ADORepoName -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName
         $pkg.Version | Should -Be "5.0.0"
     }
 
     It "Should install resource given name and exact range exclusive (1.0.0, 5.0.0)" {
-        Install-PSResource -Name $testModuleName -Version "(1.0.0, 5.0.0)" -Repository $ADORepoName -TrustRepository  
+        Install-PSResource -Name $testModuleName -Version "(1.0.0, 5.0.0)" -Repository $ADORepoName -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName
         $pkg.Version | Should -Be "3.0.0"
@@ -118,7 +118,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
     }
 
     It "Install resource with latest (including prerelease) version given Prerelease parameter" {
-        Install-PSResource -Name $testModuleName -Prerelease -Repository $ADORepoName -TrustRepository 
+        Install-PSResource -Name $testModuleName -Prerelease -Repository $ADORepoName -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName
         $pkg.Version | Should -Be "5.2.5"
@@ -126,7 +126,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
     }
 
     It "Install resource via InputObject by piping from Find-PSresource" {
-        Find-PSResource -Name $testModuleName -Repository $ADORepoName | Install-PSResource -TrustRepository 
+        Find-PSResource -Name $testModuleName -Repository $ADORepoName | Install-PSResource -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName
         $pkg.Version | Should -Be "5.0.0"
@@ -238,15 +238,15 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'ManualValidatio
     It "Install resource under AllUsers scope - Unix only" -Skip:(Get-IsWindows) {
         Install-PSResource -Name $testModuleName -Repository $TestGalleryName -Scope AllUsers
         $pkg = Get-Module $testModuleName -ListAvailable
-        $pkg.Name | Should -Be $testModuleName 
+        $pkg.Name | Should -Be $testModuleName
         $pkg.Path.Contains("/usr/") | Should -Be $true
     }
 
     # This needs to be manually tested due to prompt
     It "Install resource that requires accept license without -AcceptLicense flag" {
         Install-PSResource -Name $testModuleName2  -Repository $TestGalleryName
-        $pkg = Get-InstalledPSResource $testModuleName2 
-        $pkg.Name | Should -Be $testModuleName2 
+        $pkg = Get-InstalledPSResource $testModuleName2
+        $pkg.Name | Should -Be $testModuleName2
         $pkg.Version | Should -Be "0.0.1.0"
     }
 
@@ -255,7 +255,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'ManualValidatio
         Set-PSResourceRepository PoshTestGallery -Trusted:$false
 
         Install-PSResource -Name $testModuleName -Repository $TestGalleryName -confirm:$false
-    
+
         $pkg = Get-Module $testModuleName -ListAvailable
         $pkg.Name | Should -Be $testModuleName
 

--- a/test/PublishPSResourceTests/PublishPSResourceADOServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceADOServer.Tests.ps1
@@ -48,7 +48,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
 
         $testModuleName = "test_local_mod"
         $ADOPublicRepoName = "PSGetTestingPublicFeed"
-        $ADOPublicRepoUri = "https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell-public-test/nuget/v3/index.json"
+        $ADOPublicRepoUri = "https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/psresourceget-public-test-ci/nuget/v3/index.json"
         Register-PSResourceRepository -Name $ADOPublicRepoName -Uri $ADOPublicRepoUri
 
         $ADOPrivateRepoName = "PSGetTestFeedWithPrivateAccess"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Updated the feed name to the new feed

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
