### PR TITLE
Fix broken `-Quiet` parameter for `Save-PSResource`

### DIFF
--- a/src/code/SavePSResource.cs
+++ b/src/code/SavePSResource.cs
@@ -161,7 +161,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         /// <summary>
         /// Check validation for signed and catalog files
-
         /// </summary>
         [Parameter]
         public SwitchParameter AuthenticodeCheck { get; set; }
@@ -169,6 +168,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Suppresses progress information.
         /// </summary>
+        [Parameter] 
         public SwitchParameter Quiet { get; set; }
 
         /// <summary>

--- a/test/SavePSResourceTests/SavePSResourceLocalTests.ps1
+++ b/test/SavePSResourceTests/SavePSResourceLocalTests.ps1
@@ -198,4 +198,10 @@ Describe 'Test Save-PSResource for local repositories' -tags 'CI' {
         $err.Count | Should -Not -BeNullOrEmpty
         $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.SavePSResource"
     }
+
+    It "Save module using -Quiet" {
+        $res = Save-PSResource -Name $moduleName -Version "1.0.0" -Repository $localRepo -Path $SaveDir -PassThru -TrustRepository -Quiet
+        $res.Name | Should -Be $moduleName
+        $res.Version | Should -Be "1.0.0"
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
The `-Quiet` parameter for `Save-PSResource` lost the `[Parameter]` attribute that allows PowerShell to recognize it as a parameter for the cmdlet.  This likely got dropped when resolving a merge conflict.  This PR adds `[Parameter]` back in and adds a test that is meant to ensure parameter binding for `-Quiet` always works for the cmdlet (ie. it does not test functionality of -Quiet).

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
