### PR TITLE
Cmdlets should respect SwitchParameter values not presence alone

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -342,7 +342,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 allPkgsInstalled.AddRange(installedPkgs);
             }
 
-            if (!_cmdletPassedIn.MyInvocation.BoundParameters.ContainsKey("WhatIf") && _pkgNamesToInstall.Count > 0)
+            if ((!_cmdletPassedIn.MyInvocation.BoundParameters.ContainsKey("WhatIf") || (SwitchParameter)_cmdletPassedIn.MyInvocation.BoundParameters["WhatIf"] == false) && _pkgNamesToInstall.Count > 0)
             {
                 string repositoryWording = repositoryNamesToSearch.Count > 1 ? "registered repositories" : "repository";
                 _cmdletPassedIn.WriteError(new ErrorRecord(
@@ -624,7 +624,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     }
 
                     // If -WhatIf is passed in, early out.
-                    if (_cmdletPassedIn.MyInvocation.BoundParameters.ContainsKey("WhatIf"))
+                    if (_cmdletPassedIn.MyInvocation.BoundParameters.ContainsKey("WhatIf") && (SwitchParameter)_cmdletPassedIn.MyInvocation.BoundParameters["WhatIf"] == true)
                     {
                         return pkgsSuccessfullyInstalled;
                     }

--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -186,17 +186,20 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     break;
 
                 case PSGalleryParameterSet:
-                    try
+                    if (PSGallery)
                     {
-                        items.Add(PSGalleryParameterSetHelper(Priority, Trusted));
-                    }
-                    catch (Exception e)
-                    {
-                        ThrowTerminatingError(new ErrorRecord(
-                            new PSInvalidOperationException(e.Message),
-                            "ErrorInPSGalleryParameterSet",
-                            ErrorCategory.InvalidArgument,
-                            this));
+                        try
+                        {
+                            items.Add(PSGalleryParameterSetHelper(Priority, Trusted));
+                        }
+                        catch (Exception e)
+                        {
+                            ThrowTerminatingError(new ErrorRecord(
+                                new PSInvalidOperationException(e.Message),
+                                "ErrorInPSGalleryParameterSet",
+                                ErrorCategory.InvalidArgument,
+                                this));
+                        }
                     }
                     break;
 

--- a/test/InstallPSResourceTests/InstallPSResourceRepositorySearching.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceRepositorySearching.Tests.ps1
@@ -137,4 +137,12 @@ Describe 'Test Install-PSResource for searching and looping through repositories
         $err | Should -HaveCount 0
         $warningVar | Should -Not -BeNullOrEmpty
     }
+
+    It "install resources from repository should respect WhatIf value of false" {
+        # Package "test_module" exists in the following repositories (in this order): localRepo, PSGallery, NuGetGallery
+        $res = Install-PSResource -Name $testModuleName -Repository $PSGalleryName -TrustRepository -SkipDependencyCheck -PassThru -WhatIf:$false
+        $res | Should -Not -BeNullOrEmpty
+        $res.Name | Should -Be $testModuleName
+        $res.Repository | Should -Be $PSGalleryName
+    }
 }

--- a/test/ResourceRepositoryTests/RegisterPSResourceRepository.Tests.ps1
+++ b/test/ResourceRepositoryTests/RegisterPSResourceRepository.Tests.ps1
@@ -85,6 +85,12 @@ Describe "Test Register-PSResourceRepository" -tags 'CI' {
         $res.Priority | Should -Be 50
     }
 
+    It "register repository with PSGallery switch parameter value of false (PSGalleryParameterSet)" {
+        Unregister-PSResourceRepository -Name $PSGalleryName
+        $res = Register-PSResourceRepository -PSGallery:$false -PassThru
+        $res  | Should -BeNullOrEmpty
+    }
+
     It "register repository with PSGallery, Trusted parameters (PSGalleryParameterSet)" {
         Unregister-PSResourceRepository -Name $PSGalleryName
         $res = Register-PSResourceRepository -PSGallery -Trusted -PassThru


### PR DESCRIPTION
Some parameter switches like `-WhatIf`, `-PSGallery` for certain cmdlets were not being checked and used logically in the correct manner. The previous code was simply checking if the parameter switch was supplied and if so, equating that to the value of the parameter switch being true. This meant that in a scenario like, `-WhatIf:$false` the code detected presence of the `-WhatIf` parameter and did not install the package. Now, switch parameter values are checked. For `-PSGallery` switch parameter in `Register-PSResourceRepository` providing `-PSGallery:$false` will mean PSGallery is not registered and no error is reported.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1805 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
