### PR TITLE
Use authentication challenge for unauthenticated container registry repository

### DIFF
--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -20,7 +20,6 @@ using Microsoft.PowerShell.PSResourceGet.Cmdlets;
 using System.Text;
 using System.Security.Cryptography;
 using System.Text.Json;
-using ResourceType = Microsoft.PowerShell.PSResourceGet.UtilClasses.ResourceType;
 
 namespace Microsoft.PowerShell.PSResourceGet
 {

--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PowerShell.PSResourceGet
         const string containerRegistryFindImageVersionUrlTemplate = "https://{0}/v2/{1}/tags/list"; // 0 - registry, 1 - repo(modulename)
         const string containerRegistryStartUploadTemplate = "https://{0}/v2/{1}/blobs/uploads/"; // 0 - registry, 1 - packagename
         const string containerRegistryEndUploadTemplate = "https://{0}{1}&digest=sha256:{2}"; // 0 - registry, 1 - location, 2 - digest
-        const string defaultScope = "repository:*:*";
+        const string defaultScope = "&scope=repository:*:*&scope=registry:catalog:*";
         const string containerRegistryRepositoryListTemplate = "https://{0}/v2/_catalog"; // 0 - registry
 
         #endregion
@@ -482,11 +482,11 @@ namespace Microsoft.PowerShell.PSResourceGet
                                     return false;
                                 }
 
-                                string content = "grant_type=access_token&service=" + service + "&scope=" + defaultScope;
+                                string content = "grant_type=access_token&service=" + service + defaultScope;
                                 var contentHeaders = new Collection<KeyValuePair<string, string>> { new KeyValuePair<string, string>("Content-Type", "application/x-www-form-urlencoded") };
 
                                 // get the anonymous access token
-                                var url = $"{realm}?service={service}&scope={defaultScope}";
+                                var url = $"{realm}?service={service}{defaultScope}";
 
                                 // we dont check the errorrecord here because we want to return false if we get a 401 and not throw an error
                                 var results = GetHttpResponseJObjectUsingContentHeaders(url, HttpMethod.Get, content, contentHeaders, out _);

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -151,12 +151,11 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $err[0].FullyQualifiedErrorId | Should -BeExactly "FindCommandOrDscResourceFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
-    It "Should not find all resources given Name '*'" {
+    It "Should find all resources given Name '*'" {
         # FindAll()
         $res = Find-PSResource -Name "*" -Repository $ACRRepoName -ErrorVariable err -ErrorAction SilentlyContinue
-        $res | Should -BeNullOrEmpty
+        $res | Should -Not -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "FindAllFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
     }
 
     It "Should find script given Name" {

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -287,7 +287,7 @@ Describe 'Test Find-PSResource for unauthenticated ACR repository' -tags 'CI' {
     It "Should find resource given specific Name, Version null" {
 
         if ($skipOnWinPS) {
-            Set-ItResult -Pending -Reason "Skipping test on Windows PowerShell"
+            Set-ItResult -Pending -Because "Skipping test on Windows PowerShell"
             return
         }
 

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -268,16 +268,29 @@ Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {
     }
 }
 
+# Skip this test fo
 Describe 'Test Find-PSResource for unauthenticated ACR repository' -tags 'CI' {
     BeforeAll {
-        Register-PSResourceRepository -Name "Unauthenticated" -Uri "https://psresourcegetnoauth.azurecr.io/" -ApiVersion "ContainerRegistry"
+        $skipOnWinPS =  $PSVersionTable.PSVersion.Major -eq 5
+
+        if (-not $skipOnWinPS) {
+            Register-PSResourceRepository -Name "Unauthenticated" -Uri "https://psresourcegetnoauth.azurecr.io/" -ApiVersion "ContainerRegistry"
+        }
     }
 
     AfterAll {
-        Unregister-PSResourceRepository -Name "Unauthenticated"
+        if (-not $skipOnWinPS) {
+            Unregister-PSResourceRepository -Name "Unauthenticated"
+        }
     }
 
     It "Should find resource given specific Name, Version null" {
+
+        if ($skipOnWinPS) {
+            Set-ItResult -Pending -Reason "Skipping test on Windows PowerShell"
+            return
+        }
+
         $res = Find-PSResource -Name "hello-world" -Repository "Unauthenticated"
         $res.Name | Should -Be "hello-world"
         $res.Version | Should -Be "5.0.0"

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -256,3 +256,19 @@ Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {
         $res.Dependencies[0].Name | Should -Be "Az.Accounts"
     }
 }
+
+Describe 'Test Find-PSResource for unauthenticated ACR repository' -tags 'CI' {
+    BeforeAll {
+        Register-PSResourceRepository -Name "Unauthenticated" -Uri "https://psresourcegetnoauth.azurecr.io/" -ApiVersion "ContainerRegistry"
+    }
+
+    AfterAll {
+        Unregister-PSResourceRepository -Name "Unauthenticated"
+    }
+
+    It "Should find resource given specific Name, Version null" {
+        $res = Find-PSResource -Name "hello-world" -Repository "Unauthenticated"
+        $res.Name | Should -Be "hello-world"
+        $res.Version | Should -Be "5.0.0"
+    }
+}

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -155,7 +155,7 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         # FindAll()
         $res = Find-PSResource -Name "*" -Repository $ACRRepoName -ErrorVariable err -ErrorAction SilentlyContinue
         $res | Should -Not -BeNullOrEmpty
-        $err.Count | Should -BeGreaterThan 0
+        $res.Count | Should -BeGreaterThan 0
     }
 
     It "Should find script given Name" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request includes several changes to improve the handling and testing of unauthenticated access tokens for container registries. The most important changes include updating token templates, modifying access token retrieval logic, and adding new tests for unauthenticated repositories.

### Improvements to token handling:

* [`src/code/ContainerRegistryServerAPICalls.cs`](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L41-R49): Updated the `containerRegistryAccessTokenTemplate` to include `registry:catalog:*` scope and added a new `defaultScope` constant.

### Modifications to access token retrieval logic:

* [`src/code/ContainerRegistryServerAPICalls.cs`](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L395-R407): Modified the `GetContainerRegistryAccessToken` method to retrieve and return an anonymous access token if available. [[1]](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L395-R407) [[2]](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L440-R522)
* [`src/code/ContainerRegistryServerAPICalls.cs`](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L440-R522): Updated the `IsContainerRegistryUnauthenticated` method to check for an authentication challenge header and retrieve an anonymous access token if present.

### Code simplification:

* [`src/code/ContainerRegistryServerAPICalls.cs`](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L1759-R1833): Simplified the `FindPackages` method to handle repository names with and without the `psresource/` prefix.

### Testing improvements:

* [`test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1`](diffhunk://#diff-54ca5062e42b3513eb4fd586b8fa96eb1bd1e7801a0d3cbb4cc925d2de74b275L154-R158): Modified a test to ensure all resources are found given the name `*`.
* [`test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1`](diffhunk://#diff-54ca5062e42b3513eb4fd586b8fa96eb1bd1e7801a0d3cbb4cc925d2de74b275R270-R298): Added a new test for finding resources in an unauthenticated ACR repository.

## PR Context

Unauthenticated ACR other than MCR respond with an auth challenge to acquire an anonymous token. This token is required for further operations.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
