### PR TITLE
Bugfix: Uninstall-PSResource should delete subdirectories without Access Denied error on OneDrive

### DIFF
--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1711,6 +1711,13 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     }
                     else if (ex is System.IO.IOException)
                     {
+                        string psVersion = System.Management.Automation.Runspaces.Runspace.DefaultRunspace.Version.ToString();
+                        if (ex.Message.Contains("The directory is not empty") && psVersion.StartsWith("5"))
+                        {
+                            // there is a known bug with WindowsPowerShell and OneDrive based module paths, where at uninstall time .NET Directory.Delete() will give 'The directory is not empty.' error
+                            throw new Exception(string.Format("Cannot uninstall module with OneDrive based path on WindowsPowerShell due to .NET issue. Try installing and uninstalling using PowerShellCore if using OneDrive."), ex);
+                        }
+
                         throw new Exception(string.Format("Access denied to path while deleting path {0}", dirPath), ex);
                     }
                     else

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1715,7 +1715,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                         if (ex.Message.Contains("The directory is not empty") && psVersion.StartsWith("5"))
                         {
                             // there is a known bug with WindowsPowerShell and OneDrive based module paths, where .NET Directory.Delete() will throw a 'The directory is not empty.' error.
-                            throw new Exception(string.Format("Cannot uninstall module with OneDrive based path on WindowsPowerShell due to .NET issue. Try installing and uninstalling using PowerShellCore if using OneDrive."), ex);
+                            throw new Exception(string.Format("Cannot uninstall module with OneDrive based path on Windows PowerShell due to .NET issue. Try installing and uninstalling using PowerShell 7+ if using OneDrive."), ex);
                         }
 
                         throw new Exception(string.Format("Access denied to path while deleting path {0}", dirPath), ex);

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1714,7 +1714,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                         string psVersion = System.Management.Automation.Runspaces.Runspace.DefaultRunspace.Version.ToString();
                         if (ex.Message.Contains("The directory is not empty") && psVersion.StartsWith("5"))
                         {
-                            // there is a known bug with WindowsPowerShell and OneDrive based module paths, where at uninstall time .NET Directory.Delete() will give 'The directory is not empty.' error
+                            // there is a known bug with WindowsPowerShell and OneDrive based module paths, where .NET Directory.Delete() will throw a 'The directory is not empty.' error.
                             throw new Exception(string.Format("Cannot uninstall module with OneDrive based path on WindowsPowerShell due to .NET issue. Try installing and uninstalling using PowerShellCore if using OneDrive."), ex);
                         }
 

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1658,6 +1658,16 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             }
         }
 
+        private static void SetAttributesHelper(DirectoryInfo directory)
+        {
+            foreach (var subDirectory in directory.GetDirectories())
+            {
+                subDirectory.Attributes = FileAttributes.Normal;
+                SetAttributesHelper(subDirectory);
+            }
+
+            directory.Attributes = FileAttributes.Normal;
+        }
         /// <Summary>
         /// Deletes a directory and its contents
         /// This is a workaround for .NET Directory.Delete(), which can fail with WindowsPowerShell
@@ -1672,13 +1682,17 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             }
 
             // Remove read only file attributes first
-            foreach (var dirFilePath in Directory.GetFiles(dirPath,"*",SearchOption.AllDirectories))
+            foreach (var dirFilePath in Directory.GetFiles(dirPath, "*", SearchOption.AllDirectories))
             {
                 if (File.GetAttributes(dirFilePath).HasFlag(FileAttributes.ReadOnly))
                 {
                     File.SetAttributes(dirFilePath, File.GetAttributes(dirFilePath) & ~FileAttributes.ReadOnly);
                 }
             }
+
+            DirectoryInfo rootDir = new DirectoryInfo(dirPath);
+            SetAttributesHelper(rootDir);
+
             // Delete directory recursive, try multiple times before throwing ( #1662 )
             int maxAttempts = 5;
             int msDelay = 5;
@@ -1686,7 +1700,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             {
                 try
                 {
-                    Directory.Delete(dirPath,true);
+                    Directory.Delete(dirPath, true);
                     return;
                 }
                 catch (Exception ex)
@@ -1694,6 +1708,10 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     if (attempt < maxAttempts && (ex is IOException || ex is UnauthorizedAccessException))
                     {
                         Thread.Sleep(msDelay);
+                    }
+                    else if (ex is System.IO.IOException)
+                    {
+                        throw new Exception(string.Format("Access denied to path while deleting path {0}", dirPath), ex);
                     }
                     else
                     {


### PR DESCRIPTION
Currently, when uninstalling a module that was installed to a OneDrive module path, it deletes the module files successfully but not the subdirectories and an error is thrown. The subdirectories need to also have their file attribute set to `FileAttributes.Normal` to allow for deletion.

Tested manually on PS7.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1793
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
