### PR TITLE
Bugfix: Update-PSResource should not re-install dependency packages which already satisfy dependency criteria

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -587,6 +587,16 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                                     }
                                 }
 
+                                string depPkgNameVersion = $"{depPkg.Name}{depPkg.Version.ToString()}";
+                                if (_packagesOnMachine.Contains(depPkgNameVersion) && !depPkg.IsPrerelease)
+                                {
+                                    // if a dependency package is already installed, do not install it again.
+                                    // to determine if the package version is already installed, _packagesOnMachine is used but it only contains name, version info, not version with prerelease info
+                                    // if the dependency package is found to be prerelease, it is safer to install it (and worse case it reinstalls)
+                                    _cmdletPassedIn.WriteVerbose($"Dependency '{depPkg.Name}' with version '{depPkg.Version}' is already installed.");
+                                    continue;
+                                }
+
                                 packagesHash = BeginPackageInstall(
                                             searchVersionType: VersionType.SpecificVersion,
                                             specificVersion: depVersion,

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -25,6 +25,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
     {
         #region Members
         private List<string> _pathsToInstallPkg;
+        private HashSet<string> _packagesOnMachine;
         private CancellationTokenSource _cancellationTokenSource;
         private FindHelper _findHelper;
         private InstallHelper _installHelper;
@@ -157,6 +158,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             RepositorySettings.CheckRepositoryStore();
 
             _pathsToInstallPkg = Utils.GetAllInstallationPaths(this, Scope);
+            List<string> pathsToSearch = Utils.GetAllResourcePaths(this, Scope);
+            _packagesOnMachine = Utils.GetInstalledPackages(pathsToSearch, this);
             _cancellationTokenSource = new CancellationTokenSource();
             var networkCred = Credential != null ? new NetworkCredential(Credential.UserName, Credential.Password) : null;
 
@@ -216,7 +219,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 pathsToInstallPkg: _pathsToInstallPkg,
                 scope: Scope,
                 tmpPath: _tmpPath,
-                pkgsInstalled: new HashSet<string>(StringComparer.InvariantCultureIgnoreCase));
+                pkgsInstalled: _packagesOnMachine);
 
             if (PassThru)
             {


### PR DESCRIPTION
Update-PSResource currently re-installs dependency packages even if they already satisfy depdendency criteria. For example, when installing Az.Network if dependency package Az.Accounts is already installed, the code would re-install Az.Accounts:

<img width="1749" height="303" alt="UpdateBugfixPreFix" src="https://github.com/user-attachments/assets/9f2a2686-3832-4f92-83f2-9a4e19fa7b26" />

With this fix, Update-PSResource first collects a list of all installed packages, and then when considering a package's dependency packages it checks against that list of already installed packages.

<img width="1736" height="173" alt="UpdateBugfixWithFix" src="https://github.com/user-attachments/assets/4feb61e0-0216-4a59-b5e6-99ec200dfb15" />

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes #1878 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
