### PR TITLE
Bugfix: Update-PSScriptFileInfo should populate all #Requires lines/properties

### DIFF
--- a/src/code/PSScriptRequires.cs
+++ b/src/code/PSScriptRequires.cs
@@ -38,12 +38,12 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         /// <summary>
         /// The assemblies this script requires, specified like: #requires -Assembly path\to\foo.dll#requires -Assembly "System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" 
         /// </summary>
-        public string[] RequiredAssemblies { get; private set; }
+        public string[] RequiredAssemblies { get; private set; } = Utils.EmptyStrArray;
 
         /// <summary>
         /// The PowerShell Edition this script requires, specified like: #requires -PSEdition Desktop
         /// </summary>
-        public string[] RequiredPSEditions { get; private set; }
+        public string[] RequiredPSEditions { get; private set; } = Utils.EmptyStrArray;
 
         /// <summary>
         /// The PowerShell version this script requires, specified like: #requires -Version 3
@@ -179,14 +179,12 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             {
                 psRequiresLines.Add(String.Empty);
                 psRequiresLines.Add("#Requires -RunAsAdministrator");
-                psRequiresLines.Add(String.Empty);
             }
 
             if (!String.IsNullOrEmpty(RequiredApplicationId))
             {
                 psRequiresLines.Add(String.Empty);
                 psRequiresLines.Add(String.Format("#Requires -ShellId {0}", RequiredApplicationId));
-                psRequiresLines.Add(String.Empty);
             }
 
             if (RequiredAssemblies.Length > 0)
@@ -196,8 +194,21 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 {
                     psRequiresLines.Add(String.Format("#Requires -Assembly {0}", assembly));
                 }
+            }
 
+            if (RequiredPSEditions.Length > 0)
+            {
                 psRequiresLines.Add(String.Empty);
+                foreach (string psEdition in RequiredPSEditions)
+                {
+                    psRequiresLines.Add(String.Format("#Requires -PSEdition {0}", psEdition));
+                }
+            }
+
+            if (RequiredPSVersion != null)
+            {
+                psRequiresLines.Add(String.Empty);
+                psRequiresLines.Add(String.Format("#Requires -Version {0}", RequiredPSVersion.ToString()));
             }
 
             if (RequiredModules.Length > 0)
@@ -208,24 +219,6 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     psRequiresLines.Add(String.Format("#Requires -Module {0}", moduleSpec.ToString()));
                 }
 
-                psRequiresLines.Add(String.Empty);
-            }
-
-            if (RequiredPSEditions.Length > 0)
-            {
-                psRequiresLines.Add(String.Empty);
-                foreach (string psEdition in RequiredPSEditions)
-                {
-                    psRequiresLines.Add(String.Format("#Requires -PSEdition {0}", psEdition));
-                }
-
-                psRequiresLines.Add(String.Empty);
-            }
-
-            if (RequiredPSVersion != null)
-            {
-                psRequiresLines.Add(String.Empty);
-                psRequiresLines.Add(String.Format("#Requires -Version {0}", RequiredPSVersion.ToString()));
                 psRequiresLines.Add(String.Empty);
             }
 

--- a/src/code/PSScriptRequires.cs
+++ b/src/code/PSScriptRequires.cs
@@ -8,7 +8,6 @@ using System.Management.Automation.Language;
 using System.Linq;
 using System.Collections.ObjectModel;
 using Microsoft.PowerShell.Commands;
-using Newtonsoft.Json;
 
 namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 {

--- a/src/code/PSScriptRequires.cs
+++ b/src/code/PSScriptRequires.cs
@@ -8,6 +8,7 @@ using System.Management.Automation.Language;
 using System.Linq;
 using System.Collections.ObjectModel;
 using Microsoft.PowerShell.Commands;
+using Newtonsoft.Json;
 
 namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 {
@@ -19,10 +20,35 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         #region Properties
 
         /// <summary>
-        /// The list of modules required by the script.
+        /// The modules this script requires, specified like: #requires -Module NetAdapter#requires -Module @{Name="NetAdapter"; Version="1.0.0.0"}
         /// Hashtable keys: GUID, MaxVersion, ModuleName (Required), RequiredVersion, Version.
         /// </summary>
         public ModuleSpecification[] RequiredModules { get; private set; } = Array.Empty<ModuleSpecification>();
+
+        /// <summary>
+        ///  Specifies if this script requires elevated privileges, specified like: #requires -RunAsAdministrator
+        /// </summary>
+        public bool IsElevationRequired { get; private set; }
+
+        /// <summary>
+        /// The application id this script requires, specified like: #requires -Shellid Shell
+        /// </summary>
+        public string RequiredApplicationId { get; private set; }
+
+        /// <summary>
+        /// The assemblies this script requires, specified like: #requires -Assembly path\to\foo.dll#requires -Assembly "System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" 
+        /// </summary>
+        public string[] RequiredAssemblies { get; private set; }
+
+        /// <summary>
+        /// The PowerShell Edition this script requires, specified like: #requires -PSEdition Desktop
+        /// </summary>
+        public string[] RequiredPSEditions { get; private set; }
+
+        /// <summary>
+        /// The PowerShell version this script requires, specified like: #requires -Version 3
+        /// </summary>
+        public Version RequiredPSVersion { get; private set; }
 
         #endregion
 
@@ -72,15 +98,15 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     requiresComment,
                     out Token[] tokens,
                     out ParseError[] parserErrors);
-                
+
                 if (parserErrors.Length > 0)
                 {
                     foreach (ParseError err in parserErrors)
                     {
                         errorsList.Add(new ErrorRecord(
-                            new InvalidOperationException($"Could not requires comments as valid PowerShell input due to {err.Message}."), 
-                            err.ErrorId, 
-                            ErrorCategory.ParserError, 
+                            new InvalidOperationException($"Could not requires comments as valid PowerShell input due to {err.Message}."),
+                            err.ErrorId,
+                            ErrorCategory.ParserError,
                             null));
                     }
 
@@ -92,20 +118,51 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 ScriptRequirements parsedScriptRequirements = ast.ScriptRequirements;
                 ReadOnlyCollection<ModuleSpecification> parsedModules = new List<ModuleSpecification>().AsReadOnly();
 
-                if (parsedScriptRequirements != null && parsedScriptRequirements.RequiredModules != null)
+                if (parsedScriptRequirements != null)
                 {
-                    RequiredModules = parsedScriptRequirements.RequiredModules.ToArray();
+                    // System.Management.Automation.Language.ScriptRequirements properties are listed here:
+                    // https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptrequirements?view=powershellsdk-7.4.0
+
+                    if (parsedScriptRequirements.IsElevationRequired)
+                    {
+                        IsElevationRequired = true;
+                    }
+
+                    if (parsedScriptRequirements.RequiredApplicationId != null)
+                    {
+                        RequiredApplicationId = parsedScriptRequirements.RequiredApplicationId;
+                    }
+
+                    if (parsedScriptRequirements.RequiredAssemblies != null)
+                    {
+                        RequiredAssemblies = parsedScriptRequirements.RequiredAssemblies.ToArray();
+                    }
+
+                    if (parsedScriptRequirements.RequiredModules != null)
+                    {
+                        RequiredModules = parsedScriptRequirements.RequiredModules.ToArray();
+                    }
+
+                    if (parsedScriptRequirements.RequiredPSEditions != null)
+                    {
+                        RequiredPSEditions = parsedScriptRequirements.RequiredPSEditions.ToArray();
+                    }
+
+                    if (parsedScriptRequirements.RequiredPSVersion != null)
+                    {
+                        RequiredPSVersion = parsedScriptRequirements.RequiredPSVersion;
+                    }
                 }
             }
             catch (Exception e)
             {
                 errorsList.Add(new ErrorRecord(
-                    new ArgumentException($"Parsing RequiredModules failed due to {e.Message}"), 
-                    "requiredModulesAstParseThrewError", 
-                    ErrorCategory.ParserError, 
+                    new ArgumentException($"Parsing RequiredModules failed due to {e.Message}"),
+                    "requiredModulesAstParseThrewError",
+                    ErrorCategory.ParserError,
                     null));
                 errors = errorsList.ToArray();
-                
+
                 return false;
             }
 
@@ -118,6 +175,31 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         internal string[] EmitContent()
         {
             List<string> psRequiresLines = new List<string>();
+            if (IsElevationRequired)
+            {
+                psRequiresLines.Add(String.Empty);
+                psRequiresLines.Add("#Requires -RunAsAdministrator");
+                psRequiresLines.Add(String.Empty);
+            }
+
+            if (!String.IsNullOrEmpty(RequiredApplicationId))
+            {
+                psRequiresLines.Add(String.Empty);
+                psRequiresLines.Add(String.Format("#Requires -ShellId {0}", RequiredApplicationId));
+                psRequiresLines.Add(String.Empty);
+            }
+
+            if (RequiredAssemblies.Length > 0)
+            {
+                psRequiresLines.Add(String.Empty);
+                foreach (string assembly in RequiredAssemblies)
+                {
+                    psRequiresLines.Add(String.Format("#Requires -Assembly {0}", assembly));
+                }
+
+                psRequiresLines.Add(String.Empty);
+            }
+
             if (RequiredModules.Length > 0)
             {
                 psRequiresLines.Add(String.Empty);
@@ -125,7 +207,25 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 {
                     psRequiresLines.Add(String.Format("#Requires -Module {0}", moduleSpec.ToString()));
                 }
-                
+
+                psRequiresLines.Add(String.Empty);
+            }
+
+            if (RequiredPSEditions.Length > 0)
+            {
+                psRequiresLines.Add(String.Empty);
+                foreach (string psEdition in RequiredPSEditions)
+                {
+                    psRequiresLines.Add(String.Format("#Requires -PSEdition {0}", psEdition));
+                }
+
+                psRequiresLines.Add(String.Empty);
+            }
+
+            if (RequiredPSVersion != null)
+            {
+                psRequiresLines.Add(String.Empty);
+                psRequiresLines.Add(String.Format("#Requires -Version {0}", RequiredPSVersion.ToString()));
                 psRequiresLines.Add(String.Empty);
             }
 

--- a/test/PSScriptFileInfoTests/UpdatePSScriptFileInfo.Tests.ps1
+++ b/test/PSScriptFileInfoTests/UpdatePSScriptFileInfo.Tests.ps1
@@ -264,6 +264,34 @@ Describe "Test Update-PSScriptFileInfo" -tags 'CI' {
         $results -like "*#Requires*ModuleName*Version*" | Should -BeTrue
     }
 
+    It "update script file with varying Required properties (IsElevationRequired, RequiredApplicationId, RequiredAssembliesRequiredPSEditions, RequiredPSVersion) should retain those Require statements" {
+        $testScriptWithRequiredProperties = Join-Path -Path $script:testScriptsFolderPath -ChildPath "ScriptWithAllRequiresProperties.ps1"
+        Update-PSScriptFileInfo -Path $testScriptWithRequiredProperties -Version "2.0.0.0"
+        Test-PSScriptFileInfo $testScriptWithRequiredProperties | Should -Be $true
+
+        $requiredApplicationId = "Shell"
+        $requiredAssemblies = @("path\to\foo.dll")
+        $requiredPSEditions = @("Desktop")
+        $requiredPSVersion = "5.1"
+
+        Test-Path -Path $testScriptWithRequiredProperties | Should -BeTrue
+        $results = Get-Content -Path $testScriptWithRequiredProperties -Raw
+        $results.Contains("#Requires -RunAsAdministrator") | Should -BeTrue
+        $results -like "*#Requires -ShellId*" | Should -BeTrue
+        $results -like "*#Requires*Assembly*" | Should -BeTrue
+        $results -like "*#Requires*PSEdition*" | Should -BeTrue
+        $results -like "*#Requires*Version*" | Should -BeTrue
+
+        $scriptFileObj = Get-PSScriptFileInfo -Path $testScriptWithRequiredProperties
+        $scriptFileObj.ScriptRequiresComment.RequiredModules[0] | Should -Be "Microsoft.PowerShell.PSResourceGet"
+        $scriptFileObj.ScriptRequiresComment.IsElevationRequired | Should -Be $true
+        $scriptFileObj.ScriptRequiresComment.RequiredApplicationId | Should -Be $requiredApplicationId
+        $scriptFileObj.ScriptRequiresComment.RequiredAssemblies | Should -Be $requiredAssemblies
+        $scriptFileObj.ScriptRequiresComment.RequiredPSEditions | Should -Be $requiredPSEditions
+        $scriptFileObj.ScriptRequiresComment.RequiredPSVersion | Should -Be $requiredPSVersion
+        $scriptFileObj.ScriptMetadataComment.Version | Should -Be "2.0.0.0"
+    }
+
     It "update script file RequiredScripts property" {
         $requiredScript1 = "RequiredScript1"
         $requiredScript2 = "RequiredScript2"

--- a/test/testFiles/testScripts/ScriptWithAllRequiresProperties.ps1
+++ b/test/testFiles/testScripts/ScriptWithAllRequiresProperties.ps1
@@ -1,0 +1,54 @@
+<#PSScriptInfo
+
+.VERSION 2.0.0.0
+
+.GUID 3951be04-bd06-4337-8dc3-a620bf539fbd
+
+.AUTHOR annavied
+
+.COMPANYNAME 
+
+.COPYRIGHT 
+
+.TAGS 
+
+.LICENSEURI 
+
+.PROJECTURI 
+
+.ICONURI 
+
+.EXTERNALMODULEDEPENDENCIES 
+
+.REQUIREDSCRIPTS 
+
+.EXTERNALSCRIPTDEPENDENCIES 
+
+.RELEASENOTES
+
+
+.PRIVATEDATA
+
+
+#>
+
+#Requires -RunAsAdministrator
+
+#Requires -ShellId Shell
+
+#Requires -Assembly path\to\foo.dll
+
+#Requires -PSEdition Desktop
+
+#Requires -Version 5.1
+
+#Requires -Module Microsoft.PowerShell.PSResourceGet
+
+<#
+
+.DESCRIPTION
+        This is a test script
+
+    .SYNOPSIS
+        Test the Update-PSScriptFileInfo cmdlet
+#>


### PR DESCRIPTION
Currently `Update-PSScriptFileInfo` populates only the `RequiredModules` field for `#Requires` statements, but there are other types of `#Requires` statements based on different properties that are possible, such as `IsRequiredElevation`, `RequiredPSVersion` and more in the [docs here](https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptrequirements?view=powershellsdk-7.4.0) 

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1832

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
