### PR TITLE
Improve performance of ContainerRegistry repositories by caching token

### DIFF
--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -54,6 +54,8 @@ namespace Microsoft.PowerShell.PSResourceGet
 
         const string containerRegistryRepositoryListTemplate = "https://{0}/v2/_catalog"; // 0 - registry
 
+        private string _cachedContainterRegistryToken = null;
+
         #endregion
 
         #region Constructor
@@ -67,6 +69,8 @@ namespace Microsoft.PowerShell.PSResourceGet
             {
                 Credentials = networkCredential
             };
+
+            _cachedContainterRegistryToken = null;
 
             _sessionClient = new HttpClient(handler);
             _sessionClient.Timeout = TimeSpan.FromMinutes(10);
@@ -384,6 +388,12 @@ namespace Microsoft.PowerShell.PSResourceGet
             string tenantID = string.Empty;
             errRecord = null;
 
+            if (!string.IsNullOrEmpty(_cachedContainterRegistryToken))
+            {
+                _cmdletPassedIn.WriteVerbose("Using cached container registry access token.");
+                return _cachedContainterRegistryToken;
+            }
+
             var repositoryCredentialInfo = Repository.CredentialInfo;
             if (repositoryCredentialInfo != null)
             {
@@ -444,6 +454,9 @@ namespace Microsoft.PowerShell.PSResourceGet
             {
                 return null;
             }
+
+            _cmdletPassedIn.WriteVerbose("Container registry access token retrieved.");
+            _cachedContainterRegistryToken = containerRegistryAccessToken;
 
             return containerRegistryAccessToken;
         }
@@ -739,7 +752,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             {
                 using (JsonDocument metadataJSONDoc = JsonDocument.Parse(serverPkgInfo.Metadata))
                 {
-                    string pkgVersionString = String.Empty; 
+                    string pkgVersionString = String.Empty;
                     JsonElement rootDom = metadataJSONDoc.RootElement;
 
                     if (rootDom.TryGetProperty("ModuleVersion", out JsonElement pkgVersionElement))


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request introduces caching for container registry access tokens in the `ContainerRegistryServerAPICalls` class to avoid unnecessary repeated retrievals. The main changes focus on improving performance and reducing redundant network calls by storing and reusing the access token during the object's lifetime.

**Container registry access token caching:**

* Added a private field `_cachedContainterRegistryToken` to store the access token for reuse.
* Initialized the cached token to `null` in the constructor to ensure a fresh start for each instance.
* Updated `GetContainerRegistryAccessToken` to check for and return the cached token if available, logging a verbose message when the cache is used.
* After successfully retrieving a new access token, the method now stores it in the cache and logs a verbose message.

## PR Context

In local testing, the improvement in performance for find with wildcard improved by 88% and install with dependencies improved by 83%

**NOTE:** We create a new instance of `ContainerRegistryServerAPICalls` for each invocation of any cmdlet. The cache is only shared within a single cmdlet invocation.

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
