### PR TITLE
Uninstall-PSResource should not fail silently when resource was not found or prerelease criteria not met

### DIFF
--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -182,6 +182,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             WriteDebug("In UninstallPSResource::UninstallPkgHelper");
             var successfullyUninstalled = false;
             GetHelper getHelper = new GetHelper(this);
+
+            HashSet<string> requestedPackageNames = new HashSet<string>(Name, StringComparer.InvariantCultureIgnoreCase);
             List<string> dirsToDelete = getHelper.FilterPkgPathsByName(Name, _pathsToSearch);
             int totalDirs = dirsToDelete.Count;
             errRecords = new List<ErrorRecord>();
@@ -257,15 +259,19 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                     return successfullyUninstalled;
                 }
+
+                requestedPackageNames.Remove(pkgName);
             }
 
             // the package requested for uninstallation was found by name, but not satisfied by version criteria (i.e version didn't exist or match prerelease criteria) so write error
-            if (currentUninstalledDirCount == 0)
+            // if (currentUninstalledDirCount == 0)
+            if (requestedPackageNames.Count > 0)
             {
+                string[] pkgsFailedToUninstall = requestedPackageNames.ToArray();
                 string prereleaseMessage = Prerelease ? "prerelease " : String.Empty;
                 string versionMessage = Version != null ? $"matching '{Version} '" : String.Empty;
 
-                string warningMessage = $"Cannot uninstall {prereleaseMessage}version(s) {versionMessage}of resource '{String.Join(", ", Name)}' because it does not exist.";
+                string warningMessage = $"Cannot uninstall {prereleaseMessage}version(s) {versionMessage}of resource '{String.Join(", ", pkgsFailedToUninstall)}' because it does not exist.";
 
                 WriteWarning(warningMessage);
             }

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -264,7 +264,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             // the package requested for uninstallation was found by name, but not satisfied by version criteria (i.e version didn't exist or match prerelease criteria) so write error
-            // if (currentUninstalledDirCount == 0)
             if (requestedPackageNames.Count > 0)
             {
                 string[] pkgsFailedToUninstall = requestedPackageNames.ToArray();

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -259,13 +259,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
             }
 
-            // If we found package to uninstall by name, but not satisfied by version criteria (i.e version didn't exist or match prerelease criteria) write error
+            // the package requested for uninstallation was found by name, but not satisfied by version criteria (i.e version didn't exist or match prerelease criteria) so write error
             if (currentUninstalledDirCount == 0)
             {
                 string prereleaseMessage = Prerelease ? "prerelease " : String.Empty;
-                string versionMessage = Version != null ? "matching '{Version} '" : String.Empty;
+                string versionMessage = Version != null ? $"matching '{Version} '" : String.Empty;
 
-                string warningMessage = $"Cannot uninstall {prereleaseMessage}version(s) '{versionMessage}'of resource '{String.Join(", ", Name)}' because it does not exist.";
+                string warningMessage = $"Cannot uninstall {prereleaseMessage}version(s) {versionMessage}of resource '{String.Join(", ", Name)}' because it does not exist.";
 
                 WriteWarning(warningMessage);
             }

--- a/src/code/UninstallPSResource.cs
+++ b/src/code/UninstallPSResource.cs
@@ -259,6 +259,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
             }
 
+            // If we found package to uninstall by name, but not satisfied by version criteria (i.e version didn't exist or match prerelease criteria) write error
+            if (currentUninstalledDirCount == 0)
+            {
+                string prereleaseMessage = Prerelease ? "prerelease " : String.Empty;
+                string versionMessage = Version != null ? "matching '{Version} '" : String.Empty;
+
+                string warningMessage = $"Cannot uninstall {prereleaseMessage}version(s) '{versionMessage}'of resource '{String.Join(", ", Name)}' because it does not exist.";
+
+                WriteWarning(warningMessage);
+            }
+
             return successfullyUninstalled;
         }
 

--- a/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
+++ b/test/UninstallPSResourceTests/UninstallPSResource.Tests.ps1
@@ -110,6 +110,32 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
         $pkgs.Version | Should -Not -Contain "1.0.0"
     }
 
+    It "Do not uninstall existing module when requested version does not exist and write warning instead" {
+        Uninstall-PSResource -Name $testModuleName -Version "9.9.9" -SkipDependencyCheck -WarningVariable warn -WarningAction SilentlyContinue
+
+        # Module should still be present since no prerelease versions were found
+        $res = Get-InstalledPSResource -Name $testModuleName
+        $res | Should -Not -BeNullOrEmpty
+        $res.Name | Should -Be $testModuleName
+
+        # Warning should have been written
+        $warn.Count | Should -Be 1
+        $warn[0] | Should -Match "Cannot uninstall version"
+    }
+
+    It "Do not uninstall existing module when requested version range does not exist and write warning instead" {
+        Uninstall-PSResource -Name $testModuleName -Version "[9.9.9, 10.0.0]" -SkipDependencyCheck -WarningVariable warn -WarningAction SilentlyContinue
+
+        # Module should still be present since no prerelease versions were found
+        $res = Get-InstalledPSResource -Name $testModuleName
+        $res | Should -Not -BeNullOrEmpty
+        $res.Name | Should -Be $testModuleName
+
+        # Warning should have been written
+        $warn.Count | Should -Be 1
+        $warn[0] | Should -Match "Cannot uninstall version"
+    }
+
     $testCases = @{Version="[1.0.0.0]";          ExpectedVersion="1.0.0.0"; Reason="validate version, exact match"},
                  @{Version="1.0.0.0";            ExpectedVersion="1.0.0.0"; Reason="validate version, exact match without bracket syntax"},
                  @{Version="[1.0.0.0, 5.0.0.0]"; ExpectedVersion="5.0.0.0"; Reason="validate version, exact range inclusive"},
@@ -233,6 +259,35 @@ Describe 'Test Uninstall-PSResource for Modules' -tags 'CI' {
         $stableVersionPkgs = $res | Where-Object {$_.IsPrerelease -ne $true}
         # versions 3.0.0 falls in range but should not be uninstalled as Prerelease parameter only selects prerelease versions to uninstall
         $stableVersionPkgs.Count | Should -Be 2
+    }
+
+    It "Write warning when using -Prerelease flag with only stable versions installed" {
+        # $testModuleName (test_module2) only has stable versions installed
+        $pkg = Get-InstalledPSResource $testModuleName
+        $pkg | Should -Not -BeNullOrEmpty
+
+        # Try to uninstall with -Prerelease flag, should show warning
+        Uninstall-PSResource -Name $testModuleName -Prerelease -SkipDependencyCheck -WarningVariable warn -WarningAction SilentlyContinue
+
+        # Module should still be present since no prerelease versions were found
+        $res = Get-InstalledPSResource -Name $testModuleName
+        $res | Should -Not -BeNullOrEmpty
+        $res.Name | Should -Be $testModuleName
+        $res.Version | Should -Be $pkg.Version
+
+        # Warning should have been written
+        $warn.Count | Should -Be 1
+        $warn[0] | Should -Match "Cannot uninstall prerelease version"
+    }
+
+    It "Write warning when multiple modules are requested to be uninstalled but one does not exist" {
+        Uninstall-PSResource $testModuleName, "nonExistantModule" -SkipDependencyCheck -WarningVariable warn -WarningAction SilentlyContinue
+        $res = Get-InstalledPSResource -Name $testModuleName
+        $res | Should -BeNullOrEmpty
+
+        # Warning should have been written
+        $warn.Count | Should -Be 1
+        $warn[0] | Should -Match "Cannot uninstall version"        
     }
 
     It "Uninstall module using -WhatIf, should not uninstall the module" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Uninstall-PSResource currently silently fails when a package has only stable versions installed and `Uninstall-PSResource -Name pkg -Prerelease` is run. Including the `-Prerelease` parameter for Uninstall-PSResource means only prerelease versions should be uninstalled, not stable ones. If a package doesn't have prerelease versions installed then instead of silently failing PSResourceGet should write a warning. Also updated warnings for other scenarios where PSResourceGet was silently failing, i.e if multiple packages were requested for uninstallation, and only a subset were able to be uninstalled then write warnings for the other packages.

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #842 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
