### PR TITLE
Fix 1794 by handling if prerelease is supplied as boolean too

### DIFF
--- a/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
@@ -31,7 +31,7 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
 
     AfterEach {
         Uninstall-PSResource "test_module", "test_module2", "test_script", "TestModule99", "testModuleWithlicense", `
-            "TestFindModule","ClobberTestModule1", "ClobberTestModule2", "PackageManagement", "TestTestScript", `
+            "TestFindModule", "ClobberTestModule1", "ClobberTestModule2", "PackageManagement", "TestTestScript", `
             "TestModuleWithDependency", "TestModuleWithPrereleaseDep", "PrereleaseModule" -SkipDependencyCheck -ErrorAction SilentlyContinue
     }
 
@@ -40,9 +40,9 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
     }
 
     $testCases = [array](
-        @{Name="*";                          ErrorId="NameContainsWildcard"},
-        @{Name="Test_Module*";               ErrorId="NameContainsWildcard"},
-        @{Name="Test?Module","Test[Module";  ErrorId="ErrorFilteringNamesForUnsupportedWildcards"}
+        @{Name = "*"; ErrorId = "NameContainsWildcard" },
+        @{Name = "Test_Module*"; ErrorId = "NameContainsWildcard" },
+        @{Name = "Test?Module", "Test[Module"; ErrorId = "ErrorFilteringNamesForUnsupportedWildcards" }
     )
 
     It "Should not install resource with wildcard in name" -TestCases $testCases {
@@ -388,6 +388,7 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
         $res.Name | Should -Contain $testModuleName
     }
 
+    # -RequiredResource
     It "Install modules using -RequiredResource with hashtable" {
         $rrHash = @{
             test_module  = @{
@@ -416,6 +417,16 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
         $res3 = Get-InstalledPSResource $testModuleName2
         $res3.Name | Should -Be $testModuleName2
         $res3.Version | Should -Be "0.0.93"
+    }
+
+    It "Install module using -RequiredResource with hashtable, and prerelease is boolean true" {
+        Install-PSResource -TrustRepository -RequiredResource @{
+            'TestModule99' = @{
+                'repository' = 'PSGallery'
+                'prerelease' = $true
+            }
+        }
+        (Get-InstalledPSResource -Name 'TestModule99').'Prerelease' | Should -Be 'beta2'
     }
 
     It "Install modules using -RequiredResource with JSON string" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

* Fix #1794 by handle prelease if a boolean too.
  * Fix and context was suggested to me by Copilot.
* Seems #1448 is related too.
* Applied some quick fixes suggested by C# VSCode extension.

Tested like so:

```pwsh
# Build
& '.\build.ps1' -Clean -Build -BuildFramework net472

# Import built DLL
Import-Module -Name '.out\Microsoft.PowerShell.PSResourceGet\Microsoft.PowerShell.PSResourceGet.dll'

# Test issue from #1794
$DebugPreference = 'Continue'; Install-PSResource -TrustRepository -RequiredResource @{
    'PrereleaseTest' = @{
        'repository' = 'PSGallery'
        'prerelease' = $true
        'Scope'      = 'CurrentUser'
    }
} -WhatIf
```

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
