### PR TITLE
Added -PassThru Parameter for Compress-PSResource

### DIFF
--- a/src/code/CompressPSResource.cs
+++ b/src/code/CompressPSResource.cs
@@ -36,7 +36,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public string DestinationPath { get; set; }
 
         /// <summary>
-        /// Bypasses validating a resource module manifest before publishing.
+        /// When specified, passes the full path of the nupkg through the pipeline.
+        /// </summary>
+        [Parameter(Mandatory = false, HelpMessage = "Pass the full path of the nupkg through the pipeline")]
+        public SwitchParameter PassThru { get; set; }
+
+        /// <summary>
+        /// Bypasses validating a resource module manifest before compressing.
         /// </summary>
         [Parameter]
         public SwitchParameter SkipModuleManifestValidate { get; set; }
@@ -61,6 +67,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 this,
                 Path,
                 DestinationPath,
+                PassThru,
                 SkipModuleManifestValidate);
 
             _publishHelper.CheckAllParameterPaths();

--- a/src/code/PublishHelper.cs
+++ b/src/code/PublishHelper.cs
@@ -61,18 +61,20 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private string outputDir = string.Empty;
         internal bool ScriptError = false;
         internal bool ShouldProcess = true;
+        internal bool PassThru = false;
 
         #endregion
 
         #region Constructors
 
-        internal PublishHelper(PSCmdlet cmdlet, string path, string destinationPath, bool skipModuleManifestValidate)
+        internal PublishHelper(PSCmdlet cmdlet, string path, string destinationPath, bool passThru, bool skipModuleManifestValidate)
         {
             _callerCmdlet = CallerCmdlet.CompressPSResource;
             _cmdOperation = "Compress";
             _cmdletPassedIn = cmdlet;
             Path = path;
             DestinationPath = destinationPath;
+            PassThru = passThru;
             SkipModuleManifestValidate = skipModuleManifestValidate;
             outputDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString());
             outputNupkgDir = destinationPath;
@@ -562,6 +564,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 if (success)
                 {
+                    if (PassThru)
+                    {
+                        _cmdletPassedIn.WriteObject(System.IO.Path.Combine(outputNupkgDir, _pkgName + "." + _pkgVersion.ToNormalizedString() + ".nupkg"));
+                    }
                     _cmdletPassedIn.WriteVerbose("Successfully packed the resource into a .nupkg");
                 }
                 else

--- a/test/PublishPSResourceTests/CompressPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/CompressPSResource.Tests.ps1
@@ -155,7 +155,6 @@ Describe "Test Compress-PSResource" -tags 'CI' {
     }
 
     It "Compress-PSResource -PassThru returns the path to the nupkg" {
-        Wait-Debugger
         $version = "1.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
 

--- a/test/PublishPSResourceTests/CompressPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/CompressPSResource.Tests.ps1
@@ -153,6 +153,18 @@ Describe "Test Compress-PSResource" -tags 'CI' {
 
         Test-Path -Path (Join-Path -Path $unzippedPath -ChildPath $testFile) | Should -Be $True
     }
+
+    It "Compress-PSResource -PassThru returns the path to the nupkg" {
+        Wait-Debugger
+        $version = "1.0.0"
+        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
+
+        $nupkgPath = Compress-PSResource -Path $script:PublishModuleBase -DestinationPath $script:repositoryPath -PassThru
+
+        $expectedPath = Join-Path -Path $script:repositoryPath -ChildPath "$script:PublishModuleName.$version.nupkg"
+        $nupkgPath | Should -Be $expectedPath
+    }
+
 <# Test for Signing the nupkg. Signing doesn't work
     It "Compressed Module is able to be signed with a certificate" {
 		$version = "1.0.0"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request introduces a new `PassThru` parameter to the `CompressPSResource` cmdlet, enabling the full path of the generated `.nupkg` file to be returned through the pipeline. Additionally, it includes updates to the `PublishHelper` class to support this new functionality and adds a test case to verify the `PassThru` parameter's behavior.

### New Feature Addition:

* [`src/code/CompressPSResource.cs`](diffhunk://#diff-c046fb180aefcf869155e3b40d85f183dd123e5e0b6ec5e813efd411f94610a3L39-R45): Added the `PassThru` parameter to the `CompressPSResource` cmdlet, allowing the full path of the `.nupkg` file to be passed through the pipeline. [[1]](diffhunk://#diff-c046fb180aefcf869155e3b40d85f183dd123e5e0b6ec5e813efd411f94610a3L39-R45) [[2]](diffhunk://#diff-c046fb180aefcf869155e3b40d85f183dd123e5e0b6ec5e813efd411f94610a3R70)

### Internal Code Updates:

* [`src/code/PublishHelper.cs`](diffhunk://#diff-de173e5cd669c3f87b931f1b38ebaa7633861e9c809176f0cec1735585d68549R64-R77): Updated the `PublishHelper` class to handle the new `PassThru` parameter, including changes to the constructor and the `PackNupkg` method to write the `.nupkg` file path to the pipeline if `PassThru` is specified. [[1]](diffhunk://#diff-de173e5cd669c3f87b931f1b38ebaa7633861e9c809176f0cec1735585d68549R64-R77) [[2]](diffhunk://#diff-de173e5cd669c3f87b931f1b38ebaa7633861e9c809176f0cec1735585d68549R567-R570)

### Testing:

* [`test/PublishPSResourceTests/CompressPSResource.Tests.ps1`](diffhunk://#diff-8214d34f8b6d7fd40d95dab82c9c569dd62919c12ac16e599af4255985a15cb7R156-R167): Added a new test case to ensure that the `Compress-PSResource` cmdlet with the `-PassThru` parameter correctly returns the path to the `.nupkg` file.

## PR Context

-PassThru parameter was included in the mockup of the Compress-PSResource cmdlet but was not included in the previous PR.
This PR aims to fix that. -PassThru would be very useful for scripting Compress with Publish where the variable can be sent directly to Publish's -NupkgPath.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
