### PR TITLE
Modify filter query parameter

### DIFF
--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -913,7 +913,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             // JFrog/Artifactory requires an empty search term to enumerate all packages in the feed
-            // It also deems 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter to be a bad request, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
             if (_isJFrogRepo) {
                 queryBuilder.SearchTerm = "''";
 
@@ -925,6 +924,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
             }
             else {
+                // For ADO, 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter create a bad request error, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
                 if (includePrerelease) {
                     queryBuilder.AdditionalParameters["includePrerelease"] = "true";
                     filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
@@ -962,13 +962,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 queryBuilder.AdditionalParameters["$orderby"] = "Id desc";
             }
 
-            // JFrog/Artifactory deems 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter to be a bad request, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
                 if (_isJFrogRepo) {
                     filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
                 }
                 else {
+                    // For ADO, 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter create a bad request error, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
                     filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
                 }
             } else {
@@ -976,6 +976,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     filterBuilder.AddCriterion("IsLatestVersion eq true");
                 }
                 else {
+                    // For ADO, 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter create a bad request error, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
                     filterBuilder.AddCriterion("IsLatestVersion");
                 }
             }
@@ -1010,13 +1011,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 queryBuilder.AdditionalParameters["$orderby"] = "Id desc";
             }
 
-            // JFrog/Artifactory deems 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter to be a bad request, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
                 if (_isJFrogRepo) {
                     filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
                 }
                 else {
+                    // For ADO, 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter create a bad request error, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
                     filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
                 }
             } else {
@@ -1024,6 +1025,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     filterBuilder.AddCriterion("IsLatestVersion eq true");
                 }
                 else {
+                    // For ADO, 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter create a bad request error, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
                     filterBuilder.AddCriterion("IsLatestVersion");
                 }
             }
@@ -1062,13 +1064,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 queryBuilder.AdditionalParameters["$orderby"] = "Id desc";
             }
 
-            // It also deems 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter to be a bad request, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
                 if (_isJFrogRepo) {
                     filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
                 }
                 else {
+                    // For ADO, 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter create a bad request error, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
                     filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
                 }
             } else {
@@ -1076,6 +1078,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     filterBuilder.AddCriterion("IsLatestVersion eq true");
                 }
                 else {
+                    // For ADO, 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter create a bad request error, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
                     filterBuilder.AddCriterion("IsLatestVersion");
                 }
             }
@@ -1168,13 +1171,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             // JFrog/Artifactory requires an empty search term to enumerate all packages in the feed
-            // It also deems 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter to be a bad request, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
                 if (_isJFrogRepo) {
                     filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
                 }
                 else {
+                    // For ADO, 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter create a bad request error, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
                     filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
                 }
             } else {
@@ -1182,6 +1185,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     filterBuilder.AddCriterion("IsLatestVersion eq true");
                 }
                 else {
+                    // For ADO, 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter create a bad request error, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
                     filterBuilder.AddCriterion("IsLatestVersion");
                 }
             }

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -966,33 +966,23 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 queryBuilder.AdditionalParameters["$orderby"] = "Id desc";
             }
 
+            // JFrog/Artifactory deems 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter to be a bad request, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
+                if (_isJFrogRepo) {
+                    filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
+                }
+                else {
+                    filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
+                }
             } else {
-                filterBuilder.AddCriterion("IsLatestVersion");
+                if (_isJFrogRepo) {
+                    filterBuilder.AddCriterion("IsLatestVersion eq true");
+                }
+                else {
+                    filterBuilder.AddCriterion("IsLatestVersion");
+                }
             }
-
-            // // JFrog/Artifactory requires an empty search term to enumerate all packages in the feed
-            // // It also deems 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter to be a bad request, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
-            // if (_isJFrogRepo) {
-            //     queryBuilder.SearchTerm = "''";
-
-            //     if (includePrerelease) {
-            //         queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-            //         filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
-            //     } else {
-            //         filterBuilder.AddCriterion("IsLatestVersion eq true");
-            //     }
-            // }
-            // else {
-            //     if (includePrerelease) {
-            //         queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-            //         filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
-            //     } else {
-            //         filterBuilder.AddCriterion("IsLatestVersion");
-            //     }
-            // }
 
             filterBuilder.AddCriterion($"substringof('PS{(isSearchingModule ? "Module" : "Script")}', Tags) eq true");
 
@@ -1024,13 +1014,23 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 queryBuilder.AdditionalParameters["$orderby"] = "Id desc";
             }
 
+            // JFrog/Artifactory deems 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter to be a bad request, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
+                if (_isJFrogRepo) {
+                    filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
+                }
+                else {
+                    filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
+                }
             } else {
-                filterBuilder.AddCriterion("IsLatestVersion eq true");
+                if (_isJFrogRepo) {
+                    filterBuilder.AddCriterion("IsLatestVersion eq true");
+                }
+                else {
+                    filterBuilder.AddCriterion("IsLatestVersion");
+                }
             }
-
 
             // can only find from Modules endpoint
             var tagPrefix = isSearchingForCommands ? "PSCommand_" : "PSDscResource_";
@@ -1066,7 +1066,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 queryBuilder.AdditionalParameters["$orderby"] = "Id desc";
             }
 
-            // JFrog/Artifactory requires an empty search term to enumerate all packages in the feed
             // It also deems 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter to be a bad request, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -649,10 +649,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (!_isJFrogRepo) {
                 filterBuilder.AddCriterion($"Id eq '{packageName}'");
             }
-            else
-            {
-
-            }
 
             filterBuilder.AddCriterion($"NormalizedVersion eq '{version}'");
             if (type != ResourceType.None) {

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -355,7 +355,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 filterBuilder.AddCriterion($"Id eq '{packageName}'");
             }
 
-            filterBuilder.AddCriterion(includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion");
+            filterBuilder.AddCriterion(includePrerelease ? "IsAbsoluteLatestVersion eq true" : "IsLatestVersion eq true");
             if (type != ResourceType.None) {
                 filterBuilder.AddCriterion(GetTypeFilterForRequest(type));
             }
@@ -424,7 +424,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 filterBuilder.AddCriterion($"Id eq '{packageName}'");
             }
 
-            filterBuilder.AddCriterion(includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion");
+            filterBuilder.AddCriterion(includePrerelease ? "IsAbsoluteLatestVersion eq true" : "IsLatestVersion eq true");
             if (type != ResourceType.None) {
                 filterBuilder.AddCriterion(GetTypeFilterForRequest(type));
             }
@@ -648,6 +648,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // however filtering on 'and Title eq '<packageName>' returns "Response status code does not indicate success: 500".
             if (!_isJFrogRepo) {
                 filterBuilder.AddCriterion($"Id eq '{packageName}'");
+            }
+            else
+            {
+
             }
 
             filterBuilder.AddCriterion($"NormalizedVersion eq '{version}'");
@@ -919,9 +923,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
+                filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
             } else {
-                filterBuilder.AddCriterion("IsLatestVersion");
+                filterBuilder.AddCriterion("IsLatestVersion eq true");
             }
             var requestUrlV2 = $"{Repository.Uri}{typeEndpoint}/Search()?{queryBuilder.BuildQueryString()}";
             return HttpRequestCall(requestUrlV2, out errRecord);
@@ -959,9 +963,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
+                filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
             } else {
-                filterBuilder.AddCriterion("IsLatestVersion");
+                filterBuilder.AddCriterion("IsLatestVersion eq true");
             }
 
             filterBuilder.AddCriterion($"substringof('PS{(isSearchingModule ? "Module" : "Script")}', Tags) eq true");
@@ -996,9 +1000,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
+                filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
             } else {
-                filterBuilder.AddCriterion("IsLatestVersion");
+                filterBuilder.AddCriterion("IsLatestVersion eq true");
             }
 
 
@@ -1038,11 +1042,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
+                filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
             } else {
-                filterBuilder.AddCriterion("IsLatestVersion");
+                filterBuilder.AddCriterion("IsLatestVersion eq true");
             }
-
 
             var names = packageName.Split(new char[] {'*'}, StringSplitOptions.RemoveEmptyEntries);
 
@@ -1133,11 +1136,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
+                filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
             } else {
-                filterBuilder.AddCriterion("IsLatestVersion");
+                filterBuilder.AddCriterion("IsLatestVersion eq true");
             }
-
 
             var names = packageName.Split(new char[] {'*'}, StringSplitOptions.RemoveEmptyEntries);
 

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -917,16 +917,26 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             // JFrog/Artifactory requires an empty search term to enumerate all packages in the feed
+            // It also deems 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter to be a bad request, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
             if (_isJFrogRepo) {
                 queryBuilder.SearchTerm = "''";
+
+                if (includePrerelease) {
+                    queryBuilder.AdditionalParameters["includePrerelease"] = "true";
+                    filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
+                } else {
+                    filterBuilder.AddCriterion("IsLatestVersion eq true");
+                }
+            }
+            else {
+                if (includePrerelease) {
+                    queryBuilder.AdditionalParameters["includePrerelease"] = "true";
+                    filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
+                } else {
+                    filterBuilder.AddCriterion("IsLatestVersion");
+                }
             }
 
-            if (includePrerelease) {
-                queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
-            } else {
-                filterBuilder.AddCriterion("IsLatestVersion eq true");
-            }
             var requestUrlV2 = $"{Repository.Uri}{typeEndpoint}/Search()?{queryBuilder.BuildQueryString()}";
             return HttpRequestCall(requestUrlV2, out errRecord);
         }
@@ -956,17 +966,33 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 queryBuilder.AdditionalParameters["$orderby"] = "Id desc";
             }
 
-            // JFrog/Artifactory requires an empty search term to enumerate all packages in the feed
-            if (_isJFrogRepo) {
-                queryBuilder.SearchTerm = "''";
-            }
-
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
+                filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
             } else {
-                filterBuilder.AddCriterion("IsLatestVersion eq true");
+                filterBuilder.AddCriterion("IsLatestVersion");
             }
+
+            // // JFrog/Artifactory requires an empty search term to enumerate all packages in the feed
+            // // It also deems 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter to be a bad request, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
+            // if (_isJFrogRepo) {
+            //     queryBuilder.SearchTerm = "''";
+
+            //     if (includePrerelease) {
+            //         queryBuilder.AdditionalParameters["includePrerelease"] = "true";
+            //         filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
+            //     } else {
+            //         filterBuilder.AddCriterion("IsLatestVersion eq true");
+            //     }
+            // }
+            // else {
+            //     if (includePrerelease) {
+            //         queryBuilder.AdditionalParameters["includePrerelease"] = "true";
+            //         filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
+            //     } else {
+            //         filterBuilder.AddCriterion("IsLatestVersion");
+            //     }
+            // }
 
             filterBuilder.AddCriterion($"substringof('PS{(isSearchingModule ? "Module" : "Script")}', Tags) eq true");
 
@@ -1040,11 +1066,23 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 queryBuilder.AdditionalParameters["$orderby"] = "Id desc";
             }
 
+            // JFrog/Artifactory requires an empty search term to enumerate all packages in the feed
+            // It also deems 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter to be a bad request, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
+                if (_isJFrogRepo) {
+                    filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
+                }
+                else {
+                    filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
+                }
             } else {
-                filterBuilder.AddCriterion("IsLatestVersion eq true");
+                if (_isJFrogRepo) {
+                    filterBuilder.AddCriterion("IsLatestVersion eq true");
+                }
+                else {
+                    filterBuilder.AddCriterion("IsLatestVersion");
+                }
             }
 
             var names = packageName.Split(new char[] {'*'}, StringSplitOptions.RemoveEmptyEntries);
@@ -1134,11 +1172,23 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 queryBuilder.AdditionalParameters["$orderby"] = "Id desc";
             }
 
+            // JFrog/Artifactory requires an empty search term to enumerate all packages in the feed
+            // It also deems 'IsLatestVersion eq true' and 'IsAbsoluteLatestVersion eq true' in the filter to be a bad request, so we use 'IsLatestVersion' or 'IsAbsoluteLatestVersion' only
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
-                filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
+                if (_isJFrogRepo) {
+                    filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
+                }
+                else {
+                    filterBuilder.AddCriterion("IsAbsoluteLatestVersion");
+                }
             } else {
-                filterBuilder.AddCriterion("IsLatestVersion eq true");
+                if (_isJFrogRepo) {
+                    filterBuilder.AddCriterion("IsLatestVersion eq true");
+                }
+                else {
+                    filterBuilder.AddCriterion("IsLatestVersion");
+                }
             }
 
             var names = packageName.Split(new char[] {'*'}, StringSplitOptions.RemoveEmptyEntries);

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -918,8 +918,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 if (includePrerelease) {
                     queryBuilder.AdditionalParameters["includePrerelease"] = "true";
+                    // note: we add 'eq true' because some PMPs (currently we know of JFrog, but others may do this too) will proxy the query unedited to the upstream remote and if that's PSGallery, it doesn't handle IsAbsoluteLatestVersion correctly
                     filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
                 } else {
+                    // note: we add 'eq true' because some PMPs (currently we know of JFrog, but others may do this too) will proxy the query unedited to the upstream remote and if that's PSGallery, it doesn't handle IsLatestVersion correctly
                     filterBuilder.AddCriterion("IsLatestVersion eq true");
                 }
             }
@@ -965,6 +967,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
                 if (_isJFrogRepo) {
+                    // note: we add 'eq true' because some PMPs (currently we know of JFrog, but others may do this too) will proxy the query unedited to the upstream remote and if that's PSGallery, it doesn't handle IsAbsoluteLatestVersion correctly
                     filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
                 }
                 else {
@@ -1014,6 +1017,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
                 if (_isJFrogRepo) {
+                    // note: we add 'eq true' because some PMPs (currently we know of JFrog, but others may do this too) will proxy the query unedited to the upstream remote and if that's PSGallery, it doesn't handle IsAbsoluteLatestVersion correctly
                     filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
                 }
                 else {
@@ -1022,6 +1026,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
             } else {
                 if (_isJFrogRepo) {
+                    // note: we add 'eq true' because some PMPs (currently we know of JFrog, but others may do this too) will proxy the query unedited to the upstream remote and if that's PSGallery, it doesn't handle IsLatestVersion correctly
                     filterBuilder.AddCriterion("IsLatestVersion eq true");
                 }
                 else {
@@ -1067,6 +1072,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
                 if (_isJFrogRepo) {
+                    // note: we add 'eq true' because some PMPs (currently we know of JFrog, but others may do this too) will proxy the query unedited to the upstream remote and if that's PSGallery, it doesn't handle IsAbsoluteLatestVersion correctly
                     filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
                 }
                 else {
@@ -1075,6 +1081,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
             } else {
                 if (_isJFrogRepo) {
+                    // note: we add 'eq true' because some PMPs (currently we know of JFrog, but others may do this too) will proxy the query unedited to the upstream remote and if that's PSGallery, it doesn't handle IsLatestVersion correctly
                     filterBuilder.AddCriterion("IsLatestVersion eq true");
                 }
                 else {
@@ -1174,6 +1181,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (includePrerelease) {
                 queryBuilder.AdditionalParameters["includePrerelease"] = "true";
                 if (_isJFrogRepo) {
+                    // note: we add 'eq true' because some PMPs (currently we know of JFrog, but others may do this too) will proxy the query unedited to the upstream remote and if that's PSGallery, it doesn't handle IsAbsoluteLatestVersion correctly
                     filterBuilder.AddCriterion("IsAbsoluteLatestVersion eq true");
                 }
                 else {
@@ -1182,6 +1190,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
             } else {
                 if (_isJFrogRepo) {
+                    // note: we add 'eq true' because some PMPs (currently we know of JFrog, but others may do this too) will proxy the query unedited to the upstream remote and if that's PSGallery, it doesn't handle IsLatestVersion correctly
                     filterBuilder.AddCriterion("IsLatestVersion eq true");
                 }
                 else {


### PR DESCRIPTION
Modify $filter query parameters IsLatestVersion and IsAbsoluteVersion to be `IsLatestVersion eq true` or `IsAbsoluteVersion eq true` for Artifactory to resolve Artifactory issue. For ADO Search() based queries including `eq true` returns a BadRequest error so it's not included.

Based on the API call Artifactory is performing as supplied here: https://github.com/PowerShell/PowerShellGallery/issues/273#issuecomment-2257318777

the count returns 1 but the response doesn't include a package, however including the `eq true` actually honors the filter and the response is successful in getting a package from PSGallery (from our testing).

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1656 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
