### PR TITLE
Get metadata properties when finding a PSResource from a ContainerRegistry

### DIFF
--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -992,7 +992,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     }
                 }
 
-                if (rootDom.TryGetProperty("PrivateData", out JsonElement privateDataElement) && privateDataElement.TryGetProperty("PSData", out JsonElement psDataElement))
+                if (rootDom.TryGetProperty("PrivateData", out JsonElement privateDataElement) && privateDataElement.ValueKind == JsonValueKind.Object && privateDataElement.TryGetProperty("PSData", out JsonElement psDataElement))
                 {
                     // some properties that may be in PrivateData.PSData: LicenseUri, ProjectUri, IconUri, ReleaseNotes
                     if (!metadata.ContainsKey("LicenseUrl") && psDataElement.TryGetProperty("LicenseUri", out JsonElement psDataLicenseUriElement))

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -852,9 +852,9 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     pkgVersion = ParseHttpVersion(versionValue, out string prereleaseLabel);
                     metadata["Version"] = pkgVersion;
 
-                    if (rootDom.TryGetProperty("PrivateData", out JsonElement privateDataElement) && privateDataElement.TryGetProperty("PSData", out JsonElement psDataElement))
+                    if (rootDom.TryGetProperty("PrivateData", out JsonElement versionPrivateDataElement) && versionPrivateDataElement.TryGetProperty("PSData", out JsonElement versionPSDataElement))
                     {
-                        if (psDataElement.TryGetProperty("Prerelease", out JsonElement pkgPrereleaseLabelElement) && !String.IsNullOrEmpty(pkgPrereleaseLabelElement.ToString().Trim()))
+                        if (versionPSDataElement.TryGetProperty("Prerelease", out JsonElement pkgPrereleaseLabelElement) && !String.IsNullOrEmpty(pkgPrereleaseLabelElement.ToString().Trim()))
                         {
                             prereleaseLabel = pkgPrereleaseLabelElement.ToString().Trim();
                             versionValue += $"-{prereleaseLabel}";
@@ -884,19 +884,19 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 metadata["NormalizedVersion"] = parsedNormalizedVersion.ToNormalizedString();
 
                 // License Url
-                if (rootDom.TryGetProperty("LicenseUrl", out JsonElement licenseUrlElement) || rootDom.TryGetProperty("licenseUrl", out licenseUrlElement))
+                if (rootDom.TryGetProperty("LicenseUrl", out JsonElement licenseUrlElement) || rootDom.TryGetProperty("licenseUrl", out licenseUrlElement) || rootDom.TryGetProperty("LicenseUri", out licenseUrlElement))
                 {
                     metadata["LicenseUrl"] = ParseHttpUrl(licenseUrlElement.ToString()) as Uri;
                 }
 
                 // Project Url
-                if (rootDom.TryGetProperty("ProjectUrl", out JsonElement projectUrlElement) || rootDom.TryGetProperty("projectUrl", out projectUrlElement))
+                if (rootDom.TryGetProperty("ProjectUrl", out JsonElement projectUrlElement) || rootDom.TryGetProperty("projectUrl", out projectUrlElement) || rootDom.TryGetProperty("ProjectUri", out projectUrlElement))
                 {
                     metadata["ProjectUrl"] = ParseHttpUrl(projectUrlElement.ToString()) as Uri;
                 }
 
                 // Icon Url
-                if (rootDom.TryGetProperty("IconUrl", out JsonElement iconUrlElement) || rootDom.TryGetProperty("iconUrl", out iconUrlElement))
+                if (rootDom.TryGetProperty("IconUrl", out JsonElement iconUrlElement) || rootDom.TryGetProperty("iconUrl", out iconUrlElement) || rootDom.TryGetProperty("IconUri", out iconUrlElement))
                 {
                     metadata["IconUrl"] = ParseHttpUrl(iconUrlElement.ToString()) as Uri;
                 }
@@ -938,14 +938,19 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 }
 
                 // Author
-                if (rootDom.TryGetProperty("Authors", out JsonElement authorsElement) || rootDom.TryGetProperty("authors", out authorsElement))
+                if (rootDom.TryGetProperty("Authors", out JsonElement authorsElement) || rootDom.TryGetProperty("authors", out authorsElement) || rootDom.TryGetProperty("Author", out authorsElement))
                 {
                     metadata["Authors"] = authorsElement.ToString();
+                }
 
-                    // CompanyName
-                    // CompanyName is not provided in v3 pkg metadata response, so we've just set it to the author,
-                    // which is often the company
-                    metadata["CompanyName"] = authorsElement.ToString();
+                if (rootDom.TryGetProperty("CompanyName", out JsonElement companyNameElement))
+                {                
+                    metadata["CompanyName"] = companyNameElement.ToString();
+                }
+                else
+                {
+                    // if CompanyName property is not provided set it to the Author value which is often the same.
+                    metadata["CompanyName"] = metadata["Authors"];
                 }
 
                 // Copyright
@@ -978,12 +983,36 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     {
                         metadata["Dependencies"] = ParseContainerRegistryDependencies(moduleListDepsElement, out errorMsg).ToArray();
                     }
-                    else if (rootDom.TryGetProperty("PrivateData", out JsonElement privateDataElement) && privateDataElement.TryGetProperty("PSData", out JsonElement psDataElement))
+                    else if (rootDom.TryGetProperty("PrivateData", out JsonElement depsPrivateDataElement) && depsPrivateDataElement.TryGetProperty("PSData", out JsonElement depsPSDataElement))
                     {
-                        if (psDataElement.TryGetProperty("ModuleList", out JsonElement privateDataModuleListDepsElement))
+                        if (depsPSDataElement.TryGetProperty("ModuleList", out JsonElement privateDataModuleListDepsElement))
                         {
                             metadata["Dependencies"] = ParseContainerRegistryDependencies(privateDataModuleListDepsElement, out errorMsg).ToArray();
                         }
+                    }
+                }
+
+                if (rootDom.TryGetProperty("PrivateData", out JsonElement privateDataElement) && privateDataElement.TryGetProperty("PSData", out JsonElement psDataElement))
+                {
+                    // some properties that may be in PrivateData.PSData: LicenseUri, ProjectUri, IconUri, ReleaseNotes
+                    if (!(metadata.ContainsKey("LicenseUrl") || metadata.ContainsKey("licenseUrl")) && psDataElement.TryGetProperty("LicenseUri", out JsonElement psDataLicenseUriElement))
+                    {
+                        metadata["LicenseUrl"] = ParseHttpUrl(psDataLicenseUriElement.ToString()) as Uri;
+                    }
+
+                    if (!(metadata.ContainsKey("ProjectUrl") || metadata.ContainsKey("ProjectUrl")) && psDataElement.TryGetProperty("ProjectUri", out JsonElement psDataProjectUriElement))
+                    {
+                        metadata["ProjectUrl"] = ParseHttpUrl(psDataProjectUriElement.ToString()) as Uri;
+                    }
+
+                    if (!(metadata.ContainsKey("IconUrl") || metadata.ContainsKey("IconUrl")) && psDataElement.TryGetProperty("IconUri", out JsonElement psDataIconUriElement))
+                    {
+                        metadata["IconUrl"] = ParseHttpUrl(psDataIconUriElement.ToString()) as Uri;
+                    }
+
+                    if (!metadata.ContainsKey("ReleaseNotes") && psDataElement.TryGetProperty("ReleaseNotes", out JsonElement psDataReleaseNotesElement))
+                    {
+                        metadata["ReleaseNotes"] = psDataReleaseNotesElement.ToString();
                     }
                 }
 

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -884,19 +884,19 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 metadata["NormalizedVersion"] = parsedNormalizedVersion.ToNormalizedString();
 
                 // License Url
-                if (rootDom.TryGetProperty("LicenseUrl", out JsonElement licenseUrlElement) || rootDom.TryGetProperty("licenseUrl", out licenseUrlElement) || rootDom.TryGetProperty("LicenseUri", out licenseUrlElement))
+                if (rootDom.TryGetProperty("LicenseUrl", out JsonElement licenseUrlElement) || rootDom.TryGetProperty("licenseUrl", out licenseUrlElement))
                 {
                     metadata["LicenseUrl"] = ParseHttpUrl(licenseUrlElement.ToString()) as Uri;
                 }
 
                 // Project Url
-                if (rootDom.TryGetProperty("ProjectUrl", out JsonElement projectUrlElement) || rootDom.TryGetProperty("projectUrl", out projectUrlElement) || rootDom.TryGetProperty("ProjectUri", out projectUrlElement))
+                if (rootDom.TryGetProperty("ProjectUrl", out JsonElement projectUrlElement) || rootDom.TryGetProperty("projectUrl", out projectUrlElement))
                 {
                     metadata["ProjectUrl"] = ParseHttpUrl(projectUrlElement.ToString()) as Uri;
                 }
 
                 // Icon Url
-                if (rootDom.TryGetProperty("IconUrl", out JsonElement iconUrlElement) || rootDom.TryGetProperty("iconUrl", out iconUrlElement) || rootDom.TryGetProperty("IconUri", out iconUrlElement))
+                if (rootDom.TryGetProperty("IconUrl", out JsonElement iconUrlElement) || rootDom.TryGetProperty("iconUrl", out iconUrlElement))
                 {
                     metadata["IconUrl"] = ParseHttpUrl(iconUrlElement.ToString()) as Uri;
                 }
@@ -995,17 +995,17 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 if (rootDom.TryGetProperty("PrivateData", out JsonElement privateDataElement) && privateDataElement.TryGetProperty("PSData", out JsonElement psDataElement))
                 {
                     // some properties that may be in PrivateData.PSData: LicenseUri, ProjectUri, IconUri, ReleaseNotes
-                    if (!(metadata.ContainsKey("LicenseUrl") || metadata.ContainsKey("licenseUrl")) && psDataElement.TryGetProperty("LicenseUri", out JsonElement psDataLicenseUriElement))
+                    if (!metadata.ContainsKey("LicenseUrl") && psDataElement.TryGetProperty("LicenseUri", out JsonElement psDataLicenseUriElement))
                     {
                         metadata["LicenseUrl"] = ParseHttpUrl(psDataLicenseUriElement.ToString()) as Uri;
                     }
 
-                    if (!(metadata.ContainsKey("ProjectUrl") || metadata.ContainsKey("ProjectUrl")) && psDataElement.TryGetProperty("ProjectUri", out JsonElement psDataProjectUriElement))
+                    if (!metadata.ContainsKey("ProjectUrl") && psDataElement.TryGetProperty("ProjectUri", out JsonElement psDataProjectUriElement))
                     {
                         metadata["ProjectUrl"] = ParseHttpUrl(psDataProjectUriElement.ToString()) as Uri;
                     }
 
-                    if (!(metadata.ContainsKey("IconUrl") || metadata.ContainsKey("IconUrl")) && psDataElement.TryGetProperty("IconUri", out JsonElement psDataIconUriElement))
+                    if (!metadata.ContainsKey("IconUrl") && psDataElement.TryGetProperty("IconUri", out JsonElement psDataIconUriElement))
                     {
                         metadata["IconUrl"] = ParseHttpUrl(psDataIconUriElement.ToString()) as Uri;
                     }
@@ -1013,6 +1013,29 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     if (!metadata.ContainsKey("ReleaseNotes") && psDataElement.TryGetProperty("ReleaseNotes", out JsonElement psDataReleaseNotesElement))
                     {
                         metadata["ReleaseNotes"] = psDataReleaseNotesElement.ToString();
+                    }
+
+                    if (!metadata.ContainsKey("Tags") && psDataElement.TryGetProperty("Tags", out JsonElement psDataTagsElement))
+                    {
+                        string[] pkgTags = Utils.EmptyStrArray;
+                        if (psDataTagsElement.ValueKind == JsonValueKind.Array)
+                        {
+                            var arrayLength = psDataTagsElement.GetArrayLength();
+                            List<string> tags = new List<string>(arrayLength);
+                            foreach (var tag in psDataTagsElement.EnumerateArray())
+                            {
+                                tags.Add(tag.ToString());
+                            }
+
+                            pkgTags = tags.ToArray();
+                        }
+                        else if (psDataTagsElement.ValueKind == JsonValueKind.String)
+                        {
+                            string tagStr = psDataTagsElement.ToString();
+                            pkgTags = tagStr.Split(Utils.WhitespaceSeparator, StringSplitOptions.RemoveEmptyEntries);
+                        }
+
+                        metadata["Tags"] = pkgTags;
                     }
                 }
 

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -232,6 +232,26 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $res.Dependencies.Length | Should -Be 1
         $res.Dependencies[0].Name | Should -Be "Az.Accounts"
     }
+
+    It "Should find resource and its associated author, licenseUri, projectUri, releaseNotes, etc properties" {
+        $res = Find-PSResource -Name "Az.Storage" -Version "8.0.0" -Repository $ACRRepoName
+        $res.Author | Should -Be "Microsoft Corporation"
+        $res.CompanyName | Should -Be "Microsoft Corporation"
+        $res.LicenseUri | Should -Be "https://aka.ms/azps-license"
+        $res.ProjectUri | Should -Be "https://github.com/Azure/azure-powershell"
+        $res.ReleaseNotes.Length | Should -Not -Be 0
+    }
+
+    It "Install script with companyname, copyright, and repository source location and validate" {
+        Install-PSResource -Name "Install-VSCode" -Version "1.4.2" -Repository $PSGalleryName -TrustRepository
+
+        $res = Get-InstalledPSResource "Install-VSCode" -Version "1.4.2"
+        $res.Name | Should -Be "Install-VSCode"
+        $res.Version | Should -Be "1.4.2"
+        $res.CompanyName | Should -Be "Microsoft Corporation"
+        $res.Copyright | Should -Be "(c) Microsoft Corporation"
+        $res.RepositorySourceLocation | Should -Be $PSGalleryUri
+    }
 }
 
 Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -240,6 +240,7 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $res.LicenseUri | Should -Be "https://aka.ms/azps-license"
         $res.ProjectUri | Should -Be "https://github.com/Azure/azure-powershell"
         $res.ReleaseNotes.Length | Should -Not -Be 0
+        $res.Tags.Length | Should -Be 5
     }
 
     It "Install script with companyname, copyright, and repository source location and validate" {

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -242,17 +242,6 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $res.ReleaseNotes.Length | Should -Not -Be 0
         $res.Tags.Length | Should -Be 5
     }
-
-    It "Install script with companyname, copyright, and repository source location and validate" {
-        Install-PSResource -Name "Install-VSCode" -Version "1.4.2" -Repository $PSGalleryName -TrustRepository
-
-        $res = Get-InstalledPSResource "Install-VSCode" -Version "1.4.2"
-        $res.Name | Should -Be "Install-VSCode"
-        $res.Version | Should -Be "1.4.2"
-        $res.CompanyName | Should -Be "Microsoft Corporation"
-        $res.Copyright | Should -Be "(c) Microsoft Corporation"
-        $res.RepositorySourceLocation | Should -Be $PSGalleryUri
-    }
 }
 
 Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {


### PR DESCRIPTION
Retrieve metadata properties when finding a PSResource from a ContainerRegistry repository. Previously the `Author`, `CompanyName`, `LicenseUri`, `ProjectUri`, and `IconUri`, `ReleaseNotes`, `Tags` were not being retrieved for the PSResource, but can be present in the manifest's PrivateData.PSData property.

### New tests:

* Added tests in `test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1` to validate the extraction of metadata properties such as `Author`, `CompanyName`, `LicenseUri`, `ProjectUri`, `ReleaseNotes`, and `Tags`.

Resolves #1608 
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
