### PR TITLE
NuGet v3 dependencies - Fix #1840

### DIFF
--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -726,7 +726,8 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     {
                         foreach (
                             JsonElement dependencyGroup in dependencyGroupsElement.EnumerateArray().Where(
-                                x => !string.IsNullOrWhiteSpace(x.GetProperty("@id").GetString())
+                                x => x.TryGetProperty("id", out JsonElement idProperty) &&
+                                !string.IsNullOrWhiteSpace(idProperty.GetString())
                             )
                         )
                         {
@@ -736,7 +737,8 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                                 {
                                     foreach (
                                         JsonElement dependency in dependenciesElement.EnumerateArray().Where(
-                                            x => !string.IsNullOrWhiteSpace(x.GetProperty("@id").GetString())
+                                            x => x.TryGetProperty("id", out JsonElement idProperty) &&
+                                            !string.IsNullOrWhiteSpace(idProperty.GetString())
                                         )
                                     )
                                     {

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -724,12 +724,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
                     if (dependencyGroupsElement.ValueKind == JsonValueKind.Array)
                     {
-                        foreach (
-                            JsonElement dependencyGroup in dependencyGroupsElement.EnumerateArray().Where(
-                                x => x.TryGetProperty("id", out JsonElement idProperty) &&
-                                !string.IsNullOrWhiteSpace(idProperty.GetString())
-                            )
-                        )
+                        foreach (JsonElement dependencyGroup in dependencyGroupsElement.EnumerateArray())
                         {
                             if (dependencyGroup.TryGetProperty("dependencies", out JsonElement dependenciesElement))
                             {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

I wrongfully checked for property `@id` both in `dependencyGroups` and `dependencies`, but that property is not mandatory as pointed out by @fflaten.

This should fix #1840 by:

* Don't check for any property in `dependencyGroups`.
* Check for property `id` instead of `@id` for `dependencies`.

Tested like so:

```pwsh
# Build the project
& <project_root>\build.ps1 -Clean -Build -BuildFramework net472

# Import the built DLL
Import-Module -Name '<project_root>\out\Microsoft.PowerShell.PSResourceGet\Microsoft.PowerShell.PSResourceGet.dll'

# Register necessary resource repositories if not present
foreach ($Repository in 'pwsh.gallery', 'preview.pwsh.gallery') {
    if ((Get-PSResourceRepository).Where{$_.'Name' -eq $Repository}.'Count' -le 0) {
        Write-Information -InformationAction 'Continue' -MessageData (
            '"{0}" was not already registered.' -f $Repository
        )
        Register-PSResourceRepository -Name $Repository `
            -Uri ('https://{0}/index.json' -f $Repository) -ApiVersion 'v3' -Priority 60
    }
    else {
        Write-Information -InformationAction 'Continue' -MessageData (
            '"{0}" was already registered.' -f $Repository
        )
    }
}

# Find a package we know will have dependencies
## pwsh.gallery
(Find-PSResource -Repository 'pwsh.gallery' -Name 'Az').'Dependencies'
## preview.pwsh.gallery
(Find-PSResource -Repository 'preview.pwsh.gallery' -Name 'Az').'Dependencies'

# Check what Save-PSResource would do
Save-PSResource -Repository 'pwsh.gallery' -TrustRepository -Name 'Az' -WhatIf
```

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
