### PR TITLE
Use runspace to acquire version to avoid CLM issues

### DIFF
--- a/src/code/InternalHooks.cs
+++ b/src/code/InternalHooks.cs
@@ -22,5 +22,10 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             var fieldInfo = typeof(InternalHooks).GetField(property, BindingFlags.Static | BindingFlags.NonPublic);
             fieldInfo?.SetValue(null, value);
         }
+
+        public static string GetUserString()
+        {
+            return Microsoft.PowerShell.PSResourceGet.Cmdlets.UserAgentInfo.UserAgentString();
+        }
     }
 }

--- a/src/code/ServerFactory.cs
+++ b/src/code/ServerFactory.cs
@@ -12,11 +12,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
     {
         static UserAgentInfo()
         {
-            using (System.Management.Automation.PowerShell ps = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace))
-            {
-                _psVersion = ps.AddScript("$PSVersionTable").Invoke<Hashtable>()[0]["PSVersion"].ToString();
-            }
-
+            _psVersion = System.Management.Automation.Runspaces.Runspace.DefaultRunspace.Version.ToString();
             _psResourceGetVersion = typeof(UserAgentInfo).Assembly.GetName().Version.ToString();
             _distributionChannel = System.Environment.GetEnvironmentVariable("POWERSHELL_DISTRIBUTION_CHANNEL") ?? "unknown";
         }

--- a/test/ConstrainedLanguageMode.Tests.ps1
+++ b/test/ConstrainedLanguageMode.Tests.ps1
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# In future, we will add more tests to be executed in Constrained Language Mode.
+Describe "Test UserAgentInfo" {
+    It "GetUserString returns a non-null, non-empty string" {
+        $userAgentString = [Microsoft.PowerShell.PSResourceGet.InternalHooks]::GetUserString()
+        $userAgentString | Should -Not -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request introduces a new helper method to retrieve the user agent string and simplifies how the PowerShell version is determined for user agent construction. The changes improve maintainability and reliability by reducing the use of PowerShell scripts and exposing a direct way to access the user agent string.

User agent string handling:

* Added a new static method `GetUserString` to `InternalHooks` that returns the user agent string via `UserAgentInfo.UserAgentString()`.

PowerShell version detection:

* Updated the static constructor of `UserAgentInfo` to retrieve the PowerShell version using `Runspace.DefaultRunspace.Version` instead of executing a PowerShell script, simplifying and making the version detection more robust.

## PR Context

Fixes #1676

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
