### PR TITLE
Bugfix: Find and Install unlisted versions of a package given name and version

### DIFF
--- a/src/code/ContainerRegistryResponseUtil.cs
+++ b/src/code/ContainerRegistryResponseUtil.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         #region Overriden Methods
 
-        public override IEnumerable<PSResourceResult> ConvertToPSResourceResult(FindResults responseResults)
+        public override IEnumerable<PSResourceResult> ConvertToPSResourceResult(FindResults responseResults, bool isResourceRequestedWithWildcard = false)
         {
             Hashtable[] responses = responseResults.HashtableResponse;
             foreach (Hashtable response in responses)

--- a/src/code/LocalResponseUtil.cs
+++ b/src/code/LocalResponseUtil.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         #endregion
 
         #region Overriden Methods
-        public override IEnumerable<PSResourceResult> ConvertToPSResourceResult(FindResults responseResults)
+        public override IEnumerable<PSResourceResult> ConvertToPSResourceResult(FindResults responseResults, bool isResourceRequestedWithWildcard = false)
         {
             foreach (Hashtable response in responseResults.HashtableResponse)
             {

--- a/src/code/NuGetServerResponseUtil.cs
+++ b/src/code/NuGetServerResponseUtil.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         #endregion
 
         #region Overriden Methods
-        public override IEnumerable<PSResourceResult> ConvertToPSResourceResult(FindResults responseResults)
+        public override IEnumerable<PSResourceResult> ConvertToPSResourceResult(FindResults responseResults, bool isResourceRequestedWithWildcard = false)
         {
             // in FindHelper:
             // serverApi.FindName() -> return responses, and out errRecord

--- a/src/code/ResponseUtil.cs
+++ b/src/code/ResponseUtil.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         #region Methods
 
-        public abstract IEnumerable<PSResourceResult> ConvertToPSResourceResult(FindResults responseResults);
+        public abstract IEnumerable<PSResourceResult> ConvertToPSResourceResult(FindResults responseResults, bool isResourceRequestedWithWildcard = false);
 
         #endregion
     

--- a/src/code/V2ResponseUtil.cs
+++ b/src/code/V2ResponseUtil.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         #endregion
 
         #region Overriden Methods
-        public override IEnumerable<PSResourceResult> ConvertToPSResourceResult(FindResults responseResults)
+        public override IEnumerable<PSResourceResult> ConvertToPSResourceResult(FindResults responseResults, bool isResourceRequestedWithWildcard = false)
         {
             // in FindHelper:
             // serverApi.FindName() -> return responses, and out errRecord
@@ -58,8 +58,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         yield return new PSResourceResult(returnedObject: null, exception: parseException, isTerminatingError: false);
                     }
 
+                    // For V2 resources, specifically PSGallery, return unlisted version resources only when not requested with wildcard name
                     // Unlisted versions will have a published year as 1900 or earlier.
-                    if (!psGetInfo.PublishedDate.HasValue || psGetInfo.PublishedDate.Value.Year > 1900)
+                    if (!isResourceRequestedWithWildcard || !psGetInfo.PublishedDate.HasValue || psGetInfo.PublishedDate.Value.Year > 1900)
                     {
                         yield return new PSResourceResult(returnedObject: psGetInfo, exception: null, isTerminatingError: false);
                     }

--- a/src/code/V3ResponseUtil.cs
+++ b/src/code/V3ResponseUtil.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         #region Overriden Methods
 
-        public override IEnumerable<PSResourceResult> ConvertToPSResourceResult(FindResults responseResults)
+        public override IEnumerable<PSResourceResult> ConvertToPSResourceResult(FindResults responseResults, bool isResourceRequestedWithWildcard = false)
         {
             // in FindHelper:
             // serverApi.FindName() -> return responses, and out errRecord

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -415,11 +415,10 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
     It "find should not return a module that has all unlisted versions, given full name and no version (i.e non wildcard name)" {
         # FindName() scenario
         # 'test_completelyunlisted' only has version 0.0.1, which is unlisted
-        $res = Find-PSResource -Name "test_completelyunlisted" -Repository $PSGalleryName
+        $res = Find-PSResource -Name "test_completelyunlisted" -Repository $PSGalleryName -ErrorVariable err
         $res | Should -BeNullOrEmpty
         $err.Count | Should -BeGreaterThan 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
-        $res | Should -BeNullOrEmpty
     }
 
     It "find should return a module version even if all versions are unlisted, given full name and version (i.e non wildcard name)" {

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -457,4 +457,18 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'ManualValidat
 
         $duplicatePkgsFound | Should -BeFalse
     }
+
+    It "find should return an unlisted module when it was requested explicitly by full name and version (i.e no wildcards)" {
+        # 'test_unlisted' is an unlisted package
+        $res = Find-PSResource -Name "test_unlisted" -Version "0.0.1" -Repository $PSGalleryName
+        $res | Should -Not -BeNullOrEmpty
+        $res.Version | Should -Be "0.0.1"
+    }
+
+    It "find should not return an unlisted module with it was requested with wildcards in the name" {
+        # 'test_unlisted' is an unlisted package whereas 'test_notunlisted' is listed
+        $res = Find-PSResource -Name "test_*unlisted" -Repository $PSGalleryName
+        $res.Count | Should -Be 1
+        $res[0].Name | Should -Be "test_notunlisted"
+    }
 }

--- a/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceV2Server.Tests.ps1
@@ -12,7 +12,6 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
     BeforeAll{
         $PSGalleryName = Get-PSGalleryName
         $testModuleName = "test_module"
-        $testModuleNameWithUnlistedVersion = "test_module10"
         $testScriptName = "test_script"
         $commandName = "Get-TargetResource"
         $dscResourceName = "SystemLocale"
@@ -413,11 +412,40 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'CI' {
         $err.Count | Should -Be 0
     }
 
-    It "should not find and write error when finding package version that is unlisted" {
-        $res = Find-PSResource -Name $testModuleNameWithUnlistedVersion -Version "1.0.0.0" -Repository $PSGalleryName -ErrorVariable err -ErrorAction SilentlyContinue
-        $res | Should -HaveCount 0
-        $err | Should -HaveCount 1
+    It "find should not return a module that has all unlisted versions, given full name and no version (i.e non wildcard name)" {
+        # FindName() scenario
+        # 'test_completelyunlisted' only has version 0.0.1, which is unlisted
+        $res = Find-PSResource -Name "test_completelyunlisted" -Repository $PSGalleryName
+        $res | Should -BeNullOrEmpty
+        $err.Count | Should -BeGreaterThan 0
         $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
+        $res | Should -BeNullOrEmpty
+    }
+
+    It "find should return a module version even if all versions are unlisted, given full name and version (i.e non wildcard name)" {
+        # FindVersion() scenario
+        # test_completelyunlisted has 1 version, 0.0.1, which is unlisted
+        $res = Find-PSResource -Name "test_completelyunlisted" -Version "0.0.1" -Repository $PSGalleryName
+        $res | Should -Not -BeNullOrEmpty
+        $res.Version | Should -Be "0.0.1"
+    }
+
+    It "find should return an unlisted module, where the module has a mix of listed and unlisted versions, given full name and version (i.e non wildcard name)" {
+        # FindVersion scenario
+        # 'test_unlisted' version 0.0.3 is unlisted
+        $res = Find-PSResource -Name "test_unlisted" -Version "0.0.3" -Repository $PSGalleryName
+        $res | Should -Not -BeNullOrEmpty
+        $res.Version | Should -Be "0.0.3"
+    }
+
+    It "find should not return an unlisted module with it was requested with wildcards in the name" {
+        # FindNameGlobbing() scenario
+        # 'test_completelyunlisted' has all unlisted versions -> should not be returned
+        # whereas 'test_unlisted' has a listed verison and 'test_notunlisted' has all listed versions -> should be returned
+        $res = Find-PSResource -Name "test_*unlisted" -Repository $PSGalleryName
+        $res.Count | Should -Be 2
+        $res.Name | Should -Contain 'test_unlisted'
+        $res.Name | Should -Contain 'test_notunlisted'
     }
 }
 
@@ -456,41 +484,5 @@ Describe 'Test HTTP Find-PSResource for V2 Server Protocol' -tags 'ManualValidat
         }
 
         $duplicatePkgsFound | Should -BeFalse
-    }
-
-    It "find should not return a module that has all unlisted versions, given full name and no version (i.e non wildcard name)" {
-        # FindName() scenario
-        # 'test_completelyunlisted' only has version 0.0.1, which is unlisted
-        $res = Find-PSResource -Name "test_completelyunlisted" -Repository $PSGalleryName
-        $res | Should -BeNullOrEmpty
-        $err.Count | Should -BeGreaterThan 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "PackageNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.FindPSResource"
-        $res | Should -BeNullOrEmpty
-    }
-
-    It "find should return a module version even if all versions are unlisted, given full name and version (i.e non wildcard name)" {
-        # FindVersion() scenario
-        # test_completelyunlisted has 1 version, 0.0.1, which is unlisted
-        $res = Find-PSResource -Name "test_completelyunlisted" -Version "0.0.1" -Repository $PSGalleryName
-        $res | Should -Not -BeNullOrEmpty
-        $res.Version | Should -Be "0.0.1"
-    }
-
-    It "find should return an unlisted module, where the module has a mix of listed and unlisted versions, given full name and version (i.e non wildcard name)" {
-        # FindVersion scenario
-        # 'test_unlisted' version 0.0.3 is unlisted
-        $res = Find-PSResource -Name "test_unlisted" -Version "0.0.3" -Repository $PSGalleryName
-        $res | Should -Not -BeNullOrEmpty
-        $res.Version | Should -Be "0.0.3"
-    }
-
-    It "find should not return an unlisted module with it was requested with wildcards in the name" {
-        # FindNameGlobbing() scenario
-        # 'test_completelyunlisted' has all unlisted versions -> should not be returned
-        # whereas 'test_unlisted' has a listed verison and 'test_notunlisted' has all listed versions -> should be returned
-        $res = Find-PSResource -Name "test_*unlisted" -Repository $PSGalleryName
-        $res.Count | Should -Be 2
-        $res.Name | Should -Contain 'test_unlisted'
-        $res.Name | Should -Contain 'test_notunlisted'
     }
 }

--- a/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
@@ -573,6 +573,16 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
         $res | Should -Not -BeNullOrEmpty
         $res.Version | Should -Be $version
     }
+
+        It "Install resource that is unlisted" {
+        # 'test_unlisted' is an unlisted package
+        $moduleName = 'test_unlisted'
+        $version = '0.0.1'
+        Install-PSResource -Name $moduleName -Repository $PSGalleryName -TrustRepository
+        $res = Get-InstalledPSResource $moduleName
+        $res | Should -Not -BeNullOrEmpty
+        $res.Version | Should -Be $version
+    }
 }
 
 Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'ManualValidationOnly' {

--- a/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
@@ -574,11 +574,12 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
         $res.Version | Should -Be $version
     }
 
-        It "Install resource that is unlisted" {
-        # 'test_unlisted' is an unlisted package
+    It "Install resource that is unlisted" {
+        # InstallVersion scenario
+        # 'test_unlisted' version 0.0.3 is unlisted
         $moduleName = 'test_unlisted'
-        $version = '0.0.1'
-        Install-PSResource -Name $moduleName -Repository $PSGalleryName -TrustRepository
+        $version = '0.0.3'
+        Install-PSResource -Name $moduleName -Version $version -Repository $PSGalleryName -TrustRepository
         $res = Get-InstalledPSResource $moduleName
         $res | Should -Not -BeNullOrEmpty
         $res.Version | Should -Be $version


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
PowerShellGet v2 allowed for finding and installing unlisted versions of package, given that a full/non-wildcard name and a version were both specified. PSResourceGet changed this but fixing this to ensure backwards compatibility and provide support for requested scenarios. Scenarios include a team that may publish a module version, unlist it for consuming and testing it works as expected before making it listed again, or testing if a package version is unlisted and not missing altogether.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1771 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
