### PR TITLE
Check for ModulePrefix parameter presence instead of it being a dynamic parameter

### DIFF
--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -142,7 +142,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             _networkCredential = Credential != null ? new NetworkCredential(Credential.UserName, Credential.Password) : null;
 
-            // Create a respository story (the PSResourceRepository.xml file) if it does not already exist
+            // Create the repository store file (PSResourceRepository.xml) if it does not already exist
             // This is to create a better experience for those who have just installed v3 and want to get up and running quickly
             RepositorySettings.CheckRepositoryStore();
 

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -155,7 +155,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (repository is null || repository.ApiVersion != PSRepositoryInfo.APIVersion.ContainerRegistry)
                     {
                         ThrowTerminatingError(new ErrorRecord(
-                            new PSInvalidOperationException("ModulePrefix parameter can only be provided with the Repository parameter for a registered repository of type 'ContainerRegistry'"),
+                            new PSInvalidOperationException("ModulePrefix parameter can only be provided for a registered repository of type 'ContainerRegistry'"),
                             "ModulePrefixParameterIncorrectlyProvided",
                             ErrorCategory.InvalidOperation,
                             this));

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -17,13 +17,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         "PSResource",
         SupportsShouldProcess = true)]
     [Alias("pbres")]
-    public sealed class PublishPSResource : PSCmdlet, IDynamicParameters
+    public sealed class PublishPSResource : PSCmdlet
     {
         #region Parameters
 
         private const string PathParameterSet = "PathParameterSet";
         private const string NupkgPathParameterSet = "NupkgPathParameterSet";
-        private ContainerRegistryDynamicParameters _pkgPrefix;
 
         /// <summary>
         /// Specifies the API key that you want to use to publish a module to the online gallery.
@@ -117,20 +116,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         [ValidateNotNullOrEmpty]
         public string NupkgPath { get; set; }
 
-        #endregion
-
-        #region DynamicParameters
-        public object GetDynamicParameters()
-        {
-            PSRepositoryInfo repository = RepositorySettings.Read(new[] { Repository }, out string[] _).FirstOrDefault();
-            if (repository is not null && repository.ApiVersion == PSRepositoryInfo.APIVersion.ContainerRegistry)
-            {
-                _pkgPrefix = new ContainerRegistryDynamicParameters();
-                return _pkgPrefix;
-            }
-
-            return null;
-        }
+        /// <summary>
+        /// Prefix for module name which only applies to repositories of type 'ContainerRegistry'
+        /// </summary>
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        public string ModulePrefix { get; set; }
 
         #endregion
 
@@ -151,15 +142,41 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             _networkCredential = Credential != null ? new NetworkCredential(Credential.UserName, Credential.Password) : null;
 
+            // Create a respository story (the PSResourceRepository.xml file) if it does not already exist
+            // This is to create a better experience for those who have just installed v3 and want to get up and running quickly
+            RepositorySettings.CheckRepositoryStore();
+
+            if (MyInvocation.BoundParameters.ContainsKey(nameof(ModulePrefix)))
+            {
+                if (MyInvocation.BoundParameters.ContainsKey(nameof(Repository))) // can remove if Repository is 'Mandatory' parameter
+                {
+                    // at this point it is ensured PSResourceRepository.xml file is created
+                    PSRepositoryInfo repository = RepositorySettings.Read(new[] { Repository }, out string[] _).FirstOrDefault();
+                    if (repository is null || repository.ApiVersion != PSRepositoryInfo.APIVersion.ContainerRegistry)
+                    {
+                        ThrowTerminatingError(new ErrorRecord(
+                            new PSInvalidOperationException("ModulePrefix parameter can only be provided with the Repository parameter for a registered repository of type 'ContainerRegistry'"),
+                            "ModulePrefixParameterIncorrectlyProvided",
+                            ErrorCategory.InvalidOperation,
+                            this));
+                    }
+                }
+                else
+                {
+                    // can remove if Repository is 'Mandatory' parameter
+                    ThrowTerminatingError(new ErrorRecord(
+                        new PSInvalidOperationException("ModulePrefix parameter can only be provided with the Repository parameter."),
+                        "ModulePrefixParameterProvidedWithoutRepositoryParameter",
+                        ErrorCategory.InvalidOperation,
+                        this));
+                }
+            }
+
             if (!string.IsNullOrEmpty(NupkgPath))
             {
                 _isNupkgPathSpecified = true;
                 Path = NupkgPath;
             }
-
-            // Create a respository story (the PSResourceRepository.xml file) if it does not already exist
-            // This is to create a better experience for those who have just installed v3 and want to get up and running quickly
-            RepositorySettings.CheckRepositoryStore();
 
             _publishHelper = new PublishHelper(
                 this,
@@ -186,18 +203,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return;
             }
 
-            string modulePrefix = _pkgPrefix?.ModulePrefix;
-
-            _publishHelper.PushResource(Repository, modulePrefix, SkipDependenciesCheck, _networkCredential);
+            _publishHelper.PushResource(Repository, ModulePrefix, SkipDependenciesCheck, _networkCredential);
         }
 
         #endregion
 
-    }
-
-    public class ContainerRegistryDynamicParameters
-    {
-        [Parameter]
-        public string ModulePrefix { get; set; }
     }
 }

--- a/src/code/PublishPSResource.cs
+++ b/src/code/PublishPSResource.cs
@@ -148,7 +148,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (MyInvocation.BoundParameters.ContainsKey(nameof(ModulePrefix)))
             {
-                if (MyInvocation.BoundParameters.ContainsKey(nameof(Repository))) // can remove if Repository is 'Mandatory' parameter
+                if (MyInvocation.BoundParameters.ContainsKey(nameof(Repository)))
                 {
                     // at this point it is ensured PSResourceRepository.xml file is created
                     PSRepositoryInfo repository = RepositorySettings.Read(new[] { Repository }, out string[] _).FirstOrDefault();
@@ -163,7 +163,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
                 else
                 {
-                    // can remove if Repository is 'Mandatory' parameter
                     ThrowTerminatingError(new ErrorRecord(
                         new PSInvalidOperationException("ModulePrefix parameter can only be provided with the Repository parameter."),
                         "ModulePrefixParameterProvidedWithoutRepositoryParameter",


### PR DESCRIPTION
For `Publish-PSResource` declare `ModulePrefix` as a regular parameter instead of a dynamic parameter. This allows for better error message writing and error handling with regards to how this parameter works with repositories.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1827 #1806 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
