### PR TITLE
Bugfix for ContainerRegistry repository to parse out dependencies from metadata

### DIFF
--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -970,13 +970,18 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 {
                     metadata["Dependencies"] = ParseContainerRegistryDependencies(requiredModulesElement, out errorMsg).ToArray();
                 }
+
                 if (string.Equals(packageName, "Az", StringComparison.OrdinalIgnoreCase) || packageName.StartsWith("Az.", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (rootDom.TryGetProperty("PrivateData", out JsonElement privateDataElement) && privateDataElement.TryGetProperty("PSData", out JsonElement psDataElement))
+                    if (rootDom.TryGetProperty("ModuleList", out JsonElement moduleListDepsElement))
                     {
-                        if (psDataElement.TryGetProperty("ModuleList", out JsonElement moduleListDepsElement))
+                        metadata["Dependencies"] = ParseContainerRegistryDependencies(moduleListDepsElement, out errorMsg).ToArray();
+                    }
+                    else if (rootDom.TryGetProperty("PrivateData", out JsonElement privateDataElement) && privateDataElement.TryGetProperty("PSData", out JsonElement psDataElement))
+                    {
+                        if (psDataElement.TryGetProperty("ModuleList", out JsonElement privateDataModuleListDepsElement))
                         {
-                            metadata["Dependencies"] = ParseContainerRegistryDependencies(moduleListDepsElement, out errorMsg).ToArray();
+                            metadata["Dependencies"] = ParseContainerRegistryDependencies(privateDataModuleListDepsElement, out errorMsg).ToArray();
                         }
                     }
                 }

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -237,19 +237,17 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
 
 Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {
     BeforeAll {
-        [Microsoft.PowerShell.PSResourceGet.UtilClasses.InternalHooks]::SetTestHook("MARPrefix", "azure-powershell/");
         Register-PSResourceRepository -Name "MAR" -Uri "https://mcr.microsoft.com" -ApiVersion "ContainerRegistry"
     }
 
     AfterAll {
-        [Microsoft.PowerShell.PSResourceGet.UtilClasses.InternalHooks]::SetTestHook("MARPrefix", $null);
         Unregister-PSResourceRepository -Name "MAR"
     }
 
     It "Should find resource given specific Name, Version null" {
         $res = Find-PSResource -Name "Az.Accounts" -Repository "MAR"
         $res.Name | Should -Be "Az.Accounts"
-        $res.Version | Should -Be "3.0.4"
+        $res.Version | Should -Be "4.0.0"
     }
 
     It "Should find resource and its dependency given specific Name and Version" {

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -227,6 +227,12 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $res.Version | Should -Be "1.0.0"
         $res.Type.ToString() | Should -Be "Script"
     }
+
+    It "Should find resource with dependency, given Name and Version" {
+        $res = Find-PSResource -Name "Az.Storage" -Version "8.0.0" -Repository $ACRRepoName
+        $res.Dependencies.Length | Should -Be 1
+        $res.Dependencies[0].Name | Should -Be "Az.Accounts"
+    }
 }
 
 Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {
@@ -244,5 +250,11 @@ Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {
         $res = Find-PSResource -Name "Az.Accounts" -Repository "MAR"
         $res.Name | Should -Be "Az.Accounts"
         $res.Version | Should -Be "3.0.4"
+    }
+
+    It "Should find resource and its dependency given specific Name and Version" {
+        $res = Find-PSResource -Name "Az.Storage" -Version "8.0.0" -Repository "MAR"
+        $res.Dependencies.Length | Should -Be 1
+        $res.Dependencies[0].Name | Should -Be "Az.Accounts"
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
For ContainerRegistry repositories, we currently check for dependencies from `RequiredModules` and `PrivateData.ModuleList` but Az modules will have it in `ModuleList` element not within PrivateData.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
