### PR TITLE
Bugfix - Correctly match package names from local repos

### DIFF
--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -255,35 +255,55 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             FindResults findResponse = new FindResults();
             errRecord = null;
 
-            WildcardPattern pkgNamePattern = new WildcardPattern($"{packageName}.*", WildcardOptions.IgnoreCase);
+            WildcardPattern pkgNamePattern = new WildcardPattern($"{packageName}.", WildcardOptions.IgnoreCase);
             NuGetVersion latestVersion = new NuGetVersion("0.0.0.0");
             String latestVersionPath = String.Empty;
             string actualPkgName = packageName;
 
+            string regexPattern = $"{packageName}" + @".\d+\.\d+\.\d+(?:-\w+|.\d)*.nupkg";
+            Regex rx = new Regex(regexPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+            _cmdletPassedIn.WriteDebug($"pattern is: {regexPattern}");
+
             foreach (string path in Directory.GetFiles(Repository.Uri.LocalPath))
             {
                 string packageFullName = Path.GetFileName(path);
-
-                if (!String.IsNullOrEmpty(packageFullName) && pkgNamePattern.IsMatch(packageFullName))
+                MatchCollection matches = rx.Matches(packageFullName);
+                if (matches.Count == 0)
                 {
-                    NuGetVersion nugetVersion = GetInfoFromFileName(packageFullName: packageFullName, packageName: packageName, actualName: out actualPkgName, out errRecord);
-                    _cmdletPassedIn.WriteDebug($"Version parsed as '{nugetVersion}'");
+                    continue;
+                }
 
-                    if (errRecord != null)
-                    {
-                        return findResponse;
-                    }
+                Match match = matches[0];
 
-                    if ((!nugetVersion.IsPrerelease || includePrerelease) && (nugetVersion > latestVersion))
+                GroupCollection groups = match.Groups;
+                if (groups.Count == 0)
+                {
+                    continue;
+                }
+
+                Capture group = groups[0];
+
+                _cmdletPassedIn.WriteDebug($"package name is: {packageFullName}");
+                // string pkgFoundName = packageFullName.Substring(0, group.Index);
+
+                NuGetVersion nugetVersion = GetInfoFromFileName(packageFullName: packageFullName, packageName: packageName, actualName: out actualPkgName, out errRecord);
+                _cmdletPassedIn.WriteDebug($"Version parsed as '{nugetVersion}'");
+
+                if (errRecord != null)
+                {
+                    return findResponse;
+                }
+
+                if ((!nugetVersion.IsPrerelease || includePrerelease) && (nugetVersion > latestVersion))
+                {
+                    if (nugetVersion > latestVersion)
                     {
-                        if (nugetVersion > latestVersion)
-                        {
-                            latestVersion = nugetVersion;
-                            latestVersionPath = path;
-                        }
+                        latestVersion = nugetVersion;
+                        latestVersionPath = path;
                     }
                 }
-            }
+            }            
 
             if (String.IsNullOrEmpty(latestVersionPath))
             {
@@ -881,6 +901,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // packageFullName will look like package.1.0.0.nupkg
             errRecord = null;
 
+            // Microsoft.Graph.Users
+            // Microsoft.Graph.Users.Actions
+            // packageName should contain the pkg name that the user searched for
+            // actualName will be the name with the casing package.nupkg had, which is the casing we use when returning to the user
             string[] packageWithoutName = packageFullName.ToLower().Split(new string[]{ $"{packageName.ToLower()}." }, StringSplitOptions.RemoveEmptyEntries);
             string packageVersionAndExtension = packageWithoutName[0];
             string[] originalFileNameParts = packageFullName.Split(new string[]{ $".{packageVersionAndExtension}" }, StringSplitOptions.RemoveEmptyEntries);

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -259,10 +259,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             String latestVersionPath = String.Empty;
             string actualPkgName = packageName;
 
+            // this regex pattern matches packageName followed by a version (4 digit or 3 with prerelease word)
             string regexPattern = $"{packageName}" + @".\d+\.\d+\.\d+(?:-\w+|.\d)*.nupkg";
             Regex rx = new Regex(regexPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
-            _cmdletPassedIn.WriteDebug($"pattern is: {regexPattern}");
+            _cmdletPassedIn.WriteDebug($"package file name pattern to be searched for is: {regexPattern}");
 
             foreach (string path in Directory.GetFiles(Repository.Uri.LocalPath))
             {

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -255,7 +255,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             FindResults findResponse = new FindResults();
             errRecord = null;
 
-            WildcardPattern pkgNamePattern = new WildcardPattern($"{packageName}.", WildcardOptions.IgnoreCase);
             NuGetVersion latestVersion = new NuGetVersion("0.0.0.0");
             String latestVersionPath = String.Empty;
             string actualPkgName = packageName;

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -913,10 +913,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // packageFullName will look like package.1.0.0.nupkg
             errRecord = null;
 
-            // Microsoft.Graph.Users
-            // Microsoft.Graph.Users.Actions
-            // packageName should contain the pkg name that the user searched for
-            // actualName will be the name with the casing package.nupkg had, which is the casing we use when returning to the user
             string[] packageWithoutName = packageFullName.ToLower().Split(new string[]{ $"{packageName.ToLower()}." }, StringSplitOptions.RemoveEmptyEntries);
             string packageVersionAndExtension = packageWithoutName[0];
             string[] originalFileNameParts = packageFullName.Split(new string[]{ $".{packageVersionAndExtension}" }, StringSplitOptions.RemoveEmptyEntries);

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -387,6 +387,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return findResponse;
             }
 
+            // this regex pattern matches packageName followed by the requested version
             string regexPattern = $"{packageName}.{requiredVersion.ToNormalizedString()}" + @".nupkg";
             Regex rx = new Regex(regexPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
             _cmdletPassedIn.WriteDebug($"pattern is: {regexPattern}");

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -283,9 +283,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 Capture group = groups[0];
 
-                _cmdletPassedIn.WriteDebug($"package name is: {packageFullName}");
-                // string pkgFoundName = packageFullName.Substring(0, group.Index);
-
                 NuGetVersion nugetVersion = GetInfoFromFileName(packageFullName: packageFullName, packageName: packageName, actualName: out actualPkgName, out errRecord);
                 _cmdletPassedIn.WriteDebug($"Version parsed as '{nugetVersion}'");
 
@@ -302,7 +299,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         latestVersionPath = path;
                     }
                 }
-            }            
+            }
 
             if (String.IsNullOrEmpty(latestVersionPath))
             {

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -150,7 +150,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         # Package $testModuleName version 4.0.0 does not exist
         # previously if Find-PSResource -Version against local repo did not find that package's version it kept looking at
         # similar named packages and would fault. This test is to ensure only the specified package and its version is checked
-        $res = Find-PSResource -Name $testModuleName -Version "4.0.0" -Repository $localRepo
+        $res = Find-PSResource -Name $testModuleName -Version "4.0.0" -Repository $localRepo -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -BeNullOrEmpty
         $err.Count | Should -Not -Be 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
There was a bug in how we parse out name and version information from package file names when performing search against local repositories. 

If you have a package `test` and test.submodule` present in the local repository their files will look like this:
```
`test.1.0.0.nupkg`
`test.submodule.1.0.0.nupkg`
```
We used WildCardPattern class before, with pattern `{packageName}.*" which would pick up both packages if package `test` was searched for. The code logic then assumed the rest of the part of the name would be the version so it would search through both package names and try to parse `submodule.1.0.0` into a version. 

This fix uses Regex more accurately created for the package name and to expect a version right after the name, not text.

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes #1641 #1648 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
