### PR TITLE
Fix catalog access

### DIFF
--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -516,8 +516,6 @@ namespace Microsoft.PowerShell.PSResourceGet
                                 }
 
                                 anonymousAccessToken = results["access_token"].ToString();
-
-                                _cmdletPassedIn.WriteDebug("Anonymous access token retrieved");
                                 return true;
                             }
                         }
@@ -770,7 +768,7 @@ namespace Microsoft.PowerShell.PSResourceGet
                     if (!NuGetVersion.TryParse(pkgVersionString, out NuGetVersion pkgVersion))
                     {
                         errRecord = new ErrorRecord(
-                            new ArgumentException($"Version {pkgVersionString} to be parsed from metadata is not a valid NuGet version."),
+                            new ArgumentException($"Version {pkgVersionString} to be parsed from metadata is not a valid NuGet version for package '{packageName}'."),
                             "ParseMetadataFailure",
                             ErrorCategory.InvalidArgument,
                             this);
@@ -1775,7 +1773,7 @@ namespace Microsoft.PowerShell.PSResourceGet
                 if (!NuGetVersion.TryParse(pkgVersionString, out NuGetVersion pkgVersion))
                 {
                     errRecord = new ErrorRecord(
-                        new ArgumentException($"Version {pkgVersionString} to be parsed from metadata is not a valid NuGet version."),
+                        new ArgumentException($"Version {pkgVersionString} to be parsed from metadata is not a valid NuGet version for package '{packageName}'."),
                         "FindNameFailure",
                         ErrorCategory.InvalidArgument,
                         this);

--- a/src/code/PSRepositoryInfo.cs
+++ b/src/code/PSRepositoryInfo.cs
@@ -104,7 +104,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
         internal bool IsMARRepository()
         {
-            return (ApiVersion == APIVersion.ContainerRegistry && Uri.Host.Contains("mcr.microsoft.com"));
+            return (ApiVersion == APIVersion.ContainerRegistry && Uri.Host.StartsWith("mcr.microsoft") );
         }
 
         #endregion


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request introduces enhancements and bug fixes to the `ContainerRegistryServerAPICalls` class, focusing on improving authentication flexibility, error handling, and debugging capabilities. The key changes include adding support for catalog-specific access tokens, refining error messages, and enhancing debug logging.

### Authentication Improvements:
* Added new constants (`catalogScope`, `grantTypeTemplate`, `authUrlTemplate`) to support catalog-specific access tokens for enhanced flexibility in authentication. (`[src/code/ContainerRegistryServerAPICalls.csR50-R53](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046R50-R53)`)
* Updated the `GetContainerRegistryAccessToken` method to accept a `needCatalogAccess` parameter, enabling conditional generation of access tokens based on catalog access requirements. (`[src/code/ContainerRegistryServerAPICalls.csL374-R378](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L374-R378)`)
* Enhanced the `IsContainerRegistryUnauthenticated` method to handle catalog-specific access tokens and adjust the request content and URL accordingly. (`[src/code/ContainerRegistryServerAPICalls.csL487-R508](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L487-R508)`)

### Debugging and Error Handling Enhancements:
* Improved debug logging in methods like `IsContainerRegistryUnauthenticated` to provide detailed error records and traceability during token retrieval failures. (`[[1]](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L487-R508)`, `[[2]](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L511)`)
* Refined error messages to include additional context, such as the package name, when NuGet version parsing fails. (`[[1]](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L764-R771)`, `[[2]](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L1763-R1783)`)
* Added a debug log and continuation logic to skip invalid package versions instead of terminating the process. (`[src/code/ContainerRegistryServerAPICalls.csL1763-R1783](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046L1763-R1783)`)

### Code Quality Improvements:
* Ensured HTTP GET requests in `GetHttpResponseJObjectUsingContentHeaders` do not include a body, aligning with HTTP standards. (`[[1]](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046R998-R1001)`, `[[2]](diffhunk://#diff-797089eb5a2953d0c9625b558ce132908a233a537c9b4131369a1e990a6b3046R1022)`)
* Updated the `IsMARRepository` method to use `StartsWith` instead of `Contains` for more precise matching of the repository host. (`[src/code/PSRepositoryInfo.csL107-R107](diffhunk://#diff-0fcf235bac601398fb6d19a998b56d615108c1995c57a94c0213686cc9c75fd3L107-R107)`)

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
