### PR TITLE
Fix 1541 "`-WhatIf` results in extra, unwanted output and a spurious error"

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -658,7 +658,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     }
 
                     // If -WhatIf is passed in, early out.
-                    if (!_cmdletPassedIn.ShouldProcess("Exit ShouldProcess"))
+                    if (_cmdletPassedIn.MyInvocation.BoundParameters.ContainsKey("WhatIf"))
                     {
                         return pkgsSuccessfullyInstalled;
                     }

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         public InstallHelper(PSCmdlet cmdletPassedIn, NetworkCredential networkCredential)
         {
-            CancellationTokenSource source = new CancellationTokenSource();
+            CancellationTokenSource source = new();
             _cancellationToken = source.Token;
             _cmdletPassedIn = cmdletPassedIn;
             _networkCredential = networkCredential;
@@ -183,7 +183,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             ScopeType scope)
         {
             _cmdletPassedIn.WriteDebug("In InstallHelper::ProcessRepositories()");
-            List<PSResourceInfo> allPkgsInstalled = new List<PSResourceInfo>();
+            List<PSResourceInfo> allPkgsInstalled = new();
             if (repository != null && repository.Length != 0)
             {
                 // Write error and disregard repository entries containing wildcards.
@@ -262,7 +262,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             var noToAll = false;
 
             var findHelper = new FindHelper(_cancellationToken, _cmdletPassedIn, _networkCredential);
-            List<string> repositoryNamesToSearch = new List<string>();
+            List<string> repositoryNamesToSearch = new();
             bool sourceTrusted = false;
 
             // Loop through all the repositories provided (in priority order) until there no more packages to install.
@@ -547,7 +547,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             FindHelper findHelper)
         {
             _cmdletPassedIn.WriteDebug("In InstallHelper::InstallPackages()");
-            List<PSResourceInfo> pkgsSuccessfullyInstalled = new List<PSResourceInfo>();
+            List<PSResourceInfo> pkgsSuccessfullyInstalled = new();
 
             // Install parent package to the temp directory,
             // Get the dependencies from the installed package,
@@ -1328,7 +1328,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (File.Exists(moduleManifest))
             {
-                using (StreamReader sr = new StreamReader(moduleManifest))
+                using (StreamReader sr = new(moduleManifest))
                 {
                     var text = sr.ReadToEnd();
 
@@ -1336,9 +1336,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     var patternToSkip1 = "#\\s*RequireLicenseAcceptance\\s*=\\s*\\$true";
                     var patternToSkip2 = "\\*\\s*RequireLicenseAcceptance\\s*=\\s*\\$true";
 
-                    Regex rgx = new Regex(pattern);
-                    Regex rgxComment1 = new Regex(patternToSkip1);
-                    Regex rgxComment2 = new Regex(patternToSkip2);
+                    Regex rgx = new(pattern);
+                    Regex rgxComment1 = new(patternToSkip1);
+                    Regex rgxComment2 = new(patternToSkip2);
                     if (rgx.IsMatch(text) && !rgxComment1.IsMatch(text) && !rgxComment2.IsMatch(text))
                     {
                         requireLicenseAcceptance = true;
@@ -1409,14 +1409,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             // Get installed modules, then get all possible paths
             // selectPrereleaseOnly is false because even if Prerelease is true we want to include both stable and prerelease, would never select prerelease only.
-            GetHelper getHelper = new GetHelper(_cmdletPassedIn);
+            GetHelper getHelper = new(_cmdletPassedIn);
             IEnumerable<PSResourceInfo> pkgsAlreadyInstalled = getHelper.GetPackagesFromPath(
                 name: new string[] { "*" },
                 versionRange: VersionRange.All,
                 pathsToSearch: _pathsToSearch,
                 selectPrereleaseOnly: false);
 
-            List<string> listOfCmdlets = new List<string>();
+            List<string> listOfCmdlets = new();
             if (parsedMetadataHashtable.ContainsKey("CmdletsToExport"))
             {
                 if (parsedMetadataHashtable["CmdletsToExport"] is object[] cmdletsToExport)
@@ -1430,8 +1430,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             foreach (var pkg in pkgsAlreadyInstalled)
             {
-                List<string> duplicateCmdlets = new List<string>();
-                List<string> duplicateCmds = new List<string>();
+                List<string> duplicateCmdlets = new();
+                List<string> duplicateCmds = new();
                 // See if any of the cmdlets or commands in the pkg we're trying to install exist within a package that's already installed
                 if (pkg.Includes.Cmdlet != null && pkg.Includes.Cmdlet.Length != 0)
                 {

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -330,7 +330,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 allPkgsInstalled.AddRange(installedPkgs);
             }
 
-            if (_pkgNamesToInstall.Count > 0)
+            if (!_cmdletPassedIn.MyInvocation.BoundParameters.ContainsKey("WhatIf") && _pkgNamesToInstall.Count > 0)
             {
                 string repositoryWording = repositoryNamesToSearch.Count > 1 ? "registered repositories" : "repository";
                 _cmdletPassedIn.WriteError(new ErrorRecord(

--- a/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
@@ -1,15 +1,17 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+Param()
+
 $ProgressPreference = "SilentlyContinue"
 $modPath = "$psscriptroot/../PSGetTestUtils.psm1"
 Import-Module $modPath -Force -Verbose
 
 $psmodulePaths = $env:PSModulePath -split ';'
-Write-Verbose -Verbose "Current module search paths: $psmodulePaths"
+Write-Verbose -Verbose -Message "Current module search paths: $psmodulePaths"
 
 Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
-
 
     BeforeAll {
         $localRepo = "psgettestlocal"
@@ -51,7 +53,7 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
         $res.Version | Should -Be "5.0.0"
     }
 
-	It "Install resource given Name parameter from UNC repository" {
+    It "Install resource given Name parameter from UNC repository" {
         Install-PSResource -Name $testModuleName -Repository $localUNCRepo -TrustRepository
         $res = Get-InstalledPSResource -Name $testModuleName
         $res.Name | Should -Be $testModuleName
@@ -67,7 +69,7 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
 
     It "Install multiple resources by name" {
         $pkgNames = @($testModuleName, $testModuleName2)
-        Install-PSResource -Name $pkgNames -Repository $localRepo -TrustRepository  
+        Install-PSResource -Name $pkgNames -Repository $localRepo -TrustRepository
         $pkg = Get-InstalledPSResource $pkgNames
         $pkg.Name | Should -Be $pkgNames
     }
@@ -80,7 +82,7 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
     }
 
     It "Should install resource given name and exact version with bracket syntax" {
-        Install-PSResource -Name $testModuleName -Version "[1.0.0.0]" -Repository $localRepo -TrustRepository  
+        Install-PSResource -Name $testModuleName -Version "[1.0.0.0]" -Repository $localRepo -TrustRepository
         $res = Get-InstalledPSResource $testModuleName
         $res.Name | Should -Be $testModuleName
         $res.Version | Should -Be "1.0.0"
@@ -94,7 +96,7 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
     }
 
     It "Should install resource given name and exact range exclusive (1.0.0.0, 5.0.0.0)" {
-        Install-PSResource -Name $testModuleName -Version "(1.0.0.0, 5.0.0.0)" -Repository $localRepo -TrustRepository  
+        Install-PSResource -Name $testModuleName -Version "(1.0.0.0, 5.0.0.0)" -Repository $localRepo -TrustRepository
         $res = Get-InstalledPSResource $testModuleName
         $res.Name | Should -Be $testModuleName
         $res.Version | Should -Be "3.0.0"
@@ -107,7 +109,7 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
         }
         catch
         {}
-        $Error[0].FullyQualifiedErrorId | Should -be "IncorrectVersionFormat,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
+        $Error[0].FullyQualifiedErrorId | Should -Be "IncorrectVersionFormat,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
 
         $res = Get-InstalledPSResource $testModuleName -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
@@ -128,7 +130,7 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
     }
 
     It "Install resource with latest (including prerelease) version given Prerelease parameter" {
-        Install-PSResource -Name $testModuleName -Prerelease -Repository $localRepo -TrustRepository 
+        Install-PSResource -Name $testModuleName -Prerelease -Repository $localRepo -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName
         $pkg.Version | Should -Be "5.2.5"
@@ -168,14 +170,14 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
     }
 
     It "Install resource via InputObject by piping from Find-PSresource" {
-        Find-PSResource -Name $testModuleName -Repository $localRepo | Install-PSResource -TrustRepository 
+        Find-PSResource -Name $testModuleName -Repository $localRepo | Install-PSResource -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName
         $pkg.Version | Should -Be "5.0.0"
     }
 
     It "Install resource via InputObject by piping from Find-PSResource" {
-        $modules = Find-PSResource -Name "*" -Repository $localRepo 
+        $modules = Find-PSResource -Name "*" -Repository $localRepo
         $modules.Count | Should -BeGreaterThan 1
 
         Install-PSResource -TrustRepository -InputObject $modules
@@ -187,7 +189,7 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
     It "Install resource under location specified in PSModulePath" {
         Install-PSResource -Name $testModuleName -Repository $localRepo -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
-        $pkg.Name | Should -Be $testModuleName 
+        $pkg.Name | Should -Be $testModuleName
         ($env:PSModulePath).Contains($pkg.InstalledLocation)
     }
 
@@ -209,7 +211,7 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
 
     # Windows only
     It "Install resource under no specified scope - Windows only" -Skip:(!(Get-IsWindows)) {
-        Install-PSResource -Name $testModuleName -Repository $localRepo -TrustRepository 
+        Install-PSResource -Name $testModuleName -Repository $localRepo -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName
         $pkg.InstalledLocation.ToString().Contains("Documents") | Should -Be $true
@@ -237,7 +239,7 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
         Install-PSResource -Name $testModuleName -Repository $localRepo -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName
-        Install-PSResource -Name $testModuleName -Repository $localRepo -TrustRepository -WarningVariable WarningVar -warningaction SilentlyContinue
+        Install-PSResource -Name $testModuleName -Repository $localRepo -TrustRepository -WarningVariable WarningVar -WarningAction SilentlyContinue
         $WarningVar | Should -Not -BeNullOrEmpty
     }
 
@@ -254,6 +256,8 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
 
     It "Install module using -WhatIf, should not install the module" {
         Install-PSResource -Name $testModuleName -Version "1.0.0.0" -Repository $localRepo -TrustRepository -WhatIf
+        $? | Should -BeTrue
+
         $res = Get-InstalledPSResource -Name $testModuleName -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
     }
@@ -267,11 +271,11 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
     It "Get definition for alias 'isres'" {
         (Get-Alias isres).Definition | Should -BeExactly 'Install-PSResource'
     }
-    
+
     It "Not install resource that lists dependency packages which cannot be found" {
         $localRepoUri = Join-Path -Path $TestDrive -ChildPath "testdir"
         Save-PSResource -Name "test_script" -Repository "PSGallery" -TrustRepository -Path $localRepoUri -AsNupkg -SkipDependencyCheck
-        Write-Host $localRepoUri
+        Write-Information -InformationAction Continue -MessageData $localRepoUri
         $res = Install-PSResource -Name "test_script" -Repository $localRepo -TrustRepository -PassThru -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0

--- a/test/InstallPSResourceTests/InstallPSResourceV3Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV3Server.Tests.ps1
@@ -1,12 +1,15 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+Param()
+
 $ProgressPreference = "SilentlyContinue"
 $modPath = "$psscriptroot/../PSGetTestUtils.psm1"
 Import-Module $modPath -Force -Verbose
 
 $psmodulePaths = $env:PSModulePath -split ';'
-Write-Verbose -Verbose "Current module search paths: $psmodulePaths"
+Write-Verbose -Verbose -Message "Current module search paths: $psmodulePaths"
 
 Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
 
@@ -32,8 +35,8 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
     }
 
     $testCases = @{Name="*";                          ErrorId="NameContainsWildcard"},
-                 @{Name="Test_Module*";               ErrorId="NameContainsWildcard"},
-                 @{Name="Test?Module","Test[Module";  ErrorId="ErrorFilteringNamesForUnsupportedWildcards"}
+    @{Name="Test_Module*";               ErrorId="NameContainsWildcard"},
+    @{Name="Test?Module","Test[Module";  ErrorId="ErrorFilteringNamesForUnsupportedWildcards"}
 
     It "Should not install resource with wildcard in name" -TestCases $testCases {
         param($Name, $ErrorId)
@@ -60,7 +63,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
 
     It "Install multiple resources by name" {
         $pkgNames = @($testModuleName, $testModuleName2)
-        Install-PSResource -Name $pkgNames -Repository $NuGetGalleryName -TrustRepository  
+        Install-PSResource -Name $pkgNames -Repository $NuGetGalleryName -TrustRepository
         $pkg = Get-InstalledPSResource $pkgNames
         $pkg.Name | Should -Be $pkgNames
     }
@@ -70,7 +73,15 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
         $pkg = Get-InstalledPSResource "NonExistantModule" -ErrorAction SilentlyContinue
         $pkg.Name | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" 
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
+    }
+
+    It "Install module using -WhatIf, should not install the module" {
+        Install-PSResource -Name $testModuleName -Repository $NuGetGalleryName -TrustRepository -WhatIf
+        $? | Should -BeTrue
+
+        $res = Get-InstalledPSResource $testModuleName
+        $res | Should -BeNullOrEmpty
     }
 
     # Do some version testing, but Find-PSResource should be doing thorough testing
@@ -82,21 +93,21 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
     }
 
     It "Should install resource given name and exact version with bracket syntax" {
-        Install-PSResource -Name $testModuleName -Version "[1.0.0]" -Repository $NuGetGalleryName -TrustRepository  
+        Install-PSResource -Name $testModuleName -Version "[1.0.0]" -Repository $NuGetGalleryName -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName
         $pkg.Version | Should -Be "1.0.0"
     }
 
     It "Should install resource given name and exact range inclusive [1.0.0, 5.0.0]" {
-        Install-PSResource -Name $testModuleName -Version "[1.0.0, 5.0.0]" -Repository $NuGetGalleryName -TrustRepository  
+        Install-PSResource -Name $testModuleName -Version "[1.0.0, 5.0.0]" -Repository $NuGetGalleryName -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName
         $pkg.Version | Should -Be "5.0.0"
     }
 
     It "Should install resource given name and exact range exclusive (1.0.0, 5.0.0)" {
-        Install-PSResource -Name $testModuleName -Version "(1.0.0, 5.0.0)" -Repository $NuGetGalleryName -TrustRepository  
+        Install-PSResource -Name $testModuleName -Version "(1.0.0, 5.0.0)" -Repository $NuGetGalleryName -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName
         $pkg.Version | Should -Be "3.0.0"
@@ -110,7 +121,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
         }
         catch
         {}
-        $Error[0].FullyQualifiedErrorId | Should -be "IncorrectVersionFormat,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
+        $Error[0].FullyQualifiedErrorId | Should -Be "IncorrectVersionFormat,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
 
         $res = Get-InstalledPSResource $testModuleName -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
@@ -124,7 +135,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
     }
 
     It "Install resource with latest (including prerelease) version given Prerelease parameter" {
-        Install-PSResource -Name $testModuleName -Prerelease -Repository $NuGetGalleryName -TrustRepository 
+        Install-PSResource -Name $testModuleName -Prerelease -Repository $NuGetGalleryName -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName
         $pkg.Version | Should -Be "5.2.5"
@@ -132,7 +143,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
     }
 
     It "Install resource via InputObject by piping from Find-PSresource" {
-        Find-PSResource -Name $testModuleName -Repository $NuGetGalleryName | Install-PSResource -TrustRepository 
+        Find-PSResource -Name $testModuleName -Repository $NuGetGalleryName | Install-PSResource -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName
         $pkg.Version | Should -Be "5.0.0"
@@ -203,7 +214,7 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
         Install-PSResource -Name $testModuleName -Repository $NuGetGalleryName -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName
-        Install-PSResource -Name $testModuleName -Repository $NuGetGalleryName -TrustRepository -WarningVariable WarningVar -warningaction SilentlyContinue
+        Install-PSResource -Name $testModuleName -Repository $NuGetGalleryName -TrustRepository -WarningVariable WarningVar -WarningAction SilentlyContinue
         $WarningVar | Should -Not -BeNullOrEmpty
     }
 
@@ -265,35 +276,35 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
 
     It "Install modules using -RequiredResource with hashtable" {
         $rrHash = @{
-            test_module = @{
-               version = "[1.0.0,5.0.0)"
-               repository = $NuGetGalleryName
-            }
-
-             test_module2 = @{
-               version = "[1.0.0,5.0.0]"
-               repository = $NuGetGalleryName
-               prerelease = "true"
-            }
-
-             TestModule99 = @{
+            test_module  = @{
+                version    = "[1.0.0,5.0.0)"
                 repository = $NuGetGalleryName
             }
-          }
 
-          Install-PSResource -RequiredResource $rrHash -TrustRepository
+            test_module2 = @{
+                version    = "[1.0.0,5.0.0]"
+                repository = $NuGetGalleryName
+                prerelease = "true"
+            }
 
-          $res1 = Get-InstalledPSResource $testModuleName
-          $res1.Name | Should -Be $testModuleName
-          $res1.Version | Should -Be "3.0.0"
+            TestModule99 = @{
+                repository = $NuGetGalleryName
+            }
+        }
 
-          $res2 = Get-InstalledPSResource $testModuleName2
-          $res2.Name | Should -Be $testModuleName2
-          $res2.Version | Should -Be "5.0.0"
+        Install-PSResource -RequiredResource $rrHash -TrustRepository
 
-          $res3 = Get-InstalledPSResource "TestModule99"
-          $res3.Name | Should -Be "TestModule99"
-          $res3.Version | Should -Be "0.0.93"
+        $res1 = Get-InstalledPSResource $testModuleName
+        $res1.Name | Should -Be $testModuleName
+        $res1.Version | Should -Be "3.0.0"
+
+        $res2 = Get-InstalledPSResource $testModuleName2
+        $res2.Name | Should -Be $testModuleName2
+        $res2.Version | Should -Be "5.0.0"
+
+        $res3 = Get-InstalledPSResource "TestModule99"
+        $res3.Name | Should -Be "TestModule99"
+        $res3.Version | Should -Be "0.0.93"
     }
 
     It "Install modules using -RequiredResource with JSON string" {
@@ -312,19 +323,19 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
            }
          }"
 
-          Install-PSResource -RequiredResource $rrJSON -TrustRepository
+        Install-PSResource -RequiredResource $rrJSON -TrustRepository
 
-          $res1 = Get-InstalledPSResource $testModuleName
-          $res1.Name | Should -Be $testModuleName
-          $res1.Version | Should -Be "3.0.0"
+        $res1 = Get-InstalledPSResource $testModuleName
+        $res1.Name | Should -Be $testModuleName
+        $res1.Version | Should -Be "3.0.0"
 
-          $res2 = Get-InstalledPSResource $testModuleName2
-          $res2.Name | Should -Be $testModuleName2
-          $res2.Version | Should -Be "5.0.0.0"
+        $res2 = Get-InstalledPSResource $testModuleName2
+        $res2.Name | Should -Be $testModuleName2
+        $res2.Version | Should -Be "5.0.0.0"
 
-          $res3 = Get-InstalledPSResource "testModule99"
-          $res3.Name | Should -Be "testModule99"
-          $res3.Version | Should -Be "0.0.93"
+        $res3 = Get-InstalledPSResource "testModule99"
+        $res3.Name | Should -Be "testModule99"
+        $res3.Version | Should -Be "0.0.93"
     }
 
     It "Install modules using -RequiredResourceFile with PSD1 file" {
@@ -388,15 +399,15 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'ManualValidatio
     It "Install resource under AllUsers scope - Unix only" -Skip:(Get-IsWindows) {
         Install-PSResource -Name $testModuleName -Repository $TestGalleryName -Scope AllUsers
         $pkg = Get-Module $testModuleName -ListAvailable
-        $pkg.Name | Should -Be $testModuleName 
+        $pkg.Name | Should -Be $testModuleName
         $pkg.Path.Contains("/usr/") | Should -Be $true
     }
 
     # This needs to be manually tested due to prompt
     It "Install resource that requires accept license without -AcceptLicense flag" {
         Install-PSResource -Name $testModuleName2  -Repository $TestGalleryName
-        $pkg = Get-InstalledPSResource $testModuleName2 
-        $pkg.Name | Should -Be $testModuleName2 
+        $pkg = Get-InstalledPSResource $testModuleName2
+        $pkg.Name | Should -Be $testModuleName2
         $pkg.Version | Should -Be "2.0.0"
     }
 
@@ -404,8 +415,8 @@ Describe 'Test Install-PSResource for V3Server scenarios' -tags 'ManualValidatio
     It "Install resource should prompt 'trust repository' if repository is not trusted" {
         Set-PSResourceRepository PoshTestGallery -Trusted:$false
 
-        Install-PSResource -Name $testModuleName -Repository $TestGalleryName -confirm:$false
-    
+        Install-PSResource -Name $testModuleName -Repository $TestGalleryName -Confirm:$false
+
         $pkg = Get-Module $testModuleName -ListAvailable
         $pkg.Name | Should -Be $testModuleName
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

* Fixed check for whether -WhatIf was passed
* Don't throw if -WhatIf was passed if no packages to install
* Make sure tests exists and works
* Fix and surpress PSScriptAnalyzer warnings in tests I touced

## PR Context

#1541

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
