### PR TITLE
Bugfix for local repo casing issue on Linux

### DIFF
--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -260,7 +260,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string actualPkgName = packageName;
 
             // this regex pattern matches packageName followed by a version (4 digit or 3 with prerelease word)
-            string regexPattern = $"{packageName}" + @"\.\d+\.\d+\.\d+(?:[a-zA-Z0-9-.]+|.\d)?.nupkg";
+            string regexPattern = $"{packageName}" + @"(\.\d+){1,3}(?:[a-zA-Z0-9-.]+|.\d)?\.nupkg";
             Regex rx = new Regex(regexPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
             _cmdletPassedIn.WriteDebug($"package file name pattern to be searched for is: {regexPattern}");
 

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -260,7 +260,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string actualPkgName = packageName;
 
             // this regex pattern matches packageName followed by a version (4 digit or 3 with prerelease word)
-            string regexPattern = $"{packageName}" + @".\d+\.\d+\.\d+(?:[a-zA-Z0-9-.]+|.\d)?.nupkg";
+            string regexPattern = $"{packageName}" + @"\.\d+\.\d+\.\d+(?:[a-zA-Z0-9-.]+|.\d)?.nupkg";
             Regex rx = new Regex(regexPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
             _cmdletPassedIn.WriteDebug($"package file name pattern to be searched for is: {regexPattern}");
 

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -261,27 +261,16 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             // this regex pattern matches packageName followed by a version (4 digit or 3 with prerelease word)
             string regexPattern = $"{packageName}" + @"(\.\d+){1,3}(?:[a-zA-Z0-9-.]+|.\d)?\.nupkg";
-            Regex rx = new Regex(regexPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
             _cmdletPassedIn.WriteDebug($"package file name pattern to be searched for is: {regexPattern}");
 
             foreach (string path in Directory.GetFiles(Repository.Uri.LocalPath))
             {
                 string packageFullName = Path.GetFileName(path);
-                MatchCollection matches = rx.Matches(packageFullName);
-                if (matches.Count == 0)
+                bool isMatch = Regex.IsMatch(packageFullName, regexPattern, RegexOptions.IgnoreCase);
+                if (!isMatch)
                 {
                     continue;
                 }
-
-                Match match = matches[0];
-
-                GroupCollection groups = match.Groups;
-                if (groups.Count == 0)
-                {
-                    continue;
-                }
-
-                Capture group = groups[0];
 
                 NuGetVersion nugetVersion = GetInfoFromFileName(packageFullName: packageFullName, packageName: packageName, actualName: out actualPkgName, out errRecord);
                 _cmdletPassedIn.WriteDebug($"Version parsed as '{nugetVersion}'");
@@ -389,7 +378,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             // this regex pattern matches packageName followed by the requested version
             string regexPattern = $"{packageName}.{requiredVersion.ToNormalizedString()}" + @".nupkg";
-            Regex rx = new Regex(regexPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
             _cmdletPassedIn.WriteDebug($"pattern is: {regexPattern}");
             string pkgPath = String.Empty;
             string actualPkgName = String.Empty;
@@ -397,21 +385,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             foreach (string path in Directory.GetFiles(Repository.Uri.LocalPath))
             {
                 string packageFullName = Path.GetFileName(path);
-                MatchCollection matches = rx.Matches(packageFullName);
-                if (matches.Count == 0)
+                bool isMatch = Regex.IsMatch(packageFullName, regexPattern, RegexOptions.IgnoreCase);
+                if (!isMatch)
                 {
                     continue;
                 }
-
-                Match match = matches[0];
-
-                GroupCollection groups = match.Groups;
-                if (groups.Count == 0)
-                {
-                    continue;
-                }
-
-                Capture group = groups[0];
 
                 NuGetVersion nugetVersion = GetInfoFromFileName(packageFullName: packageFullName, packageName: packageName, actualName: out actualPkgName, out errRecord);
                 _cmdletPassedIn.WriteDebug($"Version parsed as '{nugetVersion}'");

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -425,7 +425,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     _cmdletPassedIn.WriteDebug("Found matching version");
                     string pkgFullName = $"{actualPkgName}.{nugetVersion.ToString()}.nupkg";
-                    pkgPath = Path.Combine(Repository.Uri.LocalPath, pkgFullName);
+                    pkgPath = path;
                     break;
                 }
             }

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -12,7 +12,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
     BeforeAll{
         $localRepo = "psgettestlocal"
         $localUNCRepo = 'psgettestlocal3'
-        $testModuleName = "test_local_mod"
+        $testModuleName = "test_Local_Mod"
         $testModuleName2 = "test_local_mod2"
         $testModuleName3 = "Test_Local_Mod3"
         $similarTestModuleName = "test_local_mod.similar"

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -61,7 +61,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
     }
 
     It "find resource given specific Name with incorrect casing and Version (should return correct casing)" {
-        # FindName()
+        # FindVersion()
         $res = Find-PSResource -Name "test_local_mod3" -Version "1.0.0" -Repository $localRepo
         $res.Name | Should -Be $testModuleName3
         $res.Version | Should -Be "1.0.0"

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -12,7 +12,7 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
     BeforeAll{
         $localRepo = "psgettestlocal"
         $localUNCRepo = 'psgettestlocal3'
-        $testModuleName = "test_Local_Mod"
+        $testModuleName = "test_local_mod"
         $testModuleName2 = "test_local_mod2"
         $testModuleName3 = "Test_Local_Mod3"
         $similarTestModuleName = "test_local_mod.similar"
@@ -56,6 +56,13 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
     It "find resource given specific Name with incorrect casing (should return correct casing)" {
         # FindName()
         $res = Find-PSResource -Name "test_local_mod3" -Repository $localRepo
+        $res.Name | Should -Be $testModuleName3
+        $res.Version | Should -Be "1.0.0"
+    }
+
+    It "find resource given specific Name with incorrect casing and Version (should return correct casing)" {
+        # FindName()
+        $res = Find-PSResource -Name "test_local_mod3" -Version "1.0.0" -Repository $localRepo
         $res.Name | Should -Be $testModuleName3
         $res.Version | Should -Be "1.0.0"
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

For the FindNameHelper() the regex was:
test_local_mod.\d+\.\d+\.\d+(?:[a-zA-Z0-9-.]+|.\d)?.nupkg

The first '.' matches any character whereas our intention with the regex is to match the literal '.' so I added a backslash before the '.' to escape it. If the package being searched for is `test_local_mod` it was matching test_local_mod.1.0.0.nupkg and also test_local_mod_2.1.0.0.nupkg where the '_' character was getting matched by '.' in regex 
 and `2.1.0.0` was getting considered as the version.

The main issue Amber had found was that for FindVersionHelper() the path for the .nupkg was being constructed and we use lowercasing so on Linux that path will not be correct. Instead, once we find a matching package (by name and version) we should use the `path` given from the file system that has the correct casing.
# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
