### PR TITLE
Bugfix: Populate Includes Metadata for Package from Containerregistry Repository

### DIFF
--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -1082,6 +1082,15 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     { "NormalizedVersion", metadata["NormalizedVersion"].ToString() }
                 };
 
+                var typeInfo = ParseHttpMetadataType(metadata["Tags"] as string[], out ArrayList commandNames, out ArrayList cmdletNames, out ArrayList dscResourceNames);
+                var resourceHashtable = new Hashtable {
+                    { nameof(PSResourceInfo.Includes.Command), new PSObject(commandNames) },
+                    { nameof(PSResourceInfo.Includes.Cmdlet), new PSObject(cmdletNames) },
+                    { nameof(PSResourceInfo.Includes.DscResource), new PSObject(dscResourceNames) }
+                };
+
+                var includes = new ResourceIncludes(resourceHashtable);
+
                 psGetInfo = new PSResourceInfo(
                     additionalMetadata: additionalMetadataHashtable,
                     author: metadata["Authors"] as String,
@@ -1090,7 +1099,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     dependencies: metadata["Dependencies"] as Dependency[],
                     description: metadata["Description"] as String,
                     iconUri: null,
-                    includes: null,
+                    includes: includes,
                     installedDate: null,
                     installedLocation: null,
                     isPrerelease: (bool)metadata["IsPrerelease"],

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -1082,7 +1082,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     { "NormalizedVersion", metadata["NormalizedVersion"].ToString() }
                 };
 
-                var typeInfo = ParseHttpMetadataType(metadata["Tags"] as string[], out ArrayList commandNames, out ArrayList cmdletNames, out ArrayList dscResourceNames);
+                ParseHttpMetadataType(metadata["Tags"] as string[], out ArrayList commandNames, out ArrayList cmdletNames, out ArrayList dscResourceNames);
                 var resourceHashtable = new Hashtable {
                     { nameof(PSResourceInfo.Includes.Command), new PSObject(commandNames) },
                     { nameof(PSResourceInfo.Includes.Cmdlet), new PSObject(cmdletNames) },
@@ -1708,16 +1708,22 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             out ArrayList dscResourceNames)
         {
             // possible type combinations:
-            // M, C
-            // M, D
-            // M
-            // S
+                // M, C
+                // M, D
+                // M
+                // S
 
             commandNames = new ArrayList();
             cmdletNames = new ArrayList();
             dscResourceNames = new ArrayList();
 
             ResourceType pkgType = ResourceType.Module;
+
+            if (tags == null)
+            {
+                return pkgType;
+            }
+
             foreach (string tag in tags)
             {
                 if (String.Equals(tag, "PSScript", StringComparison.InvariantCultureIgnoreCase))

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -1708,10 +1708,10 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             out ArrayList dscResourceNames)
         {
             // possible type combinations:
-                // M, C
-                // M, D
-                // M
-                // S
+            // M, C
+            // M, D
+            // M
+            // S
 
             commandNames = new ArrayList();
             cmdletNames = new ArrayList();

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -12,6 +12,7 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $testModuleParentName = "test_parent_mod"
         $testModuleDependencyName = "test_dependency_mod"
         $testScriptName = "test-script"
+        $testModuleWithIncludes = "test-resourcewithincludes"
         $ACRRepoName = "ACRRepo"
         $ACRRepoUri = "https://psresourcegettest.azurecr.io"
         Get-NewPSResourceRepositoryFile
@@ -261,6 +262,14 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
         $res.ProjectUri | Should -Be "https://github.com/Azure/azure-powershell"
         $res.ReleaseNotes.Length | Should -Not -Be 0
         $res.Tags.Length | Should -Be 5
+    }
+
+    It "Should find resource and its associated Includes property" {
+        $res = Find-PSResource $testModuleWithIncludes -Repository $ACRRepoName
+        $res.Includes | Should -Not -BeNullOrEmpty
+        $res.Includes.Cmdlet | Should -Be "cmdlet1"
+        $res.Includes.Command | Should -Be "cmd1"
+        $res.Includes.DscResource | Should -Be "dsc1"
     }
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->
Find-PSResource wasn't populating `Includes` metadata for a package retrieved from a ContainerRegistry repository, so updated the code in PSResourceInfo.cs to call the method to retrieve that metadata.
# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1845

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
