### PR TITLE
Local repository network connection failure should not fail silently

### DIFF
--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -263,7 +263,24 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string regexPattern = $"{packageName}" + @"(\.\d+){1,3}(?:[a-zA-Z0-9-.]+|.\d)?\.nupkg";
             _cmdletPassedIn.WriteDebug($"package file name pattern to be searched for is: {regexPattern}");
 
-            foreach (string path in Directory.GetFiles(Repository.Uri.LocalPath))
+            string[] foundFiles = Utils.EmptyStrArray;
+            try
+            {
+                foundFiles = Directory.GetFiles(Repository.Uri.LocalPath);
+            }
+            catch (Exception e)
+            {
+                _cmdletPassedIn.WriteWarning($"Unable to resolve repository source '{Repository.Uri.LocalPath}' due to exception: {e.Message}");
+                errRecord = new ErrorRecord(
+                    exception: e,
+                    "FileAccessFailure",
+                    ErrorCategory.ReadError,
+                    this);
+
+                return findResponse;
+            }
+
+            foreach (string path in foundFiles)
             {
                 string packageFullName = Path.GetFileName(path);
                 bool isMatch = Regex.IsMatch(packageFullName, regexPattern, RegexOptions.IgnoreCase);
@@ -333,7 +350,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             List<Hashtable> pkgsFound = new List<Hashtable>();
             errRecord = null;
 
-            Hashtable pkgVersionsFound = GetMatchingFilesGivenNamePattern(packageNameWithWildcard: packageName, includePrerelease: includePrerelease);
+            Hashtable pkgVersionsFound = GetMatchingFilesGivenNamePattern(packageNameWithWildcard: packageName, includePrerelease: includePrerelease, out errRecord);
+            if (errRecord != null)
+            {
+                // ErrorRecord errRecord is only set if directory access to retrieve files failed (i.e network error when accessing file share, incorrect directory path, etc), not if desired files within directory are not found since this is a wildcard scenario.
+                return findResponse;
+            }
 
             List<string> pkgNamesList = pkgVersionsFound.Keys.Cast<string>().ToList();
             foreach(string pkgFound in pkgNamesList)
@@ -382,7 +404,24 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string pkgPath = String.Empty;
             string actualPkgName = String.Empty;
 
-            foreach (string path in Directory.GetFiles(Repository.Uri.LocalPath))
+            string[] foundFiles = Utils.EmptyStrArray;
+            try
+            {
+                foundFiles = Directory.GetFiles(Repository.Uri.LocalPath);
+            }
+            catch (Exception e)
+            {
+                _cmdletPassedIn.WriteWarning($"Unable to resolve repository source '{Repository.Uri.LocalPath}' due to exception: {e.Message}");
+                errRecord = new ErrorRecord(
+                    exception: e,
+                    "FileAccessFailure",
+                    ErrorCategory.ReadError,
+                    this);
+
+                return findResponse;
+            }
+
+            foreach (string path in foundFiles)
             {
                 string packageFullName = Path.GetFileName(path);
                 bool isMatch = Regex.IsMatch(packageFullName, regexPattern, RegexOptions.IgnoreCase);
@@ -450,7 +489,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             List<Hashtable> pkgsFound = new List<Hashtable>();
             errRecord = null;
 
-            Hashtable pkgVersionsFound = GetMatchingFilesGivenNamePattern(packageNameWithWildcard: String.Empty, includePrerelease: includePrerelease);
+            Hashtable pkgVersionsFound = GetMatchingFilesGivenNamePattern(packageNameWithWildcard: String.Empty, includePrerelease: includePrerelease, errRecord: out errRecord);
+            if (errRecord != null)
+            {
+                // ErrorRecord errRecord is only set if directory access to retrieve files failed (i.e network error when accessing file share, incorrect directory path, etc), not if desired files within directory are not found since this is a wildcard scenario.
+                return findResponse;
+            }
 
             List<string> pkgNamesList = pkgVersionsFound.Keys.Cast<string>().ToList();
             foreach(string pkgFound in pkgNamesList)
@@ -496,7 +540,24 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             NuGetVersion latestVersion = new NuGetVersion("0.0.0.0");
             String latestVersionPath = String.Empty;
 
-            foreach (string path in Directory.GetFiles(Repository.Uri.LocalPath))
+            string[] foundFiles = Utils.EmptyStrArray;
+            try
+            {
+                foundFiles = Directory.GetFiles(Repository.Uri.LocalPath);
+            }
+            catch (Exception e)
+            {
+                _cmdletPassedIn.WriteWarning($"Unable to resolve repository source '{Repository.Uri.LocalPath}' due to exception: {e.Message}");
+                errRecord = new ErrorRecord(
+                    exception: e,
+                    "FileAccessFailure",
+                    ErrorCategory.ReadError,
+                    this);
+
+                return fs;
+            }
+
+            foreach (string path in foundFiles)
             {
                 string packageFullName = Path.GetFileName(path);
 
@@ -581,7 +642,24 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             WildcardPattern pkgNamePattern = new WildcardPattern($"{packageName}.{version}.nupkg*", WildcardOptions.IgnoreCase);
             String pkgVersionPath = String.Empty;
 
-            foreach (string path in Directory.GetFiles(Repository.Uri.LocalPath))
+            string[] foundFiles = Utils.EmptyStrArray;
+            try
+            {
+                foundFiles = Directory.GetFiles(Repository.Uri.LocalPath);
+            }
+            catch (Exception e)
+            {
+                _cmdletPassedIn.WriteWarning($"Unable to resolve repository source '{Repository.Uri.LocalPath}' due to exception: {e.Message}");
+                errRecord = new ErrorRecord(
+                    exception: e,
+                    "FileAccessFailure",
+                    ErrorCategory.ReadError,
+                    this);
+
+                return fs;
+            }
+
+            foreach (string path in foundFiles)
             {
                 string packageFullName = Path.GetFileName(path);
 
@@ -778,7 +856,24 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             Hashtable pkgVersionsFound = new Hashtable(StringComparer.OrdinalIgnoreCase);
             errRecord = null;
 
-            foreach (string path in Directory.GetFiles(Repository.Uri.LocalPath))
+            string[] foundFiles = Utils.EmptyStrArray;
+            try
+            {
+                foundFiles = Directory.GetFiles(Repository.Uri.LocalPath);
+            }
+            catch (Exception e)
+            {
+                _cmdletPassedIn.WriteWarning($"Unable to resolve repository source '{Repository.Uri.LocalPath}' due to exception: {e.Message}");
+                errRecord = new ErrorRecord(
+                    exception: e,
+                    "FileAccessFailure",
+                    ErrorCategory.ReadError,
+                    this);
+
+                return pkgVersionsFound;
+            }
+
+            foreach (string path in foundFiles)
             {
                 string packageFullName = Path.GetFileName(path);
 
@@ -809,9 +904,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// hashtable with those that match the name wildcard pattern and prerelease requirements provided.
         /// This helper method is called for FindAll(), FindTags(), FindNameGlobbing() scenarios.
         /// </summary>
-        private Hashtable GetMatchingFilesGivenNamePattern(string packageNameWithWildcard, bool includePrerelease)
+        private Hashtable GetMatchingFilesGivenNamePattern(string packageNameWithWildcard, bool includePrerelease, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In LocalServerApiCalls::GetMatchingFilesGivenNamePattern()");
+            errRecord = null;
             bool isNameFilteringRequired = !String.IsNullOrEmpty(packageNameWithWildcard);
 
             // wildcard name possibilities: power*, *get, power*get
@@ -820,7 +916,24 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             Regex rx = new Regex(@"\.\d+\.", RegexOptions.Compiled | RegexOptions.IgnoreCase);
             Hashtable pkgVersionsFound = new Hashtable(StringComparer.OrdinalIgnoreCase);
 
-            foreach (string path in Directory.GetFiles(Repository.Uri.LocalPath))
+            string[] foundFiles = Utils.EmptyStrArray;
+            try
+            {
+                foundFiles = Directory.GetFiles(Repository.Uri.LocalPath);
+            }
+            catch (Exception e)
+            {
+                _cmdletPassedIn.WriteWarning($"Unable to resolve repository source '{Repository.Uri.LocalPath}' due to exception: {e.Message}");
+                errRecord = new ErrorRecord(
+                    exception: e,
+                    "FileAccessFailure",
+                    ErrorCategory.ReadError,
+                    this);
+
+                return pkgVersionsFound;
+            }
+
+            foreach (string path in foundFiles)
             {
                 string packageFullName = Path.GetFileName(path);
                 MatchCollection matches = rx.Matches(packageFullName);

--- a/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceLocal.Tests.ps1
@@ -16,6 +16,7 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
     BeforeAll {
         $localRepo = "psgettestlocal"
         $localUNCRepo = "psgettestlocal3"
+        $localPrivateRepo = "psgettestlocal5"
         $localNupkgRepo = "localNupkgRepo"
         $testModuleName = "test_local_mod"
         $testModuleName2 = "test_local_mod2"
@@ -295,5 +296,23 @@ Describe 'Test Install-PSResource for local repositories' -tags 'CI' {
         $pkg = Get-InstalledPSResource $nupkgName
         $pkg.Name | Should -Be $nupkgName
         $pkg.Version | Should -Be $nupkgVersion
+    }
+
+    It "Install should not silently fail if network connection to local private repository cannot be established and remainder repositories should be searched" {
+        $privateRepo = Get-PSResourceRepository $localPrivateRepo
+        $res = Install-PSResource -Name $testModuleName -TrustRepository -PassThru -WarningVariable WarningVar -WarningAction SilentlyContinue
+        $WarningVar | Should -Not -BeNullOrEmpty
+        $WarningVar[0] | Should -Match "$($privateRepo.Uri.LocalPath)"
+        $res.Name | Should -Contain $testModuleName
+        $res.Version | Should -Be "1.0.0"
+    }
+
+    It "Install should not silently fail if network connection to local private repository cannot be established and package version was provided and remainder repositories should be searched" {
+        $privateRepo = Get-PSResourceRepository $localPrivateRepo
+        $res = Install-PSResource -Name $testModuleName -Version "1.0.0" -TrustRepository -PassThru -WarningVariable WarningVar -WarningAction SilentlyContinue
+        $WarningVar | Should -Not -BeNullOrEmpty
+        $WarningVar[0] | Should -Match "$($privateRepo.Uri.LocalPath)"
+        $res.Name | Should -Contain $testModuleName
+        $res.Version | Should -Be "1.0.0"
     }
 }

--- a/test/PSGetTestUtils.psm1
+++ b/test/PSGetTestUtils.psm1
@@ -269,8 +269,17 @@ function Register-LocalRepos {
         Trusted = $false
     }
     Register-PSResourceRepository @localRepoParams2
+    
+    $path4 = "\\localhost\PSRepoLocal"
+    $localRepoParams2 = @{
+        Name = "psgettestlocal5"
+        Uri = $path4
+        Priority = 30
+        Trusted = $false
+    }
+    Register-PSResourceRepository @localRepoParams2
 
-    Write-Verbose "registered psgettestlocal, psgettestlocal2, psgettestlocal3, psgettestlocal4"
+    Write-Verbose "registered psgettestlocal, psgettestlocal2, psgettestlocal3, psgettestlocal4, psgettestlocal5"
 }
 
 function Register-LocalTestNupkgsRepo {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->
If a local repository is registered that is not available (for example private repository when machine is out of office), then an error is thrown. In the case where multiple repositories were requested to be checked, the error gets swallowed up and the user is not informed about the error. This PR ensures that the error is caught and populated in ErrorRecord and a warning is additionally written.

Note: With this fix an error and warning will both be written. A future fix will be made to ensure only 1 is written, but breaking up the fix so it can be taken in this release.
# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1923 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
