### PR TITLE
Filter out path separators in package names

### DIFF
--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -189,12 +189,17 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
                     if (name.Contains("?") || name.Contains("["))
                     {
-                        errorMsgsList.Add(String.Format("-Name with wildcards '?' and '[' are not supported for this cmdlet so Name entry: {0} will be discarded.", name));
+                        errorMsgsList.Add(String.Format("-Name with wildcards '?' and '[' are not supported for this cmdlet so Name entry: '{0}' will be discarded.", name));
                         continue;
                     }
 
                     isContainWildcard = true;
                     namesWithSupportedWildcards.Add(name);
+                }
+                else if(name.Contains("/") || name.Contains("\\"))
+                {
+                    errorMsgsList.Add(String.Format("-Name with path separator '/' or '\\' is not supported for this cmdlet so Name entry: '{0}' will be discarded.", name));
+                    continue;
                 }
                 else
                 {

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -196,9 +196,9 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                     isContainWildcard = true;
                     namesWithSupportedWildcards.Add(name);
                 }
-                else if(name.Contains("/") || name.Contains("\\"))
+                else if(name.StartsWith("/") || name.StartsWith("\\"))
                 {
-                    errorMsgsList.Add(String.Format("-Name with path separator '/' or '\\' is not supported for this cmdlet so Name entry: '{0}' will be discarded.", name));
+                    errorMsgsList.Add(String.Format("-Name starting with path separator '/' or '\\' is not supported for this cmdlet so Name entry: '{0}' will be discarded.", name));
                     continue;
                 }
                 else

--- a/test/SavePSResourceTests/SavePSResourceV2.Tests.ps1
+++ b/test/SavePSResourceTests/SavePSResourceV2.Tests.ps1
@@ -208,4 +208,10 @@ Describe 'Test HTTP Save-PSResource for V2 Server Protocol' -tags 'CI' {
         $pkg.Name | Should -Be $testModuleNameWithLicense
         $pkg.Version | Should -Be "2.0"
     }
+
+    It "Not save module that has path separator in name" {
+        Save-PSResource -Name "/$testModuleName" -Repository $PSGalleryName -Path $SaveDir -ErrorVariable err -ErrorAction SilentlyContinue -TrustRepository
+        $err.Count | Should -BeGreaterThan 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly 'ErrorFilteringNamesForUnsupportedWildcards,Microsoft.PowerShell.PSResourceGet.Cmdlets.SavePSResource'
+    }
 }

--- a/test/SavePSResourceTests/SavePSResourceV3.Tests.ps1
+++ b/test/SavePSResourceTests/SavePSResourceV3.Tests.ps1
@@ -159,4 +159,10 @@ Describe 'Test HTTP Save-PSResource for V3 Server Protocol' -tags 'CI' {
         $res = Save-PSResource 'TestModuleWithDependencyE' -Repository $NuGetGalleryName -TrustRepository -PassThru
         $res.Length | Should -Be 4
     }
+
+    It "Not save module that has path separator in name" {
+        Save-PSResource -Name "/$testModuleName" -Repository $NuGetGalleryName -Path $SaveDir -ErrorVariable err -ErrorAction SilentlyContinue -TrustRepository
+        $err.Count | Should -BeGreaterThan 0
+        $err[0].FullyQualifiedErrorId | Should -BeExactly 'ErrorFilteringNamesForUnsupportedWildcards,Microsoft.PowerShell.PSResourceGet.Cmdlets.SavePSResource'
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

 `Utils.ProcessNameWildcards` detects and potentially filters out wildcard characters and unwanted characters from Name input. `Save-PSResource` and other cmdlets call this method. This method will now also filter out path separator characters at the start of a package name, if present, and write an appropriate error message. When a path separator is present at the start some servers (like V3 API ones) ignore or filter it out, and make a successful request for the package but then our own comparisons against the package name later fail, so it is better to filter out path separators at the start and be clearer with the error.

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes #1901 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
