### PR TITLE
Update ContainerRegistry dependency parsing logic to account for AzPreview package

### DIFF
--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -972,7 +972,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     metadata["Dependencies"] = ParseContainerRegistryDependencies(requiredModulesElement, out errorMsg).ToArray();
                 }
 
-                if (packageName.StartsWith("Az", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(packageName, "Az", StringComparison.OrdinalIgnoreCase) || string.Equals(packageName, "Azpreview", StringComparison.OrdinalIgnoreCase) || packageName.StartsWith("Az.", StringComparison.OrdinalIgnoreCase))
                 {
                     if (rootDom.TryGetProperty("ModuleList", out JsonElement moduleListDepsElement))
                     {

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -972,7 +972,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     metadata["Dependencies"] = ParseContainerRegistryDependencies(requiredModulesElement, out errorMsg).ToArray();
                 }
 
-                if (string.Equals(packageName, "Az", StringComparison.OrdinalIgnoreCase) || packageName.StartsWith("Az.", StringComparison.OrdinalIgnoreCase))
+                if (packageName.StartsWith("Az", StringComparison.OrdinalIgnoreCase))
                 {
                     if (rootDom.TryGetProperty("ModuleList", out JsonElement moduleListDepsElement))
                     {

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -247,7 +247,7 @@ Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {
     It "Should find resource given specific Name, Version null" {
         $res = Find-PSResource -Name "Az.Accounts" -Repository "MAR"
         $res.Name | Should -Be "Az.Accounts"
-        $res.Version | Should -Be "4.0.2"
+        $res.Version | Should -BeGreaterThan "4.0.0"
     }
 
     It "Should find resource and its dependency given specific Name and Version" {

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -257,7 +257,7 @@ Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {
     }
 
     It "Should find Azpreview resource and it's dependency given specific Name and Version" {
-        $res = Find-PSResource -Name "Az.Storage" -Version "13.2.0" -Repository "MAR"
+        $res = Find-PSResource -Name "Azpreview" -Version "13.2.0" -Repository "MAR"
         $res.Dependencies.Length | Should -Not -Be 0
     }
 }

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -255,4 +255,9 @@ Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {
         $res.Dependencies.Length | Should -Be 1
         $res.Dependencies[0].Name | Should -Be "Az.Accounts"
     }
+
+    It "Should find Azpreview resource and it's dependency given specific Name and Version" {
+        $res = Find-PSResource -Name "Az.Storage" -Version "13.2.0" -Repository "MAR"
+        $res.Dependencies.Length | Should -Not -Be 0
+    }
 }

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -247,7 +247,7 @@ Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {
     It "Should find resource given specific Name, Version null" {
         $res = Find-PSResource -Name "Az.Accounts" -Repository "MAR"
         $res.Name | Should -Be "Az.Accounts"
-        $res.Version | Should -Be "4.0.0"
+        $res.Version | Should -Be "4.0.2"
     }
 
     It "Should find resource and its dependency given specific Name and Version" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
When consuming a package from a container registry, we have a certain logic to look for Az package's dependencies, update this logic to include AzPreview package
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
