### PR TITLE
WIP: Integrate AzArtifacts Credential Provider

### DIFF
--- a/src/code/CredentialProvider.cs
+++ b/src/code/CredentialProvider.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Security;
+using System.Management.Automation;
+using System.Text.Json;
+
+namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
+{
+    internal static class CredentialProvider
+    {
+        private static string FindCredProviderFromPluginsPath()
+        {
+            // Get environment variable "NUGET_PLUGIN_PATHS"
+            // The environment variable NUGET_PLUGIN_PATHS should have the value of the .exe or .dll of the credential provider found in plugins\netfx\CredentialProvider.Microsoft\
+            // For example, $env:NUGET_PLUGIN_PATHS="my-alternative-location\CredentialProvider.Microsoft.exe".
+            // OR $env:NUGET_PLUGIN_PATHS="my-alternative-location\CredentialProvider.Microsoft.dll"
+
+            return Environment.GetEnvironmentVariable("NUGET_PLUGIN_PATHS", EnvironmentVariableTarget.User) ?? Environment.GetEnvironmentVariable("NUGET_PLUGIN_PATHS", EnvironmentVariableTarget.Machine);
+        }
+
+        private static string FindCredProviderFromDefaultLocation()
+        {
+            // Default locations are either:
+            // $env:UserProfile\.nuget\plugins\netfx\CredentialProvider\CredentialProvider.Microsoft.exe
+            // OR $env:UserProfile\.nuget\plugins\netcore\CredentialProvider\CredentialProvider.Microsoft.exe (or) CredentialProvider.Microsoft.dll
+            var credProviderDefaultLocation = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "plugins");
+
+            var netCorePath = Path.Combine(credProviderDefaultLocation, "netcore", "CredentialProvider.Microsoft");
+            var netFxPath = Path.Combine(credProviderDefaultLocation, "netfx", "CredentialProvider.Microsoft");
+            var credProviderPath = string.Empty;
+            if (Directory.Exists(netCorePath))
+            {
+                if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                {
+                    credProviderPath = Path.Combine(netCorePath, "CredentialProvider.Microsoft.exe");
+                }
+                else
+                {
+                    credProviderPath = Path.Combine(netCorePath, "CredentialProvider.Microsoft.dll");
+                }
+            }
+            else if (Directory.Exists(netFxPath) && Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                credProviderPath = Path.Combine(netFxPath, "CredentialProvider.Microsoft.exe");
+            }
+
+            return credProviderPath;
+        }
+
+        private static string FindCredProviderFromVSLocation(out ErrorRecord error)
+        {
+            error = null;
+
+            // C:\Program Files\Microsoft Visual Studio\
+            var visualStudioPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Microsoft Visual Studio");
+            // "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\Plugins\CredentialProvider.Microsoft\CredentialProvider.Microsoft.exe"
+            // "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\Plugins\CredentialProvider.Microsoft\CredentialProvider.Microsoft.dll"
+
+            var credProviderPath = string.Empty;
+            if (Directory.Exists(visualStudioPath))
+            {
+                if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                {
+                    credProviderPath = VSCredentialProviderFile(visualStudioPath, "CredentialProvider.Microsoft.exe", out error);
+                }
+                else if (string.IsNullOrEmpty(credProviderPath))
+                {
+                    credProviderPath = VSCredentialProviderFile(visualStudioPath, "CredentialProvider.Microsoft.dll", out error);
+                }
+            }
+
+            return credProviderPath;
+        }
+
+        private static string VSCredentialProviderFile(string visualStudioPath, string credProviderFile, out ErrorRecord error)
+        {
+            error = null;
+            try
+            {
+                // Search for the file in the directory and subdirectories
+                string[] exeFile = Directory.GetFiles(visualStudioPath, credProviderFile, SearchOption.AllDirectories);
+
+                if (exeFile.Length > 0)
+                {
+                    return exeFile[0];
+                }
+            }
+            catch (UnauthorizedAccessException e)
+            {
+                error = new ErrorRecord(
+                            e,
+                            "AccessToCredentialProviderFileDenied",
+                            ErrorCategory.PermissionDenied,
+                            null);
+            }
+            catch (Exception ex)
+            {
+                error = new ErrorRecord(
+                            ex,
+                            "ErrorRetrievingCredentialProvider",
+                            ErrorCategory.NotSpecified,
+                            null);
+            }
+
+            return string.Empty;
+        }
+
+        internal static PSCredential GetCredentialsFromProvider(Uri uri, PSCmdlet cmdletPassedIn)
+        {
+            string credProviderPath = string.Empty;
+
+            //  Find credential provider
+            //  Option 1. Use env var 'NUGET_PLUGIN_PATHS' to find credential provider.
+            //   See: https://docs.microsoft.com/en-us/nuget/reference/extensibility/nuget-cross-platform-plugins#plugin-installation-and-discovery
+            //  Nuget prioritizes credential providers stored in the NUGET_PLUGIN_PATHS env var
+            credProviderPath = FindCredProviderFromPluginsPath();
+
+            //  Option 2. Check default locations ($env:UserProfile\.nuget\plugins)
+            //  .NET Core based plugins should be installed in:
+            //      %UserProfile%/.nuget/plugins/netcore
+            //  .NET Framework based plugins should be installed in:
+            //      %UserProfile%/.nuget/plugins/netfx
+            if (String.IsNullOrEmpty(credProviderPath))
+            {
+                credProviderPath = FindCredProviderFromDefaultLocation();
+            }
+
+            //  Option 3. Check Visual Studio installation paths
+            if (String.IsNullOrEmpty(credProviderPath))
+            {
+                credProviderPath = FindCredProviderFromVSLocation(out ErrorRecord error);
+                if (error != null)
+                {
+                    cmdletPassedIn.WriteError(error);
+                    return null;
+                }
+            }
+
+            if (string.IsNullOrEmpty(credProviderPath))
+            {
+                cmdletPassedIn.WriteError(new ErrorRecord(
+                        new ArgumentNullException("Path to the Azure Artifacts Credential Provider is null or empty. See https://github.com/NuGet/Home/wiki/NuGet-cross-plat-authentication-plugin#plugin-installation-and-discovery to set up the Credential Provider."),
+                        "CredentialProviderPathIsNullOrEmpty",
+                        ErrorCategory.InvalidArgument,
+                        null));
+                return null;
+            }
+
+            // Check case sensitivity here
+            if (!File.Exists(credProviderPath))
+            {
+                cmdletPassedIn.WriteError(new ErrorRecord(
+                        new FileNotFoundException($"Path found '{credProviderPath}' is not a valid Azure Artifact Credential Provider executable. See https://github.com/NuGet/Home/wiki/NuGet-cross-plat-authentication-plugin#plugin-installation-and-discovery to set up the Credential Provider."),
+                        "CredentialProviderFileNotFound",
+                        ErrorCategory.ObjectNotFound,
+                        null));
+                return null;
+            }
+
+            cmdletPassedIn.WriteVerbose($"Credential Provider path found at: '{credProviderPath}'");
+
+            string fileName = credProviderPath;
+            // If running on unix machines, the Credential Provider needs to be called with dotnet cli.
+            if (credProviderPath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            {
+                fileName = "dotnet";
+            }
+
+            string arguments = string.Equals(fileName, "dotnet", StringComparison.OrdinalIgnoreCase) ?
+                                                       $"{credProviderPath} -Uri {uri} -NonInteractive -IsRetry -F Json" :
+                                                       $"-Uri {uri} -NonInteractive -IsRetry -F Json";
+            string fullCallingCmd = string.Equals(fileName, "dotnet", StringComparison.OrdinalIgnoreCase) ?
+                                                       $"dotnet {credProviderPath} -Uri {uri} -NonInteractive -IsRetry -F Json" :
+                                                       $"{credProviderPath} -Uri {uri} -NonInteractive -IsRetry -F Json";
+            cmdletPassedIn.WriteVerbose($"Calling Credential Provider with the following: '{fullCallingCmd}'");
+            using (Process process = new Process())
+            {
+                // Windows call should look like:   "CredentialProvider.Microsoft.exe -Uri <uri> -NonInteractive -IsRetry -F Json"
+                // Unix call should look like:      "dotnet CredentialProvider.Microsoft.dll -Uri <uri> -NonInteractive -IsRetry -F Json"
+                process.StartInfo.FileName = fileName;
+                process.StartInfo.Arguments = arguments;
+                process.StartInfo.UseShellExecute = false;
+                process.StartInfo.RedirectStandardOutput = true;
+                process.StartInfo.RedirectStandardError = true;
+                process.Start();
+                var output = process.StandardOutput.ReadToEnd();
+                var stdError = process.StandardError.ReadToEnd();
+
+                // Timeout in milliseconds (e.g., 5000 ms = 5 seconds)
+                process.WaitForExit(5000);
+
+                if (process.ExitCode != 0)
+                {
+                    if (!string.IsNullOrEmpty(stdError))
+                    {
+                        cmdletPassedIn.WriteError(new ErrorRecord(
+                                new ArgumentException($"Standard error: {stdError}"),
+                                "ProcessStandardError",
+                                ErrorCategory.InvalidResult,
+                                credProviderPath));
+                    }
+
+                    cmdletPassedIn.WriteError(new ErrorRecord(
+                            new Exception($"Process exited with code {process.ExitCode}"),
+                            "ProcessExitCodeError",
+                            ErrorCategory.InvalidResult,
+                            credProviderPath));
+                }
+                else if (string.IsNullOrEmpty(output))
+                {
+                    cmdletPassedIn.WriteError(new ErrorRecord(
+                            new ArgumentException($"Standard output is empty."),
+                            "ProcessStandardOutputError",
+                            ErrorCategory.InvalidResult,
+                            credProviderPath));
+                }
+
+                string username = string.Empty;
+                SecureString passwordSecure = new SecureString();
+                try
+                {
+                    using (JsonDocument doc = JsonDocument.Parse(output))
+                    {
+                        JsonElement root = doc.RootElement;
+                        if (root.TryGetProperty("Username", out JsonElement usernameToken))
+                        {
+                            username = usernameToken.GetString();
+                            cmdletPassedIn.WriteVerbose("Username retrieved from Credential Provider.");
+                        }
+                        if (String.IsNullOrEmpty(username))
+                        {
+                            cmdletPassedIn.WriteError(new ErrorRecord(
+                                    new ArgumentNullException("Credential Provider username is null or empty. See https://github.com/NuGet/Home/wiki/NuGet-cross-plat-authentication-plugin#plugin-installation-and-discovery for more info."),
+                                    "CredentialProviderUserNameIsNullOrEmpty",
+                                    ErrorCategory.InvalidArgument,
+                                    null));
+                            return null;
+                        }
+
+                        if (root.TryGetProperty("Password", out JsonElement passwordToken))
+                        {
+                            string password = passwordToken.GetString();
+                            if (String.IsNullOrEmpty(password))
+                            {
+                                cmdletPassedIn.WriteError(new ErrorRecord(
+                                        new ArgumentNullException("Credential Provider password is null or empty. See https://github.com/NuGet/Home/wiki/NuGet-cross-plat-authentication-plugin#plugin-installation-and-discovery for more info."),
+                                        "CredentialProviderUserNameIsNullOrEmpty",
+                                        ErrorCategory.InvalidArgument,
+                                        null));
+                                return null;
+                            }
+
+                            passwordSecure = Utils.ConvertToSecureString(password);
+                            cmdletPassedIn.WriteVerbose("Password retrieved from Credential Provider.");
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    cmdletPassedIn.WriteError(new ErrorRecord(
+                            new Exception("Error retrieving credentials from Credential Provider. See https://github.com/NuGet/Home/wiki/NuGet-cross-plat-authentication-plugin#plugin-installation-and-discovery for more info.", e),
+                            "InvalidCredentialProviderResponse",
+                            ErrorCategory.InvalidResult,
+                            null));
+                    return null;
+                }
+
+                return new PSCredential(username, passwordSecure);
+            }
+        }
+    }
+}

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -202,7 +202,16 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
 
                 repositoryNamesToSearch.Add(currentRepository.Name);
-                _networkCredential = Utils.SetNetworkCredential(currentRepository, _networkCredential, _cmdletPassedIn);
+
+                // Set network credentials via passed in credentials, AzArtifacts CredentialProvider, or SecretManagement.
+                if (currentRepository.CredentialProvider.Equals(PSRepositoryInfo.CredentialProviderType.AzArtifacts))
+                { 
+                    _networkCredential = Utils.SetCredentialProviderNetworkCredential(currentRepository, _networkCredential, _cmdletPassedIn);
+                }
+                else {
+                    _networkCredential = Utils.SetSecretManagementNetworkCredential(currentRepository, _networkCredential, _cmdletPassedIn);
+                }
+
                 ServerApiCall currentServer = ServerFactory.GetServer(currentRepository, _cmdletPassedIn, _networkCredential);
                 if (currentServer == null)
                 {
@@ -386,7 +395,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
 
                 repositoryNamesToSearch.Add(currentRepository.Name);
-                _networkCredential = Utils.SetNetworkCredential(currentRepository, _networkCredential, _cmdletPassedIn);
+
+                // Set network credentials via passed in credentials, AzArtifacts CredentialProvider, or SecretManagement.
+                if (currentRepository.CredentialProvider.Equals(PSRepositoryInfo.CredentialProviderType.AzArtifacts))
+                {
+                    _networkCredential = Utils.SetCredentialProviderNetworkCredential(currentRepository, _networkCredential, _cmdletPassedIn);
+                }
+                else
+                {
+                    _networkCredential = Utils.SetSecretManagementNetworkCredential(currentRepository, _networkCredential, _cmdletPassedIn);
+                }
+
                 ServerApiCall currentServer = ServerFactory.GetServer(currentRepository, _cmdletPassedIn, _networkCredential);
                 if (currentServer == null)
                 {
@@ -590,7 +609,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
 
                 repositoryNamesToSearch.Add(currentRepository.Name);
-                _networkCredential = Utils.SetNetworkCredential(currentRepository, _networkCredential, _cmdletPassedIn);
+
+                // Set network credentials via passed in credentials, AzArtifacts CredentialProvider, or SecretManagement.
+                if (currentRepository.CredentialProvider.Equals(PSRepositoryInfo.CredentialProviderType.AzArtifacts))
+                {
+                    _networkCredential = Utils.SetCredentialProviderNetworkCredential(currentRepository, _networkCredential, _cmdletPassedIn);
+                }
+                else
+                {
+                    _networkCredential = Utils.SetSecretManagementNetworkCredential(currentRepository, _networkCredential, _cmdletPassedIn);
+                }
+
                 ServerApiCall currentServer = ServerFactory.GetServer(currentRepository, _cmdletPassedIn, _networkCredential);
                 if (currentServer == null)
                 {

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -286,7 +286,16 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 string repoName = currentRepository.Name;
                 sourceTrusted = currentRepository.Trusted || trustRepository;
 
-                _networkCredential = Utils.SetNetworkCredential(currentRepository, _networkCredential, _cmdletPassedIn);
+                // Set network credentials via passed in credentials, AzArtifacts CredentialProvider, or SecretManagement.
+                if (currentRepository.CredentialProvider.Equals(PSRepositoryInfo.CredentialProviderType.AzArtifacts))
+                {
+                    _networkCredential = Utils.SetCredentialProviderNetworkCredential(currentRepository, _networkCredential, _cmdletPassedIn);
+                }
+                else
+                {
+                    _networkCredential = Utils.SetSecretManagementNetworkCredential(currentRepository, _networkCredential, _cmdletPassedIn);
+                }
+
                 ServerApiCall currentServer = ServerFactory.GetServer(currentRepository, _cmdletPassedIn, _networkCredential);
 
                 if (currentServer == null)
@@ -355,59 +364,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             return allPkgsInstalled;
-        }
-
-        /// <summary>
-        /// Checks if any of the package versions are already installed and if they are removes them from the list of packages to install.
-        /// </summary>
-        private List<PSResourceInfo> FilterByInstalledPkgs(List<PSResourceInfo> packages)
-        {
-            // Package install paths.
-            // _pathsToInstallPkg will only contain the paths specified within the -Scope param (if applicable).
-            // _pathsToSearch will contain all resource package subdirectories within _pathsToInstallPkg path locations.
-            // e.g.:
-            // ./InstallPackagePath1/PackageA
-            // ./InstallPackagePath1/PackageB
-            // ./InstallPackagePath2/PackageC
-            // ./InstallPackagePath3/PackageD
-
-            _cmdletPassedIn.WriteDebug("In InstallHelper::FilterByInstalledPkgs()");
-            // Get currently installed packages.
-            var getHelper = new GetHelper(_cmdletPassedIn);
-            var installedPackageNames = new HashSet<string>(StringComparer.CurrentCultureIgnoreCase);
-            foreach (var installedPkg in getHelper.GetInstalledPackages(
-                pkgs: packages,
-                pathsToSearch: _pathsToSearch))
-            {
-                installedPackageNames.Add(installedPkg.Name);
-            }
-
-            if (installedPackageNames.Count is 0)
-            {
-                return packages;
-            }
-
-            // Return only packages that are not already installed.
-            var filteredPackages = new List<PSResourceInfo>();
-            foreach (var pkg in packages)
-            {
-                if (!installedPackageNames.Contains(pkg.Name))
-                {
-                    // Add packages that still need to be installed.
-                    filteredPackages.Add(pkg);
-                }
-                else
-                {
-                    // Remove from tracking list of packages to install.
-                    pkg.AdditionalMetadata.TryGetValue("NormalizedVersion", out string normalizedVersion);
-                    _cmdletPassedIn.WriteWarning($"Resource '{pkg.Name}' with version '{normalizedVersion}' is already installed.  If you would like to reinstall, please run the cmdlet again with the -Reinstall parameter");
-
-                    // Remove from tracking list of packages to install.
-                    _pkgNamesToInstall.RemoveAll(x => x.Equals(pkg.Name, StringComparison.InvariantCultureIgnoreCase));
-                }
-            }
-
-            return filteredPackages;
         }
 
         /// <summary>

--- a/src/code/PSRepositoryInfo.cs
+++ b/src/code/PSRepositoryInfo.cs
@@ -27,30 +27,26 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             ContainerRegistry
         }
 
+        public enum CredentialProviderType
+        {
+            None,
+            AzArtifacts
+        }
+
         #endregion
 
         #region Constructor
 
-        public PSRepositoryInfo(string name, Uri uri, int priority, bool trusted, PSCredentialInfo credentialInfo, APIVersion apiVersion, bool allowed)
+        public PSRepositoryInfo(string name, Uri uri, int priority, bool trusted, PSCredentialInfo credentialInfo, CredentialProviderType credentialProvider, APIVersion apiVersion, bool allowed)
         {
             Name = name;
             Uri = uri;
             Priority = priority;
             Trusted = trusted;
             CredentialInfo = credentialInfo;
+            CredentialProvider = credentialProvider;
             ApiVersion = apiVersion;
             IsAllowedByPolicy = allowed;
-        }
-
-        #endregion
-
-        #region Enum
-
-        public enum RepositoryProviderType
-        {
-            None,
-            ACR,
-            AzureDevOps
         }
 
         #endregion
@@ -58,43 +54,43 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         #region Properties
 
         /// <summary>
-        /// the Name of the repository
+        /// The Name of the repository.
         /// </summary>
         public string Name { get; }
 
         /// <summary>
-        /// the Uri for the repository
+        /// The Uri for the repository.
         /// </summary>
         public Uri Uri { get; }
 
         /// <summary>
-        /// whether the repository is trusted
+        /// Whether the repository is trusted.
         /// </summary>
         public bool Trusted { get; }
 
         /// <summary>
-        /// the priority of the repository
+        /// The priority of the repository.
         /// </summary>
         [ValidateRange(0, 100)]
         public int Priority { get; }
 
         /// <summary>
-        /// the type of repository provider (eg, AzureDevOps, ContainerRegistry, etc.)
+        /// The credential information for repository authentication.
         /// </summary>
-        public RepositoryProviderType RepositoryProvider { get; }
+        public PSCredentialInfo CredentialInfo { get; set; }
 
         /// <summary>
-        /// the credential information for repository authentication
+        /// Specifies which credential provider to use.
         /// </summary>
-        public PSCredentialInfo CredentialInfo { get; }
+        public CredentialProviderType CredentialProvider { get; set; }
 
         /// <summary>
-        /// the API protocol version for the repository
+        /// The API protocol version for the repository.
         /// </summary>
         public APIVersion ApiVersion { get; }
 
         // <summary>
-        /// is it allowed by policy
+        /// Specifies whether the repository is allowed by policy.
         /// </summary>
         public bool IsAllowedByPolicy { get; set; }
 

--- a/src/code/PublishHelper.cs
+++ b/src/code/PublishHelper.cs
@@ -379,7 +379,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     return;
                 }
 
-                _networkCredential = Utils.SetNetworkCredential(repository, _networkCredential, _cmdletPassedIn);
+                // Set network credentials via passed in credentials, AzArtifacts CredentialProvider, or SecretManagement.
+                if (repository.CredentialProvider.Equals(PSRepositoryInfo.CredentialProviderType.AzArtifacts))
+                {
+                    _networkCredential = Utils.SetCredentialProviderNetworkCredential(repository, _networkCredential, _cmdletPassedIn);
+                }
+                else
+                {
+                    _networkCredential = Utils.SetSecretManagementNetworkCredential(repository, _networkCredential, _cmdletPassedIn);
+                }
 
                 // Check if dependencies already exist within the repo if:
                 // 1) the resource to publish has dependencies and

--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -117,13 +117,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         public object GetDynamicParameters()
         {
-            if (Uri.Contains("pkgs.dev.azure.com") || Uri.Contains("pkgs.visualstudio.com"))
+            if(Uri.EndsWith(".azurecr.io") || Uri.EndsWith(".azurecr.io/") || Uri.Contains("mcr.microsoft.com"))
             {
-                _credentialProvider = new CredentialProviderDynamicParameters();
-                return _credentialProvider;
+                return null;
             }
 
-            return null;
+            _credentialProvider = new CredentialProviderDynamicParameters();
+            return _credentialProvider;
         }
 
         #endregion
@@ -144,7 +144,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 repoApiVersion = ApiVersion;
             }
 
-            PSRepositoryInfo.CredentialProviderType credentialProvider = _credentialProvider.CredentialProvider;
+            PSRepositoryInfo.CredentialProviderType? credentialProvider = _credentialProvider?.CredentialProvider;
 
             switch (ParameterSetName)
             {
@@ -438,10 +438,22 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
     public class CredentialProviderDynamicParameters
     {
+        PSRepositoryInfo.CredentialProviderType? _credProvider = null;
+
         /// <summary>
         /// Specifies which credential provider to use.
         /// </summary>
         [Parameter]
-        public PSRepositoryInfo.CredentialProviderType CredentialProvider { get; set; }
+        public PSRepositoryInfo.CredentialProviderType? CredentialProvider {
+            get
+            { 
+                return _credProvider; 
+            }
+
+            set
+            {
+                _credProvider = value;
+            }      
+        }
     }
 }

--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -62,7 +62,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
                 // Add PSGallery to the newly created store
                 Uri psGalleryUri = new Uri(PSGalleryRepoUri);
-                Add(PSGalleryRepoName, psGalleryUri, DefaultPriority, DefaultTrusted, repoCredentialInfo: null, PSRepositoryInfo.APIVersion.V2, force: false);
+                Add(PSGalleryRepoName, psGalleryUri, DefaultPriority, DefaultTrusted, repoCredentialInfo: null, repoCredentialProvider: CredentialProviderType.None, APIVersion.V2, force: false);
             }
 
             // Open file (which should exist now), if cannot/is corrupted then throw error
@@ -76,7 +76,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             }
         }
 
-        public static PSRepositoryInfo AddRepository(string repoName, Uri repoUri, int repoPriority, bool repoTrusted, PSRepositoryInfo.APIVersion? apiVersion, PSCredentialInfo repoCredentialInfo, bool force, PSCmdlet cmdletPassedIn, out string errorMsg)
+        public static PSRepositoryInfo AddRepository(string repoName, Uri repoUri, int repoPriority, bool repoTrusted, APIVersion? apiVersion, PSCredentialInfo repoCredentialInfo, CredentialProviderType? repoCredentialProvider, bool force, PSCmdlet cmdletPassedIn, out string errorMsg)
         {
             errorMsg = String.Empty;
             if (repoName.Equals("PSGallery", StringComparison.OrdinalIgnoreCase))
@@ -85,11 +85,11 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 return null;
             }
 
-            return AddToRepositoryStore(repoName, repoUri, repoPriority, repoTrusted, apiVersion, repoCredentialInfo, force, cmdletPassedIn, out errorMsg);
+            return AddToRepositoryStore(repoName, repoUri, repoPriority, repoTrusted, apiVersion, repoCredentialInfo, repoCredentialProvider, force, cmdletPassedIn, out errorMsg);
         }
 
 
-        public static PSRepositoryInfo AddToRepositoryStore(string repoName, Uri repoUri, int repoPriority, bool repoTrusted, PSRepositoryInfo.APIVersion? apiVersion, PSCredentialInfo repoCredentialInfo, bool force, PSCmdlet cmdletPassedIn, out string errorMsg)
+        public static PSRepositoryInfo AddToRepositoryStore(string repoName, Uri repoUri, int repoPriority, bool repoTrusted, APIVersion? apiVersion, PSCredentialInfo repoCredentialInfo, CredentialProviderType? credentialProvider, bool force, PSCmdlet cmdletPassedIn, out string errorMsg)
         {
             errorMsg = string.Empty;
             // remove trailing and leading whitespaces, and if Name is just whitespace Name should become null now and be caught by following condition
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 return null;
             }
 
-            PSRepositoryInfo.APIVersion resolvedAPIVersion = apiVersion ?? GetRepoAPIVersion(repoUri);
+            APIVersion resolvedAPIVersion = apiVersion ?? GetRepoAPIVersion(repoUri);
 
             if (repoCredentialInfo != null)
             {
@@ -131,6 +131,13 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 }
             }
 
+            CredentialProviderType resolvedCredentialProvider = credentialProvider ?? CredentialProviderType.None;
+            // If it's an ADO feed with an ADO designated URL (eg: msazure.pkgs.) then add the 'CredentialProvider' attribute to the repository and by default set it to AzArtifacts
+            if ((repoUri.AbsoluteUri.Contains("pkgs.dev.azure.com") || repoUri.AbsoluteUri.Contains("pkgs.visualstudio.com")) && credentialProvider == null)
+            {
+                resolvedCredentialProvider = CredentialProviderType.AzArtifacts;
+            }
+
             if (!cmdletPassedIn.ShouldProcess(repoName, "Register repository to repository store"))
             {
                 return null;
@@ -141,13 +148,13 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 return null;
             }
 
-            var repo = RepositorySettings.Add(repoName, repoUri, repoPriority, repoTrusted, repoCredentialInfo, resolvedAPIVersion, force);
+            var repo = Add(repoName, repoUri, repoPriority, repoTrusted, repoCredentialInfo, resolvedCredentialProvider, resolvedAPIVersion, force);
 
             return repo;
         }
 
 
-        public static PSRepositoryInfo UpdateRepositoryStore(string repoName, Uri repoUri, int repoPriority, bool repoTrusted, bool isSet, int defaultPriority, PSRepositoryInfo.APIVersion? apiVersion, PSCredentialInfo repoCredentialInfo, PSCmdlet cmdletPassedIn, out string errorMsg)
+        public static PSRepositoryInfo UpdateRepositoryStore(string repoName, Uri repoUri, int repoPriority, bool repoTrusted, bool isSet, int defaultPriority, APIVersion? apiVersion, PSCredentialInfo repoCredentialInfo, CredentialProviderType? credentialProvider, PSCmdlet cmdletPassedIn, out string errorMsg)
         {
             errorMsg = string.Empty;
             // repositories with Uri Scheme "temp" may have PSPath Uri's like: "Temp:\repo"
@@ -182,7 +189,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
             // determine trusted value to pass in (true/false if set, null otherwise, hence the nullable bool variable)
             bool? _trustedNullable = isSet ? new bool?(repoTrusted) : new bool?();
-
+            
             if (repoCredentialInfo != null)
             {
                 bool isSecretManagementModuleAvailable = Utils.IsSecretManagementModuleAvailable(repoName, cmdletPassedIn);
@@ -216,7 +223,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 return null;
             }
 
-            return Update(repoName, repoUri, repoPriority, _trustedNullable, apiVersion, repoCredentialInfo, cmdletPassedIn, out errorMsg);
+            return Update(repoName, repoUri, repoPriority, _trustedNullable, apiVersion, repoCredentialInfo, credentialProvider, cmdletPassedIn, out errorMsg);
         }
 
         /// <summary>
@@ -224,7 +231,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         /// Returns: PSRepositoryInfo containing information about the repository just added to the repository store
         /// </summary>
         /// <param name="sectionName"></param>
-        public static PSRepositoryInfo Add(string repoName, Uri repoUri, int repoPriority, bool repoTrusted, PSCredentialInfo repoCredentialInfo, PSRepositoryInfo.APIVersion apiVersion, bool force)
+        public static PSRepositoryInfo Add(string repoName, Uri repoUri, int repoPriority, bool repoTrusted, PSCredentialInfo repoCredentialInfo, CredentialProviderType repoCredentialProvider, APIVersion apiVersion, bool force)
         {
             try
             {
@@ -238,7 +245,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     }
 
                     // Delete the existing repository before overwriting it (otherwire multiple repos with the same name will be added)
-                    List<PSRepositoryInfo> removedRepositories = RepositorySettings.Remove(new string[] { repoName }, out string[] errorList);
+                    List<PSRepositoryInfo> removedRepositories = Remove(new string[] { repoName }, out string[] errorList);
 
                     // Need to load the document again because of changes after removing
                     doc = LoadXDocument(FullRepositoryPath);
@@ -261,7 +268,8 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     new XAttribute("Url", repoUri),
                     new XAttribute("APIVersion", apiVersion),
                     new XAttribute("Priority", repoPriority),
-                    new XAttribute("Trusted", repoTrusted)
+                    new XAttribute("Trusted", repoTrusted),
+                    new XAttribute("CredentialProvider", repoCredentialProvider)
                     );
 
                 if (repoCredentialInfo != null)
@@ -282,14 +290,14 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
             bool isAllowed = GroupPolicyRepositoryEnforcement.IsGroupPolicyEnabled() ? GroupPolicyRepositoryEnforcement.IsRepositoryAllowed(repoUri) : true;
 
-            return new PSRepositoryInfo(repoName, repoUri, repoPriority, repoTrusted, repoCredentialInfo, apiVersion, isAllowed);
+            return new PSRepositoryInfo(repoName, repoUri, repoPriority, repoTrusted, repoCredentialInfo, repoCredentialProvider, apiVersion, isAllowed);
         }
 
         /// <summary>
         /// Updates a repository name, Uri, priority, installation policy, or credential information
         /// Returns:  void
         /// </summary>
-        public static PSRepositoryInfo Update(string repoName, Uri repoUri, int repoPriority, bool? repoTrusted, PSRepositoryInfo.APIVersion? apiVersion, PSCredentialInfo repoCredentialInfo, PSCmdlet cmdletPassedIn, out string errorMsg)
+        public static PSRepositoryInfo Update(string repoName, Uri repoUri, int repoPriority, bool? repoTrusted, APIVersion? apiVersion, PSCredentialInfo repoCredentialInfo, CredentialProviderType? credentialProvider, PSCmdlet cmdletPassedIn, out string errorMsg)
         {
             errorMsg = string.Empty;
             PSRepositoryInfo updatedRepo;
@@ -303,7 +311,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     bool repoIsTrusted = !(repoTrusted == null || repoTrusted == false);
                     repoPriority = repoPriority < 0 ? DefaultPriority : repoPriority;
 
-                    return AddToRepositoryStore(repoName, repoUri, repoPriority, repoIsTrusted, apiVersion, repoCredentialInfo, force:true, cmdletPassedIn, out errorMsg);
+                    return AddToRepositoryStore(repoName, repoUri, repoPriority, repoIsTrusted, apiVersion, repoCredentialInfo, credentialProvider, force:true, cmdletPassedIn, out errorMsg);
                 }
 
                 // Check that repository node we are attempting to update has all required attributes: Name, Url (or Uri), Priority, Trusted.
@@ -417,15 +425,15 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 }
 
                 // Update APIVersion if necessary
-                PSRepositoryInfo.APIVersion resolvedAPIVersion = PSRepositoryInfo.APIVersion.Unknown;
+                APIVersion resolvedAPIVersion = APIVersion.Unknown;
                 if (apiVersion != null)
                 {
-                    resolvedAPIVersion = (PSRepositoryInfo.APIVersion)apiVersion;
+                    resolvedAPIVersion = (APIVersion)apiVersion;
                     node.Attribute("APIVersion").Value = resolvedAPIVersion.ToString();
                 }
                 else
                 {
-                    resolvedAPIVersion = (PSRepositoryInfo.APIVersion)Enum.Parse(typeof(PSRepositoryInfo.APIVersion), node.Attribute("APIVersion").Value, ignoreCase: true);
+                    resolvedAPIVersion = (APIVersion)Enum.Parse(typeof(APIVersion), node.Attribute("APIVersion").Value, ignoreCase: true);
                 }
 
 
@@ -445,14 +453,29 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
                 }
 
+                // Update CredentialProvider if necessary
+                CredentialProviderType resolvedCredentialProvider = credentialProvider ?? CredentialProviderType.None;
+                if (credentialProvider != null)
+                {
+                    resolvedCredentialProvider = (CredentialProviderType)credentialProvider;
+                    if (node.Attribute("CredentialProvider") == null)
+                    {
+                        node.Add(new XAttribute("CredentialProvider", resolvedCredentialProvider.ToString()));
+                    }
+                    else
+                    {
+                        node.Attribute("CredentialProvider").Value = resolvedCredentialProvider.ToString();
+                    }
+                }
+
                 bool isAllowed = GroupPolicyRepositoryEnforcement.IsGroupPolicyEnabled() ? GroupPolicyRepositoryEnforcement.IsRepositoryAllowed(thisUrl) : true;
 
-                RepositoryProviderType repositoryProvider= GetRepositoryProviderType(thisUrl);
                 updatedRepo = new PSRepositoryInfo(repoName,
                     thisUrl,
                     Int32.Parse(node.Attribute("Priority").Value),
                     Boolean.Parse(node.Attribute("Trusted").Value),
                     thisCredentialInfo,
+                    resolvedCredentialProvider,
                     resolvedAPIVersion,
                     isAllowed);
 
@@ -523,6 +546,12 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     continue;
                 }
 
+                CredentialProviderType resolvedCredentialProvider = CredentialProviderType.None;
+                if (node.Attribute("CredentialProvider") != null)
+                {
+                    resolvedCredentialProvider = (CredentialProviderType)Enum.Parse(typeof(CredentialProviderType), node.Attribute("CredentialProvider").Value, ignoreCase: true);
+                }
+
                 // determine if repo had Url or Uri (less likely) attribute
                 bool urlAttributeExists = node.Attribute("Url") != null;
                 bool uriAttributeExists = node.Attribute("Uri") != null;
@@ -537,14 +566,14 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
                 bool isAllowed = GroupPolicyRepositoryEnforcement.IsGroupPolicyEnabled() ? GroupPolicyRepositoryEnforcement.IsRepositoryAllowed(repoUri) : true;
 
-                RepositoryProviderType repositoryProvider= GetRepositoryProviderType(repoUri);
                 removedRepos.Add(
                     new PSRepositoryInfo(repo,
                         new Uri(node.Attribute(attributeUrlUriName).Value),
                         Int32.Parse(node.Attribute("Priority").Value),
                         Boolean.Parse(node.Attribute("Trusted").Value),
                         repoCredentialInfo,
-                        (PSRepositoryInfo.APIVersion)Enum.Parse(typeof(PSRepositoryInfo.APIVersion), node.Attribute("APIVersion").Value, ignoreCase: true),
+                        resolvedCredentialProvider,
+                        (APIVersion)Enum.Parse(typeof(APIVersion), node.Attribute("APIVersion").Value, ignoreCase: true),
                         isAllowed));
 
                 // Remove item from file
@@ -630,11 +659,17 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
                     if (repo.Attribute("APIVersion") == null)
                     {
-                        PSRepositoryInfo.APIVersion apiVersion = GetRepoAPIVersion(thisUrl);
+                        APIVersion apiVersion = GetRepoAPIVersion(thisUrl);
 
                         XElement repoXElem = FindRepositoryElement(doc, repo.Attribute("Name").Value);
                         repoXElem.SetAttributeValue("APIVersion", apiVersion.ToString());
                         doc.Save(FullRepositoryPath);
+                    }
+
+                    CredentialProviderType credentialProvider = CredentialProviderType.None;
+                    if (repo.Attribute("CredentialProvider") != null)
+                    {
+                        credentialProvider = (CredentialProviderType)Enum.Parse(typeof(CredentialProviderType), repo.Attribute("CredentialProvider").Value, ignoreCase: true);
                     }
 
                     PSCredentialInfo thisCredentialInfo;
@@ -669,8 +704,6 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                         continue;
                     }
 
-                    RepositoryProviderType repositoryProvider= GetRepositoryProviderType(thisUrl);
-
                     bool isAllowed = GroupPolicyRepositoryEnforcement.IsGroupPolicyEnabled() ? GroupPolicyRepositoryEnforcement.IsRepositoryAllowed(thisUrl) : true;
 
                     PSRepositoryInfo currentRepoItem = new PSRepositoryInfo(repo.Attribute("Name").Value,
@@ -678,7 +711,8 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                         Int32.Parse(repo.Attribute("Priority").Value),
                         Boolean.Parse(repo.Attribute("Trusted").Value),
                         thisCredentialInfo,
-                        (PSRepositoryInfo.APIVersion)Enum.Parse(typeof(PSRepositoryInfo.APIVersion), repo.Attribute("APIVersion").Value, ignoreCase: true),
+                        credentialProvider,
+                        (APIVersion)Enum.Parse(typeof(APIVersion), repo.Attribute("APIVersion").Value, ignoreCase: true),
                         isAllowed);
 
                     foundRepos.Add(currentRepoItem);
@@ -738,11 +772,17 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
                         if (node.Attribute("APIVersion") == null)
                         {
-                            PSRepositoryInfo.APIVersion apiVersion = GetRepoAPIVersion(thisUrl);
+                            APIVersion apiVersion = GetRepoAPIVersion(thisUrl);
 
                             XElement repoXElem = FindRepositoryElement(doc, node.Attribute("Name").Value);
                             repoXElem.SetAttributeValue("APIVersion", apiVersion.ToString());
                             doc.Save(FullRepositoryPath);
+                        }
+
+                        CredentialProviderType credentialProvider = CredentialProviderType.None;
+                        if (node.Attribute("CredentialProvider") != null)
+                        {
+                            credentialProvider = (CredentialProviderType)Enum.Parse(typeof(CredentialProviderType), node.Attribute("CredentialProvider").Value, ignoreCase: true);
                         }
 
                         PSCredentialInfo thisCredentialInfo;
@@ -777,8 +817,6 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                             continue;
                         }
 
-                        RepositoryProviderType repositoryProvider= GetRepositoryProviderType(thisUrl);
-
                         bool isAllowed = GroupPolicyRepositoryEnforcement.IsGroupPolicyEnabled() ? GroupPolicyRepositoryEnforcement.IsRepositoryAllowed(thisUrl) : true;
 
                         PSRepositoryInfo currentRepoItem = new PSRepositoryInfo(node.Attribute("Name").Value,
@@ -786,7 +824,8 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                             Int32.Parse(node.Attribute("Priority").Value),
                             Boolean.Parse(node.Attribute("Trusted").Value),
                             thisCredentialInfo,
-                            (PSRepositoryInfo.APIVersion)Enum.Parse(typeof(PSRepositoryInfo.APIVersion), node.Attribute("APIVersion").Value, ignoreCase: true),
+                            credentialProvider,
+                            (APIVersion)Enum.Parse(typeof(APIVersion), node.Attribute("APIVersion").Value, ignoreCase: true),
                             isAllowed);
 
                         foundRepos.Add(currentRepoItem);
@@ -840,54 +879,38 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             return XDocument.Load(xmlReader);
         }
 
-        private static PSRepositoryInfo.APIVersion GetRepoAPIVersion(Uri repoUri)
+        private static APIVersion GetRepoAPIVersion(Uri repoUri)
         {
             if (repoUri.AbsoluteUri.EndsWith("/v2", StringComparison.OrdinalIgnoreCase))
             {
                 // Scenario: V2 server protocol repositories (i.e PSGallery)
-                return PSRepositoryInfo.APIVersion.V2;
+                return APIVersion.V2;
             }
             else if (repoUri.AbsoluteUri.EndsWith("/index.json", StringComparison.OrdinalIgnoreCase))
             {
                 // Scenario: V3 server protocol repositories (i.e NuGet.org, Azure Artifacts (ADO), Artifactory, Github Packages, MyGet.org)
-                return PSRepositoryInfo.APIVersion.V3;
+                return APIVersion.V3;
             }
             else if (repoUri.AbsoluteUri.EndsWith("/nuget", StringComparison.OrdinalIgnoreCase))
             {
                 // Scenario: ASP.Net application feed created with NuGet.Server to host packages
-                return PSRepositoryInfo.APIVersion.NugetServer;
+                return APIVersion.NugetServer;
             }
             else if (repoUri.Scheme.Equals(Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase) || repoUri.Scheme.Equals("temp", StringComparison.OrdinalIgnoreCase))
             {
                 // repositories with Uri Scheme "temp" may have PSPath Uri's like: "Temp:\repo" and we should consider them as local repositories.
-                return PSRepositoryInfo.APIVersion.Local;
+                return APIVersion.Local;
             }
             else if (repoUri.AbsoluteUri.EndsWith(".azurecr.io") || repoUri.AbsoluteUri.EndsWith(".azurecr.io/") || repoUri.AbsoluteUri.Contains("mcr.microsoft.com"))
             {
-                return PSRepositoryInfo.APIVersion.ContainerRegistry;
+                return APIVersion.ContainerRegistry;
             }
             else
             {
-                return PSRepositoryInfo.APIVersion.Unknown;
+                return APIVersion.Unknown;
             }
         }
 
-        private static RepositoryProviderType GetRepositoryProviderType(Uri repoUri)
-        {
-            string absoluteUri = repoUri.AbsoluteUri;
-            // We want to use contains instead of EndsWith to accomodate for trailing '/'
-            if (absoluteUri.Contains("azurecr.io") || absoluteUri.Contains("mcr.microsoft.com")){
-                return RepositoryProviderType.ACR;
-            }
-            // TODO: add a regex for this match
-            // eg: *pkgs.*/_packaging/*
-            else if (absoluteUri.Contains("pkgs.")){
-                return RepositoryProviderType.AzureDevOps;
-            }
-            else {
-                return RepositoryProviderType.None;
-            }
-        }
         #endregion
     }
 }

--- a/src/code/SetPSResourceRepository.cs
+++ b/src/code/SetPSResourceRepository.cs
@@ -109,14 +109,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public object GetDynamicParameters()
         {
             PSRepositoryInfo repository = RepositorySettings.Read(new[] { Name }, out string[] _).FirstOrDefault();
-            if (repository is not null &&
-                  (repository.Uri.AbsoluteUri.Contains("pkgs.dev.azure.com") || repository.Uri.AbsoluteUri.Contains("pkgs.visualstudio.com")))
+            if (repository is not null && 
+                (repository.Uri.AbsoluteUri.EndsWith(".azurecr.io") || repository.Uri.AbsoluteUri.EndsWith(".azurecr.io/") || repository.Uri.AbsoluteUri.Contains("mcr.microsoft.com")))
             {
-                _credentialProvider = new CredentialProviderDynamicParameters();
-                return _credentialProvider;
+                return null;
             }
 
-            return null;
+            _credentialProvider = new CredentialProviderDynamicParameters();
+            return _credentialProvider;
         }
 
         #endregion
@@ -161,7 +161,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 repoApiVersion = ApiVersion;
             }
 
-            PSRepositoryInfo.CredentialProviderType credentialProvider = _credentialProvider.CredentialProvider;
+            PSRepositoryInfo.CredentialProviderType? credentialProvider = _credentialProvider?.CredentialProvider;
 
             List<PSRepositoryInfo> items = new List<PSRepositoryInfo>();
 
@@ -306,7 +306,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return null;
             }
 
-            PSRepositoryInfo.CredentialProviderType credentialProvider = _credentialProvider.CredentialProvider;
+            PSRepositoryInfo.CredentialProviderType? credentialProvider = _credentialProvider?.CredentialProvider;
 
             try
             {

--- a/src/code/SetPSResourceRepository.cs
+++ b/src/code/SetPSResourceRepository.cs
@@ -95,6 +95,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public PSCredentialInfo CredentialInfo { get; set; }
 
         /// <summary>
+        /// Specifies which credential provider to use.
+        /// </summary>
+        [Parameter(ParameterSetName = NameParameterSet)]
+        public PSRepositoryInfo.CredentialProviderType CredentialProvider { get; set; }      
+
+        /// <summary>
         /// When specified, displays the successfully registered repository and its information.
         /// </summary>
         [Parameter]
@@ -118,10 +124,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 !MyInvocation.BoundParameters.ContainsKey(nameof(Priority)) &&
                 !MyInvocation.BoundParameters.ContainsKey(nameof(Trusted)) &&
                 !MyInvocation.BoundParameters.ContainsKey(nameof(ApiVersion)) &&
-                !MyInvocation.BoundParameters.ContainsKey(nameof(CredentialInfo)))
+                !MyInvocation.BoundParameters.ContainsKey(nameof(CredentialInfo)) &&
+                !MyInvocation.BoundParameters.ContainsKey(nameof(CredentialProvider)))
             {
                 ThrowTerminatingError(new ErrorRecord(
-                    new ArgumentException("Must set Uri, Priority, Trusted, ApiVersion, or CredentialInfo parameter"),
+                    new ArgumentException("Must set Uri, Priority, Trusted, ApiVersion, CredentialInfo, or CredentialProvider parameter"),
                     "SetRepositoryParameterBindingFailure",
                     ErrorCategory.InvalidArgument,
                     this));
@@ -151,11 +158,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         items.Add(RepositorySettings.UpdateRepositoryStore(Name, 
                             _uri, 
                             Priority,
-                            Trusted, 
+                            Trusted,
                             isSet,
                             DefaultPriority,
                             repoApiVersion,
                             CredentialInfo,
+                            CredentialProvider,
                             this,
                             out string errorMsg));
 
@@ -293,6 +301,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     DefaultPriority,
                     ApiVersion,
                     repoCredentialInfo,
+                    CredentialProvider,
                     this,
                     out string errorMsg);
 

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1238,6 +1238,22 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 }
             }
         }
+
+        internal static string GetCaseInsensitiveFilePath(string directory, string fileName)
+        {
+            var files = Directory.GetFiles(directory);
+            foreach (var file in files)
+            {
+                if (string.Equals(Path.GetFileName(file), fileName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return file;
+                }
+            }
+
+            // File not found
+            return null;
+        }
+
         #endregion
 
         #region PSDataFile parsing

--- a/test/CredentialProvider.Tests.ps1
+++ b/test/CredentialProvider.Tests.ps1
@@ -1,0 +1,74 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Import-Module "$psscriptroot\PSGetTestUtils.psm1" -Force
+
+Describe 'Test Azure Artifacts Credential Provider' -tags 'CI' {
+
+    BeforeAll{
+        $TestModuleName = "PackageManagement"
+        $ADORepoName = "ADORepository"
+        $ADORepoUri = "https://pkgs.dev.azure.com/mscodehub/PowerShellCore/_packaging/PowerShellCore_PublicPackages/nuget/v2"
+        $LocalRepoName = "LocalRepository"
+        $LocalRepoUri = Join-Path -Path $TestDrive -ChildPath "testdir"
+        $null = New-Item $LocalRepoUri -ItemType Directory -Force
+
+        Get-NewPSResourceRepositoryFile
+        Register-PSResourceRepository -Name $ADORepoName -Uri $ADORepoUri -Trusted
+    }
+
+    AfterAll {
+        Uninstall-PSResource $TestModuleName -SkipDependencyCheck -ErrorAction SilentlyContinue
+
+        Get-RevertPSResourceRepositoryFile
+    }
+
+    It "Find resource given specific Name and Repository" {
+        $res = Find-PSResource -Name $TestModuleName -Repository $ADORepoName
+        $res.Name | Should -Be $TestModuleName
+    }
+    
+    It "Install resource given specific Name and Repository" {
+        Install-PSResource -Name $TestModuleName -Repository $ADORepoName
+        
+        Get-InstalledPSResource -Name $TestModuleName | Should -Not -BeNullOrEmpty
+    }
+
+    It "Register repository with local path (CredentialProvider should be set to 'None')" {
+        Register-PSResourceRepository -Name $LocalRepoName -Uri $LocalRepoUri -Force
+        $repo = Get-PSResourceRepository -Name $LocalRepoName
+        $repo.CredentialProvider | Should -Be "None"
+    }
+    
+    It "Set CredentialProvider for local path repository" {
+        Register-PSResourceRepository -Name $LocalRepoName -Uri $LocalRepoUri -Trusted -Force
+        $repo = Get-PSResourceRepository -Name $LocalRepoName
+        $repo.CredentialProvider | Should -Be "None"
+
+        Set-PSResourceRepository -Name $LocalRepoName -CredentialProvider AzArtifacts
+        $repo2 = Get-PSResourceRepository -Name $LocalRepoName
+        $repo2.CredentialProvider | Should -Be "AzArtifacts"
+    }
+
+    It "Register repository with ADO Uri (CredentialProvider should be set to 'AzArtifacts')" {
+        Register-PSResourceRepository -Name $ADORepoName -Uri $ADORepoUri -Force
+        $repo = Get-PSResourceRepository -Name $ADORepoName
+        $repo.CredentialProvider | Should -Be "AzArtifacts"
+    }
+
+    It "Set CredentialProvider for ADO repository" {
+        Register-PSResourceRepository -Name $ADORepoName -Uri $ADORepoUri -Trusted -Force
+        $repo = Get-PSResourceRepository -Name $ADORepoName
+        $repo.CredentialProvider | Should -Be "AzArtifacts"
+
+        Set-PSResourceRepository -Name $ADORepoName -CredentialProvider None
+        $repo2 = Get-PSResourceRepository -Name $ADORepoName
+        $repo2.CredentialProvider | Should -Be "None"
+    }
+
+    It "Register repository with ADO Uri (CredentialProvider should be set to 'AzArtifacts')" {
+        Register-PSResourceRepository -Name $ADORepoName -Uri $ADORepoUri -CredentialProvider None -Force
+        $repo = Get-PSResourceRepository -Name $ADORepoName
+        $repo.CredentialProvider | Should -Be "None"
+    }
+}

--- a/test/FindPSResourceTests/FindPSResourceADOV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceADOV2Server.Tests.ps1
@@ -14,7 +14,7 @@ Describe 'Test HTTP Find-PSResource for ADO V2 Server Protocol' -tags 'CI' {
         $ADOV2RepoName = "PSGetTestingPublicFeed"
         $ADOV2RepoUri = "https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/psresourceget-public-test-ci/nuget/v2"
         Get-NewPSResourceRepositoryFile
-        Register-PSResourceRepository -Name $ADOV2RepoName -Uri $ADOV2RepoUri
+        Register-PSResourceRepository -Name $ADOV2RepoName -Uri $ADOV2RepoUri -CredentialProvider "None"
     }
 
     AfterAll {

--- a/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
@@ -24,8 +24,6 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
     }
 
     It "find resource given specific Name, Version null" {
-        $repo = Get-PSResourceRepository $GithubPackagesRepoName
-        Write-Error "Repo: $repo;  repo credential provider: $($repo.CredentialProvider)"
         # FindName()
         $res = Find-PSResource -Name $testModuleName -Repository $GithubPackagesRepoName -Credential $credential
         $res.Name | Should -Be $testModuleName

--- a/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceGithubPackages.Tests.ps1
@@ -24,6 +24,8 @@ Describe 'Test HTTP Find-PSResource for Github Packages Server' -tags 'CI' {
     }
 
     It "find resource given specific Name, Version null" {
+        $repo = Get-PSResourceRepository $GithubPackagesRepoName
+        Write-Error "Repo: $repo;  repo credential provider: $($repo.CredentialProvider)"
         # FindName()
         $res = Find-PSResource -Name $testModuleName -Repository $GithubPackagesRepoName -Credential $credential
         $res.Name | Should -Be $testModuleName


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR integrates the Azure Artifacts Credential Provider into PSResourceGet. 
**Information on the cred provider and how to install, discover, and use the cred provider is located here:** https://github.com/NuGet/Home/wiki/NuGet-cross-plat-authentication-plugin#plugin-installation-and-discovery.
Please use this link for setting up and configuring the cred provider for PSResourceGet as well. 


This PR adds a new dynamic parameter to `Register-PSResourceRepository` and `Set-PSResourceRepository` called `-CredentialProvider`, which is an enum with values `None` and `AzArtifacts`.  The parameter only works with repositories that are _not_ `ContainerRegistry` repositories.  This is because the credential provider only works with Azure Artifact feeds, however Azure Artifact feeds can have any uri.  Instead of only allowing the parameter to be used with Azure Artifact feeds, we are not allowing use for feeds in which we _know_ we cannot use the credential provider for. 

PSResourceGet will automatically set the value `CredentialProvider` to `AzArtifacts` if it recognizes that the repository is definitely an Azure Artifacts feed.  This is done by checking to see if the uri contains `pkgs.dev.azure.com` or `pkgs.visualstudio.com`.  This check is done when registering a new repository or when PSResourceGet reads repositories from the `PSResourceRepository.xml` file. 

PSResourceGet looks for the credential provider any time network credentials are set.  The new priority ordering for credentials is:
&nbsp;&nbsp;&nbsp;&nbsp; 1. Credentials passed in via parameter `-Credential`.
&nbsp;&nbsp;&nbsp;&nbsp; 2. Credentials retrieved via the AzArtifacts Credential Provider.
&nbsp;&nbsp;&nbsp;&nbsp; 3. Credentials retrieved from SecretManagement.

The Credential Provider can be bypassed by setting the `-CredentialProvider` parameter to `None`.


If the `CredentialProvider` property is set to `AzArtifacts` for a repository, PSResourceGet will attempt to find the Credential Provider file on the machine in the following order:
&nbsp;&nbsp;&nbsp;&nbsp; 1. Checking the environment variable `NUGET_PLUGIN_PATHS`
&nbsp;&nbsp;&nbsp;&nbsp; 2. Checking the default locations: `$env:UserProfile\.nuget\plugins`
&nbsp;&nbsp;&nbsp;&nbsp; 3. Checking the fixed location where Visual Studio is installed:  `common7\IDE\CommonExtensions\Microsoft\NuGet`
More information on this discovery process can be found in the link above.


Once the Credential Provider is found, PSResourceGet calls the provider with the following arguments:
`CredentialProvider.Microsoft.exe -Uri <uri> -NonInteractive -IsRetry -F Json`
Or
`dotnet CredentialProvider.Microsoft.dll -Uri <uri> -NonInteractive -IsRetry -F Json`

Right now, this means that for Unix machines, there is a dependency on the dotnet cli to call the Credential Provider.


Once credentials are retrieved, they are used to make the network call, as is done when using the `-Credential` parameter or SecretManagement.


<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1658
Resolves #1601 
Resolves #1511

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
