### PR TITLE
Fix 1811 by removing ToLower() from temp install path

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -454,7 +454,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             // If script, just move the files over, if module, move the version directory over
             var tempModuleVersionDir = (!isModule || isLocalRepo) ? dirNameVersion
-                : Path.Combine(tempInstallPath, pkgInfo.Name.ToLower(), newVersion);
+                : Path.Combine(tempInstallPath, pkgInfo.Name, newVersion);
 
             _cmdletPassedIn.WriteVerbose($"Installation source path is: '{tempModuleVersionDir}'");
             _cmdletPassedIn.WriteVerbose($"Installation destination path is: '{finalModuleVersionDir}'");
@@ -984,7 +984,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 // Expand the zip file
                 var pkgVersion = pkgToInstall.Version.ToString();
-                var tempDirNameVersion = Path.Combine(tempInstallPath, pkgName.ToLower(), pkgVersion);
+                var tempDirNameVersion = Path.Combine(tempInstallPath, pkgName, pkgVersion);
                 Directory.CreateDirectory(tempDirNameVersion);
 
                 if (!TryExtractToDirectory(pathToFile, tempDirNameVersion, out error))


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #1811 by removing ToLower() from temp install path.

Rationale: <https://github.com/PowerShell/PSResourceGet/issues/1811#issuecomment-3041236262>

* Final install path does not use ToLower()
* This sneaky problem would only fail on case sensitive file systems.

Test results on Pop!_OS 22.04:

<details><summary>Click to expand</summary>

```pwsh
PS /home/pop> $ErrorActionPreference = 'Continue'; $DebugPreference = 'Continue'; Install-PSResource -Scope 'CurrentUser' -TrustRepository -Name 'Microsoft.PowerShell.UnixTabCompletion'
DEBUG: In GetHelper::GetPackagesFromPath()
DEBUG: In GetHelper::FilterPkgPathsByName()
DEBUG: In GetHelper::FilterPkgPathsByVersion()
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.BootStrapper'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.BootStrapper'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.BootStrapper/1.0.1'
DEBUG: Package version parsed as NuGet version: '1.0.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.BootStrapper/1.0.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.HealthcareApis'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.HealthcareApis'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.HealthcareApis/2.0.0'
DEBUG: Package version parsed as NuGet version: '2.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.HealthcareApis/2.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az/11.4.0'
DEBUG: Package version parsed as NuGet version: '11.4.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az/11.4.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/ExchangeOnlineManagement'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/ExchangeOnlineManagement'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/ExchangeOnlineManagement/3.4.0'
DEBUG: Package version parsed as NuGet version: '3.4.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/ExchangeOnlineManagement/3.4.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Sql'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Sql'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Sql/4.14.0'
DEBUG: Package version parsed as NuGet version: '4.14.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Sql/4.14.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Files'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Files'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Files/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Files/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.NetAppFiles'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.NetAppFiles'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.NetAppFiles/0.15.1'
DEBUG: Package version parsed as NuGet version: '0.15.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.NetAppFiles/0.15.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.StorageSync'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.StorageSync'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.StorageSync/2.1.1'
DEBUG: Package version parsed as NuGet version: '2.1.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.StorageSync/2.1.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.LoadTesting'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.LoadTesting'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.LoadTesting/1.0.0'
DEBUG: Package version parsed as NuGet version: '1.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.LoadTesting/1.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Migration.Tool'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Migration.Tool'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Migration.Tool/1.1.0'
DEBUG: Package version parsed as NuGet version: '1.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Migration.Tool/1.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Elastic'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Elastic'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Elastic/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Elastic/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.CostManagement'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.CostManagement'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.CostManagement/0.3.1'
DEBUG: Package version parsed as NuGet version: '0.3.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.CostManagement/0.3.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Peering'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Peering'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Peering/0.4.0'
DEBUG: Package version parsed as NuGet version: '0.4.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Peering/0.4.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Reports'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Reports'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Reports/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Reports/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PSPKI'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PSPKI'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/PSPKI/4.2.0'
DEBUG: Package version parsed as NuGet version: '4.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/PSPKI/4.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Search'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Search'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Search/0.10.0'
DEBUG: Package version parsed as NuGet version: '0.10.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Search/0.10.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ImportExport'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ImportExport'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ImportExport/0.2.0'
DEBUG: Package version parsed as NuGet version: '0.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ImportExport/0.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PSReadLine'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PSReadLine'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/PSReadLine/2.3.4'
DEBUG: Package version parsed as NuGet version: '2.3.4'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/PSReadLine/2.3.4/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.AlertsManagement'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.AlertsManagement'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.AlertsManagement/0.6.1'
DEBUG: Package version parsed as NuGet version: '0.6.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.AlertsManagement/0.6.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Workspaces'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Workspaces'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Workspaces/1.2.1111'
DEBUG: Package version parsed as NuGet version: '1.2.1111'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Workspaces/1.2.1111/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.PowerBIEmbedded'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.PowerBIEmbedded'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.PowerBIEmbedded/2.0.0'
DEBUG: Package version parsed as NuGet version: '2.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.PowerBIEmbedded/2.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.PostgreSql'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.PostgreSql'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.PostgreSql/1.1.0'
DEBUG: Package version parsed as NuGet version: '1.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.PostgreSql/1.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Office365DnsChecker'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Office365DnsChecker'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Office365DnsChecker/2.0.1'
DEBUG: Package version parsed as NuGet version: '2.0.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Office365DnsChecker/2.0.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Profile'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Profile'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Profile/1.2.1111'
DEBUG: Package version parsed as NuGet version: '1.2.1111'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Profile/1.2.1111/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Mail'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Mail'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Mail/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Mail/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.SignalR'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.SignalR'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.SignalR/2.0.0'
DEBUG: Package version parsed as NuGet version: '2.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.SignalR/2.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DataProtection'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DataProtection'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DataProtection/2.2.0'
DEBUG: Package version parsed as NuGet version: '2.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DataProtection/2.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DataLakeAnalytics'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DataLakeAnalytics'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DataLakeAnalytics/1.0.3'
DEBUG: Package version parsed as NuGet version: '1.0.3'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DataLakeAnalytics/1.0.3/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/DefenderMAPS'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/DefenderMAPS'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/DefenderMAPS/1.0.3'
DEBUG: Package version parsed as NuGet version: '1.0.3'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/DefenderMAPS/1.0.3/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Devices.CorporateManagement'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Devices.CorporateManagement'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Devices.CorporateManagement/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Devices.CorporateManagement/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement.Actions'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement.Actions'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement.Actions/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement.Actions/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.RecoveryServices'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.RecoveryServices'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.RecoveryServices/6.7.1'
DEBUG: Package version parsed as NuGet version: '6.7.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.RecoveryServices/6.7.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Cdn'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Cdn'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Cdn/3.1.2'
DEBUG: Package version parsed as NuGet version: '3.1.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Cdn/3.1.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.HealthBot'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.HealthBot'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.HealthBot/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.HealthBot/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.EventHub'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.EventHub'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.EventHub/4.2.0'
DEBUG: Package version parsed as NuGet version: '4.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.EventHub/4.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/VSTeam'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/VSTeam'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/VSTeam/7.15.2'
DEBUG: Package version parsed as NuGet version: '7.15.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/VSTeam/7.15.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.SecretStore'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.SecretStore'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.SecretStore/1.0.6'
DEBUG: Package version parsed as NuGet version: '1.0.6'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.SecretStore/1.0.6/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Education'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Education'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Education/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Education/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Databricks'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Databricks'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Databricks/1.7.1'
DEBUG: Package version parsed as NuGet version: '1.7.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Databricks/1.7.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DataBox'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DataBox'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DataBox/0.3.0'
DEBUG: Package version parsed as NuGet version: '0.3.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DataBox/0.3.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Marketplace'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Marketplace'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Marketplace/0.4.0'
DEBUG: Package version parsed as NuGet version: '0.4.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Marketplace/0.4.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Tools.Predictor'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Tools.Predictor'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Tools.Predictor/1.1.3'
DEBUG: Package version parsed as NuGet version: '1.1.3'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Tools.Predictor/1.1.3/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Fleet'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Fleet'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Fleet/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Fleet/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DedicatedHsm'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DedicatedHsm'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DedicatedHsm/0.3.0'
DEBUG: Package version parsed as NuGet version: '0.3.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DedicatedHsm/0.3.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ResourceGraph'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ResourceGraph'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ResourceGraph/0.13.0'
DEBUG: Package version parsed as NuGet version: '0.13.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ResourceGraph/0.13.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Optimized.Mga.AzureAD'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Optimized.Mga.AzureAD'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Optimized.Mga.AzureAD/0.0.0.0'
DEBUG: Package version parsed as NuGet version: '0.0.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Optimized.Mga.AzureAD/0.0.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.ChangeNotifications'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.ChangeNotifications'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.ChangeNotifications/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.ChangeNotifications/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.HPCCache'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.HPCCache'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.HPCCache/0.1.1'
DEBUG: Package version parsed as NuGet version: '0.1.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.HPCCache/0.1.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.NetworkAnalytics'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.NetworkAnalytics'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.NetworkAnalytics/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.NetworkAnalytics/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Maps'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Maps'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Maps/0.8.0'
DEBUG: Package version parsed as NuGet version: '0.8.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Maps/0.8.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.VoiceServices'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.VoiceServices'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.VoiceServices/0.1.1'
DEBUG: Package version parsed as NuGet version: '0.1.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.VoiceServices/0.1.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.StorageMover'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.StorageMover'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.StorageMover/1.3.0'
DEBUG: Package version parsed as NuGet version: '1.3.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.StorageMover/1.3.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Portal'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Portal'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Portal/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Portal/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ConfidentialLedger'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ConfidentialLedger'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ConfidentialLedger/1.0.0'
DEBUG: Package version parsed as NuGet version: '1.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ConfidentialLedger/1.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.CrossDeviceExperiences'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.CrossDeviceExperiences'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.CrossDeviceExperiences/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.CrossDeviceExperiences/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.TimeSeriesInsights'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.TimeSeriesInsights'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.TimeSeriesInsights/0.2.0'
DEBUG: Package version parsed as NuGet version: '0.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.TimeSeriesInsights/0.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Nevergreen'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Nevergreen'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Nevergreen/2402.1'
DEBUG: Package version parsed as NuGet version: '2402.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Nevergreen/2402.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Reports'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Reports'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Reports/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Reports/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MarketplaceOrdering'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MarketplaceOrdering'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.MarketplaceOrdering/2.0.0'
DEBUG: Package version parsed as NuGet version: '2.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.MarketplaceOrdering/2.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Billing'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Billing'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Billing/2.0.3'
DEBUG: Package version parsed as NuGet version: '2.0.3'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Billing/2.0.3/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.SchemaExtensions'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.SchemaExtensions'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.SchemaExtensions/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.SchemaExtensions/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement.Administration'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement.Administration'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement.Administration/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement.Administration/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.CosmosDB'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.CosmosDB'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.CosmosDB/1.14.1'
DEBUG: Package version parsed as NuGet version: '1.14.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.CosmosDB/1.14.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PSWindowsUpdate'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PSWindowsUpdate'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/PSWindowsUpdate/2.2.1.4'
DEBUG: Package version parsed as NuGet version: '2.2.1.4'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/PSWindowsUpdate/2.2.1.4/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Optimized.Mga.Mail'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Optimized.Mga.Mail'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Optimized.Mga.Mail/0.0.0.0'
DEBUG: Package version parsed as NuGet version: '0.0.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Optimized.Mga.Mail/0.0.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DiskPool'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DiskPool'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DiskPool/0.3.0'
DEBUG: Package version parsed as NuGet version: '0.3.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DiskPool/0.3.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Optimized.Mga'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Optimized.Mga'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Optimized.Mga/4.0.0'
DEBUG: Package version parsed as NuGet version: '4.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Optimized.Mga/4.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Financials'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Financials'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Financials/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Financials/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Users.Functions'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Users.Functions'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Users.Functions/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Users.Functions/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DeviceUpdate'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DeviceUpdate'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DeviceUpdate/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DeviceUpdate/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.PersonalContacts'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.PersonalContacts'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.PersonalContacts/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.PersonalContacts/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Optimized.Mga.Report'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Optimized.Mga.Report'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Optimized.Mga.Report/0.0.0.3'
DEBUG: Package version parsed as NuGet version: '0.0.0.3'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Optimized.Mga.Report/0.0.0.3/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/WinGet'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/WinGet'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/WinGet/0.0.8'
DEBUG: Package version parsed as NuGet version: '0.0.8'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/WinGet/0.0.8/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/IntuneBackupAndRestore'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/IntuneBackupAndRestore'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/IntuneBackupAndRestore/3.2.0'
DEBUG: Package version parsed as NuGet version: '3.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/IntuneBackupAndRestore/3.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.ManagedTenants'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.ManagedTenants'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.ManagedTenants/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.ManagedTenants/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.KeyVault'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.KeyVault'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.KeyVault/5.2.1'
DEBUG: Package version parsed as NuGet version: '5.2.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.KeyVault/5.2.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt/1.2.1111'
DEBUG: Package version parsed as NuGet version: '1.2.1111'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt/1.2.1111/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Compute.ManagedService'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Compute.ManagedService'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Compute.ManagedService/0.7.0'
DEBUG: Package version parsed as NuGet version: '0.7.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Compute.ManagedService/0.7.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.NewRelic'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.NewRelic'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.NewRelic/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.NewRelic/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.CognitiveServices'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.CognitiveServices'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.CognitiveServices/1.14.1'
DEBUG: Package version parsed as NuGet version: '1.14.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.CognitiveServices/1.14.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Sites'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Sites'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Sites/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Sites/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ApplicationMonitor'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ApplicationMonitor'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ApplicationMonitor/2.0.0'
DEBUG: Package version parsed as NuGet version: '2.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ApplicationMonitor/2.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Users.Functions'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Users.Functions'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Users.Functions/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Users.Functions/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DataMigration'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DataMigration'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DataMigration/0.14.4'
DEBUG: Package version parsed as NuGet version: '0.14.4'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DataMigration/0.14.4/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.NetworkCloud'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.NetworkCloud'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.NetworkCloud/1.0.0'
DEBUG: Package version parsed as NuGet version: '1.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.NetworkCloud/1.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Workloads'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Workloads'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Workloads/0.1.1'
DEBUG: Package version parsed as NuGet version: '0.1.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Workloads/0.1.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Admin'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Admin'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Admin/1.2.1111'
DEBUG: Package version parsed as NuGet version: '1.2.1111'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Admin/1.2.1111/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PSSemVer'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PSSemVer'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/PSSemVer/1.0.5'
DEBUG: Package version parsed as NuGet version: '1.0.5'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/PSSemVer/1.0.5/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ContainerRegistry'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ContainerRegistry'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ContainerRegistry/4.1.3'
DEBUG: Package version parsed as NuGet version: '4.1.3'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ContainerRegistry/4.1.3/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MSGraphFunctions'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MSGraphFunctions'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/MSGraphFunctions/2.5.0'
DEBUG: Package version parsed as NuGet version: '2.5.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/MSGraphFunctions/2.5.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MachineLearningCompute'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MachineLearningCompute'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.MachineLearningCompute/0.7.0'
DEBUG: Package version parsed as NuGet version: '0.7.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.MachineLearningCompute/0.7.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ServiceFabric'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ServiceFabric'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ServiceFabric/3.3.2'
DEBUG: Package version parsed as NuGet version: '3.3.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ServiceFabric/3.3.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/AzSK.AzureDevOps'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/AzSK.AzureDevOps'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/AzSK.AzureDevOps/0.9.15'
DEBUG: Package version parsed as NuGet version: '0.9.15'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/AzSK.AzureDevOps/0.9.15/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Functions'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Functions'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Functions/4.0.7'
DEBUG: Package version parsed as NuGet version: '4.0.7'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Functions/4.0.7/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Users.Actions'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Users.Actions'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Users.Actions/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Users.Actions/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.WindowsUpdates'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.WindowsUpdates'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.WindowsUpdates/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.WindowsUpdates/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Users.Actions'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Users.Actions'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Users.Actions/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Users.Actions/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.IotCentral'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.IotCentral'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.IotCentral/0.10.0'
DEBUG: Package version parsed as NuGet version: '0.10.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.IotCentral/0.10.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MachineLearning'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MachineLearning'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.MachineLearning/1.1.3'
DEBUG: Package version parsed as NuGet version: '1.1.3'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.MachineLearning/1.1.3/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Datadog'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Datadog'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Datadog/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Datadog/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.ChangeNotifications'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.ChangeNotifications'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.ChangeNotifications/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.ChangeNotifications/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DeviceProvisioningServices'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DeviceProvisioningServices'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DeviceProvisioningServices/0.10.0'
DEBUG: Package version parsed as NuGet version: '0.10.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DeviceProvisioningServices/0.10.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.FluidRelay'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.FluidRelay'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.FluidRelay/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.FluidRelay/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement.Actions'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement.Actions'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement.Actions/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement.Actions/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.SecretManagement'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.SecretManagement'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.SecretManagement/1.1.2'
DEBUG: Package version parsed as NuGet version: '1.1.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.SecretManagement/1.1.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PoshRSJob'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PoshRSJob'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/PoshRSJob/1.7.4.4'
DEBUG: Package version parsed as NuGet version: '1.7.4.4'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/PoshRSJob/1.7.4.4/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DataFactory'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DataFactory'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DataFactory/1.18.3'
DEBUG: Package version parsed as NuGet version: '1.18.3'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DataFactory/1.18.3/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Compliance'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Compliance'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Compliance/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Compliance/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Capacities'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Capacities'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Capacities/1.2.1111'
DEBUG: Package version parsed as NuGet version: '1.2.1111'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Capacities/1.2.1111/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Batch'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Batch'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Batch/3.5.0'
DEBUG: Package version parsed as NuGet version: '3.5.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Batch/3.5.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DigitalTwins'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DigitalTwins'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DigitalTwins/0.2.0'
DEBUG: Package version parsed as NuGet version: '0.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DigitalTwins/0.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.BotService'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.BotService'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.BotService/0.5.0'
DEBUG: Package version parsed as NuGet version: '0.5.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.BotService/0.5.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Media'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Media'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Media/1.1.2'
DEBUG: Package version parsed as NuGet version: '1.1.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Media/1.1.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Identity.Governance'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Identity.Governance'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Identity.Governance/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Identity.Governance/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Support'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Support'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Support/1.0.0'
DEBUG: Package version parsed as NuGet version: '1.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Support/1.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Qumulo'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Qumulo'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Qumulo/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Qumulo/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Mail'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Mail'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Mail/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Mail/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/AWSPowerShell.NetCore'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/AWSPowerShell.NetCore'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/AWSPowerShell.NetCore/4.1.545'
DEBUG: Package version parsed as NuGet version: '4.1.545'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/AWSPowerShell.NetCore/4.1.545/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.PSResourceGet'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.PSResourceGet'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.PSResourceGet/1.0.3'
DEBUG: Package version parsed as NuGet version: '1.0.3'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.PSResourceGet/1.0.3/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.KubernetesConfiguration'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.KubernetesConfiguration'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.KubernetesConfiguration/0.7.0'
DEBUG: Package version parsed as NuGet version: '0.7.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.KubernetesConfiguration/0.7.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.EventGrid'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.EventGrid'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.EventGrid/1.6.0'
DEBUG: Package version parsed as NuGet version: '1.6.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.EventGrid/1.6.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DevTestLabs'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DevTestLabs'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DevTestLabs/1.0.2'
DEBUG: Package version parsed as NuGet version: '1.0.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DevTestLabs/1.0.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Ssh'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Ssh'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Ssh/0.2.0'
DEBUG: Package version parsed as NuGet version: '0.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Ssh/0.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Compliance'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Compliance'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Compliance/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Compliance/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/JWTDetails'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/JWTDetails'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/JWTDetails/1.0.2'
DEBUG: Package version parsed as NuGet version: '1.0.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/JWTDetails/1.0.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ADDomainServices'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ADDomainServices'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ADDomainServices/0.2.0'
DEBUG: Package version parsed as NuGet version: '0.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ADDomainServices/0.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.RDInfra.RDPowershell'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.RDInfra.RDPowershell'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.RDInfra.RDPowershell/1.0.3414.0'
DEBUG: Package version parsed as NuGet version: '1.0.3414.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.RDInfra.RDPowershell/1.0.3414.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.EdgeOrder'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.EdgeOrder'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.EdgeOrder/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.EdgeOrder/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.FirmwareAnalysis'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.FirmwareAnalysis'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.FirmwareAnalysis/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.FirmwareAnalysis/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/AzSK'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/AzSK'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/AzSK/4.16.0'
DEBUG: Package version parsed as NuGet version: '4.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/AzSK/4.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.PrivateDns'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.PrivateDns'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.PrivateDns/1.0.4'
DEBUG: Package version parsed as NuGet version: '1.0.4'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.PrivateDns/1.0.4/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Files'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Files'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Files/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Files/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.StackHCI'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.StackHCI'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.StackHCI/2.3.1'
DEBUG: Package version parsed as NuGet version: '2.3.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.StackHCI/2.3.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/AIPService'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/AIPService'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/AIPService/3.0.0.1'
DEBUG: Package version parsed as NuGet version: '3.0.0.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/AIPService/3.0.0.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PolicyFileEditor'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PolicyFileEditor'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/PolicyFileEditor/3.0.1'
DEBUG: Package version parsed as NuGet version: '3.0.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/PolicyFileEditor/3.0.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PSScriptAnalyzer'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PSScriptAnalyzer'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/PSScriptAnalyzer/1.22.0'
DEBUG: Package version parsed as NuGet version: '1.22.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/PSScriptAnalyzer/1.22.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/platyPS'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/platyPS'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/platyPS/0.14.2'
DEBUG: Package version parsed as NuGet version: '0.14.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/platyPS/0.14.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.PersonalContacts'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.PersonalContacts'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.PersonalContacts/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.PersonalContacts/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Reports'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Reports'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Reports/1.2.1111'
DEBUG: Package version parsed as NuGet version: '1.2.1111'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Reports/1.2.1111/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.People'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.People'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.People/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.People/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DataLakeStore'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DataLakeStore'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DataLakeStore/1.3.0'
DEBUG: Package version parsed as NuGet version: '1.3.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DataLakeStore/1.3.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MobileNetwork'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MobileNetwork'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.MobileNetwork/0.3.0'
DEBUG: Package version parsed as NuGet version: '0.3.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.MobileNetwork/0.3.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/powershell-yaml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/powershell-yaml'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/powershell-yaml/0.4.7'
DEBUG: Package version parsed as NuGet version: '0.4.7'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/powershell-yaml/0.4.7/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MariaDb'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MariaDb'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.MariaDb/0.2.1'
DEBUG: Package version parsed as NuGet version: '0.2.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.MariaDb/0.2.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Online.SharePoint.PowerShell'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Online.SharePoint.PowerShell'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Online.SharePoint.PowerShell/16.0.24614.12000'
DEBUG: Package version parsed as NuGet version: '16.0.24614.12000'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Online.SharePoint.PowerShell/16.0.24614.12000/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.SelfHelp'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.SelfHelp'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.SelfHelp/0.1.1'
DEBUG: Package version parsed as NuGet version: '0.1.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.SelfHelp/0.1.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ImageBuilder'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ImageBuilder'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ImageBuilder/0.4.0'
DEBUG: Package version parsed as NuGet version: '0.4.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ImageBuilder/0.4.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.VMware'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.VMware'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.VMware/0.6.0'
DEBUG: Package version parsed as NuGet version: '0.6.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.VMware/0.6.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Intune.USB.Creator'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Intune.USB.Creator'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Intune.USB.Creator/1.0.1.315'
DEBUG: Package version parsed as NuGet version: '1.0.1.315'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Intune.USB.Creator/1.0.1.315/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DnsResolver'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DnsResolver'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DnsResolver/0.2.1'
DEBUG: Package version parsed as NuGet version: '0.2.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DnsResolver/0.2.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/AzViz'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/AzViz'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/AzViz/1.2.1'
DEBUG: Package version parsed as NuGet version: '1.2.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/AzViz/1.2.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Relay'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Relay'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Relay/2.0.0'
DEBUG: Package version parsed as NuGet version: '2.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Relay/2.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Alb'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Alb'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Alb/0.1.1'
DEBUG: Package version parsed as NuGet version: '0.1.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Alb/0.1.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Mailozaurr'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Mailozaurr'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Mailozaurr/1.0.2'
DEBUG: Package version parsed as NuGet version: '1.0.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Mailozaurr/1.0.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.NetworkFunction'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.NetworkFunction'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.NetworkFunction/0.1.2'
DEBUG: Package version parsed as NuGet version: '0.1.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.NetworkFunction/0.1.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Users'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Users'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Users/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Users/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Migrate'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Migrate'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Migrate/2.3.0'
DEBUG: Package version parsed as NuGet version: '2.3.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Migrate/2.3.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ConnectedMachine'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ConnectedMachine'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ConnectedMachine/0.7.0'
DEBUG: Package version parsed as NuGet version: '0.7.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ConnectedMachine/0.7.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Planner'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Planner'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Planner/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Planner/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Identity.Governance'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Identity.Governance'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Identity.Governance/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Identity.Governance/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DesktopVirtualization'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DesktopVirtualization'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DesktopVirtualization/4.3.0'
DEBUG: Package version parsed as NuGet version: '4.3.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DesktopVirtualization/4.3.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.GraphServices'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.GraphServices'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.GraphServices/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.GraphServices/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.SchemaExtensions'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.SchemaExtensions'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.SchemaExtensions/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.SchemaExtensions/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.NotificationHubs'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.NotificationHubs'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.NotificationHubs/1.1.2'
DEBUG: Package version parsed as NuGet version: '1.1.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.NotificationHubs/1.1.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Attestation'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Attestation'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Attestation/2.0.0'
DEBUG: Package version parsed as NuGet version: '2.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Attestation/2.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Calendar'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Calendar'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Calendar/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Calendar/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/WindowsAutoPilotIntune'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/WindowsAutoPilotIntune'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/WindowsAutoPilotIntune/5.6'
DEBUG: Package version parsed as NuGet version: '5.6'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/WindowsAutoPilotIntune/5.6/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PSIntuneAuth'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PSIntuneAuth'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/PSIntuneAuth/1.2.3'
DEBUG: Package version parsed as NuGet version: '1.2.3'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/PSIntuneAuth/1.2.3/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Security'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Security'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Security/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Security/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ProviderHub'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ProviderHub'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ProviderHub/0.2.0'
DEBUG: Package version parsed as NuGet version: '0.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ProviderHub/0.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DevCenter'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DevCenter'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DevCenter/1.1.0'
DEBUG: Package version parsed as NuGet version: '1.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DevCenter/1.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Applications'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Applications'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Applications/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Applications/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Aks'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Aks'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Aks/6.0.1'
DEBUG: Package version parsed as NuGet version: '6.0.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Aks/6.0.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftTeams'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftTeams'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/MicrosoftTeams/6.0.0'
DEBUG: Package version parsed as NuGet version: '6.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/MicrosoftTeams/6.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ManagedServiceIdentity'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ManagedServiceIdentity'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ManagedServiceIdentity/1.2.0'
DEBUG: Package version parsed as NuGet version: '1.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ManagedServiceIdentity/1.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.StreamAnalytics'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.StreamAnalytics'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.StreamAnalytics/2.0.0'
DEBUG: Package version parsed as NuGet version: '2.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.StreamAnalytics/2.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ManagementPartner'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ManagementPartner'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ManagementPartner/0.7.3'
DEBUG: Package version parsed as NuGet version: '0.7.3'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ManagementPartner/0.7.3/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/SharePointPnPPowerShellOnline'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/SharePointPnPPowerShellOnline'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/SharePointPnPPowerShellOnline/3.29.2101.0'
DEBUG: Package version parsed as NuGet version: '3.29.2101.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/SharePointPnPPowerShellOnline/3.29.2101.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.BillingBenefits'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.BillingBenefits'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.BillingBenefits/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.BillingBenefits/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.PolicyInsights'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.PolicyInsights'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.PolicyInsights/1.6.4'
DEBUG: Package version parsed as NuGet version: '1.6.4'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.PolicyInsights/1.6.4/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.HdInsightOnAks'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.HdInsightOnAks'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.HdInsightOnAks/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.HdInsightOnAks/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Confluent'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Confluent'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Confluent/0.2.0'
DEBUG: Package version parsed as NuGet version: '0.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Confluent/0.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ManagedNetworkFabric'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ManagedNetworkFabric'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ManagedNetworkFabric/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ManagedNetworkFabric/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MachineLearningServices'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MachineLearningServices'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.MachineLearningServices/1.0.0'
DEBUG: Package version parsed as NuGet version: '1.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.MachineLearningServices/1.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ServiceLinker'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ServiceLinker'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ServiceLinker/0.2.0'
DEBUG: Package version parsed as NuGet version: '0.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ServiceLinker/0.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.OperationalInsights'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.OperationalInsights'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.OperationalInsights/3.2.0'
DEBUG: Package version parsed as NuGet version: '3.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.OperationalInsights/3.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Tools.Installer'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Tools.Installer'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Tools.Installer/1.0.0'
DEBUG: Package version parsed as NuGet version: '1.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Tools.Installer/1.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.LabServices'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.LabServices'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.LabServices/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.LabServices/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DirectoryObjects'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DirectoryObjects'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DirectoryObjects/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DirectoryObjects/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Search'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Search'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Search/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Search/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Automanage'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Automanage'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Automanage/1.0.0'
DEBUG: Package version parsed as NuGet version: '1.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Automanage/1.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DeploymentManager'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DeploymentManager'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DeploymentManager/1.1.0'
DEBUG: Package version parsed as NuGet version: '1.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DeploymentManager/1.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Notes'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Notes'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Notes/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Notes/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DirectoryObjects'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DirectoryObjects'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DirectoryObjects/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DirectoryObjects/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftGraphSecurity'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftGraphSecurity'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/MicrosoftGraphSecurity/1.0.0'
DEBUG: Package version parsed as NuGet version: '1.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/MicrosoftGraphSecurity/1.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ElasticSan'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ElasticSan'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ElasticSan/1.0.0'
DEBUG: Package version parsed as NuGet version: '1.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ElasticSan/1.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/SetBIOS'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/SetBIOS'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/SetBIOS/1.0'
DEBUG: Package version parsed as NuGet version: '1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/SetBIOS/1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Groups'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Groups'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Groups/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Groups/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MySql'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MySql'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.MySql/1.1.1'
DEBUG: Package version parsed as NuGet version: '1.1.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.MySql/1.1.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Education'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Education'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Education/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Education/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.AnalysisServices'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.AnalysisServices'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.AnalysisServices/1.1.4'
DEBUG: Package version parsed as NuGet version: '1.1.4'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.AnalysisServices/1.1.4/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PartnerCenter.NetCore'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PartnerCenter.NetCore'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/PartnerCenter.NetCore/1.5.1908.1'
DEBUG: Package version parsed as NuGet version: '1.5.1908.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/PartnerCenter.NetCore/1.5.1908.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Devices.ServiceAnnouncement'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Devices.ServiceAnnouncement'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Devices.ServiceAnnouncement/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Devices.ServiceAnnouncement/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Groups'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Groups'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Groups/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Groups/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ApiManagement'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ApiManagement'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ApiManagement/4.0.2'
DEBUG: Package version parsed as NuGet version: '4.0.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ApiManagement/4.0.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.RedisEnterpriseCache'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.RedisEnterpriseCache'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.RedisEnterpriseCache/1.2.0'
DEBUG: Package version parsed as NuGet version: '1.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.RedisEnterpriseCache/1.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PSPackageProject'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PSPackageProject'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/PSPackageProject/0.1.18'
DEBUG: Package version parsed as NuGet version: '0.1.18'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/PSPackageProject/0.1.18/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement.Functions'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement.Functions'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement.Functions/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement.Functions/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Identity.DirectoryManagement'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Identity.DirectoryManagement'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Identity.DirectoryManagement/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Identity.DirectoryManagement/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.WindowsIotServices'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.WindowsIotServices'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.WindowsIotServices/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.WindowsIotServices/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Identity.SignIns'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Identity.SignIns'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Identity.SignIns/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Identity.SignIns/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Blueprint'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Blueprint'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Blueprint/0.4.2'
DEBUG: Package version parsed as NuGet version: '0.4.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Blueprint/0.4.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Quota'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Quota'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Quota/0.1.1'
DEBUG: Package version parsed as NuGet version: '0.1.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Quota/0.1.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Identity.Partner'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Identity.Partner'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Identity.Partner/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Identity.Partner/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.CodeSigning'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.CodeSigning'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.CodeSigning/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.CodeSigning/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.SpringCloud'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.SpringCloud'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.SpringCloud/0.3.1'
DEBUG: Package version parsed as NuGet version: '0.3.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.SpringCloud/0.3.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Identity.DirectoryManagement'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Identity.DirectoryManagement'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Identity.DirectoryManagement/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Identity.DirectoryManagement/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/newtonsoft.json'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/newtonsoft.json'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/newtonsoft.json/1.0.2.201'
DEBUG: Package version parsed as NuGet version: '1.0.2.201'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/newtonsoft.json/1.0.2.201/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Devices.ServiceAnnouncement'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Devices.ServiceAnnouncement'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Devices.ServiceAnnouncement/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Devices.ServiceAnnouncement/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Users'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Users'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Users/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Users/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.SecurityInsights'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.SecurityInsights'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.SecurityInsights/3.1.1'
DEBUG: Package version parsed as NuGet version: '3.1.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.SecurityInsights/3.1.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/AzSK.AAD'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/AzSK.AAD'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/AzSK.AAD/1.0.1'
DEBUG: Package version parsed as NuGet version: '1.0.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/AzSK.AAD/1.0.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ArcResourceBridge'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ArcResourceBridge'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ArcResourceBridge/1.0.0'
DEBUG: Package version parsed as NuGet version: '1.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ArcResourceBridge/1.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Accounts'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Accounts'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Accounts/5.1.1'
DEBUG: Package version parsed as NuGet version: '5.1.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Accounts/5.1.1/PSGetModuleInfo.xml'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Accounts/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Accounts/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/RunAsUser'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/RunAsUser'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/RunAsUser/2.4.0'
DEBUG: Package version parsed as NuGet version: '2.4.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/RunAsUser/2.4.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Reservations'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Reservations'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Reservations/0.12.0'
DEBUG: Package version parsed as NuGet version: '0.12.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Reservations/0.12.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/SpeculationControl'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/SpeculationControl'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/SpeculationControl/1.0.18'
DEBUG: Package version parsed as NuGet version: '1.0.18'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/SpeculationControl/1.0.18/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ConnectedKubernetes'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ConnectedKubernetes'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ConnectedKubernetes/0.10.1'
DEBUG: Package version parsed as NuGet version: '0.10.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ConnectedKubernetes/0.10.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Search'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Search'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Search/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Search/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.TrafficManager'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.TrafficManager'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.TrafficManager/1.2.2'
DEBUG: Package version parsed as NuGet version: '1.2.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.TrafficManager/1.2.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Applications'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Applications'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Applications/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Applications/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.IotHub'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.IotHub'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.IotHub/2.7.5'
DEBUG: Package version parsed as NuGet version: '2.7.5'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.IotHub/2.7.5/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ChangeAnalysis'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ChangeAnalysis'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ChangeAnalysis/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ChangeAnalysis/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ManagedServices'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ManagedServices'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ManagedServices/3.0.0'
DEBUG: Package version parsed as NuGet version: '3.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ManagedServices/3.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MonitoringSolutions'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MonitoringSolutions'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.MonitoringSolutions/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.MonitoringSolutions/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Tools.Migration'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Tools.Migration'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Tools.Migration/11.0.2'
DEBUG: Package version parsed as NuGet version: '11.0.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Tools.Migration/11.0.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Storage'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Storage'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Storage/6.1.2'
DEBUG: Package version parsed as NuGet version: '6.1.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Storage/6.1.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ResourceMover'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ResourceMover'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ResourceMover/1.2.0'
DEBUG: Package version parsed as NuGet version: '1.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ResourceMover/1.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.WinGet.Client'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.WinGet.Client'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.WinGet.Client/1.9.25190'
DEBUG: Package version parsed as NuGet version: '1.9.25190'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.WinGet.Client/1.9.25190/PSGetModuleInfo.xml'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.WinGet.Client/1.7.10661'
DEBUG: Package version parsed as NuGet version: '1.7.10661'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.WinGet.Client/1.7.10661/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/EnterprisePolicyAsCode'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/EnterprisePolicyAsCode'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/EnterprisePolicyAsCode/9.1.5'
DEBUG: Package version parsed as NuGet version: '9.1.5'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/EnterprisePolicyAsCode/9.1.5/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PnP.PowerShell'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PnP.PowerShell'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/PnP.PowerShell/2.4.0'
DEBUG: Package version parsed as NuGet version: '2.4.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/PnP.PowerShell/2.4.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement.Enrollment'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement.Enrollment'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement.Enrollment/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement.Enrollment/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Resources'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Resources'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Resources/6.16.0'
DEBUG: Package version parsed as NuGet version: '6.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Resources/6.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DynatraceObservability'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DynatraceObservability'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DynatraceObservability/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DynatraceObservability/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.ThreadJob'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.ThreadJob'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.ThreadJob/2.1.0'
DEBUG: Package version parsed as NuGet version: '2.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.ThreadJob/2.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.CrossDeviceExperiences'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.CrossDeviceExperiences'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.CrossDeviceExperiences/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.CrossDeviceExperiences/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MSOnline'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MSOnline'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/MSOnline/1.1.183.81'
DEBUG: Package version parsed as NuGet version: '1.1.183.81'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/MSOnline/1.1.183.81/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ConnectedNetwork'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ConnectedNetwork'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ConnectedNetwork/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ConnectedNetwork/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.CustomLocation'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.CustomLocation'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.CustomLocation/0.1.1'
DEBUG: Package version parsed as NuGet version: '0.1.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.CustomLocation/0.1.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.BareMetal'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.BareMetal'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.BareMetal/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.BareMetal/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.StackEdge'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.StackEdge'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.StackEdge/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.StackEdge/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.HanaOnAzure'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.HanaOnAzure'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.HanaOnAzure/0.3.0'
DEBUG: Package version parsed as NuGet version: '0.3.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.HanaOnAzure/0.3.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Compute'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Compute'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Compute/7.1.2'
DEBUG: Package version parsed as NuGet version: '7.1.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Compute/7.1.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Planner'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Planner'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Planner/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Planner/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Identity.SignIns'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Identity.SignIns'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Identity.SignIns/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Identity.SignIns/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Dashboard'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Dashboard'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Dashboard/0.1.1'
DEBUG: Package version parsed as NuGet version: '0.1.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Dashboard/0.1.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Devices.CloudPrint'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Devices.CloudPrint'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Devices.CloudPrint/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Devices.CloudPrint/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement.Enrollment'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement.Enrollment'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement.Enrollment/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement.Enrollment/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Quantum'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Quantum'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Quantum/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Quantum/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Maintenance'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Maintenance'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Maintenance/1.4.1'
DEBUG: Package version parsed as NuGet version: '1.4.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Maintenance/1.4.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Teams'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Teams'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Teams/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Teams/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Cobalt'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Cobalt'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Cobalt/0.2.0'
DEBUG: Package version parsed as NuGet version: '0.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Cobalt/0.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.FrontDoor'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.FrontDoor'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.FrontDoor/1.10.0'
DEBUG: Package version parsed as NuGet version: '1.10.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.FrontDoor/1.10.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Authentication'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Authentication'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Authentication/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Authentication/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/AzSK.ADO'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/AzSK.ADO'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/AzSK.ADO/1.22.0'
DEBUG: Package version parsed as NuGet version: '1.22.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/AzSK.ADO/1.22.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.ConsoleGuiTools'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.ConsoleGuiTools'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.ConsoleGuiTools/0.7.6.0'
DEBUG: Package version parsed as NuGet version: '0.7.6.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.PowerShell.ConsoleGuiTools/0.7.6.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.App'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.App'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.App/1.0.0'
DEBUG: Package version parsed as NuGet version: '1.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.App/1.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Teams'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Teams'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Teams/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Teams/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PSSendGrid'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PSSendGrid'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/PSSendGrid/0.4.1'
DEBUG: Package version parsed as NuGet version: '0.4.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/PSSendGrid/0.4.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.CloudService'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.CloudService'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.CloudService/2.0.0'
DEBUG: Package version parsed as NuGet version: '2.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.CloudService/2.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Identity.Partner'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Identity.Partner'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Identity.Partner/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Identity.Partner/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.CustomProviders'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.CustomProviders'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.CustomProviders/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.CustomProviders/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MixedReality'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.MixedReality'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.MixedReality/0.2.0'
DEBUG: Package version parsed as NuGet version: '0.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.MixedReality/0.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Bookings'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Bookings'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Bookings/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Bookings/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.CloudCommunications'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.CloudCommunications'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.CloudCommunications/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.CloudCommunications/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Security'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Security'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Security/1.6.0'
DEBUG: Package version parsed as NuGet version: '1.6.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Security/1.6.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.CloudCommunications'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.CloudCommunications'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.CloudCommunications/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.CloudCommunications/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.HDInsight'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.HDInsight'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.HDInsight/6.1.0'
DEBUG: Package version parsed as NuGet version: '6.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.HDInsight/6.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Data'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Data'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Data/1.2.1111'
DEBUG: Package version parsed as NuGet version: '1.2.1111'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/MicrosoftPowerBIMgmt.Data/1.2.1111/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Advisor'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Advisor'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Advisor/2.0.0'
DEBUG: Package version parsed as NuGet version: '2.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Advisor/2.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Monitor'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Monitor'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Monitor/5.1.0'
DEBUG: Package version parsed as NuGet version: '5.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Monitor/5.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/ConfluencePS'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/ConfluencePS'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/ConfluencePS/2.5.1'
DEBUG: Package version parsed as NuGet version: '2.5.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/ConfluencePS/2.5.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Devices.CorporateManagement'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Devices.CorporateManagement'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Devices.CorporateManagement/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Devices.CorporateManagement/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.LogicApp'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.LogicApp'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.LogicApp/1.5.1'
DEBUG: Package version parsed as NuGet version: '1.5.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.LogicApp/1.5.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Network'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Network'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Network/7.4.0'
DEBUG: Package version parsed as NuGet version: '7.4.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Network/7.4.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Nginx'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Nginx'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Nginx/1.0.0'
DEBUG: Package version parsed as NuGet version: '1.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Nginx/1.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement.Functions'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement.Functions'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement.Functions/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.DeviceManagement.Functions/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Automation'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Automation'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Automation/1.10.0'
DEBUG: Package version parsed as NuGet version: '1.10.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Automation/1.10.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.RedisCache'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.RedisCache'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.RedisCache/1.9.0'
DEBUG: Package version parsed as NuGet version: '1.9.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.RedisCache/1.9.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PackageManagement'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PackageManagement'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/PackageManagement/1.1.7.2'
DEBUG: Package version parsed as NuGet version: '1.1.7.2'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/PackageManagement/1.1.7.2/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Websites'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Websites'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Websites/3.2.0'
DEBUG: Package version parsed as NuGet version: '3.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Websites/3.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/ImportExcel'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/ImportExcel'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/ImportExcel/7.8.6'
DEBUG: Package version parsed as NuGet version: '7.8.6'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/ImportExcel/7.8.6/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.SqlVirtualMachine'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.SqlVirtualMachine'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.SqlVirtualMachine/2.2.0'
DEBUG: Package version parsed as NuGet version: '2.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.SqlVirtualMachine/2.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement.Administration'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement.Administration'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement.Administration/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.DeviceManagement.Administration/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PartnerCenter'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/PartnerCenter'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/PartnerCenter/3.0.10'
DEBUG: Package version parsed as NuGet version: '3.0.10'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/PartnerCenter/3.0.10/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Kusto'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Kusto'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Kusto/2.3.0'
DEBUG: Package version parsed as NuGet version: '2.3.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Kusto/2.3.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ContainerInstance'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ContainerInstance'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ContainerInstance/4.0.0'
DEBUG: Package version parsed as NuGet version: '4.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ContainerInstance/4.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.GuestConfiguration'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.GuestConfiguration'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.GuestConfiguration/0.11.0'
DEBUG: Package version parsed as NuGet version: '0.11.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.GuestConfiguration/0.11.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Calendar'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Calendar'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Calendar/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Calendar/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ConnectedVMware'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ConnectedVMware'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ConnectedVMware/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ConnectedVMware/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Notes'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Notes'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Notes/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Notes/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Bookings'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Bookings'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Bookings/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.Bookings/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.People'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.People'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.People/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Beta.People/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/GetBIOS'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/GetBIOS'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/GetBIOS/1.3.3'
DEBUG: Package version parsed as NuGet version: '1.3.3'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/GetBIOS/1.3.3/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Logz'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Logz'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Logz/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Logz/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Invokeall'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Invokeall'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Invokeall/1.2.4'
DEBUG: Package version parsed as NuGet version: '1.2.4'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Invokeall/1.2.4/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Evergreen'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Evergreen'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Evergreen/2403.889'
DEBUG: Package version parsed as NuGet version: '2403.889'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Evergreen/2403.889/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DataBoxEdge'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DataBoxEdge'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DataBoxEdge/1.1.0'
DEBUG: Package version parsed as NuGet version: '1.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DataBoxEdge/1.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Sites'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Sites'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Sites/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Sites/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.PaloAltoNetworks'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.PaloAltoNetworks'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.PaloAltoNetworks/0.2.1'
DEBUG: Package version parsed as NuGet version: '0.2.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.PaloAltoNetworks/0.2.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Optimized.Mga.SharePoint'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Optimized.Mga.SharePoint'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Optimized.Mga.SharePoint/0.0.0.6'
DEBUG: Package version parsed as NuGet version: '0.0.0.6'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Optimized.Mga.SharePoint/0.0.0.6/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.AppConfiguration'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.AppConfiguration'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.AppConfiguration/1.3.0'
DEBUG: Package version parsed as NuGet version: '1.3.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.AppConfiguration/1.3.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.StackHCI.NetworkHUD'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.StackHCI.NetworkHUD'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.StackHCI.NetworkHUD/1.0.1'
DEBUG: Package version parsed as NuGet version: '1.0.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.StackHCI.NetworkHUD/1.0.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Communication'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Communication'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Communication/0.2.0'
DEBUG: Package version parsed as NuGet version: '0.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Communication/0.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ServiceBus'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ServiceBus'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ServiceBus/3.0.0'
DEBUG: Package version parsed as NuGet version: '3.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ServiceBus/3.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Security'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Security'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Security/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Security/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DevSpaces'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DevSpaces'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DevSpaces/0.7.4'
DEBUG: Package version parsed as NuGet version: '0.7.4'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DevSpaces/0.7.4/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/ModuleFast'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/ModuleFast'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/ModuleFast/0.2.0'
DEBUG: Package version parsed as NuGet version: '0.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/ModuleFast/0.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DataShare'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.DataShare'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.DataShare/1.0.1'
DEBUG: Package version parsed as NuGet version: '1.0.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.DataShare/1.0.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.StackHCIVM'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.StackHCIVM'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.StackHCIVM/1.0.1'
DEBUG: Package version parsed as NuGet version: '1.0.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.StackHCIVM/1.0.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Purview'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Purview'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Purview/0.2.0'
DEBUG: Package version parsed as NuGet version: '0.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Purview/0.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.StorageCache'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.StorageCache'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.StorageCache/0.1.0'
DEBUG: Package version parsed as NuGet version: '0.1.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.StorageCache/0.1.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Dns'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Dns'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Dns/1.2.0'
DEBUG: Package version parsed as NuGet version: '1.2.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Dns/1.2.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MSAL.PS'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/MSAL.PS'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/MSAL.PS/4.37.0.0'
DEBUG: Package version parsed as NuGet version: '4.37.0.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/MSAL.PS/4.37.0.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Synapse'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Synapse'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Synapse/3.0.5'
DEBUG: Package version parsed as NuGet version: '3.0.5'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Synapse/3.0.5/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Subscription'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Subscription'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Subscription/0.11.0'
DEBUG: Package version parsed as NuGet version: '0.11.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Subscription/0.11.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ApplicationInsights'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.ApplicationInsights'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.ApplicationInsights/2.2.3'
DEBUG: Package version parsed as NuGet version: '2.2.3'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.ApplicationInsights/2.2.3/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Devices.CloudPrint'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Devices.CloudPrint'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Devices.CloudPrint/2.16.0'
DEBUG: Package version parsed as NuGet version: '2.16.0'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Microsoft.Graph.Devices.CloudPrint/2.16.0/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Orbital'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Modules/Az.Orbital'
DEBUG: Searching through package version path: '/home/pop/.local/share/powershell/Modules/Az.Orbital/0.1.1'
DEBUG: Package version parsed as NuGet version: '0.1.1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Modules/Az.Orbital/0.1.1/PSGetModuleInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Scripts/Get-AutopilotDiagnostics.ps1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Scripts/InstalledScriptInfos/Get-AutopilotDiagnostics_InstalledScriptInfo.xml'
DEBUG: Searching through package path: '/home/pop/.local/share/powershell/Scripts/Upload-WindowsAutopilotDeviceInfo.ps1'
DEBUG: Reading package metadata from: '/home/pop/.local/share/powershell/Scripts/InstalledScriptInfos/Upload-WindowsAutopilotDeviceInfo_InstalledScriptInfo.xml'
DEBUG: In InstallPSResource::ProcessInstallHelper()
DEBUG: In InstallHelper::BeginInstallPackages()
DEBUG: Parameters passed in >>> Name: 'Microsoft.PowerShell.UnixTabCompletion'; VersionRange: ''; NuGetVersion: ''; VersionType: 'NoVersion'; Version: ''; Prerelease: 'False'; Repository: ''; AcceptLicense: 'False'; Quiet: 'False'; Reinstall: 'False'; TrustRepository: 'True'; NoClobber: 'False'; AsNupkg: 'False'; IncludeXml 'True'; SavePackage 'False'; TemporaryPath ''; SkipDependencyCheck: 'False'; AuthenticodeCheck: 'False'; PathsToInstallPkg: '/home/pop/.local/share/powershell/Modules,/home/pop/.local/share/powershell/Scripts'; Scope 'CurrentUser'
DEBUG: In InstallHelper::ProcessRepositories()
DEBUG: In InstallHelper::InstallPackages()
DEBUG: In InstallHelper::InstallPackage()
DEBUG: In V2ServerAPICalls::FindName()
DEBUG: In V2ServerAPICalls::HttpRequestCall()
DEBUG: Request url is 'https://www.powershellgallery.com/api/v2/FindPackagesById()?%24filter=Id+eq+%27Microsoft.PowerShell.UnixTabCompletion%27+and+IsLatestVersion+eq+true&%24inlinecount=allpages&id=%27Microsoft.PowerShell.UnixTabCompletion%27'
DEBUG: In V2ServerAPICalls::InstallVersion()
DEBUG: In V2ServerAPICalls::HttpRequestCallForContent()
DEBUG: Request url is 'https://www.powershellgallery.com/api/v2/package/Microsoft.PowerShell.UnixTabCompletion/0.5.0'
DEBUG: In InstallHelper::TryInstallToTempPath()
DEBUG: In InstallHelper::CallAcceptLicense()

License Acceptance
MIT License

Copyright (c) 2019 Robert Holt

Permission is hereby granted, free of charge, to any person obtaining a copy
of this software and associated documentation files (the "Software"), to deal
in the Software without restriction, including without limitation the rights
to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
copies of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
SOFTWARE.

Do you accept the license terms for module 'Microsoft.PowerShell.UnixTabCompletion'?
[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "N"): a
DEBUG: In InstallHelper::DeleteExtraneousFiles()
DEBUG: Deleting '/tmp/045eaa9d-655b-4a30-bd65-897d67dc5c57/Microsoft.PowerShell.UnixTabCompletion/0.5.0/Microsoft.PowerShell.UnixTabCompletion.nuspec'
DEBUG: Deleting '/tmp/045eaa9d-655b-4a30-bd65-897d67dc5c57/Microsoft.PowerShell.UnixTabCompletion/0.5.0/[Content_Types].xml'
DEBUG: Deleting '/tmp/045eaa9d-655b-4a30-bd65-897d67dc5c57/Microsoft.PowerShell.UnixTabCompletion/0.5.0/_rels'
DEBUG: Deleting '/tmp/045eaa9d-655b-4a30-bd65-897d67dc5c57/Microsoft.PowerShell.UnixTabCompletion/0.5.0/package'
DEBUG: In InstallHelper::CreateMetadataXMLFile()
DEBUG: In InstallHelper::TryMoveInstallContent()
DEBUG: In InstallHelper::MoveFilesIntoInstallPath()
PS /home/pop>
```

</details>

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
