### PR TITLE
Package that depend on a specific version should search for dependency with NormalizedVersion

### DIFF
--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -1174,7 +1174,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     else if(dep.VersionRange.MaxVersion != null && dep.VersionRange.MinVersion != null && dep.VersionRange.MaxVersion.OriginalVersion.Equals(dep.VersionRange.MinVersion.OriginalVersion))
                     {
                         string depPkgVersion = dep.VersionRange.MaxVersion.OriginalVersion; 
-                        FindResults responses = currentServer.FindVersion(dep.Name, version: dep.VersionRange.MaxVersion.OriginalVersion, _type, out ErrorRecord errRecord);
+                        FindResults responses = currentServer.FindVersion(dep.Name, version: dep.VersionRange.MaxVersion.ToNormalizedString(), _type, out ErrorRecord errRecord);
                         if (errRecord != null)
                         {
                             if (errRecord.Exception is ResourceNotFoundException)

--- a/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
@@ -32,7 +32,7 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
     AfterEach {
         Uninstall-PSResource "test_module", "test_module2", "test_script", "TestModule99", "testModuleWithlicense", `
             "TestFindModule", "ClobberTestModule1", "ClobberTestModule2", "PackageManagement", "TestTestScript", `
-            "TestModuleWithDependency", "TestModuleWithPrereleaseDep", "PrereleaseModule", "test-nugetversion-parent", "test-nugetversion" -SkipDependencyCheck -ErrorAction SilentlyContinue
+            "TestModuleWithDependency", "TestModuleWithPrereleaseDep", "PrereleaseModule", "test-nugetversion-parent", "test-nugetversion", "test-pkg-normalized-dependency" -SkipDependencyCheck -ErrorAction SilentlyContinue
     }
 
     AfterAll {
@@ -638,7 +638,8 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
         $depPkgName1 = "PowerShellGet"
         $depPkgName2 = "PackageManagement"
 
-        $res = Install-PSResource -Name $moduleName -Prerelease -Repository $PSGalleryName -TrustRepository -PassThru
+        Install-PSResource -Name $moduleName -Prerelease -Repository $PSGalleryName -TrustRepository
+        $res = Get-InstalledPSResource $moduleName
         $res.Name | Should -Be $moduleName
         $res.Version | Should -Be $version
 

--- a/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV2Server.Tests.ps1
@@ -631,6 +631,21 @@ Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'CI' {
         $depRes.Name | Should -Be $depPkgName
         $depRes.Version | Should -Be $depPkgVer
     }
+
+    It "Install resource that takes a dependency on package with specific version with differing normalized and semver versions" {
+        $moduleName = 'test-pkg-normalized-dependency'
+        $version = '3.9.2'
+        $depPkgName1 = "PowerShellGet"
+        $depPkgName2 = "PackageManagement"
+
+        $res = Install-PSResource -Name $moduleName -Prerelease -Repository $PSGalleryName -TrustRepository -PassThru
+        $res.Name | Should -Be $moduleName
+        $res.Version | Should -Be $version
+
+        $depRes = Get-InstalledPSResource $depPkgName1, $depPkgName2
+        $depRes.Name | Should -Contain $depPkgName1
+        $depRes.Name | Should -Contain $depPkgName2
+    }    
 }
 
 Describe 'Test Install-PSResource for V2 Server scenarios' -tags 'ManualValidationOnly' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Package that depend on a specific version shuold search for that dependency with NormalizedVersion. Using System.Version which is not normalized leads to the package not being found and error which prevents installation.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Resolves #1940 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
