### PR TITLE
Add 'ToLower' before name comparison and split

### DIFF
--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -48,7 +48,7 @@ jobs:
   - ${{ parameters.powershellExecutable }}: |
       $modulePath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath 'TempModules'
       Write-Verbose -Verbose "Install Microsoft.PowerShell.PSResourceGet to temp module path"
-      Save-Module -Name Microsoft.PowerShell.PSResourceGet -MinimumVersion 1.0.6 -Path $modulePath -Force -Verbose
+      Save-Module -Name Microsoft.PowerShell.PSResourceGet -Version 1.0.2 -Path $modulePath -Force -Verbose
       Write-Verbose -Verbose "Install Pester 4.X to temp module path"
       Save-Module -Name "Pester" -MaximumVersion 4.99 -Path $modulePath -Force
     displayName: Install Microsoft.PowerShell.PSResourceGet and Pester

--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -48,7 +48,7 @@ jobs:
   - ${{ parameters.powershellExecutable }}: |
       $modulePath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath 'TempModules'
       Write-Verbose -Verbose "Install Microsoft.PowerShell.PSResourceGet to temp module path"
-      Save-Module -Name Microsoft.PowerShell.PSResourceGet -Version 1.0.2 -Path $modulePath -Force -Verbose
+      Save-Module -Name Microsoft.PowerShell.PSResourceGet -Path $modulePath -Force -Verbose
       Write-Verbose -Verbose "Install Pester 4.X to temp module path"
       Save-Module -Name "Pester" -MaximumVersion 4.99 -Path $modulePath -Force
     displayName: Install Microsoft.PowerShell.PSResourceGet and Pester

--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -48,7 +48,7 @@ jobs:
   - ${{ parameters.powershellExecutable }}: |
       $modulePath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath 'TempModules'
       Write-Verbose -Verbose "Install Microsoft.PowerShell.PSResourceGet to temp module path"
-      Save-Module -Name Microsoft.PowerShell.PSResourceGet -RequiredVersion "1.1.0-preview2" -Path $modulePath -AllowPrerelease -Force -Verbose
+      Save-Module -Name Microsoft.PowerShell.PSResourceGet -MinimumVersion 1.0.6 -Path $modulePath -Force -Verbose
       Write-Verbose -Verbose "Install Pester 4.X to temp module path"
       Save-Module -Name "Pester" -MaximumVersion 4.99 -Path $modulePath -Force
     displayName: Install Microsoft.PowerShell.PSResourceGet and Pester

--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -48,7 +48,7 @@ jobs:
   - ${{ parameters.powershellExecutable }}: |
       $modulePath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath 'TempModules'
       Write-Verbose -Verbose "Install Microsoft.PowerShell.PSResourceGet to temp module path"
-      Save-Module -Name Microsoft.PowerShell.PSResourceGet -RequiredVersion "1.1.0-preview2" -Path $modulePath -AllowPrerelease -Force
+      Save-Module -Name Microsoft.PowerShell.PSResourceGet -RequiredVersion "1.1.0-preview2" -Path $modulePath -AllowPrerelease -Force -Verbose
       Write-Verbose -Verbose "Install Pester 4.X to temp module path"
       Save-Module -Name "Pester" -MaximumVersion 4.99 -Path $modulePath -Force
     displayName: Install Microsoft.PowerShell.PSResourceGet and Pester
@@ -59,7 +59,7 @@ jobs:
       Write-Verbose -Verbose "Importing build utilities (buildtools.psd1)"
       Import-Module -Name (Join-Path -Path '${{ parameters.buildDirectory }}' -ChildPath 'buildtools.psd1') -Force
       #
-      Install-ModulePackageForTest -PackagePath "$(System.ArtifactsDirectory)"
+      Install-ModulePackageForTest -PackagePath "$(System.ArtifactsDirectory)" -ErrorAction stop -Verbose
     displayName: Install module for test from downloaded artifact
     workingDirectory: ${{ parameters.buildDirectory }}
 

--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -48,7 +48,7 @@ jobs:
   - ${{ parameters.powershellExecutable }}: |
       $modulePath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath 'TempModules'
       Write-Verbose -Verbose "Install Microsoft.PowerShell.PSResourceGet to temp module path"
-      Save-Module -Name Microsoft.PowerShell.PSResourceGet -MinimumVersion 0.9.0-rc1 -Path $modulePath -AllowPrerelease -Force
+      Save-Module -Name Microsoft.PowerShell.PSResourceGet -RequiredVersion "1.1.0-preview2" -Path $modulePath -AllowPrerelease -Force
       Write-Verbose -Verbose "Install Pester 4.X to temp module path"
       Save-Module -Name "Pester" -MaximumVersion 4.99 -Path $modulePath -Force
     displayName: Install Microsoft.PowerShell.PSResourceGet and Pester

--- a/buildtools.psm1
+++ b/buildtools.psm1
@@ -136,7 +136,7 @@ function Install-ModulePackageForTest {
     Write-Verbose -Verbose -Message "PowerShellGet version base imported: $psgetv2Version"
     Write-Verbose -Verbose -Message "PowerShellGet prerelease base imported: $psgetv2Prerelease"
     Save-Module -Name $config.ModuleName -Repository $localRepoName -Path $installationPath -Force -Verbose -AllowPrerelease -Confirm:$false
-    Unregister-PSRepository -Name $localRepoName -Confirm:$false
+    Unregister-PSRepository -Name $localRepoName
 
     Write-Verbose -Verbose -Message "Unregistering local package repo: $localRepoName"
     Unregister-PSResourceRepository -Name $localRepoName -Confirm:$false

--- a/buildtools.psm1
+++ b/buildtools.psm1
@@ -120,6 +120,8 @@ function Install-ModulePackageForTest {
     }
 
     Write-Verbose -Verbose -Message "Installing module $($config.ModuleName) to build output path $installationPath"
+    $psgetVersion = (get-command save-psresource).Module.ModuleBase
+    Write-Verbose -Verbose -Message "Version of PSResourceGet imported: $psgetVersion"
     Save-PSResource -Name $config.ModuleName -Repository $localRepoName -Path $installationPath -SkipDependencyCheck -Prerelease -Confirm:$false -TrustRepository
 
     Write-Verbose -Verbose -Message "Unregistering local package repo: $localRepoName"

--- a/buildtools.psm1
+++ b/buildtools.psm1
@@ -126,7 +126,17 @@ function Install-ModulePackageForTest {
     Write-Verbose -Verbose -Message "PSResourceGet module base imported: $psgetModuleBase"
     Write-Verbose -Verbose -Message "PSResourceGet version base imported: $psgetVersion"
     Write-Verbose -Verbose -Message "PSResourceGet prerelease base imported: $psgetPrerelease"
-    Save-PSResource -Name $config.ModuleName -Repository $localRepoName -Path $installationPath -SkipDependencyCheck -Prerelease -Confirm:$false -TrustRepository
+    #Save-PSResource -Name $config.ModuleName -Repository $localRepoName -Path $installationPath -SkipDependencyCheck -Prerelease -Confirm:$false -TrustRepository
+
+    Register-PSRepository -Name $localRepoName -SourceLocation $packagePathWithNupkg -InstallationPolicy Trusted -Verbose
+    $psgetv2ModuleBase = (get-command save-module).Module.ModuleBase
+    $psgetv2Version = (get-command save-module).Module.Version.ToString()
+    $psgetv2Prerelease = (get-command save-module).module.PrivateData.PSData.Prerelease
+    Write-Verbose -Verbose -Message "PowerShellGet module base imported: $psgetv2ModuleBase"
+    Write-Verbose -Verbose -Message "PowerShellGet version base imported: $psgetv2Version"
+    Write-Verbose -Verbose -Message "PowerShellGet prerelease base imported: $psgetv2Prerelease"
+    Save-Module -Name $config.ModuleName -Repository $localRepoName -Path $installationPath -Force -Verbose -AllowPrerelease -Confirm:$false
+    Unregister-PSRepository -Name $localRepoName -Confirm:$false
 
     Write-Verbose -Verbose -Message "Unregistering local package repo: $localRepoName"
     Unregister-PSResourceRepository -Name $localRepoName -Confirm:$false

--- a/buildtools.psm1
+++ b/buildtools.psm1
@@ -120,8 +120,12 @@ function Install-ModulePackageForTest {
     }
 
     Write-Verbose -Verbose -Message "Installing module $($config.ModuleName) to build output path $installationPath"
-    $psgetVersion = (get-command save-psresource).Module.ModuleBase
-    Write-Verbose -Verbose -Message "Version of PSResourceGet imported: $psgetVersion"
+    $psgetModuleBase = (get-command save-psresource).Module.ModuleBase
+    $psgetVersion = (get-command save-psresource).Module.Version.ToString()
+    $psgetPrerelease = (get-command find-psresource).module.PrivateData.PSData.Prerelease
+    Write-Verbose -Verbose -Message "PSResourceGet module base imported: $psgetModuleBase"
+    Write-Verbose -Verbose -Message "PSResourceGet version base imported: $psgetVersion"
+    Write-Verbose -Verbose -Message "PSResourceGet prerelease base imported: $psgetPrerelease"
     Save-PSResource -Name $config.ModuleName -Repository $localRepoName -Path $installationPath -SkipDependencyCheck -Prerelease -Confirm:$false -TrustRepository
 
     Write-Verbose -Verbose -Message "Unregistering local package repo: $localRepoName"

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -972,6 +972,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             try
             {
                 var pathToFile = Path.Combine(tempInstallPath, $"{pkgName}.{normalizedPkgVersion}.zip");
+                _cmdletPassedIn.WriteVerbose($"pathToFile IS: {pathToFile}.");
+
+                if (File.Exists(pathToFile))
+                {
+                    _cmdletPassedIn.WriteVerbose($"pathToFile EXISTS.");
+
+                }
+                else {
+                    _cmdletPassedIn.WriteVerbose($"pathToFile DOES NOT EXIST.");
+
+                }
+
                 using var fs = File.Create(pathToFile);
                 responseStream.Seek(0, System.IO.SeekOrigin.Begin);
                 responseStream.CopyTo(fs);
@@ -980,6 +992,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // Expand the zip file
                 var pkgVersion = pkgToInstall.Version.ToString();
                 var tempDirNameVersion = Path.Combine(tempInstallPath, pkgName.ToLower(), pkgVersion);
+                
                 Directory.CreateDirectory(tempDirNameVersion);
 
                 if (!TryExtractToDirectory(pathToFile, tempDirNameVersion, out error))
@@ -992,6 +1005,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 var moduleManifest = Path.Combine(tempDirNameVersion, pkgName + PSDataFileExt);
                 var scriptPath = Path.Combine(tempDirNameVersion, pkgName + PSScriptFileExt);
 
+                _cmdletPassedIn.WriteVerbose($"MODULE MANIFEST PATH IS: {moduleManifest}.");
                 bool isModule = File.Exists(moduleManifest);
                 bool isScript = File.Exists(scriptPath);
 

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -737,6 +737,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             FindResults responses = null;
             errRecord = null;
 
+            //_cmdletPassedIn.WriteWarning($"~~~~~~~~~~~~~~~~~~ pkgNameToInstall is: '{pkgNameToInstall}'.");
+
             switch (searchVersionType)
             {
                 case VersionType.VersionRange:
@@ -813,6 +815,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 return packagesHash;
             }
+            
+            // THIS SHOULD BE THE CORRECT PKG NAME
+           // _cmdletPassedIn.WriteWarning($"~~~~~~~~~~~~~~~~~~ pkgToInstall.Name is: '{pkgToInstall.Name}'.");
 
             pkgToInstall.RepositorySourceLocation = repository.Uri.ToString();
             pkgToInstall.AdditionalMetadata.TryGetValue("NormalizedVersion", out string pkgVersion);

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -737,8 +737,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             FindResults responses = null;
             errRecord = null;
 
-            //_cmdletPassedIn.WriteWarning($"~~~~~~~~~~~~~~~~~~ pkgNameToInstall is: '{pkgNameToInstall}'.");
-
             switch (searchVersionType)
             {
                 case VersionType.VersionRange:
@@ -816,9 +814,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return packagesHash;
             }
             
-            // THIS SHOULD BE THE CORRECT PKG NAME
-           // _cmdletPassedIn.WriteWarning($"~~~~~~~~~~~~~~~~~~ pkgToInstall.Name is: '{pkgToInstall.Name}'.");
-
             pkgToInstall.RepositorySourceLocation = repository.Uri.ToString();
             pkgToInstall.AdditionalMetadata.TryGetValue("NormalizedVersion", out string pkgVersion);
             if (pkgVersion == null) {
@@ -976,14 +971,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             updatedPackagesHash = packagesHash;
             try
             {
-                if (responseStream == null)
-                {
-                    _cmdletPassedIn.WriteVerbose($"response stream is null");
-                }
-                else {
-                    _cmdletPassedIn.WriteVerbose($"response stream is NOT null");
-                }
-
                 var pathToFile = Path.Combine(tempInstallPath, $"{pkgName}.{normalizedPkgVersion}.zip");
                 _cmdletPassedIn.WriteVerbose($"pathToFile IS: {pathToFile}.");
 
@@ -1003,41 +990,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     return false;
                 }
 
-                
-                _cmdletPassedIn.WriteVerbose($"tempDirNameVersionIS: {tempDirNameVersion}.");
-
-                // Check if the directory exists
-                if (Directory.Exists(tempDirNameVersion))
-                {
-                    Console.WriteLine($"Contents of {tempDirNameVersion}:");
-
-                    // Display all files in the directory
-                    string[] files = Directory.GetFiles(tempDirNameVersion, "*.*", SearchOption.AllDirectories);
-                    foreach (string file in files)
-                    {
-                        Console.WriteLine($"File: {file}");
-                    }
-
-                    // Display all subdirectories in the directory
-                    string[] directories = Directory.GetDirectories(tempDirNameVersion, "*", SearchOption.AllDirectories);
-                    foreach (string directory in directories)
-                    {
-                        Console.WriteLine($"Directory: {directory}");
-                    }
-                }
-                else
-                {
-                    Console.WriteLine($"The directory {tempDirNameVersion} does not exist.");
-                }
-
-                
-                
                 File.Delete(pathToFile);
 
                 var moduleManifest = Path.Combine(tempDirNameVersion, pkgName + PSDataFileExt);
                 var scriptPath = Path.Combine(tempDirNameVersion, pkgName + PSScriptFileExt);
 
-                _cmdletPassedIn.WriteVerbose($"MODULE MANIFEST PATH IS: {moduleManifest}.");
                 bool isModule = File.Exists(moduleManifest);
                 bool isScript = File.Exists(scriptPath);
 

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -813,7 +813,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 return packagesHash;
             }
-            
             pkgToInstall.RepositorySourceLocation = repository.Uri.ToString();
             pkgToInstall.AdditionalMetadata.TryGetValue("NormalizedVersion", out string pkgVersion);
             if (pkgVersion == null) {
@@ -980,7 +979,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 // Expand the zip file
                 var pkgVersion = pkgToInstall.Version.ToString();
                 var tempDirNameVersion = Path.Combine(tempInstallPath, pkgName.ToLower(), pkgVersion);
-                
                 Directory.CreateDirectory(tempDirNameVersion);
                 if (!TryExtractToDirectory(pathToFile, tempDirNameVersion, out error))
                 {

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -971,18 +971,16 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             updatedPackagesHash = packagesHash;
             try
             {
-                var pathToFile = Path.Combine(tempInstallPath, $"{pkgName}.{normalizedPkgVersion}.zip");
-                _cmdletPassedIn.WriteVerbose($"pathToFile IS: {pathToFile}.");
-
-                if (File.Exists(pathToFile))
+                if (responseStream == null)
                 {
-                    _cmdletPassedIn.WriteVerbose($"pathToFile EXISTS.");
-
+                    _cmdletPassedIn.WriteVerbose($"response stream is null");
                 }
                 else {
-                    _cmdletPassedIn.WriteVerbose($"pathToFile DOES NOT EXIST.");
-
+                    _cmdletPassedIn.WriteVerbose($"response stream is NOT null");
                 }
+
+                var pathToFile = Path.Combine(tempInstallPath, $"{pkgName}.{normalizedPkgVersion}.zip");
+                _cmdletPassedIn.WriteVerbose($"pathToFile IS: {pathToFile}.");
 
                 using var fs = File.Create(pathToFile);
                 responseStream.Seek(0, System.IO.SeekOrigin.Begin);
@@ -1000,6 +998,35 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     return false;
                 }
 
+                
+                _cmdletPassedIn.WriteVerbose($"tempDirNameVersionIS: {tempDirNameVersion}.");
+
+                // Check if the directory exists
+                if (Directory.Exists(tempDirNameVersion))
+                {
+                    Console.WriteLine($"Contents of {tempDirNameVersion}:");
+
+                    // Display all files in the directory
+                    string[] files = Directory.GetFiles(tempDirNameVersion, "*.*", SearchOption.AllDirectories);
+                    foreach (string file in files)
+                    {
+                        Console.WriteLine($"File: {file}");
+                    }
+
+                    // Display all subdirectories in the directory
+                    string[] directories = Directory.GetDirectories(tempDirNameVersion, "*", SearchOption.AllDirectories);
+                    foreach (string directory in directories)
+                    {
+                        Console.WriteLine($"Directory: {directory}");
+                    }
+                }
+                else
+                {
+                    Console.WriteLine($"The directory {tempDirNameVersion} does not exist.");
+                }
+
+                
+                
                 File.Delete(pathToFile);
 
                 var moduleManifest = Path.Combine(tempDirNameVersion, pkgName + PSDataFileExt);

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -813,6 +813,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 return packagesHash;
             }
+
             pkgToInstall.RepositorySourceLocation = repository.Uri.ToString();
             pkgToInstall.AdditionalMetadata.TryGetValue("NormalizedVersion", out string pkgVersion);
             if (pkgVersion == null) {
@@ -980,6 +981,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 var pkgVersion = pkgToInstall.Version.ToString();
                 var tempDirNameVersion = Path.Combine(tempInstallPath, pkgName.ToLower(), pkgVersion);
                 Directory.CreateDirectory(tempDirNameVersion);
+
                 if (!TryExtractToDirectory(pathToFile, tempDirNameVersion, out error))
                 {
                     return false;

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -972,8 +972,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             try
             {
                 var pathToFile = Path.Combine(tempInstallPath, $"{pkgName}.{normalizedPkgVersion}.zip");
-                _cmdletPassedIn.WriteVerbose($"pathToFile IS: {pathToFile}.");
-
                 using var fs = File.Create(pathToFile);
                 responseStream.Seek(0, System.IO.SeekOrigin.Begin);
                 responseStream.CopyTo(fs);
@@ -984,7 +982,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 var tempDirNameVersion = Path.Combine(tempInstallPath, pkgName.ToLower(), pkgVersion);
                 
                 Directory.CreateDirectory(tempDirNameVersion);
-
                 if (!TryExtractToDirectory(pathToFile, tempDirNameVersion, out error))
                 {
                     return false;

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -730,7 +730,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     }
 
                     pkgMetadata = parsedScript.ToHashtable();
-                    pkgMetadata.Add("Id", packageName);
+                    pkgMetadata.Add("Id", properCasingPkgName);
                     pkgMetadata.Add(_fileTypeKey, Utils.MetadataFileType.ScriptFile);
                     pkgTags.AddRange(pkgMetadata["Tags"] as string[]);
 

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -916,7 +916,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             string[] packageWithoutName = packageFullName.ToLower().Split(new string[]{ $"{packageName.ToLower()}." }, StringSplitOptions.RemoveEmptyEntries);
             string packageVersionAndExtension = packageWithoutName[0];
-            string[] originalFileNameParts = packageFullName.Split(new string[]{ $".{packageVersionAndExtension}" }, StringSplitOptions.RemoveEmptyEntries);
+            string[] originalFileNameParts = packageFullName.ToLower().Split(new string[]{ $".{packageVersionAndExtension.ToLower()}" }, StringSplitOptions.RemoveEmptyEntries);
             actualName = String.IsNullOrEmpty(originalFileNameParts[0]) ? packageName : originalFileNameParts[0];
             int extensionDot = packageVersionAndExtension.LastIndexOf('.');
             string version = packageVersionAndExtension.Substring(0, extensionDot);

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -685,7 +685,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 string psd1FilePath = String.Empty;
                 string ps1FilePath = String.Empty;
                 string nuspecFilePath = String.Empty;
-                Utils.GetMetadataFilesFromPath(tempDiscoveryPath, packageName, out psd1FilePath, out ps1FilePath, out nuspecFilePath);
+                Utils.GetMetadataFilesFromPath(tempDiscoveryPath, packageName, out psd1FilePath, out ps1FilePath, out nuspecFilePath, out string properCasingPkgName);
 
                 List<string> pkgTags = new List<string>();
 
@@ -710,7 +710,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     pkgMetadata.Add("ProjectUri", projectUri);
                     pkgMetadata.Add("IconUri", iconUri);
                     pkgMetadata.Add("ReleaseNotes", releaseNotes);
-                    pkgMetadata.Add("Id", packageName);
+                    pkgMetadata.Add("Id", properCasingPkgName);
                     pkgMetadata.Add(_fileTypeKey, Utils.MetadataFileType.ModuleManifest);
 
                     pkgTags.AddRange(pkgHashTags);

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1172,11 +1172,12 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             return pkgsInstalledOnMachine;
         }
 
-        internal static void GetMetadataFilesFromPath(string dirPath, string packageName, out string psd1FilePath, out string ps1FilePath, out string nuspecFilePath)
+        internal static void GetMetadataFilesFromPath(string dirPath, string packageName, out string psd1FilePath, out string ps1FilePath, out string nuspecFilePath, out string properCasingPkgName)
         {
             psd1FilePath = String.Empty;
             ps1FilePath = String.Empty;
             nuspecFilePath = String.Empty;
+            properCasingPkgName = packageName;
 
             var discoveredFiles = Directory.GetFiles(dirPath, "*.*", SearchOption.AllDirectories);
             string pkgNamePattern = $"{packageName}*";
@@ -1187,14 +1188,26 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 {
                     if (file.EndsWith("psd1"))
                     {
+                        if (string.Compare($"{packageName}.psd1", file, StringComparison.OrdinalIgnoreCase) == 0)
+                        {
+                            properCasingPkgName = file.Split(new string[] { ".psd1" }, StringSplitOptions.None).First();
+                        }
                         psd1FilePath = file;
                     }
                     else if (file.EndsWith("nuspec"))
                     {
+                        if (string.Compare($"{packageName}.nuspec", file, StringComparison.OrdinalIgnoreCase) == 0)
+                        {
+                            properCasingPkgName = file.Split(new string[] { ".nuspec" }, StringSplitOptions.None).First();
+                        }
                         nuspecFilePath = file;
                     }
                     else if (file.EndsWith("ps1"))
                     {
+                        if (string.Compare($"{packageName}.ps1", file, StringComparison.OrdinalIgnoreCase) == 0)
+                        {
+                            properCasingPkgName = file.Split(new string[] { ".ps1" }, StringSplitOptions.None).First();
+                        }
                         ps1FilePath = file;
                     }
                 }

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1186,27 +1186,28 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             {
                 if (rgx.IsMatch(file))
                 {
-                    if (file.EndsWith("psd1"))
+                    string fileName = Path.GetFileName(file);
+                    if (fileName.EndsWith("psd1"))
                     {
-                        if (string.Compare($"{packageName}.psd1", file, StringComparison.OrdinalIgnoreCase) == 0)
+                        if (string.Compare($"{packageName}.psd1", fileName, StringComparison.OrdinalIgnoreCase) == 0)
                         {
-                            properCasingPkgName = file.Split(new string[] { ".psd1" }, StringSplitOptions.None).First();
+                            properCasingPkgName = Path.GetFileNameWithoutExtension(file);
                         }
                         psd1FilePath = file;
                     }
                     else if (file.EndsWith("nuspec"))
                     {
-                        if (string.Compare($"{packageName}.nuspec", file, StringComparison.OrdinalIgnoreCase) == 0)
+                        if (string.Compare($"{packageName}.nuspec", fileName, StringComparison.OrdinalIgnoreCase) == 0)
                         {
-                            properCasingPkgName = file.Split(new string[] { ".nuspec" }, StringSplitOptions.None).First();
+                            properCasingPkgName = Path.GetFileNameWithoutExtension(file);
                         }
                         nuspecFilePath = file;
                     }
                     else if (file.EndsWith("ps1"))
                     {
-                        if (string.Compare($"{packageName}.ps1", file, StringComparison.OrdinalIgnoreCase) == 0)
+                        if (string.Compare($"{packageName}.ps1", fileName, StringComparison.OrdinalIgnoreCase) == 0)
                         {
-                            properCasingPkgName = file.Split(new string[] { ".ps1" }, StringSplitOptions.None).First();
+                            properCasingPkgName = Path.GetFileNameWithoutExtension(file);
                         }
                         ps1FilePath = file;
                     }

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -55,7 +55,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         # FindName()
         $res = Find-PSResource -Name "test_local_mod3" -Repository $localRepo
         $res.Name | Should -Be $testModuleName3
-        $res.Version | Should -Be "5.0.0"
+        $res.Version | Should -Be "1.0.0"
     }
 
     It "find resource given specific Name, Version null (module) from a UNC-based local repository" {

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -12,7 +12,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
     BeforeAll{
         $localRepo = "psgettestlocal"
         $localUNCRepo = 'psgettestlocal3'
-        $testModuleName = "test_local_mod"
+        $testModuleName = "Test_Local_Mod"
         $testModuleName2 = "test_local_mod2"
         $similarTestModuleName = "test_local_mod.similar"
         $commandName = "cmd1"
@@ -44,6 +44,13 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
     It "find resource given specific Name, Version null (module)" {
         # FindName()
         $res = Find-PSResource -Name $testModuleName -Repository $localRepo
+        $res.Name | Should -Be $testModuleName
+        $res.Version | Should -Be "5.0.0"
+    }
+
+    It "find resource given specific Name with incorrect casing (should return correct casing)" {
+        # FindName()
+        $res = Find-PSResource -Name "test_local_mod" -Repository $localRepo
         $res.Name | Should -Be $testModuleName
         $res.Version | Should -Be "5.0.0"
     }

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -12,8 +12,9 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
     BeforeAll{
         $localRepo = "psgettestlocal"
         $localUNCRepo = 'psgettestlocal3'
-        $testModuleName = "Test_Local_Mod"
+        $testModuleName = "test_local_mod"
         $testModuleName2 = "test_local_mod2"
+        $testModuleName3 = "Test_Local_Mod3"
         $similarTestModuleName = "test_local_mod.similar"
         $commandName = "cmd1"
         $dscResourceName = "dsc1"
@@ -33,6 +34,8 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         New-TestModule -moduleName $testModuleName2 -repoName $localRepo -packageVersion "5.0.0" -prereleaseLabel "" -tags $tagsEscaped
         New-TestModule -moduleName $testModuleName2 -repoName $localRepo -packageVersion "5.2.5" -prereleaseLabel $prereleaseLabel -tags $tagsEscaped
 
+        New-TestModule -moduleName $testModuleName3 -repoName $localRepo -packageVersion "1.0.0" -prereleaseLabel "" -tags @()
+
         New-TestModule -moduleName $similarTestModuleName -repoName $localRepo -packageVersion "4.0.0" -prereleaseLabel "" -tags $tagsEscaped
         New-TestModule -moduleName $similarTestModuleName -repoName $localRepo -packageVersion "5.0.0" -prereleaseLabel "" -tags $tagsEscaped
     }
@@ -50,8 +53,8 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
 
     It "find resource given specific Name with incorrect casing (should return correct casing)" {
         # FindName()
-        $res = Find-PSResource -Name "test_local_mod" -Repository $localRepo
-        $res.Name | Should -Be $testModuleName
+        $res = Find-PSResource -Name "test_local_mod3" -Repository $localRepo
+        $res.Name | Should -Be $testModuleName3
         $res.Version | Should -Be "5.0.0"
     }
 

--- a/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
@@ -173,8 +173,9 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
             Write-Verbose -Verbose  "Command Name: $($command.Name)"
             Write-Verbose -Verbose  "Command Type: $($command.CommandType)"
             Write-Verbose -Verbose  "----------------------------------"
+            }
         }
-
+        
         $pkg | Should -BeNullOrEmpty
         $ev.Count | Should -Be 1
         $ev[0] | Should -Be "'testModuleClobber2' package could not be installed with error: The following commands are already available on this system: 'Test-Cmdlet1, Test-Cmdlet1'. This module 'testModuleClobber2' may override the existing commands. If you still want to install this module 'testModuleClobber2', remove the -NoClobber parameter."

--- a/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
@@ -146,21 +146,7 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
         $pkg.Version | Should -Be "1.0.0"
 
         Install-PSResource -Name $testModuleClobber2 -Repository $localRepo -TrustRepository -NoClobber -ErrorVariable ev -ErrorAction SilentlyContinue -verbose
-        $pkg = Get-InstalledPSResource $testModuleClobber2 -ErrorAction SilentlyContinue
-
-        if (!$pkg) {
-            # Get the first available module named 'clobbertestmodule1' and its exported commands
-            $module2 = (Get-Module -ListAvailable $testModuleClobber2)[0]
-            $module2Idx = $module[0]
-            # Iterate through each exported command in the module
-            foreach ($command in $module2Idx.ExportedCommands.Values) {
-            # Output the command's name and details
-            Write-Verbose -Verbose  "Command Name: $($command.Name)"
-            Write-Verbose -Verbose  "Command Type: $($command.CommandType)"
-            Write-Verbose -Verbose  "----------------------------------"
-            }
-        }
-
+        $pkg = Get-InstalledPSResource $testModuleClobber2 -ErrorAction SilentlyContinue}
         $pkg | Should -BeNullOrEmpty
         $ev.Count | Should -Be 1
         $ev[0] | Should -Be "'testModuleClobber2' package could not be installed with error: The following commands are already available on this system: 'Test-Cmdlet1, Test-Cmdlet1'. This module 'testModuleClobber2' may override the existing commands. If you still want to install this module 'testModuleClobber2', remove the -NoClobber parameter."

--- a/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
@@ -140,7 +140,12 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
     }
 
     It "Install resource with cmdlet names from a module already installed with -NoClobber (should not clobber)" {
-        Install-PSResource -Name $testModuleClobber -Repository $localRepo -TrustRepository
+        Install-PSResource -Name $testModuleClobber -Repository $localRepo -TrustRepository -Verbose
+
+        Write-Verbose -Verbose "~~~~~~~~~~~~~~~"
+        Get-ChildItem $localRepo -Recurse
+        Write-Verbose -Verbose "~~~~~~~~~~~~~~~"
+        
         $pkg = Get-InstalledPSResource $testModuleClobber
         $pkg.Name | Should -Be $testModuleClobber
         $pkg.Version | Should -Be "1.0.0"
@@ -175,7 +180,7 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
             Write-Verbose -Verbose  "----------------------------------"
             }
         }
-        
+
         $pkg | Should -BeNullOrEmpty
         $ev.Count | Should -Be 1
         $ev[0] | Should -Be "'testModuleClobber2' package could not be installed with error: The following commands are already available on this system: 'Test-Cmdlet1, Test-Cmdlet1'. This module 'testModuleClobber2' may override the existing commands. If you still want to install this module 'testModuleClobber2', remove the -NoClobber parameter."

--- a/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
@@ -140,13 +140,13 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
     }
 
     It "Install resource with cmdlet names from a module already installed with -NoClobber (should not clobber)" {
-        Install-PSResource -Name $testModuleClobber -Repository $localRepo -TrustRepository -Verbose
+        Install-PSResource -Name $testModuleClobber -Repository $localRepo -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleClobber
         $pkg.Name | Should -Be $testModuleClobber
         $pkg.Version | Should -Be "1.0.0"
 
-        Install-PSResource -Name $testModuleClobber2 -Repository $localRepo -TrustRepository -NoClobber -ErrorVariable ev -ErrorAction SilentlyContinue -verbose
-        $pkg = Get-InstalledPSResource $testModuleClobber2 -ErrorAction SilentlyContinue}
+        Install-PSResource -Name $testModuleClobber2 -Repository $localRepo -TrustRepository -NoClobber -ErrorVariable ev -ErrorAction SilentlyContinue
+        $pkg = Get-InstalledPSResource $testModuleClobber2 -ErrorAction SilentlyContinue
         $pkg | Should -BeNullOrEmpty
         $ev.Count | Should -Be 1
         $ev[0] | Should -Be "'testModuleClobber2' package could not be installed with error: The following commands are already available on this system: 'Test-Cmdlet1, Test-Cmdlet1'. This module 'testModuleClobber2' may override the existing commands. If you still want to install this module 'testModuleClobber2', remove the -NoClobber parameter."
@@ -205,7 +205,7 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
 
     # Windows only
     It "Install resource under AllUsers scope - Windows only" -Skip:(!((Get-IsWindows) -and (Test-IsAdmin))) {
-        Install-PSResource -Name $testModuleName -Repository $localRepo -TrustRepository -Scope AllUsers -Verbose
+        Install-PSResource -Name $testModuleName -Repository $localRepo -TrustRepository -Scope AllUsers
         $pkg = Get-InstalledPSResource $testModuleName -Scope AllUsers
         $pkg.Name | Should -Be $testModuleName
         $pkg.InstalledLocation.ToString().Contains("Program Files") | Should -Be $true
@@ -290,10 +290,8 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
         $nupkgName = "Microsoft.Web.Webview2"
         $nupkgVersion = "1.0.2792.45"
         $repoPath = Get-PSResourceRepository $localNupkgRepo
-        Write-Verbose -Verbose "repoPath $($repoPath.Uri)"
         $searchPkg = Find-PSResource -Name $nupkgName -Version $nupkgVersion -Repository $localNupkgRepo
-        Write-Verbose -Verbose "search name: $($searchPkg.Name)"
-        Install-PSResource -Name $nupkgName -Version $nupkgVersion -Repository $localNupkgRepo -TrustRepository -Verbose
+        Install-PSResource -Name $nupkgName -Version $nupkgVersion -Repository $localNupkgRepo -TrustRepository
         $pkg = Get-InstalledPSResource $nupkgName
         $pkg.Name | Should -Be $nupkgName
         $pkg.Version | Should -Be $nupkgVersion

--- a/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
@@ -145,8 +145,33 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
         $pkg.Name | Should -Be $testModuleClobber
         $pkg.Version | Should -Be "1.0.0"
 
-        Install-PSResource -Name $testModuleClobber2 -Repository $localRepo -TrustRepository -NoClobber -ErrorVariable ev -ErrorAction SilentlyContinue
+
+        # Get the first available module named 'clobbertestmodule1' and its exported commands
+        $module = (Get-Module -ListAvailable $testModuleClobber)[0]
+
+        # Iterate through each exported command in the module
+        foreach ($command in $module.ExportedCommands.Values) {
+            # Output the command's name and details
+            Write-Output "Command Name: $($command.Name)"
+            Write-Output "Command Type: $($command.CommandType)"
+            Write-Output "----------------------------------"
+        }
+
+
+        Install-PSResource -Name $testModuleClobber2 -Repository $localRepo -TrustRepository -NoClobber -ErrorVariable ev -ErrorAction SilentlyContinue -verbose
         $pkg = Get-InstalledPSResource $testModuleClobber2 -ErrorAction SilentlyContinue
+
+        # Get the first available module named 'clobbertestmodule1' and its exported commands
+        $module2 = (Get-Module -ListAvailable $testModuleClobber2)[0]
+
+        # Iterate through each exported command in the module
+        foreach ($command in $module2.ExportedCommands.Values) {
+            # Output the command's name and details
+            Write-Output "Command Name: $($command.Name)"
+            Write-Output "Command Type: $($command.CommandType)"
+            Write-Output "----------------------------------"
+        }
+
         $pkg | Should -BeNullOrEmpty
         $ev.Count | Should -Be 1
         $ev[0] | Should -Be "'testModuleClobber2' package could not be installed with error: The following commands are already available on this system: 'Test-Cmdlet1, Test-Cmdlet1'. This module 'testModuleClobber2' may override the existing commands. If you still want to install this module 'testModuleClobber2', remove the -NoClobber parameter."

--- a/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
@@ -147,14 +147,16 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
 
 
         # Get the first available module named 'clobbertestmodule1' and its exported commands
-        $module = (Get-Module -ListAvailable $testModuleClobber)[0]
+        $module = (Get-Module -ListAvailable $testModuleClobber)
+        Write-Verbose -Verbose "Module Name: $($module.Name)"
+        $moduleIdx = $module[0]
 
         # Iterate through each exported command in the module
-        foreach ($command in $module.ExportedCommands.Values) {
+        foreach ($command in $moduleIdx.ExportedCommands.Values) {
             # Output the command's name and details
-            Write-Output "Command Name: $($command.Name)"
-            Write-Output "Command Type: $($command.CommandType)"
-            Write-Output "----------------------------------"
+            Write-Verbose -Verbose "Command Name: $($command.Name)"
+            Write-Verbose -Verbose "Command Type: $($command.CommandType)"
+            Write-Verbose -Verbose "----------------------------------"
         }
 
 
@@ -163,13 +165,13 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
 
         # Get the first available module named 'clobbertestmodule1' and its exported commands
         $module2 = (Get-Module -ListAvailable $testModuleClobber2)[0]
-
+        $module2Idx = $module[0]
         # Iterate through each exported command in the module
-        foreach ($command in $module2.ExportedCommands.Values) {
+        foreach ($command in $module2Idx.ExportedCommands.Values) {
             # Output the command's name and details
-            Write-Output "Command Name: $($command.Name)"
-            Write-Output "Command Type: $($command.CommandType)"
-            Write-Output "----------------------------------"
+            Write-Verbose -Verbose  "Command Name: $($command.Name)"
+            Write-Verbose -Verbose  "Command Type: $($command.CommandType)"
+            Write-Verbose -Verbose  "----------------------------------"
         }
 
         $pkg | Should -BeNullOrEmpty

--- a/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
@@ -141,29 +141,9 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
 
     It "Install resource with cmdlet names from a module already installed with -NoClobber (should not clobber)" {
         Install-PSResource -Name $testModuleClobber -Repository $localRepo -TrustRepository -Verbose
-
-        Write-Verbose -Verbose "~~~~~~~~~~~~~~~"
-        Get-ChildItem $localRepo -Recurse
-        Write-Verbose -Verbose "~~~~~~~~~~~~~~~"
-        
         $pkg = Get-InstalledPSResource $testModuleClobber
         $pkg.Name | Should -Be $testModuleClobber
         $pkg.Version | Should -Be "1.0.0"
-
-
-        # Get the first available module named 'clobbertestmodule1' and its exported commands
-        $module = (Get-Module -ListAvailable $testModuleClobber)
-        Write-Verbose -Verbose "Module Name: $($module.Name)"
-        $moduleIdx = $module[0]
-
-        # Iterate through each exported command in the module
-        foreach ($command in $moduleIdx.ExportedCommands.Values) {
-            # Output the command's name and details
-            Write-Verbose -Verbose "Command Name: $($command.Name)"
-            Write-Verbose -Verbose "Command Type: $($command.CommandType)"
-            Write-Verbose -Verbose "----------------------------------"
-        }
-
 
         Install-PSResource -Name $testModuleClobber2 -Repository $localRepo -TrustRepository -NoClobber -ErrorVariable ev -ErrorAction SilentlyContinue -verbose
         $pkg = Get-InstalledPSResource $testModuleClobber2 -ErrorAction SilentlyContinue

--- a/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
@@ -163,11 +163,12 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
         Install-PSResource -Name $testModuleClobber2 -Repository $localRepo -TrustRepository -NoClobber -ErrorVariable ev -ErrorAction SilentlyContinue -verbose
         $pkg = Get-InstalledPSResource $testModuleClobber2 -ErrorAction SilentlyContinue
 
-        # Get the first available module named 'clobbertestmodule1' and its exported commands
-        $module2 = (Get-Module -ListAvailable $testModuleClobber2)[0]
-        $module2Idx = $module[0]
-        # Iterate through each exported command in the module
-        foreach ($command in $module2Idx.ExportedCommands.Values) {
+        if (!$pkg) {
+            # Get the first available module named 'clobbertestmodule1' and its exported commands
+            $module2 = (Get-Module -ListAvailable $testModuleClobber2)[0]
+            $module2Idx = $module[0]
+            # Iterate through each exported command in the module
+            foreach ($command in $module2Idx.ExportedCommands.Values) {
             # Output the command's name and details
             Write-Verbose -Verbose  "Command Name: $($command.Name)"
             Write-Verbose -Verbose  "Command Type: $($command.CommandType)"

--- a/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
         Register-LocalRepos
         Register-LocalTestNupkgsRepo
 
-        $prereleaseLabel = "alpha001"
+        $prereleaseLabel = "Alpha001"
         $tags = @()
 
         New-TestModule -moduleName $testModuleName -repoName $localRepo -packageVersion "1.0.0" -prereleaseLabel "" -tags $tags
@@ -131,12 +131,12 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
         $pkg.Version | Should -Be "3.0.0"
     }
 
-    It "Install resource with latest (including prerelease) version given Prerelease parameter" {
+    It "Install resource with latest (including prerelease) version given Prerelease parameter (prerelease casing should be correct)" {
         Install-PSResource -Name $testModuleName -Prerelease -Repository $localRepo -TrustRepository
         $pkg = Get-InstalledPSResource $testModuleName
         $pkg.Name | Should -Be $testModuleName
         $pkg.Version | Should -Be "5.2.5"
-        $pkg.Prerelease | Should -Be "alpha001"
+        $pkg.Prerelease | Should -Be "Alpha001"
     }
 
     It "Install resource with cmdlet names from a module already installed with -NoClobber (should not clobber)" {

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -271,7 +271,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         New-ModuleManifest -Path (Join-Path -Path $script:DependencyModuleBase -ChildPath "$script:DependencyModuleName.psd1") -ModuleVersion $dependencyVersion -Description "$script:DependencyModuleName module"
 
         Publish-PSResource -Path $script:DependencyModuleBase -Repository $testRepository2
-        $pkg1 = Find-PSResouce $script:DependencyModuleName -Repository $testRepository2
+        $pkg1 = Find-PSResource $script:DependencyModuleName -Repository $testRepository2
         $pkg1 | Should -Not -BeNullOrEmpty
         $pkg1.Version | Should -Be $dependencyVersion
 
@@ -281,7 +281,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
 
         Publish-PSResource -Path $script:PublishModuleBase -Repository $testRepository2
 
-        $pkg2 = Find-PSResouce $script:DependencyModuleName -Repository $testRepository2
+        $pkg2 = Find-PSResource $script:DependencyModuleName -Repository $testRepository2
         $pkg2 | Should -Not -BeNullOrEmpty
         $pkg2.Version | Should -Be $dependencyVersion
     }

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -270,16 +270,20 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $dependencyVersion = "2.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:DependencyModuleBase -ChildPath "$script:DependencyModuleName.psd1") -ModuleVersion $dependencyVersion -Description "$script:DependencyModuleName module"
 
-        Publish-PSResource -Path $script:DependencyModuleBase
+        Publish-PSResource -Path $script:DependencyModuleBase -Repository $testRepository2
+        $pkg1 = Find-PSResouce $script:DependencyModuleName -Repository $testRepository2
+        $pkg1 | Should -Not -BeNullOrEmpty
+        $pkg1.Version | Should -Be $dependencyVersion
 
         # Create module to test
         $version = "1.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module" -RequiredModules @(@{ModuleName = 'PackageManagement'; ModuleVersion = '2.0.0' })
 
-        Publish-PSResource -Path $script:PublishModuleBase
+        Publish-PSResource -Path $script:PublishModuleBase -Repository $testRepository2
 
-        $nupkg = Get-ChildItem $script:repositoryPath | select-object -Last 1
-        $nupkg.Name | Should -Be "$script:PublishModuleName.$version.nupkg"
+        $pkg2 = Find-PSResouce $script:DependencyModuleName -Repository $testRepository2
+        $pkg2 | Should -Not -BeNullOrEmpty
+        $pkg2.Version | Should -Be $dependencyVersion
     }
 
     It "Publish a module with a dependency that is not published, should throw" {
@@ -685,7 +689,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$ParentModuleName.$ParentVersion.nupkg"
         (Get-ChildItem $script:repositoryPath2).FullName | Should -Contain $expectedPath
     }
-
+<#
     It "Publish a module with required modules (both in string format and hashtable format)" {
         # look at functions in test utils for creating a module with prerelease
         $ModuleName = "ParentModule"
@@ -720,4 +724,5 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $expectedPath = Join-Path -Path $script:repositoryPath2  -ChildPath "$ModuleName.$ModuleVersion.nupkg"
         (Get-ChildItem $script:repositoryPath2).FullName | Should -Contain $expectedPath
     }
+#>
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
When installing from a local repositories, the comparison done to split a full nupkg name (eg. 'Microsoft.PowerShell.PSResourceGet.1.1.0-RC1.nupkg') into both name ('Microsoft.PowerShell.PSResourceGet') and version+extension ('1.1.0-RC1.nupkg') needs to be case insensitive. 

The .nupkg name typically all lowercase, whereas the version for a package may contain some uppercase characters that cause the split comparison to fail.

This PR adds `.ToLower()` to both the full package name and to the 'package version and extension' in order to ensure case insensitivity all round.

**Note:**  this bug was reproducible when attempting to find or install "Microsoft.PowerShell.PSResourceGet" v1.1.0-RC1 from a local repository. Bug was caught through CI failure.

_______________________

Second bug was uncovered when running tests for this PR.  When `Find-PSResource` would return packages found in a local repository it was not returning the correct casing for the package name.  This also impacted `Install` because the object returned from `Find` is then used to create file names for installation.  Incorrect casing was causing failures on Linux machines.  
The fix for this is to parse out the correct package name casing when retrieving metadata for a package so that the object that is either returned or passed on to `Install` has the correct package name.

**Note:**  this bug was reproducible when attempting to install a package from a local repository with the incorrect casing for the name.  For example, attempting to install `clobberTestMOdule2` from a local repository (correct name is ClobberTestModule2-- this package can be found on the PSGallery).

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
