### PR TITLE
Fix 1659 "Some Nuget packages fail to extract"

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -1203,7 +1203,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 using (ZipArchive archive = ZipFile.OpenRead(zipPath))
                 {
-                    foreach (ZipArchiveEntry entry in archive.Entries)
+                    foreach (ZipArchiveEntry entry in archive.Entries.Where(entry => entry.CompressedLength > 0))
                     {
                         // If a file has one or more parent directories.
                         if (entry.FullName.Contains(Path.DirectorySeparatorChar) || entry.FullName.Contains(Path.AltDirectorySeparatorChar))

--- a/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
@@ -14,12 +14,15 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
     BeforeAll {
         $localRepo = "psgettestlocal"
         $localUNCRepo = "psgettestlocal3"
+        $localNupkgRepo = "LocalNupkgRepo"
+        $localNupkgRepoUri = "test\testFiles\testNupkgs"
         $testModuleName = "test_local_mod"
         $testModuleName2 = "test_local_mod2"
         $testModuleClobber = "testModuleClobber"
         $testModuleClobber2 = "testModuleClobber2"
         Get-NewPSResourceRepositoryFile
         Register-LocalRepos
+        Register-PSResourceRepository -Name $localNupkgRepo -SourceLocation $localNupkgRepoUri
 
         $prereleaseLabel = "alpha001"
         $tags = @()
@@ -278,5 +281,14 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
         for ($i = 0; $i -lt $err.Count; $i++) {
             $err[$i].FullyQualifiedErrorId | Should -Not -Be "System.NullReferenceException,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
         }
+    }
+
+    It "Install .nupkg that contains directories (specific package throws errors when accessed by ZipFile.OpenRead)" {
+        $nupkgName = "Microsoft.Web.Webview2"
+        $nupkgVersion = "1.0.2792.45"
+        Install-PSResource -Name $nupkgName -Version $nupkgVersion -Repository $localNupkgRepo -TrustRepository
+        $pkg = Get-InstalledPSResource $nupkgName
+        $pkg.Name | Should -Be $nupkgName
+        $pkg.Version | Should -Be $nupkgVersion
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes #1659.

I noticed that the example problematic package `Microsoft.Web.WebView2` ( <https://www.nuget.org/packages/Microsoft.Web.WebView2> ) mentioned by the creator of the issue, contained directories when doing ZipFile.OpenRead and looking at the entries. Non-problematic packages, like `NuGet.Versioning` ( <https://www.nuget.org/packages/NuGet.Versioning> ) did not.

<img width="943" alt="image" src="https://github.com/user-attachments/assets/4334f4b2-1fa6-4d6e-8345-8aa0b0052f5a">

Solution: Filter out entries where length is less than or equal to 0 (because they are not files).


## PR Context

See previous chapter.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
