### PR TITLE
Fix 1823 - MAR fails to parse RequiredVersion for dependencies

### DIFF
--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -738,8 +738,9 @@ namespace Microsoft.PowerShell.PSResourceGet
             {
                 using (JsonDocument metadataJSONDoc = JsonDocument.Parse(serverPkgInfo.Metadata))
                 {
-                    string pkgVersionString = String.Empty;
+                    string pkgVersionString = String.Empty; 
                     JsonElement rootDom = metadataJSONDoc.RootElement;
+
                     if (rootDom.TryGetProperty("ModuleVersion", out JsonElement pkgVersionElement))
                     {
                         // module metadata will have "ModuleVersion" property
@@ -831,7 +832,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             errRecord = null;
             ContainerRegistryInfo serverPkgInfo = null;
 
-            var layers = foundTags["layers"];
+            JToken layers = foundTags["layers"];
             if (layers == null || layers[0] == null)
             {
                 errRecord = new ErrorRecord(
@@ -843,7 +844,7 @@ namespace Microsoft.PowerShell.PSResourceGet
                 return serverPkgInfo;
             }
 
-            var annotations = layers[0]["annotations"];
+            JToken annotations = layers[0]["annotations"];
             if (annotations == null)
             {
                 errRecord = new ErrorRecord(
@@ -856,7 +857,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             }
 
             // Check for package name
-            var pkgTitleJToken = annotations["org.opencontainers.image.title"];
+            JToken pkgTitleJToken = annotations["org.opencontainers.image.title"];
             if (pkgTitleJToken == null)
             {
                 errRecord = new ErrorRecord(
@@ -881,7 +882,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             }
 
             // Check for package metadata
-            var pkgMetadataJToken = annotations["metadata"];
+            JToken pkgMetadataJToken = annotations["metadata"];
             if (pkgMetadataJToken == null)
             {
                 errRecord = new ErrorRecord(
@@ -896,7 +897,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             var metadata = pkgMetadataJToken.ToString();
 
             // Check for package artifact type
-            var resourceTypeJToken = annotations["resourceType"];
+            JToken resourceTypeJToken = annotations["resourceType"];
             var resourceType = resourceTypeJToken != null ? resourceTypeJToken.ToString() : "None";
 
             return new ContainerRegistryInfo(metadataPkgName, metadata, resourceType);

--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -706,27 +706,28 @@ namespace Microsoft.PowerShell.PSResourceGet
                 return requiredVersionResponse;
             }
 
-            /*   Response returned looks something like:
-             *    {
-             *     "schemaVersion": 2,
-             *     "config": {
-             *       "mediaType": "application/vnd.unknown.config.v1+json",
-             *       "digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-             *       "size": 0
-             *     },
-             *     "layers": [
-             *       {
-             *         "mediaType": "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip'",
-             *         "digest": "sha256:7c55c7b66cb075628660d8249cc4866f16e34741c246a42ed97fb23ccd4ea956",
-             *         "size": 3533,
-             *         "annotations": {
-             *           "org.opencontainers.image.title": "test_module.1.0.0.nupkg",
-             *           "metadata": "{\"GUID\":\"45219bf4-10a4-4242-92d6-9bfcf79878fd\",\"FunctionsToExport\":[],\"CompanyName\":\"Anam\",\"CmdletsToExport\":[],\"VariablesToExport\":\"*\",\"Author\":\"Anam Navied\",\"ModuleVersion\":\"1.0.0\",\"Copyright\":\"(c) Anam Navied. All rights reserved.\",\"PrivateData\":{\"PSData\":{\"Tags\":[\"Test\",\"CommandsAndResource\",\"Tag2\"]}},\"RequiredModules\":[],\"Description\":\"This is a test module, for PSGallery team internal testing. Do not take a dependency on this package. This version contains tags for the package.\",\"AliasesToExport\":[]}"
-             *         }
-             *       }
-             *     ]
-             *   }
-             */
+            /*
+                Response returned looks something like:
+                {
+                    "schemaVersion": 2,
+                    "config": {
+                        "mediaType": "application/vnd.unknown.config.v1+json",
+                        "digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                        "size": 0
+                    },
+                    "layers": [
+                        {
+                            "mediaType": "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip'",
+                            "digest": "sha256:7c55c7b66cb075628660d8249cc4866f16e34741c246a42ed97fb23ccd4ea956",
+                            "size": 3533,
+                            "annotations": {
+                                "org.opencontainers.image.title": "test_module.1.0.0.nupkg",
+                                "metadata": "{\"GUID\":\"45219bf4-10a4-4242-92d6-9bfcf79878fd\",\"FunctionsToExport\":[],\"CompanyName\":\"Anam\",\"CmdletsToExport\":[],\"VariablesToExport\":\"*\",\"Author\":\"Anam Navied\",\"ModuleVersion\":\"1.0.0\",\"Copyright\":\"(c) Anam Navied. All rights reserved.\",\"PrivateData\":{\"PSData\":{\"Tags\":[\"Test\",\"CommandsAndResource\",\"Tag2\"]}},\"RequiredModules\":[],\"Description\":\"This is a test module, for PSGallery team internal testing. Do not take a dependency on this package. This version contains tags for the package.\",\"AliasesToExport\":[]}"
+                            }
+                        }
+                    ]
+                }
+            */
 
             ContainerRegistryInfo serverPkgInfo = GetMetadataProperty(foundTags, packageName, out errRecord);
             if (errRecord != null)

--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -894,7 +894,7 @@ namespace Microsoft.PowerShell.PSResourceGet
                 return serverPkgInfo;
             }
 
-            var metadata = pkgMetadataJToken.ToString();
+            string metadata = pkgMetadataJToken.ToString();
 
             // Check for package artifact type
             JToken resourceTypeJToken = annotations["resourceType"];

--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -698,9 +698,9 @@ namespace Microsoft.PowerShell.PSResourceGet
         internal Hashtable GetContainerRegistryMetadata(string packageName, string exactTagVersion, string containerRegistryAccessToken, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::GetContainerRegistryMetadata()");
-            Hashtable requiredVersionResponse = new Hashtable();
+            Hashtable requiredVersionResponse = new();
 
-            var foundTags = FindContainerRegistryManifest(packageName, exactTagVersion, containerRegistryAccessToken, out errRecord);
+            JObject foundTags = FindContainerRegistryManifest(packageName, exactTagVersion, containerRegistryAccessToken, out errRecord);
             if (errRecord != null)
             {
                 return requiredVersionResponse;
@@ -728,7 +728,7 @@ namespace Microsoft.PowerShell.PSResourceGet
              *   }
              */
 
-            var serverPkgInfo = GetMetadataProperty(foundTags, packageName, out errRecord);
+            ContainerRegistryInfo serverPkgInfo = GetMetadataProperty(foundTags, packageName, out errRecord);
             if (errRecord != null)
             {
                 return requiredVersionResponse;

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -1669,8 +1669,9 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                             }
 
                             depVersionRange = new VersionRange(
-                                            minVersion: depNuGetVersion,
-                                            includeMinVersion: true);
+                                minVersion: depNuGetVersion,
+                                includeMinVersion: true
+                            );
                         }
                         else if (dependency.TryGetProperty("RequiredVersion", out JsonElement depRequiredVersionElement))
                         {
@@ -1686,10 +1687,11 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                                 }
 
                                 depVersionRange = new VersionRange(
-                                                minVersion: depNuGetVersion,
-                                                includeMinVersion: true,
-                                                maxVersion: depNuGetVersion,
-                                                includeMaxVersion: true);
+                                    minVersion: depNuGetVersion,
+                                    includeMinVersion: true,
+                                    maxVersion: depNuGetVersion,
+                                    includeMaxVersion: true
+                                );
                             }
                         }
 

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -1639,10 +1639,10 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         internal static List<Dependency> ParseContainerRegistryDependencies(JsonElement requiredModulesElement, out string errorMsg)
         {
             errorMsg = string.Empty;
-            List<Dependency> pkgDeps = new List<Dependency>();
+            List<Dependency> pkgDeps = new();
             if (requiredModulesElement.ValueKind == JsonValueKind.Array)
             {
-                foreach (var dependency in requiredModulesElement.EnumerateArray())
+                foreach (JsonElement dependency in requiredModulesElement.EnumerateArray())
                 {
                     if (dependency.ValueKind == JsonValueKind.String)
                     {
@@ -1677,7 +1677,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                             // New-ScriptFileInfo will add "RequiredVersion" value as "null" if nothing is explicitly passed in,
                             // Which gets translated to an empty string.
                             // In this case, we just want the VersionRange to be VersionRange.All
-                            if (!string.Equals(depModuleVersionElement.ToString(), string.Empty))
+                            if (!string.Equals(depRequiredVersionElement.ToString(), string.Empty))
                             {
                                 if (!NuGetVersion.TryParse(depRequiredVersionElement.ToString(), out NuGetVersion depNuGetVersion))
                                 {

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -322,7 +322,7 @@ Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {
     }
 }
 
-# Skip this test fo
+# Skip this test for Windows PowerShell
 Describe 'Test Find-PSResource for unauthenticated ACR repository' -tags 'CI' {
     BeforeAll {
         $skipOnWinPS = $PSVersionTable.PSVersion.Major -eq 5

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -315,10 +315,10 @@ Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {
         $res = Find-PSResource -Repository 'MAR' -Name 'Az' -Version '14.4.0'
         
         # Version defined by "ModuleVersion"
-        $res.Dependencies.Where{$_.'Name' -eq 'Az.Accounts'}.'VersionRange'.ToString() | Should -Not -Be '(, )'
+        $res.Dependencies.Where{$_.'Name' -eq 'Az.Accounts'}.'VersionRange'.ToString() | Should -Be '[5.3.0, )'
         
         # Version defined by "RequiredVersion"
-        $res.Dependencies.Where{$_.'Name' -eq 'Az.Resources'}.'VersionRange'.ToString() | Should -Not -Be '(, )'
+        $res.Dependencies.Where{$_.'Name' -eq 'Az.Resources'}.'VersionRange'.ToString() | Should -Not -Be '[8.1.0, 8.1.0]'
     }
 }
 

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -318,7 +318,7 @@ Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {
         $res.Dependencies.Where{$_.'Name' -eq 'Az.Accounts'}.'VersionRange'.ToString() | Should -Be '[5.3.0, )'
         
         # Version defined by "RequiredVersion"
-        $res.Dependencies.Where{$_.'Name' -eq 'Az.Resources'}.'VersionRange'.ToString() | Should -Not -Be '[8.1.0, 8.1.0]'
+        $res.Dependencies.Where{$_.'Name' -eq 'Az.Resources'}.'VersionRange'.ToString() | Should -Be '[8.1.0, 8.1.0]'
     }
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

A little goof in an if statement in `PSResourceInfo.cs` made it so that PSResourceGet failed to get version range for dependencies where `RequiredVersion` was specified.

Fixes #1823

## PR Context

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
