### PR TITLE
Fixes bug with nuspec dependency version range calculation for RequiredModules

### DIFF
--- a/src/code/PublishHelper.cs
+++ b/src/code/PublishHelper.cs
@@ -1126,38 +1126,43 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     XmlElement element = doc.CreateElement("dependency", nameSpaceUri);
                     element.SetAttribute("id", dependencyName);
-        
-                    var requiredModulesVersionInfo = (Hashtable)requiredModules[dependencyName];
-                    string versionRange = "";
-                    if (requiredModulesVersionInfo.ContainsKey("RequiredVersion"))
+                    
+                    string dependencyVersion = requiredModules[dependencyName].ToString();
+                    if (!string.IsNullOrEmpty(dependencyVersion))
                     {
-                        // For RequiredVersion, use exact version notation [x.x.x]
-                        string requiredModulesVersion = requiredModulesVersionInfo["RequiredVersion"].ToString();
-                        versionRange = $"[{requiredModulesVersion}]";
-                    }
-                    else if (requiredModulesVersionInfo.ContainsKey("ModuleVersion") && requiredModulesVersionInfo.ContainsKey("MaximumVersion"))
-                    {
-                        // Version range when both min and max specified: [min,max]
-                        versionRange = $"[{requiredModulesVersionInfo["ModuleVersion"]}, {requiredModulesVersionInfo["MaximumVersion"]}]";
-                    }
-                    else if (requiredModulesVersionInfo.ContainsKey("ModuleVersion"))
-                    {
-                        // Only min specified: min (which means ≥ min)
-                        versionRange = requiredModulesVersionInfo["ModuleVersion"].ToString();
-                    }
-                    else if (requiredModulesVersionInfo.ContainsKey("MaximumVersion"))
-                    {
-                        // Only max specified: (, max]
-                        versionRange = $"(, {requiredModulesVersionInfo["MaximumVersion"]}]";
-                    }
+                        var requiredModulesVersionInfo = (Hashtable)requiredModules[dependencyName];
+                        string versionRange = String.Empty;
+                        if (requiredModulesVersionInfo.ContainsKey("RequiredVersion"))
+                        {
+                            // For RequiredVersion, use exact version notation [x.x.x]
+                            string requiredModulesVersion = requiredModulesVersionInfo["RequiredVersion"].ToString();
+                            versionRange = $"[{requiredModulesVersion}]";
+                        }
+                        else if (requiredModulesVersionInfo.ContainsKey("ModuleVersion") && requiredModulesVersionInfo.ContainsKey("MaximumVersion"))
+                        {
+                            // Version range when both min and max specified: [min,max]
+                            versionRange = $"[{requiredModulesVersionInfo["ModuleVersion"]}, {requiredModulesVersionInfo["MaximumVersion"]}]";
+                        }
+                        else if (requiredModulesVersionInfo.ContainsKey("ModuleVersion"))
+                        {
+                            // Only min specified: min (which means ≥ min)
+                            versionRange = requiredModulesVersionInfo["ModuleVersion"].ToString();
+                        }
+                        else if (requiredModulesVersionInfo.ContainsKey("MaximumVersion"))
+                        {
+                            // Only max specified: (, max]
+                            versionRange = $"(, {requiredModulesVersionInfo["MaximumVersion"]}]";
+                        }
 
-                    if (!string.IsNullOrEmpty(versionRange))
-                    {
-                        element.SetAttribute("version", versionRange);
+                        if (!string.IsNullOrEmpty(versionRange))
+                        {
+                            element.SetAttribute("version", versionRange);
+                        }
                     }
 
                     dependenciesElement.AppendChild(element);
                 }
+
                 metadataElement.AppendChild(dependenciesElement);
             }
 

--- a/src/code/PublishHelper.cs
+++ b/src/code/PublishHelper.cs
@@ -1122,16 +1122,38 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (requiredModules != null)
             {
                 XmlElement dependenciesElement = doc.CreateElement("dependencies", nameSpaceUri);
-
                 foreach (string dependencyName in requiredModules.Keys)
                 {
                     XmlElement element = doc.CreateElement("dependency", nameSpaceUri);
-
                     element.SetAttribute("id", dependencyName);
-                    string dependencyVersion = requiredModules[dependencyName].ToString();
-                    if (!string.IsNullOrEmpty(dependencyVersion))
+        
+                    var requiredModulesVersionInfo = (Hashtable)requiredModules[dependencyName];
+                    string versionRange = "";
+                    if (requiredModulesVersionInfo.ContainsKey("RequiredVersion"))
                     {
-                        element.SetAttribute("version", requiredModules[dependencyName].ToString());
+                        // For RequiredVersion, use exact version notation [x.x.x]
+                        string requiredModulesVersion = requiredModulesVersionInfo["RequiredVersion"].ToString();
+                        versionRange = $"[{requiredModulesVersion}]";
+                    }
+                    else if (requiredModulesVersionInfo.ContainsKey("ModuleVersion") && requiredModulesVersionInfo.ContainsKey("MaximumVersion"))
+                    {
+                        // Version range when both min and max specified: [min,max]
+                        versionRange = $"[{requiredModulesVersionInfo["ModuleVersion"]}, {requiredModulesVersionInfo["MaximumVersion"]}]";
+                    }
+                    else if (requiredModulesVersionInfo.ContainsKey("ModuleVersion"))
+                    {
+                        // Only min specified: min (which means ≥ min)
+                        versionRange = requiredModulesVersionInfo["ModuleVersion"].ToString();
+                    }
+                    else if (requiredModulesVersionInfo.ContainsKey("MaximumVersion"))
+                    {
+                        // Only max specified: (, max]
+                        versionRange = $"(, {requiredModulesVersionInfo["MaximumVersion"]}]";
+                    }
+
+                    if (!string.IsNullOrEmpty(versionRange))
+                    {
+                        element.SetAttribute("version", versionRange);
                     }
 
                     dependenciesElement.AppendChild(element);
@@ -1173,19 +1195,26 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (LanguagePrimitives.TryConvertTo<Hashtable>(reqModule, out Hashtable moduleHash))
                 {
                     string moduleName = moduleHash["ModuleName"] as string;
-
-                    if (moduleHash.ContainsKey("ModuleVersion"))
+                    var versionInfo = new Hashtable();
+            
+                    // RequiredVersion cannot be used with ModuleVersion or MaximumVersion
+                    if (moduleHash.ContainsKey("RequiredVersion"))
                     {
-                        dependenciesHash.Add(moduleName, moduleHash["ModuleVersion"]);
+                        versionInfo["RequiredVersion"] = moduleHash["RequiredVersion"].ToString();
                     }
-                    else if (moduleHash.ContainsKey("RequiredVersion"))
+                    else 
                     {
-                        dependenciesHash.Add(moduleName, moduleHash["RequiredVersion"]);
+                        // ModuleVersion and MaximumVersion can be used together
+                        if (moduleHash.ContainsKey("ModuleVersion"))
+                        {
+                            versionInfo["ModuleVersion"] = moduleHash["ModuleVersion"].ToString();
+                        }
+                        if (moduleHash.ContainsKey("MaximumVersion"))
+                        {
+                            versionInfo["MaximumVersion"] = moduleHash["MaximumVersion"].ToString();
+                        }
                     }
-                    else
-                    {
-                        dependenciesHash.Add(moduleName, string.Empty);
-                    }
+                    dependenciesHash.Add(moduleName, versionInfo);
                 }
                 else if (LanguagePrimitives.TryConvertTo<string>(reqModule, out string moduleName))
                 {

--- a/test/PublishPSResourceTests/CompressPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/CompressPSResource.Tests.ps1
@@ -185,6 +185,7 @@ Describe "Test Compress-PSResource" -tags 'CI' {
         Expand-Archive -Path $zipPath -DestinationPath $unzippedPath
 
         Test-Path -Path (Join-Path -Path $unzippedPath -ChildPath $testFile) | Should -Be $True
+        $null = Remove-Item $unzippedPath -Force -Recurse
     }
 
     It "Compresses a script" {

--- a/test/PublishPSResourceTests/CompressPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/CompressPSResource.Tests.ps1
@@ -42,6 +42,39 @@ function CreateTestModule
 '@ | Out-File -FilePath $moduleSrc
 }
 
+function CompressExpandRetrieveNuspec
+{
+    param(
+        [string]$PublishModuleBase,
+        [string]$PublishModuleName,
+        [string]$ModuleVersion,
+        [string]$RepositoryPath,
+        [string]$ModuleBasePath,
+        [string]$TestDrive,
+        [object[]]$RequiredModules,
+        [switch]$SkipModuleManifestValidate
+    )
+
+    $testFile = Join-Path -Path "TestSubDirectory" -ChildPath "TestSubDirFile.ps1"
+    $null = New-ModuleManifest -Path (Join-Path -Path $PublishModuleBase -ChildPath "$PublishModuleName.psd1") -ModuleVersion $version -Description "$PublishModuleName module" -RequiredModules $RequiredModules
+    $null = New-Item -Path (Join-Path -Path $PublishModuleBase -ChildPath $testFile) -Force
+
+    $null = Compress-PSResource -Path $PublishModuleBase -DestinationPath $repositoryPath -SkipModuleManifestValidate:$SkipModuleManifestValidate
+
+    # Must change .nupkg to .zip so that Expand-Archive can work on Windows PowerShell
+    $nupkgPath = Join-Path -Path $RepositoryPath -ChildPath "$PublishModuleName.$version.nupkg"
+    $zipPath = Join-Path -Path $RepositoryPath -ChildPath "$PublishModuleName.$version.zip"
+    Rename-Item -Path $nupkgPath -NewName $zipPath
+    $unzippedPath = Join-Path -Path $TestDrive -ChildPath "$PublishModuleName"
+    $null = New-Item $unzippedPath -Itemtype directory -Force
+    $null = Expand-Archive -Path $zipPath -DestinationPath $unzippedPath
+
+    $nuspecPath = Join-Path -Path $unzippedPath -ChildPath "$PublishModuleName.nuspec"
+    $nuspecxml = [xml](Get-Content $nuspecPath)
+    $null = Remove-Item $unzippedPath -Force -Recurse
+    return $nuspecxml
+}
+
 Describe "Test Compress-PSResource" -tags 'CI' {
     BeforeAll {
         Get-NewPSResourceRepositoryFile
@@ -216,6 +249,150 @@ Describe "Test Compress-PSResource" -tags 'CI' {
         $fileInfoObject.FullName | Should -Be $expectedPath
         $fileInfoObject.Extension | Should -Be '.nupkg'
         $fileInfoObject.Name | Should -Be "$script:PublishModuleName.$version.nupkg"
+    }
+
+    It "Compress-PSResource creates nuspec dependecy version range when RequiredVersion is in RequiredModules section" {
+        $version = "1.0.0"
+        $requiredModules = @(
+            @{
+                'ModuleName'      = 'PSGetTestRequiredModule'
+                'GUID'            = (New-Guid).Guid
+                'RequiredVersion' = '2.0.0'
+            }
+        )
+        $compressParams = @{
+            'PublishModuleBase'          = $script:PublishModuleBase
+            'PublishModuleName'          = $script:PublishModuleName
+            'ModuleVersion'              = $version
+            'RepositoryPath'             = $script:repositoryPath
+            'TestDrive'                  = $TestDrive
+            'RequiredModules'            = $requiredModules
+            'SkipModuleManifestValidate' = $true
+        }
+        $nuspecxml = CompressExpandRetrieveNuspec @compressParams
+        # removing spaces as the nuget packaging is formatting the version range and adding spaces even when the original nuspec file doesn't have spaces.
+        # e.g (,2.0.0] is being formatted to (, 2.0.0]
+        $nuspecxml.package.metadata.dependencies.dependency.version.replace(' ', '') | Should -BeExactly '[2.0.0]'
+    }
+
+    It "Compress-PSResource creates nuspec dependecy version range when ModuleVersion is in RequiredModules section" {
+        $version = "1.0.0"
+        $requiredModules = @(
+            @{
+                'ModuleName'    = 'PSGetTestRequiredModule'
+                'GUID'          = (New-Guid).Guid
+                'ModuleVersion' = '2.0.0'
+            }
+        )
+        $compressParams = @{
+            'PublishModuleBase'          = $script:PublishModuleBase
+            'PublishModuleName'          = $script:PublishModuleName
+            'ModuleVersion'              = $version
+            'RepositoryPath'             = $script:repositoryPath
+            'TestDrive'                  = $TestDrive
+            'RequiredModules'            = $requiredModules
+            'SkipModuleManifestValidate' = $true
+        }
+        $nuspecxml = CompressExpandRetrieveNuspec @compressParams
+        $nuspecxml.package.metadata.dependencies.dependency.version.replace(' ', '') | Should -BeExactly '2.0.0'
+    }
+
+    It "Compress-PSResource creates nuspec dependecy version range when MaximumVersion is in RequiredModules section" {
+        $version = "1.0.0"
+        $requiredModules = @(
+            @{
+                'ModuleName'     = 'PSGetTestRequiredModule'
+                'GUID'           = (New-Guid).Guid
+                'MaximumVersion' = '2.0.0'
+            }
+        )
+        $compressParams = @{
+            'PublishModuleBase'          = $script:PublishModuleBase
+            'PublishModuleName'          = $script:PublishModuleName
+            'ModuleVersion'              = $version
+            'RepositoryPath'             = $script:repositoryPath
+            'TestDrive'                  = $TestDrive
+            'RequiredModules'            = $requiredModules
+            'SkipModuleManifestValidate' = $true
+        }
+        $nuspecxml = CompressExpandRetrieveNuspec @compressParams
+        $nuspecxml.package.metadata.dependencies.dependency.version.replace(' ', '') | Should -BeExactly '(,2.0.0]'
+    }
+
+    It "Compress-PSResource creates nuspec dependecy version range when ModuleVersion and MaximumVersion are in RequiredModules section" {
+        $version = "1.0.0"
+        $requiredModules = @(
+            @{
+                'ModuleName'     = 'PSGetTestRequiredModule'
+                'GUID'           = (New-Guid).Guid
+                'ModuleVersion'  = '1.0.0'
+                'MaximumVersion' = '2.0.0'
+            }
+        )
+        $compressParams = @{
+            'PublishModuleBase'          = $script:PublishModuleBase
+            'PublishModuleName'          = $script:PublishModuleName
+            'ModuleVersion'              = $version
+            'RepositoryPath'             = $script:repositoryPath
+            'TestDrive'                  = $TestDrive
+            'RequiredModules'            = $requiredModules
+            'SkipModuleManifestValidate' = $true
+        }
+        $nuspecxml = CompressExpandRetrieveNuspec @compressParams
+        $nuspecxml.package.metadata.dependencies.dependency.version.replace(' ', '') | Should -BeExactly '[1.0.0,2.0.0]'
+    }
+
+    It "Compress-PSResource creates nuspec dependecy version range when there are multiple modules in RequiredModules section" {
+        $version = "1.0.0"
+        $requiredModules = @(
+            @{
+                'ModuleName'      = 'PSGetTestRequiredModuleRequiredVersion'
+                'GUID'            = (New-Guid).Guid
+                'RequiredVersion' = '1.0.0'
+            },
+            @{
+                'ModuleName'    = 'PSGetTestRequiredModuleModuleVersion'
+                'GUID'          = (New-Guid).Guid
+                'ModuleVersion' = '2.0.0'
+            },
+            @{
+                'ModuleName'     = 'PSGetTestRequiredModuleMaximumVersion'
+                'GUID'           = (New-Guid).Guid
+                'MaximumVersion' = '3.0.0'
+            },
+            @{
+                'ModuleName'     = 'PSGetTestRequiredModuleModuleAndMaximumVersion'
+                'GUID'           = (New-Guid).Guid
+                'ModuleVersion'  = '4.0.0'
+                'MaximumVersion' = '5.0.0'
+            }
+        )
+        $compressParams = @{
+            'PublishModuleBase'          = $script:PublishModuleBase
+            'PublishModuleName'          = $script:PublishModuleName
+            'ModuleVersion'              = $version
+            'RepositoryPath'             = $script:repositoryPath
+            'TestDrive'                  = $TestDrive
+            'RequiredModules'            = $requiredModules
+            'SkipModuleManifestValidate' = $true
+        }
+        $nuspecxml = CompressExpandRetrieveNuspec @compressParams
+        foreach ($dependency in $nuspecxml.package.metadata.dependencies.dependency) {
+            switch ($dependency.id) {
+                "PSGetTestRequiredModuleRequiredVersion" {
+                    $dependency.version.replace(' ', '') | Should -BeExactly '[1.0.0]'
+                }
+                "PSGetTestRequiredModuleModuleVersion" {
+                    $dependency.version.replace(' ', '') | Should -BeExactly '2.0.0'
+                }
+                "PSGetTestRequiredModuleMaximumVersion" {
+                    $dependency.version.replace(' ', '') | Should -BeExactly '(,3.0.0]'
+                }
+                "PSGetTestRequiredModuleModuleAndMaximumVersion" {
+                    $dependency.version.replace(' ', '') | Should -BeExactly '[4.0.0,5.0.0]'
+                }
+            }
+        }
     }
 
 <# Test for Signing the nupkg. Signing doesn't work


### PR DESCRIPTION


<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Fix for https://github.com/PowerShell/PSResourceGet/issues/1777. The PR generates correct nuspec dependency version range for modules specified in `RequiredModules` section of the module manifest file. 

Per the [nuget version reference doc](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#version-ranges)
* When `RequiredVersion` is specified, the version range is set as `[RequiredVersion]` which is an exact match
* When `MaximumVersion` is specified, the version range is set as `(, MaximumVersion]` which is `<=MaximumVersion`
* When `ModuleVersion` is specified, the version range is set as `ModuleVersion` which is `>=ModuleVersion`. This notation is used since `publish-module` uses the same notation
* When both `ModuleVersion` and `MaximumVersion` are specified, the version range is set to `[ModuleVersion, MaximumVersion]` which is exact range, inclusive

* Added Pester tests

## PR Context
Fix for https://github.com/PowerShell/PSResourceGet/issues/1777
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
