### PR TITLE
For Publish operation to ACR, non-anonymous access token should be retrieved

### DIFF
--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -408,6 +408,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             }
             else
             {
+                // A container registry repository is determined to be unauthenticated if it allows anonymous pull access. However, push operations always require authentication.
                 bool isRepositoryUnauthenticated = isPushOperation ? false : IsContainerRegistryUnauthenticated(Repository.Uri.ToString(), needCatalogAccess, out errRecord, out accessToken);
                 _cmdletPassedIn.WriteInformation($"Value of isRepositoryUnauthenticated: {isRepositoryUnauthenticated}", new string[] { "PSRGContainerRegistryUnauthenticatedCheck" });
 

--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -409,8 +409,6 @@ namespace Microsoft.PowerShell.PSResourceGet
             else
             {
                 bool isRepositoryUnauthenticated = isPushOperation ? false : IsContainerRegistryUnauthenticated(Repository.Uri.ToString(), needCatalogAccess, out errRecord, out accessToken);
-                InternalHooks.SetTestHook("IsRegistryUnauthenticatedCheckRequired", true);
-                InternalHooks.SetTestHook("IsRegistryUnauthenticated", isRepositoryUnauthenticated);
                 _cmdletPassedIn.WriteInformation($"Value of isRepositoryUnauthenticated: {isRepositoryUnauthenticated}", new string[] { "PSRGContainerRegistryUnauthenticatedCheck" });
 
                 _cmdletPassedIn.WriteDebug($"Is repository unauthenticated: {isRepositoryUnauthenticated}");

--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -332,7 +332,7 @@ namespace Microsoft.PowerShell.PSResourceGet
                 return null;
             }
 
-            string containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: false, out errRecord);
+            string containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: false, isPushOperation: false, out errRecord);
             if (errRecord != null)
             {
                 return null;
@@ -380,7 +380,7 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// If no credential provided at registration then, check if the ACR endpoint can be accessed without a token. If not, try using Azure.Identity to get the az access token, then ACR refresh token and then ACR access token.
         /// Note: Access token can be empty if the repository is unauthenticated
         /// </summary>
-        internal string GetContainerRegistryAccessToken(bool needCatalogAccess, out ErrorRecord errRecord)
+        internal string GetContainerRegistryAccessToken(bool needCatalogAccess, bool isPushOperation, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::GetContainerRegistryAccessToken()");
             string accessToken = string.Empty;
@@ -408,7 +408,9 @@ namespace Microsoft.PowerShell.PSResourceGet
             }
             else
             {
-                bool isRepositoryUnauthenticated = IsContainerRegistryUnauthenticated(Repository.Uri.ToString(), needCatalogAccess, out errRecord, out accessToken);
+                bool isRepositoryUnauthenticated = isPushOperation ? false : IsContainerRegistryUnauthenticated(Repository.Uri.ToString(), needCatalogAccess, out errRecord, out accessToken);
+                _cmdletPassedIn.WriteInformation($"Value of isRepositoryUnauthenticated: {isRepositoryUnauthenticated}", new string[] { "PSRGContainerRegistryUnauthenticatedCheck" });
+
                 _cmdletPassedIn.WriteDebug($"Is repository unauthenticated: {isRepositoryUnauthenticated}");
 
                 if (errRecord != null)
@@ -1330,7 +1332,7 @@ namespace Microsoft.PowerShell.PSResourceGet
 
             // Get access token (includes refresh tokens)
             _cmdletPassedIn.WriteVerbose($"Get access token for container registry server.");
-            var containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: false, out errRecord);
+            var containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: false, isPushOperation: true, out errRecord);
             if (errRecord != null)
             {
                 return false;
@@ -1795,7 +1797,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             string packageNameLowercase = packageName.ToLower();
 
             string packageNameForFind = PrependMARPrefix(packageNameLowercase);
-            string containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: false, out errRecord);
+            string containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: false, isPushOperation: false,out errRecord);
             if (errRecord != null)
             {
                 return emptyHashResponses;
@@ -1907,7 +1909,7 @@ namespace Microsoft.PowerShell.PSResourceGet
         {
             _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::FindPackages()");
             errRecord = null;
-            string containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: true, out errRecord);
+            string containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: true, isPushOperation: false, out errRecord);
             if (errRecord != null)
             {
                 return emptyResponseResults;

--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -409,6 +409,8 @@ namespace Microsoft.PowerShell.PSResourceGet
             else
             {
                 bool isRepositoryUnauthenticated = isPushOperation ? false : IsContainerRegistryUnauthenticated(Repository.Uri.ToString(), needCatalogAccess, out errRecord, out accessToken);
+                InternalHooks.SetTestHook("IsRegistryUnauthenticatedCheckRequired", true);
+                InternalHooks.SetTestHook("IsRegistryUnauthenticated", isRepositoryUnauthenticated);
                 _cmdletPassedIn.WriteInformation($"Value of isRepositoryUnauthenticated: {isRepositoryUnauthenticated}", new string[] { "PSRGContainerRegistryUnauthenticatedCheck" });
 
                 _cmdletPassedIn.WriteDebug($"Is repository unauthenticated: {isRepositoryUnauthenticated}");

--- a/src/code/InternalHooks.cs
+++ b/src/code/InternalHooks.cs
@@ -17,6 +17,10 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
         internal static string MARPrefix;
 
+        internal static bool IsRegistryUnauthenticatedCheckRequired;
+
+        internal static bool IsRegistryUnauthenticated;
+
         public static void SetTestHook(string property, object value)
         {
             var fieldInfo = typeof(InternalHooks).GetField(property, BindingFlags.Static | BindingFlags.NonPublic);
@@ -26,6 +30,16 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         public static string GetUserString()
         {
             return Microsoft.PowerShell.PSResourceGet.Cmdlets.UserAgentInfo.UserAgentString();
+        }
+
+        public static bool? GetRegistryAuthenticationStatus()
+        {
+            if (IsRegistryUnauthenticatedCheckRequired)
+            {
+                return IsRegistryUnauthenticated;
+            }
+            
+            return null;
         }
     }
 }

--- a/src/code/InternalHooks.cs
+++ b/src/code/InternalHooks.cs
@@ -17,10 +17,6 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
         internal static string MARPrefix;
 
-        internal static bool IsRegistryUnauthenticatedCheckRequired;
-
-        internal static bool IsRegistryUnauthenticated;
-
         public static void SetTestHook(string property, object value)
         {
             var fieldInfo = typeof(InternalHooks).GetField(property, BindingFlags.Static | BindingFlags.NonPublic);
@@ -30,16 +26,6 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         public static string GetUserString()
         {
             return Microsoft.PowerShell.PSResourceGet.Cmdlets.UserAgentInfo.UserAgentString();
-        }
-
-        public static bool? GetRegistryAuthenticationStatus()
-        {
-            if (IsRegistryUnauthenticatedCheckRequired)
-            {
-                return IsRegistryUnauthenticated;
-            }
-            
-            return null;
         }
     }
 }

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -346,6 +346,22 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $results[0].Version | Should -Be $correctVersion
     }
 
+    It "Publish a package should always require authentication" {
+        $version = "15.0.0"
+        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
+
+        Publish-PSResource -Path $script:PublishModuleBase -Repository $ACRRepoName -InformationVariable RegistryAuthenticated
+
+        $results = Find-PSResource -Name $script:PublishModuleName -Repository $ACRRepoName
+        $results | Should -Not -BeNullOrEmpty
+        $results[0].Name | Should -Be $script:PublishModuleName
+        $results[0].Version | Should -Be $version
+
+        Write-Verbose -Verbose "obj: $RegistryAuthenticated"
+        $RegistryAuthenticated[0].Tags | Should -Be "PSRGContainerRegistryUnauthenticatedCheck"
+        $RegistryAuthenticated[0].MessageData | Should -Be "Value of isRepositoryUnauthenticated: False"
+    }
+
     It "Publish a script"{
         $scriptVersion = "1.0.0"
         $params = @{
@@ -567,21 +583,6 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $results | Should -Not -BeNullOrEmpty
         $results[0].Name | Should -Be $packageName
         $results[0].Version | Should -Be $version
-    }
-
-    It "Publish a package should always require authentication" {
-        $version = "15.0.0"
-        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
-
-        Publish-PSResource -Path $script:PublishModuleBase -Repository $ACRRepoName -InformationVariable RegistryAuthenticated
-
-        $results = Find-PSResource -Name $script:PublishModuleName -Repository $ACRRepoName
-        $results | Should -Not -BeNullOrEmpty
-        $results[0].Name | Should -Be $script:PublishModuleName
-        $results[0].Version | Should -Be $version
-
-        $RegistryAuthenticated[0].MessageData | Should -Be "Value of isRepositoryUnauthenticated: False"
-        $RegistryAuthenticated[0].Tags | Should -Be "PSRGContainerRegistryUnauthenticatedCheck"
     }
 }
 

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -351,8 +351,10 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
 
         $infoRecord = & { Publish-PSResource -Path $script:PublishModuleBase -Repository $ACRRepoName 6>&1 } | Where-Object { $_ -is [System.Management.Automation.InformationRecord] }
+        $infoRecord | Should -Not -BeNullOrEmpty
 
-        $results = Find-PSResource -Name $script:PublishModuleName -Repository $ACRRepoName -InformationVariable FindRegistryAuthenticated
+
+        $results = Find-PSResource -Name $script:PublishModuleName -Repository $ACRRepoName
         $results | Should -Not -BeNullOrEmpty
         $results[0].Name | Should -Be $script:PublishModuleName
         $results[0].Version | Should -Be $version

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -361,7 +361,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         {
             $infoRecord | Should -Not -BeNullOrEmpty
             $infoRecord[0].Tags | Should -Be "PSRGContainerRegistryUnauthenticatedCheck"
-            $infoRecord[0].MessageData | Should -Be "Value of isRepositoryUnauthenticated: $isRegistryUnauthenticatedCheckRequired"
+            $infoRecord[0].MessageData | Should -Be "Value of isRepositoryUnauthenticated: False"
         }
     }
 

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -350,7 +350,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $version = "15.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
 
-        $infoRecord = & { Publish-PSResource -Path $script:PublishModuleBase -Repository $ACRRepoName 6>&1 } | Where-Object { $_ -is [System.Management.Automation.InformationRecord] }
+        Publish-PSResource -Path $script:PublishModuleBase -Repository $ACRRepoName -InformationVariable RegistryUnauthenticated
 
         $results = Find-PSResource -Name $script:PublishModuleName -Repository $ACRRepoName
         $results | Should -Not -BeNullOrEmpty
@@ -359,9 +359,9 @@ Describe "Test Publish-PSResource" -tags 'CI' {
 
         if ($usingAzAuth)
         {
-            $infoRecord | Should -Not -BeNullOrEmpty
-            $infoRecord[0].Tags | Should -Be "PSRGContainerRegistryUnauthenticatedCheck"
-            $infoRecord[0].MessageData | Should -Be "Value of isRepositoryUnauthenticated: False"
+            $RegistryUnauthenticated | Should -Not -BeNullOrEmpty
+            $RegistryUnauthenticated[0].Tags | Should -Be "PSRGContainerRegistryUnauthenticatedCheck"
+            $RegistryUnauthenticated[0].MessageData | Should -Be "Value of isRepositoryUnauthenticated: False"
         }
     }
 

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -568,6 +568,21 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $results[0].Name | Should -Be $packageName
         $results[0].Version | Should -Be $version
     }
+
+    It "Publish a package should always require authentication" {
+        $version = "1.0.0"
+        New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
+
+        Publish-PSResource -Path $script:PublishModuleBase -Repository $ACRRepoName -InformationVariable isRegistryUnauthenticated
+
+        $results = Find-PSResource -Name $script:PublishModuleName -Repository $ACRRepoName
+        $results | Should -Not -BeNullOrEmpty
+        $results[0].Name | Should -Be $script:PublishModuleName
+        $results[0].Version | Should -Be $version
+
+        $isRegistryUnauthenticated | Should -Be "Value of isRepositoryUnauthenticated: False"
+        $isRegistryUnauthenticated[0].Tags | Should -Be "PSRGContainerRegistryUnauthenticatedCheck"
+    }
 }
 
 Describe 'Test Publish-PSResource for MAR Repository' -tags 'CI' {

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -352,12 +352,12 @@ Describe "Test Publish-PSResource" -tags 'CI' {
 
         Publish-PSResource -Path $script:PublishModuleBase -Repository $ACRRepoName -InformationVariable RegistryAuthenticated
 
-        $results = Find-PSResource -Name $script:PublishModuleName -Repository $ACRRepoName
+        $results = Find-PSResource -Name $script:PublishModuleName -Repository $ACRRepoName -InformationVariable FindRegistryAuthenticated
         $results | Should -Not -BeNullOrEmpty
         $results[0].Name | Should -Be $script:PublishModuleName
         $results[0].Version | Should -Be $version
 
-        Write-Verbose -Verbose "obj: $RegistryAuthenticated"
+        Write-Verbose -Verbose "obj: $RegistryAuthenticated, preference: $InformationPreference, find: $FindRegistryAuthenticated"
         $RegistryAuthenticated[0].Tags | Should -Be "PSRGContainerRegistryUnauthenticatedCheck"
         $RegistryAuthenticated[0].MessageData | Should -Be "Value of isRepositoryUnauthenticated: False"
     }

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -573,15 +573,15 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $version = "15.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
 
-        Publish-PSResource -Path $script:PublishModuleBase -Repository $ACRRepoName -InformationVariable isRegistryUnauthenticated
+        Publish-PSResource -Path $script:PublishModuleBase -Repository $ACRRepoName -InformationVariable RegistryAuthenticated
 
         $results = Find-PSResource -Name $script:PublishModuleName -Repository $ACRRepoName
         $results | Should -Not -BeNullOrEmpty
         $results[0].Name | Should -Be $script:PublishModuleName
         $results[0].Version | Should -Be $version
 
-        $isRegistryUnauthenticated | Should -Be "Value of isRepositoryUnauthenticated: False"
-        $isRegistryUnauthenticated[0].Tags | Should -Be "PSRGContainerRegistryUnauthenticatedCheck"
+        $RegistryAuthenticated[0].MessageData | Should -Be "Value of isRepositoryUnauthenticated: False"
+        $RegistryAuthenticated[0].Tags | Should -Be "PSRGContainerRegistryUnauthenticatedCheck"
     }
 }
 

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -357,16 +357,11 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $results[0].Name | Should -Be $script:PublishModuleName
         $results[0].Version | Should -Be $version
 
-        $isRegistryUnauthenticatedCheckRequired = [Microsoft.PowerShell.PSResourceGet.UtilClasses.InternalHooks]::GetRegistryAuthenticationStatus()
-        if ($isRegistryUnauthenticatedCheckRequired -ne $null)
+        if ($usingAzAuth)
         {
             $infoRecord | Should -Not -BeNullOrEmpty
             $infoRecord[0].Tags | Should -Be "PSRGContainerRegistryUnauthenticatedCheck"
             $infoRecord[0].MessageData | Should -Be "Value of isRepositoryUnauthenticated: $isRegistryUnauthenticatedCheckRequired"
-
-            # Reset the test hook after use
-            [Microsoft.PowerShell.PSResourceGet.UtilClasses.InternalHooks]::SetTestHook("IsRegistryUnauthenticatedCheckRequired", $false)
-            [Microsoft.PowerShell.PSResourceGet.UtilClasses.InternalHooks]::SetTestHook("IsRegistryUnauthenticated", $false)
         }
     }
 

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -350,16 +350,15 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         $version = "15.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
 
-        Publish-PSResource -Path $script:PublishModuleBase -Repository $ACRRepoName -InformationVariable RegistryAuthenticated
+        $infoRecord = & { Publish-PSResource -Path $script:PublishModuleBase -Repository $ACRRepoName 6>&1 } | Where-Object { $_ -is [System.Management.Automation.InformationRecord] }
 
         $results = Find-PSResource -Name $script:PublishModuleName -Repository $ACRRepoName -InformationVariable FindRegistryAuthenticated
         $results | Should -Not -BeNullOrEmpty
         $results[0].Name | Should -Be $script:PublishModuleName
         $results[0].Version | Should -Be $version
 
-        Write-Verbose -Verbose "obj: $RegistryAuthenticated, preference: $InformationPreference, find: $FindRegistryAuthenticated"
-        $RegistryAuthenticated[0].Tags | Should -Be "PSRGContainerRegistryUnauthenticatedCheck"
-        $RegistryAuthenticated[0].MessageData | Should -Be "Value of isRepositoryUnauthenticated: False"
+        $infoRecord[0].Tags | Should -Be "PSRGContainerRegistryUnauthenticatedCheck"
+        $infoRecord[0].MessageData | Should -Be "Value of isRepositoryUnauthenticated: False"
     }
 
     It "Publish a script"{

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -570,7 +570,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
     }
 
     It "Publish a package should always require authentication" {
-        $version = "1.0.0"
+        $version = "15.0.0"
         New-ModuleManifest -Path (Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1") -ModuleVersion $version -Description "$script:PublishModuleName module"
 
         Publish-PSResource -Path $script:PublishModuleBase -Repository $ACRRepoName -InformationVariable isRegistryUnauthenticated


### PR DESCRIPTION
If a Container Registry has anonymous pull enabled, PSResourceGet was using that alone to determine that the registry is unauthenticated and therefore retrieving an anonymous access token. However, that doesn't account for push operation which would require permissions. This was causing registries with anonymous pull that had push operation being performed on it to result in a 401 error even if the user had ACRPush permissions. 

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes #1906 #1828 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
