### PR TITLE
Bugfix for comparing file path name to determine exact match

### DIFF
--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1196,24 +1196,24 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                         if (string.Compare($"{packageName}.psd1", fileName, StringComparison.OrdinalIgnoreCase) == 0)
                         {
                             properCasingPkgName = Path.GetFileNameWithoutExtension(file);
+                            psd1FilePath = file;
                         }
-                        psd1FilePath = file;
                     }
                     else if (file.EndsWith("nuspec"))
                     {
                         if (string.Compare($"{packageName}.nuspec", fileName, StringComparison.OrdinalIgnoreCase) == 0)
                         {
                             properCasingPkgName = Path.GetFileNameWithoutExtension(file);
+                            nuspecFilePath = file;
                         }
-                        nuspecFilePath = file;
                     }
                     else if (file.EndsWith("ps1"))
                     {
                         if (string.Compare($"{packageName}.ps1", fileName, StringComparison.OrdinalIgnoreCase) == 0)
                         {
                             properCasingPkgName = Path.GetFileNameWithoutExtension(file);
+                            ps1FilePath = file;
                         }
-                        ps1FilePath = file;
                     }
                 }
             }

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -338,4 +338,15 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res.Version | Should -Be $nupkgVersion
         $res.Prerelease | Should -Be $prereleaseLabel
     }
+
+    It "find module that has multiple manifests and use exact name match one" {
+        # Az.KeyVault has 2 manifest files - Az.KeyVault.psd1 and Az.KeyVault.Extension.psd1
+        # this test was added because PSResourceGet would previously pick the .psd1 file by pattern matching the module name, not exact matching it
+        # this meant Az.KeyVault.Extension.psd1 and its metadata was being returned.
+        # The package is present on PSGallery but issue reproduces when looking at the package's file paths in local repo
+        $PSGalleryName = Get-PSGalleryName
+        Save-PSResource -Name 'Az.KeyVault' -Version '6.3.1' -Repository $PSGalleryName -AsNupkg -Path $localRepoUriAddress -TrustRepository
+        $res = Find-PSResource -Name 'Az.KeyVault' -Repository $localRepo
+        $res.Version | Should -Be "6.3.1"
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Utils.cs has GetMetadataFilesFromPath() that is used by the PublishPSResource and LocalServerApiCalls classes.

In that method we find files which match the package name such as the .psd1, .ps1, .nuspec files. It catches file names that match `packageName*`  but that includes files that should not be matched. For example, the Az.KeyVault package has 2 .psd1 files: `AzKeyVault.psd1` and `Az.KeyVault.Extension.psd1` and the latter was getting considered as a valid match. This PR fixes that. The `string.Compare()` method is already correctly determining if the filename is a correct match so the code to store that file path as a path of interest should happen in that condition set by `string.Compare()`
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves https://github.com/Azure/azure-powershell/issues/27535
Resolves #1837 #1762 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
