### PR TITLE
Add SupportsWildcards attribute to -Repository of Install-PSResource

### DIFF
--- a/src/code/InstallPSResource.cs
+++ b/src/code/InstallPSResource.cs
@@ -17,15 +17,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
     /// The Install-PSResource cmdlet installs a resource.
     /// It returns nothing.
     /// </summary>
-    [Cmdlet(VerbsLifecycle.Install, 
-        "PSResource", 
-        DefaultParameterSetName = "NameParameterSet", 
+    [Cmdlet(VerbsLifecycle.Install,
+        "PSResource",
+        DefaultParameterSetName = "NameParameterSet",
         SupportsShouldProcess = true)]
     [Alias("isres")]
     public sealed
     class InstallPSResource : PSCmdlet
     {
-        #region Parameters 
+        #region Parameters
 
         /// <summary>
         /// Specifies the exact names of resources to install from a repository.
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         [Parameter(ParameterSetName = NameParameterSet, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
         public string Version { get; set; }
-        
+
         /// <summary>
         /// Specifies to allow installation of prerelease versions
         /// </summary>
@@ -53,6 +53,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Specifies the repositories from which to search for the resource to be installed.
         /// </summary>
+        [SupportsWildcards]
         [Parameter(ParameterSetName = NameParameterSet, ValueFromPipelineByPropertyName = true)]
         [Parameter(ParameterSetName = InputObjectParameterSet, ValueFromPipelineByPropertyName = true)]
         [ArgumentCompleter(typeof(RepositoryNameCompleter))]
@@ -83,9 +84,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             set
             {
-                if (WildcardPattern.ContainsWildcardCharacters(value)) 
-                { 
-                    throw new PSArgumentException("Wildcard characters are not allowed in the temporary path."); 
+                if (WildcardPattern.ContainsWildcardCharacters(value))
+                {
+                    throw new PSArgumentException("Wildcard characters are not allowed in the temporary path.");
                 }
 
                 // This will throw if path cannot be resolved
@@ -99,7 +100,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         [Parameter]
         public SwitchParameter TrustRepository { get; set; }
-        
+
         /// <summary>
         /// Overwrites a previously installed resource with the same name and version.
         /// </summary>
@@ -130,7 +131,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         [Parameter]
         public SwitchParameter SkipDependencyCheck { get; set; }
-        
+
         /// <summary>
         /// Check validation for signed and catalog files
         /// </summary>
@@ -287,7 +288,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         pkgCredential: Credential,
                         reqResourceParams: null);
                     break;
-                    
+
                 case InputObjectParameterSet:
                     foreach (var inputObj in InputObject) {
                         string normalizedVersionString = Utils.GetNormalizedVersionString(inputObj.Version.ToString(), inputObj.Prerelease);
@@ -362,7 +363,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             ErrorCategory.InvalidData,
                             this));
                     }
-                    
+
                     RequiredResourceHelper(pkgsInFile);
                     break;
 
@@ -379,7 +380,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                               }
                             }
                         */
-                                              
+
                         Hashtable pkgsHash = null;
                         try
                         {
@@ -441,7 +442,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     var pkgNameEmptyOrWhitespaceError = new ErrorRecord(
                         new ArgumentException($"The package name '{pkgName}' provided cannot be an empty string or whitespace."),
-                        "pkgNameEmptyOrWhitespaceError", 
+                        "pkgNameEmptyOrWhitespaceError",
                         ErrorCategory.InvalidArgument,
                         this);
 
@@ -454,7 +455,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     var requiredResourceHashtableInputFormatError = new ErrorRecord(
                         new ArgumentException($"The RequiredResource input with name '{pkgName}' does not have a valid value, the value must be a hashtable."),
-                        "RequiredResourceHashtableInputFormatError", 
+                        "RequiredResourceHashtableInputFormatError",
                         ErrorCategory.InvalidArgument,
                         this);
 
@@ -483,7 +484,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             ThrowTerminatingError(ParameterParsingError);
                         }
                     }
-                        
+
                     if (pkgParams.Scope == ScopeType.AllUsers)
                     {
                         _pathsToInstallPkg = Utils.GetAllInstallationPaths(this, pkgParams.Scope);
@@ -513,10 +514,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     "NameContainsWildcard",
                     ErrorCategory.InvalidArgument,
                     this));
-                    
+
                 return;
             }
-            
+
             foreach (string error in errorMsgs)
             {
                 WriteError(new ErrorRecord(


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR adds the `[SupportsWildcards]` attribute to the `-Repository` parameter of `Install-PSResource`. The parameter allows for wildcards but it was not marked. We need it to be marked so that PlatyPS will create the documentation correctly.

- Fixes #1705

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
