### PR TITLE
Fix Azure DevOps nuget v2 feed download

### DIFF
--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             HttpClientHandler handler = new HttpClientHandler();
             bool token = false;
 
-            if(networkCredential != null) 
+            if(networkCredential != null)
             {
                 token = String.Equals("token", networkCredential.UserName) ? true : false;
             };
@@ -72,7 +72,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             } else {
 
                 handler.Credentials = networkCredential;
-                
+
                 _sessionClient = new HttpClient(handler);
             };
 
@@ -359,7 +359,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (type != ResourceType.None) {
                 filterBuilder.AddCriterion(GetTypeFilterForRequest(type));
             }
-            
+
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             if (errRecord != null)
@@ -424,7 +424,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
-            
+
             string response = HttpRequestCall(requestUrlV2, out errRecord);
             if (errRecord != null)
             {
@@ -638,7 +638,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (!_isJFrogRepo) {
                 filterBuilder.AddCriterion($"Id eq '{packageName}'");
             }
-            
+
             filterBuilder.AddCriterion($"NormalizedVersion eq '{version}'");
             if (type != ResourceType.None) {
                 filterBuilder.AddCriterion(GetTypeFilterForRequest(type));
@@ -694,7 +694,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (!_isJFrogRepo) {
                 filterBuilder.AddCriterion($"Id eq '{packageName}'");
             }
-            
+
             filterBuilder.AddCriterion($"NormalizedVersion eq '{version}'");
             if (type != ResourceType.None) {
                 filterBuilder.AddCriterion(GetTypeFilterForRequest(type));
@@ -943,7 +943,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             filterBuilder.AddCriterion($"substringof('PS{(isSearchingModule ? "Module" : "Script")}', Tags) eq true");
-            
+
             foreach (string tag in tags)
             {
                 filterBuilder.AddCriterion($"substringof('{tag}', Tags) eq true");
@@ -987,7 +987,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 " ",
                 tags.Select(tag => $"tag:{tagPrefix}{tag}")
             ) + "'";
-                
+
 
             var requestUrlV2 = $"{Repository.Uri}/Search()?{queryBuilder.BuildQueryString()}";
 
@@ -1271,7 +1271,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (!includePrerelease) {
                 filterBuilder.AddCriterion("IsPrerelease eq false");
             }
-            
+
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
 
             // If it's a JFrog repository do not include the Id filter portion since JFrog uses 'Title' instead of 'Id',
@@ -1283,7 +1283,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (type == ResourceType.Script) {
                 filterBuilder.AddCriterion($"substringof('PS{type.ToString()}', Tags) eq true");
             }
-            
+
 
             var requestUrlV2 = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
 
@@ -1306,7 +1306,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (_isADORepo)
             {
                 // eg: https://pkgs.dev.azure.com/<org>/<project>/_packaging/<feed>/nuget/v2?id=test_module&version=5.0.0
-                requestUrlV2 = $"{Repository.Uri}?id={packageName}&version={version}";
+                requestUrlV2 = $"{Repository.Uri}?id={packageName.ToLower()}&version={version}";
             }
             else if (_isJFrogRepo)
             {

--- a/test/InstallPSResourceTests/InstallPSResourceADOV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceADOV2Server.Tests.ps1
@@ -1,0 +1,264 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+$ProgressPreference = "SilentlyContinue"
+$modPath = "$psscriptroot/../PSGetTestUtils.psm1"
+Import-Module $modPath -Force -Verbose
+
+Describe 'Test Install-PSResource for V3Server scenarios' -tags 'CI' {
+
+    BeforeAll {
+        $testModuleName = "test_local_mod"
+        $testModuleName2 = "test_local_mod2"
+        $testScriptName = "test_ado_script"
+        $ADORepoName = "PSGetTestingPublicFeed"
+        $ADORepoUri = "https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/psresourceget-public-test-ci/nuget/v2"
+        Get-NewPSResourceRepositoryFile
+        Register-PSResourceRepository -Name $ADORepoName -Uri $ADORepoUri
+    }
+
+    AfterEach {
+        Uninstall-PSResource $testModuleName, $testModuleName2, $testScriptName -Version "*" -SkipDependencyCheck -ErrorAction SilentlyContinue
+    }
+
+    AfterAll {
+        Get-RevertPSResourceRepositoryFile
+    }
+
+    $testCases = @{Name="*";                        ErrorId="NameContainsWildcard"},
+                 @{Name="Test_local_m*";            ErrorId="NameContainsWildcard"},
+                 @{Name="Test?local","Test[local";  ErrorId="ErrorFilteringNamesForUnsupportedWildcards"}
+
+    It "Should not install resource with wildcard in name" -TestCases $testCases {
+        param($Name, $ErrorId)
+        Install-PSResource -Name $Name -Repository $ADORepoName -ErrorVariable err -ErrorAction SilentlyContinue
+        $err.Count | Should -BeGreaterThan 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "$ErrorId,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
+        $res = Get-InstalledPSResource $testModuleName
+        $res | Should -BeNullOrEmpty
+    }
+
+    It "Install specific module resource by name" {
+        Install-PSResource -Name $testModuleName -Repository $ADORepoName -TrustRepository
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "5.0.0"
+    }
+
+    It "Install specific script resource by name" {
+        Install-PSResource -Name $testScriptName -Repository $ADORepoName -TrustRepository
+        $pkg = Get-InstalledPSResource $testScriptName
+        $pkg.Name | Should -Be $testScriptName
+        $pkg.Version | Should -Be "1.0.0"
+    }
+
+    It "Install multiple resources by name" {
+        $pkgNames = @($testModuleName, $testModuleName2)
+        Install-PSResource -Name $pkgNames -Repository $ADORepoName -TrustRepository
+        $pkg = Get-InstalledPSResource $pkgNames
+        $pkg.Name | Should -Be $pkgNames
+    }
+
+    It "Should not install resource given nonexistant name" {
+        Install-PSResource -Name "NonExistantModule" -Repository $ADORepoName -TrustRepository -ErrorVariable err -ErrorAction SilentlyContinue
+        $pkg = Get-InstalledPSResource "NonExistantModule"
+        $pkg | Should -BeNullOrEmpty
+        $err.Count | Should -BeGreaterThan 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
+    }
+
+    # Do some version testing, but Find-PSResource should be doing thorough testing
+    It "Should install resource given name and exact version" {
+        Install-PSResource -Name $testModuleName -Version "1.0.0" -Repository $ADORepoName -TrustRepository
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "1.0.0"
+    }
+
+    It "Should install resource given name and exact version with bracket syntax" {
+        Install-PSResource -Name $testModuleName -Version "[1.0.0]" -Repository $ADORepoName -TrustRepository
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "1.0.0"
+    }
+
+    It "Should install resource given name and exact range inclusive [1.0.0, 5.0.0]" {
+        Install-PSResource -Name $testModuleName -Version "[1.0.0, 5.0.0]" -Repository $ADORepoName -TrustRepository
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "5.0.0"
+    }
+
+    It "Should install resource given name and exact range exclusive (1.0.0, 5.0.0)" {
+        Install-PSResource -Name $testModuleName -Version "(1.0.0, 5.0.0)" -Repository $ADORepoName -TrustRepository
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "3.0.0"
+    }
+
+    # TODO: Update this test and others like it that use try/catch blocks instead of Should -Throw
+    It "Should not install resource with incorrectly formatted version such as exclusive version (1.0.0.0)" {
+        $Version = "(1.0.0.0)"
+        try {
+            Install-PSResource -Name $testModuleName -Version $Version -Repository $ADORepoName -TrustRepository -ErrorAction SilentlyContinue
+        }
+        catch
+        {}
+        $Error[0].FullyQualifiedErrorId | Should -be "IncorrectVersionFormat,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
+
+        $res = Get-InstalledPSResource $testModuleName
+        $res | Should -BeNullOrEmpty
+    }
+
+    It "Install resource when given Name, Version '*', should install the latest version" {
+        Install-PSResource -Name $testModuleName -Version "*" -Repository $ADORepoName -TrustRepository
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "5.0.0"
+    }
+
+    It "Install resource with latest (including prerelease) version given Prerelease parameter" {
+        Install-PSResource -Name $testModuleName -Prerelease -Repository $ADORepoName -TrustRepository
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "5.2.5"
+        $pkg.Prerelease | Should -Be "alpha001"
+    }
+
+    It "Install resource via InputObject by piping from Find-PSresource" {
+        Find-PSResource -Name $testModuleName -Repository $ADORepoName | Install-PSResource -TrustRepository
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "5.0.0"
+    }
+
+    It "Install resource with companyname and repository source location and validate properties" {
+        Install-PSResource -Name $testModuleName -Version "5.2.5-alpha001" -Repository $ADORepoName -TrustRepository
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Version | Should -Be "5.2.5"
+        $pkg.Prerelease | Should -Be "alpha001"
+
+        $pkg.CompanyName | Should -Be "None"
+        $pkg.RepositorySourceLocation | Should -Be $ADORepoUri
+    }
+
+    # Windows only
+    It "Install resource under CurrentUser scope - Windows only" -Skip:(!(Get-IsWindows)) {
+        Install-PSResource -Name $testModuleName -Repository $ADORepoName -TrustRepository -Scope CurrentUser
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.InstalledLocation.ToString().Contains("Documents") | Should -Be $true
+    }
+
+    # Windows only
+    It "Install resource under AllUsers scope - Windows only" -Skip:(!((Get-IsWindows) -and (Test-IsAdmin))) {
+        Install-PSResource -Name $testModuleName -Repository $ADORepoName -TrustRepository -Scope AllUsers -Verbose
+        $pkg = Get-InstalledPSResource $testModuleName -Scope AllUsers
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.InstalledLocation.ToString().Contains("Program Files") | Should -Be $true
+    }
+
+    # Windows only
+    It "Install resource under no specified scope - Windows only" -Skip:(!(Get-IsWindows)) {
+        Install-PSResource -Name $testModuleName -Repository $ADORepoName -TrustRepository
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.InstalledLocation.ToString().Contains("Documents") | Should -Be $true
+    }
+
+    # Unix only
+    # Expected path should be similar to: '/home/janelane/.local/share/powershell/Modules'
+    It "Install resource under CurrentUser scope - Unix only" -Skip:(Get-IsWindows) {
+        Install-PSResource -Name $testModuleName -Repository $ADORepoName -TrustRepository -Scope CurrentUser
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.InstalledLocation.ToString().Contains("$env:HOME/.local") | Should -Be $true
+    }
+
+    # Unix only
+    # Expected path should be similar to: '/home/janelane/.local/share/powershell/Modules'
+    It "Install resource under no specified scope - Unix only" -Skip:(Get-IsWindows) {
+        Install-PSResource -Name $testModuleName -Repository $ADORepoName -TrustRepository
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.InstalledLocation.ToString().Contains("$env:HOME/.local") | Should -Be $true
+    }
+
+    It "Should not install resource that is already installed" {
+        Install-PSResource -Name $testModuleName -Repository $ADORepoName -TrustRepository
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        Install-PSResource -Name $testModuleName -Repository $ADORepoName -TrustRepository -WarningVariable WarningVar -warningaction SilentlyContinue
+        $WarningVar | Should -Not -BeNullOrEmpty
+    }
+
+    It "Reinstall resource that is already installed with -Reinstall parameter" {
+        Install-PSResource -Name $testModuleName -Repository $ADORepoName -TrustRepository
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "5.0.0"
+        Install-PSResource -Name $testModuleName -Repository $ADORepoName -Reinstall -TrustRepository
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Version | Should -Be "5.0.0"
+    }
+
+    It "Install PSResourceInfo object piped in" {
+        Find-PSResource -Name $testModuleName -Version "1.0.0.0" -Repository $ADORepoName | Install-PSResource -TrustRepository
+        $res = Get-InstalledPSResource -Name $testModuleName
+        $res.Name | Should -Be $testModuleName
+        $res.Version | Should -Be "1.0.0"
+    }
+
+    It "Install module using -PassThru" {
+        $res = Install-PSResource -Name $testModuleName -Repository $ADORepoName -PassThru -TrustRepository
+        $res.Name | Should -Contain $testModuleName
+    }
+}
+
+Describe 'Test Install-PSResource for V3Server scenarios' -tags 'ManualValidationOnly' {
+
+    BeforeAll {
+        $testModuleName = "TestModule"
+        $testModuleName2 = "testModuleWithlicense"
+        Get-NewPSResourceRepositoryFile
+        Register-LocalRepos
+    }
+
+    AfterEach {
+        Uninstall-PSResource $testModuleName, $testModuleName2 -SkipDependencyCheck -ErrorAction SilentlyContinue
+    }
+
+    AfterAll {
+        Get-RevertPSResourceRepositoryFile
+    }
+
+    # Unix only manual test
+    # Expected path should be similar to: '/usr/local/share/powershell/Modules'
+    It "Install resource under AllUsers scope - Unix only" -Skip:(Get-IsWindows) {
+        Install-PSResource -Name $testModuleName -Repository $TestGalleryName -Scope AllUsers
+        $pkg = Get-Module $testModuleName -ListAvailable
+        $pkg.Name | Should -Be $testModuleName
+        $pkg.Path.Contains("/usr/") | Should -Be $true
+    }
+
+    # This needs to be manually tested due to prompt
+    It "Install resource that requires accept license without -AcceptLicense flag" {
+        Install-PSResource -Name $testModuleName2  -Repository $TestGalleryName
+        $pkg = Get-InstalledPSResource $testModuleName2
+        $pkg.Name | Should -Be $testModuleName2
+        $pkg.Version | Should -Be "0.0.1.0"
+    }
+
+    # This needs to be manually tested due to prompt
+    It "Install resource should prompt 'trust repository' if repository is not trusted" {
+        Set-PSResourceRepository PoshTestGallery -Trusted:$false
+
+        Install-PSResource -Name $testModuleName -Repository $TestGalleryName -confirm:$false
+
+        $pkg = Get-Module $testModuleName -ListAvailable
+        $pkg.Name | Should -Be $testModuleName
+
+        Set-PSResourceRepository PoshTestGallery -Trusted
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When downloading from Azure DevOps Artifacts feeds with NuGet v2, the package ID must be lowercase.

I read that here:

* <https://blogs.blackmarble.co.uk/rfennell/downloading-nuget-packages-with-system.net.webclient/>

## PR Context

Partially fixes #1491

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
