### PR TITLE
Request for catalog listing access for finding packages

### DIFF
--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -516,8 +516,6 @@ namespace Microsoft.PowerShell.PSResourceGet
                                 }
 
                                 anonymousAccessToken = results["access_token"].ToString();
-
-                                _cmdletPassedIn.WriteDebug("Anonymous access token retrieved");
                                 return true;
                             }
                         }
@@ -770,7 +768,7 @@ namespace Microsoft.PowerShell.PSResourceGet
                     if (!NuGetVersion.TryParse(pkgVersionString, out NuGetVersion pkgVersion))
                     {
                         errRecord = new ErrorRecord(
-                            new ArgumentException($"Version {pkgVersionString} to be parsed from metadata is not a valid NuGet version."),
+                            new ArgumentException($"Version {pkgVersionString} to be parsed from metadata is not a valid NuGet version for package '{packageName}'."),
                             "ParseMetadataFailure",
                             ErrorCategory.InvalidArgument,
                             this);
@@ -1775,7 +1773,7 @@ namespace Microsoft.PowerShell.PSResourceGet
                 if (!NuGetVersion.TryParse(pkgVersionString, out NuGetVersion pkgVersion))
                 {
                     errRecord = new ErrorRecord(
-                        new ArgumentException($"Version {pkgVersionString} to be parsed from metadata is not a valid NuGet version."),
+                        new ArgumentException($"Version {pkgVersionString} to be parsed from metadata is not a valid NuGet version for package '{packageName}'."),
                         "FindNameFailure",
                         ErrorCategory.InvalidArgument,
                         this);

--- a/src/code/PSRepositoryInfo.cs
+++ b/src/code/PSRepositoryInfo.cs
@@ -104,7 +104,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
         internal bool IsMARRepository()
         {
-            return (ApiVersion == APIVersion.ContainerRegistry && Uri.Host.Contains("mcr.microsoft.com"));
+            return (ApiVersion == APIVersion.ContainerRegistry && Uri.Host.StartsWith("mcr.microsoft") );
         }
 
         #endregion


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request introduces enhancements to the `ContainerRegistryServerAPICalls` class, focusing on improving the handling of access tokens, adding support for catalog-specific scopes, and refining error handling and debugging. The most significant changes include adding a `needCatalogAccess` parameter to methods dealing with authentication, updating templates for URL and content formatting, and improving debugging and error reporting.

### Authentication and Scopes:

* Added a `needCatalogAccess` parameter to the `GetContainerRegistryAccessToken` and `IsContainerRegistryUnauthenticated` methods to support catalog-specific access tokens. This allows finer control over authentication based on whether catalog access is needed. (`src/code/ContainerRegistryServerAPICalls.cs`, [[1]](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L374-R378) [[2]](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L447-R451)
* Updated string templates (`grantTypeTemplate` and `authUrlTemplate`) to dynamically include catalog scope when `needCatalogAccess` is true. (`src/code/ContainerRegistryServerAPICalls.cs`, [[1]](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046R50-R53) [[2]](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L485-R504)

### Error Handling and Debugging:

* Improved error handling in `FindPackagesWithVersionHelper` by skipping invalid NuGet package versions instead of returning `null`. Added debug logs to provide detailed information about skipped packages. (`src/code/ContainerRegistryServerAPICalls.cs`, [src/code/ContainerRegistryServerAPICalls.csL1764-R1781](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L1764-R1781))
* Enhanced debugging in `IsContainerRegistryUnauthenticated` to log error records when failing to retrieve anonymous access tokens. (`src/code/ContainerRegistryServerAPICalls.cs`, [src/code/ContainerRegistryServerAPICalls.csL485-R504](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L485-R504))

### Code Refinements:

* Updated `GetHttpResponseJObjectUsingContentHeaders` to ensure HTTP GET requests do not include a body, adhering to HTTP standards. (`src/code/ContainerRegistryServerAPICalls.cs`, [[1]](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046R996-R999) [[2]](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046R1020)

## PR Context

In some non-microsoft tenants, finding packages was not working.

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
