### PR TITLE
Test clean up for Publish-PSResource

### DIFF
--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -4,9 +4,9 @@
 $modPath = "$psscriptroot/../PSGetTestUtils.psm1"
 Import-Module $modPath -Force -Verbose
 
-$testDir = (get-item $psscriptroot).parent.FullName
+$script:testDir = (get-item $psscriptroot).parent.FullName
 
-function CreateTestModule
+function script:CreateTestModule
 {
     param (
         [string] $Path = "$TestDrive",
@@ -56,7 +56,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $tmpRepoPath2 = Join-Path -Path $TestDrive -ChildPath "tmpRepoPath2"
         New-Item $tmpRepoPath2 -Itemtype directory -Force
         $testRepository2 = "testRepository2"
-        Register-PSResourceRepository -Name $testRepository2 -Uri $tmpRepoPath2 -ErrorAction SilentlyContinue
+        Register-PSResourceRepository -Name $testRepository2 -Uri $tmpRepoPath2
         $script:repositoryPath2 = [IO.Path]::GetFullPath((get-psresourcerepository "testRepository2").Uri.AbsolutePath)
 
         # Create module
@@ -107,7 +107,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
     }
     AfterEach {
         # Delete all contents of the repository without deleting the repository directory itself
-        $pkgsToDelete = Join-Path -Path "$script:repositoryPath" -ChildPath "*"
+        $pkgsToDelete = Join-Path -Path "$script:repositoryPath" -ChildPath "*"  
         Remove-Item $pkgsToDelete -Recurse
 
         $pkgsToDelete = Join-Path -Path "$script:repositoryPath2" -ChildPath "*"
@@ -149,44 +149,6 @@ Describe "Test Publish-PSResource" -tags 'CI' {
 
         $expectedPath = Join-Path -Path $script:repositoryPath  -ChildPath "$script:PublishModuleName.$version.nupkg"
         (Get-ChildItem $script:repositoryPath).FullName | Should -Be $expectedPath
-    }
-
-    It "Publish should create PSResourceRepository.xml file if its not there" {
-        # Remove the PSResourceRepository.xml file
-        $powerShellGetPath = Join-Path -Path ([Environment]::GetFolderPath([System.Environment+SpecialFolder]::LocalApplicationData)) -ChildPath "PSResourceGet"
-        $originalXmlFilePath = Join-Path -Path $powerShellGetPath -ChildPath "PSResourceRepository.xml" #this is the temporary PSResourceRepository.xml file created in the 'BeforeAll' section of this test file
-
-        $tempXmlFilePath = Join-Path -Path $powerShellGetPath -ChildPath "tempfortest.xml"
-
-        if (Test-Path -Path $originalXmlFilePath) {
-            Copy-Item -Path $originalXmlFilePath -Destination $tempXmlFilePath
-            Remove-Item -Path $originalXmlFilePath -Force -ErrorAction Ignore
-        }
-
-        # Attempt to publish.
-        # Publish-PSResource should create PSResourceRepository.xml file if not present. It will register the 'PSGallery' repository as a default, so this test will still fail
-        # But we can ensure the PSResourceRepository.xml file is created.
-        $version = "1.0.0"
-        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
-
-        Publish-PSResource -Path $script:PublishModuleBase -Repository $testRepository2 -ErrorVariable err -ErrorAction SilentlyContinue
-        $err[0].FullyQualifiedErrorId | Should -Be "RepositoryNotRegistered,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
-
-        $registeredRepos = Get-PSResourceRepository
-        $registeredRepos.Count | Should -Be 1
-        $registeredRepos[0].Name | Should -Be $script:PSGalleryName
-
-        # Cleanup
-        # Remove the new PSResourceRepository.xml file created by the Publish-PSResource command and put back the original created in the 'BeforeAll' section of this test file
-        if (Test-Path -Path $tempXmlFilePath) {
-            Copy-Item -Path $tempXmlFilePath -Destination $originalXmlFilePath -Force -Verbose
-            Remove-Item -Path $tempXmlFilePath -Force -ErrorAction Ignore
-        }
-
-        # Verify old repositories are restored
-        $originalRegisteredRepo = Get-PSResourceRepository -Name $testRepository2 -ErrorVariable err2 -ErrorAction SilentlyContinue
-        $err2.Count | Should -Be 0
-        $originalRegisteredRepo.Name | Should -Be $testRepository2
     }
 
 	#region Local Source Path
@@ -765,4 +727,81 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         (Get-ChildItem $script:repositoryPath2).FullName | Should -Contain $expectedPath
     }
 #>
+}
+
+
+Describe "Test Publish-PSResource with Module Prefix" -tags 'CI' {
+
+    BeforeAll {
+        Get-NewPSResourceRepositoryFile
+        
+        $tmpRepoPath2 = Join-Path -Path $TestDrive -ChildPath "tmpRepoPath2"
+        New-Item $tmpRepoPath2 -Itemtype directory -Force
+        $testRepository2 = "testRepository2"
+        Register-PSResourceRepository -Name $testRepository2 -Uri $tmpRepoPath2
+        $script:repositoryPath2 = [IO.Path]::GetFullPath((get-psresourcerepository "testRepository2").Uri.AbsolutePath)
+
+        # Create module
+        $script:tmpModulesPath = Join-Path -Path $TestDrive -ChildPath "tmpModulesPath"
+        $script:PublishModuleName = "PSGetTestModule"
+        $script:PublishModuleBase = Join-Path $script:tmpModulesPath -ChildPath $script:PublishModuleName
+        if(!(Test-Path $script:PublishModuleBase))
+        {
+            New-Item -Path $script:PublishModuleBase -ItemType Directory -Force
+        }
+
+        $script:PSGalleryName = 'PSGallery'
+    }
+    AfterAll {
+       Get-RevertPSResourceRepositoryFile
+    }
+    AfterEach {
+        # Delete all contents of the repository without deleting the repository directory itself
+        $pkgsToDelete = Join-Path -Path "$script:repositoryPath2" -ChildPath "*"
+        Remove-Item $pkgsToDelete -Recurse
+
+        $pkgsToDelete = Join-Path -Path $script:PublishModuleBase  -ChildPath "*"
+        Remove-Item $pkgsToDelete -Recurse -ErrorAction SilentlyContinue
+    }
+
+    It "Publish should create PSResourceRepository.xml file if its not there" {
+        # Remove the PSResourceRepository.xml file
+        $powerShellGetPath = Join-Path -Path ([Environment]::GetFolderPath([System.Environment+SpecialFolder]::LocalApplicationData)) -ChildPath "PSResourceGet"
+        $originalXmlFilePath = Join-Path -Path $powerShellGetPath -ChildPath "PSResourceRepository.xml" #this is the temporary PSResourceRepository.xml file created in the 'BeforeAll' section of this test file
+
+        $tempXmlFilePath = Join-Path -Path $powerShellGetPath -ChildPath "tempfortest.xml"
+
+        try {
+            if (Test-Path -Path $originalXmlFilePath) {
+                Copy-Item -Path $originalXmlFilePath -Destination $tempXmlFilePath
+                Remove-Item -Path $originalXmlFilePath -Force -ErrorAction Ignore
+            }
+
+            # Attempt to publish.
+            # Publish-PSResource should create PSResourceRepository.xml file if not present. It will register the 'PSGallery' repository as a default, so this test will still fail
+            # But we can ensure the PSResourceRepository.xml file is created.
+            $version = "1.0.0"
+            New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
+
+            Publish-PSResource -Path $script:PublishModuleBase -Repository $testRepository2 -ErrorVariable err -ErrorAction SilentlyContinue
+            $err[0].FullyQualifiedErrorId | Should -Be "RepositoryNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
+
+            $registeredRepos = Get-PSResourceRepository
+            $registeredRepos.Count | Should -Be 1
+            $registeredRepos[0].Name | Should -Be $script:PSGalleryName
+        }
+        finally {
+            # Cleanup
+            # Remove the new PSResourceRepository.xml file created by the Publish-PSResource command and put back the original created in the 'BeforeAll' section of this test file
+            if (Test-Path -Path $tempXmlFilePath) {
+                Copy-Item -Path $tempXmlFilePath -Destination $originalXmlFilePath -Force -Verbose
+                Remove-Item -Path $tempXmlFilePath -Force -ErrorAction Ignore
+            }
+        }
+
+        # Verify old repositories are restored
+        $originalRegisteredRepo = Get-PSResourceRepository -Name $testRepository2 -ErrorVariable err2 -ErrorAction SilentlyContinue
+        $err2.Count | Should -Be 0
+        $originalRegisteredRepo.Name | Should -Be $testRepository2
+    }
 }

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -522,7 +522,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $modulePrefix = "unlisted"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
 
-        { Publish-PSResource -Path $script:PublishModuleBase -Repository $script:PSGalleryName -ModulePrefix $modulePrefix -ErrorVariable err -ErrorAction SilentlyContinue  -ErrorAction Stop } | Should -Throw "ModulePrefixParameterIncorrectlyProvided,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
+        { Publish-PSResource -Path $script:PublishModuleBase -Repository $script:PSGalleryName -ModulePrefix $modulePrefix -ErrorAction Stop } | Should -Throw "ModulePrefixParameterIncorrectlyProvided,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
     }
 
     It "not Publish a resource when ModulePrefix is provided without Repository parameter" {
@@ -530,7 +530,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $modulePrefix = "unlisted"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
 
-        { Publish-PSResource -Path $script:PublishModuleBase -ModulePrefix $modulePrefix -ErrorVariable err -ErrorAction SilentlyContinue  -ErrorAction Stop } | Should -Throw "ModulePrefixParameterProvidedWithoutRepositoryParameter,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
+        { Publish-PSResource -Path $script:PublishModuleBase -ModulePrefix $modulePrefix -ErrorAction Stop } | Should -Throw "ModulePrefixParameterProvidedWithoutRepositoryParameter,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
     }
 
     It "Publish a package given NupkgPath to a package with .psd1" {

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -522,9 +522,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $modulePrefix = "unlisted"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
 
-        Publish-PSResource -Path $script:PublishModuleBase -Repository $script:PSGalleryName -ModulePrefix $modulePrefix -ErrorVariable err -ErrorAction SilentlyContinue
-        $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "ModulePrefixParameterIncorrectlyProvided,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
+        { Publish-PSResource -Path $script:PublishModuleBase -Repository $script:PSGalleryName -ModulePrefix $modulePrefix -ErrorVariable err -ErrorAction SilentlyContinue  -ErrorAction Stop } | Should -Throw "ModulePrefixParameterIncorrectlyProvided,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
     }
 
     It "not Publish a resource when ModulePrefix is provided without Repository parameter" {
@@ -532,9 +530,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $modulePrefix = "unlisted"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
 
-        Publish-PSResource -Path $script:PublishModuleBase -ModulePrefix $modulePrefix -ErrorVariable err -ErrorAction SilentlyContinue
-        $err.Count | Should -Not -Be 0
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "ModulePrefixParameterProvidedWithoutRepositoryParameter,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
+        { Publish-PSResource -Path $script:PublishModuleBase -ModulePrefix $modulePrefix -ErrorVariable err -ErrorAction SilentlyContinue  -ErrorAction Stop } | Should -Throw "ModulePrefixParameterProvidedWithoutRepositoryParameter,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
     }
 
     It "Publish a package given NupkgPath to a package with .psd1" {

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -517,8 +517,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $results[0].Version | Should -Be $version
     }
 
-    It "not Publish a resource when ModulePrefix is given for a Repository that is not of type ContainerRegistry" 
-    {
+    It "not Publish a resource when ModulePrefix is given for a Repository that is not of type ContainerRegistry" {
         $version = "1.0.0"
         $modulePrefix = "unlisted"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -522,7 +522,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $modulePrefix = "unlisted"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
 
-        { Publish-PSResource -Path $script:PublishModuleBase -Repository $script:PSGalleryName -ModulePrefix $modulePrefix -ErrorAction Stop } | Should -Throw "ModulePrefixParameterIncorrectlyProvided,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
+        { Publish-PSResource -Path $script:PublishModuleBase -Repository $script:PSGalleryName -ModulePrefix $modulePrefix -ErrorAction Stop } | Should -Throw "ModulePrefix parameter can only be provided for a registered repository of type 'ContainerRegistry'"
     }
 
     It "not Publish a resource when ModulePrefix is provided without Repository parameter" {
@@ -530,7 +530,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $modulePrefix = "unlisted"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
 
-        { Publish-PSResource -Path $script:PublishModuleBase -ModulePrefix $modulePrefix -ErrorAction Stop } | Should -Throw "ModulePrefixParameterProvidedWithoutRepositoryParameter,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
+        { Publish-PSResource -Path $script:PublishModuleBase -ModulePrefix $modulePrefix -ErrorAction Stop } | Should -Throw "ModulePrefix parameter can only be provided with the Repository parameter."
     }
 
     It "Publish a package given NupkgPath to a package with .psd1" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Test clean-ups for 'PublishPSResource.Tests.ps1', which had a few errors causing cascading CI failures.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
