### PR TITLE
Update version, changelog, releasenotes for 1.1.0-RC1

### DIFF
--- a/CHANGELOG/preview.md
+++ b/CHANGELOG/preview.md
@@ -1,4 +1,4 @@
-## [1.1.0-RC](https://github.com/PowerShell/PSResourceGet/compare/v1.1.0-preview2...v1.1.0-RC) - 2024-09-13
+## [1.1.0-RC1](https://github.com/PowerShell/PSResourceGet/compare/v1.1.0-preview2...v1.1.0-RC1) - 2024-09-13
 
 ### New Features
 

--- a/CHANGELOG/preview.md
+++ b/CHANGELOG/preview.md
@@ -1,3 +1,20 @@
+## [1.1.0-RC](https://github.com/PowerShell/PSResourceGet/compare/v1.1.0-preview2...v1.1.0-RC) - 2024-09-13
+
+### New Features
+
+- Group Policy configurations for enabling or disabling PSResource repositories (#1730)
+
+### Bug Fixes
+
+- Fix packaging name matching when searching in local repositories (#1731)
+- `Compress-PSResource` `-PassThru` now passes `FileInfo` instead of string (#1720)
+- Fix for `Compress-PSResource` not properly compressing scripts  (#1719) 
+- Add `AcceptLicense` to Save-PSResource (#1718 Thanks @o-l-a-v!)
+- Better support for NuGet v2 feeds (#1713 Thanks @o-l-a-v!)
+- Better handling of `-WhatIf` support in `Install-PSResource` (#1531 Thanks @o-l-a-v!)
+- Fix for some nupkgs failing to extract due to empty directories (#1707 Thanks @o-l-a-v!)
+- Fix for searching for `-Name *` in `Find-PSResource` (#1706 Thanks @o-l-a-v!)
+
 ## [1.1.0-preview2](https://github.com/PowerShell/PSResourceGet/compare/v1.1.0-preview1...v1.1.0-preview2) - 2024-09-13
 
 ### New Features

--- a/src/Microsoft.PowerShell.PSResourceGet.psd1
+++ b/src/Microsoft.PowerShell.PSResourceGet.psd1
@@ -46,7 +46,7 @@
         'udres')
     PrivateData = @{
         PSData = @{
-            Prerelease   = 'preview2'
+            Prerelease   = 'RC'
             Tags         = @('PackageManagement',
                 'PSEdition_Desktop',
                 'PSEdition_Core',
@@ -56,6 +56,23 @@
             ProjectUri   = 'https://go.microsoft.com/fwlink/?LinkId=828955'
             LicenseUri   = 'https://go.microsoft.com/fwlink/?LinkId=829061'
             ReleaseNotes = @'
+## 1.1.0-RC
+
+### New Features
+
+- Group Policy configurations for enabling or disabling PSResource repositories (#1730)
+
+### Bug Fixes
+
+- Fix packaging name matching when searching in local repositories (#1731)
+- `Compress-PSResource` `-PassThru` now passes `FileInfo` instead of string (#1720)
+- Fix for `Compress-PSResource` not properly compressing scripts  (#1719) 
+- Add `AcceptLicense` to Save-PSResource (#1718 Thanks @o-l-a-v!)
+- Better support for NuGet v2 feeds (#1713 Thanks @o-l-a-v!)
+- Better handling of `-WhatIf` support in `Install-PSResource` (#1531 Thanks @o-l-a-v!)
+- Fix for some nupkgs failing to extract due to empty directories (#1707 Thanks @o-l-a-v!)
+- Fix for searching for `-Name *` in `Find-PSResource` (#1706 Thanks @o-l-a-v!)
+
 ## 1.1.0-preview2
 
 ### New Features

--- a/src/Microsoft.PowerShell.PSResourceGet.psd1
+++ b/src/Microsoft.PowerShell.PSResourceGet.psd1
@@ -46,7 +46,7 @@
         'udres')
     PrivateData = @{
         PSData = @{
-            Prerelease   = 'RC'
+            Prerelease   = 'RC1'
             Tags         = @('PackageManagement',
                 'PSEdition_Desktop',
                 'PSEdition_Core',
@@ -56,7 +56,7 @@
             ProjectUri   = 'https://go.microsoft.com/fwlink/?LinkId=828955'
             LicenseUri   = 'https://go.microsoft.com/fwlink/?LinkId=829061'
             ReleaseNotes = @'
-## 1.1.0-RC
+## 1.1.0-RC1
 
 ### New Features
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Update version, changelog, releasenotes for 1.1.0-RC1 release

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
