### PR TITLE
Publish-PSResource: honor ExternalModuleDependencies from PrivateData.PSData during dependency validation

### DIFF
--- a/src/code/PublishHelper.cs
+++ b/src/code/PublishHelper.cs
@@ -1195,7 +1195,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             //  c. A string array of module names
             //  d. A single string module name
 
-            var dependenciesHash = new Hashtable();
+            var dependenciesHash = new Hashtable(StringComparer.OrdinalIgnoreCase);
             foreach (var reqModule in requiredModules)
             {
                 if (LanguagePrimitives.TryConvertTo<Hashtable>(reqModule, out Hashtable moduleHash))
@@ -1228,21 +1228,135 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
             }
 
-            var externalModuleDeps = parsedMetadataHash.ContainsKey("ExternalModuleDependencies") ?
-                        parsedMetadataHash["ExternalModuleDependencies"] : null;
-
-            if (externalModuleDeps != null && LanguagePrimitives.TryConvertTo<string[]>(externalModuleDeps, out string[] externalModuleNames))
+            var externalModuleNames = GetExternalModuleDependencies(parsedMetadataHash);
+            foreach (var extModName in externalModuleNames)
             {
-                foreach (var extModName in externalModuleNames)
+                if (dependenciesHash.ContainsKey(extModName))
                 {
-                    if (dependenciesHash.ContainsKey(extModName))
-                    {
-                        dependenciesHash.Remove(extModName);
-                    }
+                    dependenciesHash.Remove(extModName);
                 }
             }
 
             return dependenciesHash;
+        }
+
+        private static string[] GetExternalModuleDependencies(Hashtable parsedMetadataHash)
+        {
+            if (parsedMetadataHash == null)
+            {
+                return Array.Empty<string>();
+            }
+
+            var externalModules = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            AddExternalModuleDependencies(parsedMetadataHash, externalModules);
+
+            if (TryGetHashtableValue(parsedMetadataHash, "PrivateData", out Hashtable privateData) &&
+                TryGetHashtableValue(privateData, "PSData", out Hashtable psData))
+            {
+                AddExternalModuleDependencies(psData, externalModules);
+            }
+
+            return externalModules.ToArray();
+        }
+
+        private static void AddExternalModuleDependencies(Hashtable container, HashSet<string> externalModules)
+        {
+            if (container == null || externalModules == null ||
+                !TryGetValue(container, "ExternalModuleDependencies", out object externalModuleDeps))
+            {
+                return;
+            }
+
+            if (externalModuleDeps == null)
+            {
+                return;
+            }
+
+            if (LanguagePrimitives.TryConvertTo<string[]>(externalModuleDeps, out string[] externalModuleNames) && externalModuleNames != null)
+            {
+                foreach (var name in externalModuleNames)
+                {
+                    if (!string.IsNullOrWhiteSpace(name))
+                    {
+                        externalModules.Add(name.Trim());
+                    }
+                }
+
+                return;
+            }
+
+            if (LanguagePrimitives.TryConvertTo<string>(externalModuleDeps, out string externalModuleName) &&
+                !string.IsNullOrWhiteSpace(externalModuleName))
+            {
+                externalModules.Add(externalModuleName.Trim());
+            }
+        }
+
+        private static bool TryGetHashtableValue(Hashtable source, string key, out Hashtable value)
+        {
+            value = null;
+            if (!TryGetValue(source, key, out object rawValue) || rawValue == null)
+            {
+                return false;
+            }
+
+            if (rawValue is PSObject psObject && psObject.BaseObject != null)
+            {
+                rawValue = psObject.BaseObject;
+            }
+
+            if (rawValue is Hashtable hashtable)
+            {
+                value = hashtable;
+                return true;
+            }
+
+            if (rawValue is IDictionary dictionary)
+            {
+                var converted = new Hashtable(StringComparer.OrdinalIgnoreCase);
+                foreach (DictionaryEntry entry in dictionary)
+                {
+                    converted[entry.Key] = entry.Value;
+                }
+
+                value = converted;
+                return true;
+            }
+
+            if (LanguagePrimitives.TryConvertTo<Hashtable>(rawValue, out Hashtable parsed) && parsed != null)
+            {
+                value = parsed;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryGetValue(Hashtable source, string key, out object value)
+        {
+            value = null;
+            if (source == null || string.IsNullOrWhiteSpace(key))
+            {
+                return false;
+            }
+
+            if (source.ContainsKey(key))
+            {
+                value = source[key];
+                return true;
+            }
+
+            foreach (DictionaryEntry entry in source)
+            {
+                if (entry.Key is string entryKey &&
+                    string.Equals(entryKey, key, StringComparison.OrdinalIgnoreCase))
+                {
+                    value = entry.Value;
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private bool CheckDependenciesExist(Hashtable dependencies, string repositoryName, NetworkCredential networkCredential)

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -344,6 +344,33 @@ function Test-PublishedFunction {
 
         $expectedPath = Join-Path -Path $script:repositoryPath2 -ChildPath "$script:PublishModuleName.$version.nupkg"
         (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath
+
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        $package = [System.IO.Compression.ZipFile]::OpenRead($expectedPath)
+        try {
+            $nuspecEntry = $package.Entries | Where-Object FullName -like '*.nuspec' | Select-Object -First 1
+            $nuspecEntry | Should -Not -BeNullOrEmpty
+
+            $reader = [System.IO.StreamReader]::new($nuspecEntry.Open())
+            try {
+                $nuspecXml = [xml]$reader.ReadToEnd()
+            }
+            finally {
+                $reader.Dispose()
+            }
+        }
+        finally {
+            $package.Dispose()
+        }
+
+        $namespaceManager = [System.Xml.XmlNamespaceManager]::new($nuspecXml.NameTable)
+        $namespaceManager.AddNamespace('ns', 'http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd')
+        $dependencyIds = @(
+            $nuspecXml.SelectNodes('//ns:package/ns:metadata/ns:dependencies/ns:dependency', $namespaceManager) |
+                ForEach-Object { $_.Attributes['id'].Value }
+        )
+
+        $dependencyIds | Should -Not -Contain $externalModuleName
     }
 
     It "Publish a module with -SkipDependenciesCheck" {

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -311,6 +311,41 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         {Publish-PSResource -Path $script:PublishModuleBase -ErrorAction Stop} | Should -Throw -ErrorId "DependencyNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
     }
 
+    It "Publish a module with ExternalModuleDependencies that are not published" {
+        $version = "1.0.0"
+        $externalModuleName = "PackageManagement"
+        $manifestPath = Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psd1"
+        $moduleFilePath = Join-Path -Path $script:PublishModuleBase -ChildPath "$script:PublishModuleName.psm1"
+
+        @'
+function Test-PublishedFunction {
+    Write-Output "OK"
+}
+'@ | Out-File -FilePath $moduleFilePath
+
+        @"
+@{
+    RootModule = '$script:PublishModuleName.psm1'
+    ModuleVersion = '$version'
+    Author = 'None'
+    Description = '$script:PublishModuleName module'
+    GUID = '6f703037-3e95-4dcf-b06c-916f2867cce7'
+    FunctionsToExport = @('Test-PublishedFunction')
+    RequiredModules = @('$externalModuleName')
+    PrivateData = @{
+        PSData = @{
+            ExternalModuleDependencies = @('$externalModuleName')
+        }
+    }
+}
+"@ | Out-File -FilePath $manifestPath
+
+        Publish-PSResource -Path $script:PublishModuleBase -Repository $testRepository2
+
+        $expectedPath = Join-Path -Path $script:repositoryPath2 -ChildPath "$script:PublishModuleName.$version.nupkg"
+        (Get-ChildItem $script:repositoryPath2).FullName | Should -Be $expectedPath
+    }
+
     It "Publish a module with -SkipDependenciesCheck" {
         $version = "1.0.0"
         $dependencyVersion = "2.0.0"


### PR DESCRIPTION
## Summary
  Fix `Publish-PSResource` dependency validation so `ExternalModuleDependencies` are respected for module manifests when declared under `PrivateData.PSData`.

  ## Problem
  `Publish-PSResource` excluded external dependencies only when `ExternalModuleDependencies` was present at the top level of parsed metadata.
  For module manifests, this value is typically stored under `PrivateData.PSData.ExternalModuleDependencies`, so the dependency check could still fail and incorrectly require
  `-SkipDependenciesCheck`.

  ## Root Cause
  `ParseRequiredModules()` only looked at:
  - `parsedMetadataHash["ExternalModuleDependencies"]`

  and did not also inspect:
  - `parsedMetadataHash["PrivateData"]["PSData"]["ExternalModuleDependencies"]`

  Also, dependency key matching was case-sensitive.

  ## Changes
  - Updated `ParseRequiredModules()` in `src/code/PublishHelper.cs` to:
    - read external module dependencies from both top-level metadata and `PrivateData.PSData`
    - use robust nested hashtable extraction
    - normalize matching via case-insensitive dependency map keys
  - Added regression test in:
    - `test/PublishPSResourceTests/PublishPSResource.Tests.ps1`
    - test name: `Publish a module with ExternalModuleDependencies that are not published`

  ## Validation
  - Added publish regression test covering module manifest external dependency behavior.