### PR TITLE
Add `-AcceptLicense` to `Save-PSResource`

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -1026,7 +1026,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     }
 
                     // Accept License verification
-                    if (!_savePkg && !CallAcceptLicense(pkgToInstall, moduleManifest, tempInstallPath, pkgVersion, out error))
+                    if (!CallAcceptLicense(pkgToInstall, moduleManifest, tempInstallPath, pkgVersion, out error))
                     {
                         _pkgNamesToInstall.RemoveAll(x => x.Equals(pkgToInstall.Name, StringComparison.InvariantCultureIgnoreCase));
                         return false;

--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -171,6 +171,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public SwitchParameter Quiet { get; set; }
 
+        /// <summary>
+        /// For modules that require a license, AcceptLicense automatically accepts the license agreement during installation.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter AcceptLicense { get; set; }
+
         #endregion
 
         #region Method overrides
@@ -207,7 +213,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     break;
 
                 case InputObjectParameterSet:
-                    foreach (var inputObj in InputObject) {
+                    foreach (var inputObj in InputObject)
+                    {
                         string normalizedVersionString = Utils.GetNormalizedVersionString(inputObj.Version.ToString(), inputObj.Prerelease);
                         ProcessSaveHelper(
                             pkgNames: new string[] { inputObj.Name },
@@ -230,7 +237,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private void ProcessSaveHelper(string[] pkgNames, string pkgVersion, bool pkgPrerelease, string[] pkgRepository)
         {
             WriteDebug("In SavePSResource::ProcessSaveHelper()");
-            var namesToSave = Utils.ProcessNameWildcards(pkgNames, removeWildcardEntries:false, out string[] errorMsgs, out bool nameContainsWildcard);
+            var namesToSave = Utils.ProcessNameWildcards(pkgNames, removeWildcardEntries: false, out string[] errorMsgs, out bool nameContainsWildcard);
             if (nameContainsWildcard)
             {
                 WriteError(new ErrorRecord(
@@ -238,7 +245,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     "NameContainsWildcard",
                     ErrorCategory.InvalidArgument,
                     this));
-                    
+
                 return;
             }
 
@@ -276,26 +283,27 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             // figure out if version is a prerelease or not.
             // if condition is not met, prerelease is the value passed in via the parameter.
-            if (!string.IsNullOrEmpty(pkgVersion) && pkgVersion.Contains('-')) {
+            if (!string.IsNullOrEmpty(pkgVersion) && pkgVersion.Contains('-'))
+            {
                 pkgPrerelease = true;
             }
 
             var installedPkgs = _installHelper.BeginInstallPackages(
-                names: namesToSave, 
+                names: namesToSave,
                 versionRange: versionRange,
                 nugetVersion: nugetVersion,
                 versionType: versionType,
                 versionString: pkgVersion,
-                prerelease: pkgPrerelease, 
-                repository: pkgRepository, 
-                acceptLicense: true, 
-                quiet: Quiet, 
-                reinstall: true, 
-                force: false, 
+                prerelease: pkgPrerelease,
+                repository: pkgRepository,
+                acceptLicense: AcceptLicense,
+                quiet: Quiet,
+                reinstall: true,
+                force: false,
                 trustRepository: TrustRepository,
-                noClobber: false, 
-                asNupkg: AsNupkg, 
-                includeXml: IncludeXml, 
+                noClobber: false,
+                asNupkg: AsNupkg,
+                includeXml: IncludeXml,
                 skipDependencyCheck: SkipDependencyCheck,
                 authenticodeCheck: AuthenticodeCheck,
                 savePkg: true,

--- a/test/SavePSResourceTests/SavePSResourceV2Tests.ps1
+++ b/test/SavePSResourceTests/SavePSResourceV2Tests.ps1
@@ -30,14 +30,14 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
 
     It "Save specific module resource by name" {
         Save-PSResource -Name $testModuleName -Repository $PSGalleryName -Path $SaveDir -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
         (Get-ChildItem $pkgDir.FullName) | Should -HaveCount 1
     }
 
     It "Save specific script resource by name" {
         Save-PSResource -Name $testScriptName -Repository $PSGalleryName -Path $SaveDir -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "test_script.ps1"
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ "test_script.ps1"
         $pkgDir | Should -Not -BeNullOrEmpty
         (Get-ChildItem $pkgDir.FullName) | Should -HaveCount 1
     }
@@ -53,7 +53,7 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
 
     It "Should not save resource given nonexistant name" {
         Save-PSResource -Name NonExistentModule -Repository $PSGalleryName -Path $SaveDir -ErrorVariable err -ErrorAction SilentlyContinue -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "NonExistentModule"
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ "NonExistentModule"
         $pkgDir.Name | Should -BeNullOrEmpty
     }
 
@@ -65,7 +65,7 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
 
     It "Should save resource given name and exact version" {
         Save-PSResource -Name $testModuleName -Version "1.0.0" -Repository $PSGalleryName -Path $SaveDir -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "1.0.0.0"
@@ -73,7 +73,7 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
 
     It "Should save resource given name and version '3.*'" {
         Save-PSResource -Name $testModuleName -Version "3.*" -Repository $PSGalleryName -Path $SaveDir -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "3.0.0.0"
@@ -81,7 +81,7 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
 
     It "Should save resource given name and exact version with bracket syntax" {
         Save-PSResource -Name $testModuleName -Version "[1.0.0]" -Repository $PSGalleryName -Path $SaveDir -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "1.0.0.0"
@@ -89,7 +89,7 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
 
     It "Should save resource given name and exact range inclusive [1.0.0, 3.0.0]" {
         Save-PSResource -Name $testModuleName -Version "[1.0.0, 3.0.0]" -Repository $PSGalleryName -Path $SaveDir -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "3.0.0.0"
@@ -97,7 +97,7 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
 
     It "Should save resource given name and exact range exclusive (1.0.0, 5.0.0)" {
         Save-PSResource -Name $testModuleName -Version "(1.0.0, 5.0.0)" -Repository $PSGalleryName -Path $SaveDir -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "3.0.0.0"
@@ -111,15 +111,15 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
         catch
         {}
 
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -BeNullOrEmpty
         $Error.Count | Should -BeGreaterThan 0
-        $Error[0].FullyQualifiedErrorId  | Should -Be "IncorrectVersionFormat,Microsoft.PowerShell.PSResourceGet.Cmdlets.SavePSResource"
+        $Error[0].FullyQualifiedErrorId | Should -Be "IncorrectVersionFormat,Microsoft.PowerShell.PSResourceGet.Cmdlets.SavePSResource"
     }
 
     It "Save resource with latest (including prerelease) version given Prerelease parameter" {
         Save-PSResource -Name $testModuleName -Prerelease -Repository $PSGalleryName -Path $SaveDir -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "5.2.5"
@@ -146,24 +146,24 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
     ### the input object is of type string (ie "true").
     It "Save PSResourceInfo object piped in for prerelease version object" -Pending {
         Find-PSResource -Name $testModuleName -Version "5.2.5-alpha001" -Repository $PSGalleryName | Save-PSResource -Path $SaveDir -TrustRepository -Verbose
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
         (Get-ChildItem -Path $pkgDir.FullName) | Should -HaveCount 1
     }
 
     It "Save module as a nupkg" {
         Save-PSResource -Name $testModuleName -Version "1.0.0" -Repository $PSGalleryName -Path $SaveDir -AsNupkg -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "test_module.1.0.0.nupkg"
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ "test_module.1.0.0.nupkg"
         $pkgDir | Should -Not -BeNullOrEmpty
     }
 
     It "Save module and include XML metadata file" {
         Save-PSResource -Name $testModuleName -Version "1.0.0" -Repository $PSGalleryName -Path $SaveDir -IncludeXml -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "1.0.0.0"
-        $xmlFile = Get-ChildItem -Path $pkgDirVersion.FullName | Where-Object Name -eq "PSGetModuleInfo.xml"
+        $xmlFile = Get-ChildItem -Path $pkgDirVersion.FullName | Where-Object Name -EQ "PSGetModuleInfo.xml"
         $xmlFile | Should -Not -BeNullOrEmpty
     }
 
@@ -184,8 +184,8 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
         Save-PSResource -Name $testScriptName -Repository $PSGalleryName -Path $SaveDir -TrustRepository -IncludeXml
 
         $scriptXML = $testScriptName + "_InstalledScriptInfo.xml"
-        $savedScriptFile = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "test_script.ps1"
-        $savedScriptXML = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $scriptXML
+        $savedScriptFile = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ "test_script.ps1"
+        $savedScriptXML = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $scriptXML
         $savedScriptFile | Should -Not -BeNullOrEmpty
         (Get-ChildItem $savedScriptFile.FullName) | Should -HaveCount 1
         $savedScriptXML | Should -Not -BeNullOrEmpty
@@ -198,5 +198,14 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
         Save-PSResource -Name $testModuleName -Version "5.0.0" -AuthenticodeCheck -Repository $PSGalleryName -TrustRepository -Path $SaveDir -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -BeGreaterThan 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.SavePSResource"
+    }
+
+    # Save resource that requires license
+    It "Save resource that requires accept license with -AcceptLicense flag" {
+        Save-PSResource -Repository $TestGalleryName -TrustRepository -Path $SaveDir `
+            -Name $testModuleName2 -AcceptLicense
+        $pkg = Get-InstalledPSResource -Path $SaveDir -Name $testModuleName2
+        $pkg.Name | Should -Be $testModuleName2
+        $pkg.Version | Should -Be "0.0.1.0"
     }
 }

--- a/test/SavePSResourceTests/SavePSResourceV3Tests.ps1
+++ b/test/SavePSResourceTests/SavePSResourceV3Tests.ps1
@@ -28,7 +28,7 @@ Describe 'Test HTTP Save-PSResource for V3 Server Protocol' -tags 'CI' {
 
     It "Save specific module resource by name" {
         Save-PSResource -Name $testModuleName -Repository $NuGetGalleryName -Path $SaveDir -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
         (Get-ChildItem $pkgDir.FullName) | Should -HaveCount 1
     }
@@ -44,7 +44,7 @@ Describe 'Test HTTP Save-PSResource for V3 Server Protocol' -tags 'CI' {
 
     It "Should not save resource given nonexistant name" {
         Save-PSResource -Name NonExistentModule -Repository $NuGetGalleryName -Path $SaveDir -ErrorVariable err -ErrorAction SilentlyContinue -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "NonExistentModule"
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ "NonExistentModule"
         $pkgDir.Name | Should -BeNullOrEmpty
     }
 
@@ -56,7 +56,7 @@ Describe 'Test HTTP Save-PSResource for V3 Server Protocol' -tags 'CI' {
 
     It "Should save resource given name and exact version" {
         Save-PSResource -Name $testModuleName -Version "1.0.0" -Repository $NuGetGalleryName -Path $SaveDir -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "1.0.0"
@@ -64,7 +64,7 @@ Describe 'Test HTTP Save-PSResource for V3 Server Protocol' -tags 'CI' {
 
     It "Should save resource given name and exact version with bracket syntax" {
         Save-PSResource -Name $testModuleName -Version "[1.0.0]" -Repository $NuGetGalleryName -Path $SaveDir -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "1.0.0"
@@ -72,7 +72,7 @@ Describe 'Test HTTP Save-PSResource for V3 Server Protocol' -tags 'CI' {
 
     It "Should save resource given name and exact range inclusive [1.0.0, 3.0.0]" {
         Save-PSResource -Name $testModuleName -Version "[1.0.0, 3.0.0]" -Repository $NuGetGalleryName -Path $SaveDir -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "3.0.0"
@@ -80,7 +80,7 @@ Describe 'Test HTTP Save-PSResource for V3 Server Protocol' -tags 'CI' {
 
     It "Should save resource given name and exact range exclusive (1.0.0, 5.0.0)" {
         Save-PSResource -Name $testModuleName -Version "(1.0.0, 5.0.0)" -Repository $NuGetGalleryName -Path $SaveDir -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "3.0.0"
@@ -94,15 +94,15 @@ Describe 'Test HTTP Save-PSResource for V3 Server Protocol' -tags 'CI' {
         catch
         {}
 
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -BeNullOrEmpty
         $Error.Count | Should -BeGreaterThan 0
-        $Error[0].FullyQualifiedErrorId  | Should -Be "IncorrectVersionFormat,Microsoft.PowerShell.PSResourceGet.Cmdlets.SavePSResource"
+        $Error[0].FullyQualifiedErrorId | Should -Be "IncorrectVersionFormat,Microsoft.PowerShell.PSResourceGet.Cmdlets.SavePSResource"
     }
 
     It "Save resource with latest (including prerelease) version given Prerelease parameter" {
         Save-PSResource -Name $testModuleName -Prerelease -Repository $NuGetGalleryName -Path $SaveDir -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "5.2.5"
@@ -112,24 +112,24 @@ Describe 'Test HTTP Save-PSResource for V3 Server Protocol' -tags 'CI' {
     ### the input object is of type string (ie "true").
     It "Save PSResourceInfo object piped in for prerelease version object" -Pending{
         Find-PSResource -Name $testModuleName -Version "5.2.5-alpha001" -Repository $NuGetGalleryName | Save-PSResource -Path $SaveDir -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
-        (Get-ChildItem -Path $pkgDir.FullName) | Should -HaveCount 1   
+        (Get-ChildItem -Path $pkgDir.FullName) | Should -HaveCount 1
     }
 
     It "Save module as a nupkg" {
         Save-PSResource -Name $testModuleName -Version "1.0.0" -Repository $NuGetGalleryName -Path $SaveDir -AsNupkg -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "test_module.1.0.0.nupkg"
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ "test_module.1.0.0.nupkg"
         $pkgDir | Should -Not -BeNullOrEmpty
     }
 
     It "Save module and include XML metadata file" {
         Save-PSResource -Name $testModuleName -Version "1.0.0" -Repository $NuGetGalleryName -Path $SaveDir -IncludeXml -TrustRepository
-        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq $testModuleName
+        $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -EQ $testModuleName
         $pkgDir | Should -Not -BeNullOrEmpty
         $pkgDirVersion = Get-ChildItem -Path $pkgDir.FullName
         $pkgDirVersion.Name | Should -Be "1.0.0"
-        $xmlFile = Get-ChildItem -Path $pkgDirVersion.FullName | Where-Object Name -eq "PSGetModuleInfo.xml"
+        $xmlFile = Get-ChildItem -Path $pkgDirVersion.FullName | Where-Object Name -EQ "PSGetModuleInfo.xml"
         $xmlFile | Should -Not -BeNullOrEmpty
     }
 
@@ -145,5 +145,14 @@ Describe 'Test HTTP Save-PSResource for V3 Server Protocol' -tags 'CI' {
         Save-PSResource -Name $testModuleName -Version "5.0.0" -AuthenticodeCheck -Repository $NuGetGalleryName -TrustRepository -Path $SaveDir -ErrorVariable err -ErrorAction SilentlyContinue
         $err.Count | Should -BeGreaterThan 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.SavePSResource"
+    }
+
+    # Save resource that requires license
+    It "Install resource that requires accept license with -AcceptLicense flag" {
+        Save-PSResource -Repository $NuGetGalleryName -TrustRepository -Path $SaveDir `
+            -Name "test_module_with_license" -AcceptLicense
+        $pkg = Get-InstalledPSResource -Path $SaveDir "test_module_with_license"
+        $pkg.Name | Should -Be "test_module_with_license"
+        $pkg.Version | Should -Be "2.0.0"
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes #1450, but:

* Tests likely requires more work as `Save-PSResource` accepted license by default previously:
  * <https://github.com/PowerShell/PSResourceGet/blob/fe9c4d685933d4626d0bc74b682c73a671216934/src/code/SavePSResource.cs#L291>
* Documentation for `Save-PSResource` must be updated, unless that happens automagically?

## PR Context

To fix said issue.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed]()
        - [x] Issue filed: <https://github.com/MicrosoftDocs/PowerShell-Docs-PSGet/issues/160>
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
