### PR TITLE
`Update-PSResource`: Include local-copy prerelease string when deciding update applicability

### DIFF
--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -390,7 +390,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
 
                 // If the current package is out of range, install it with the correct version.
-                if (!NuGetVersion.TryParse(installedPackage.Version.ToString(), out NuGetVersion installedVersion))
+                string installedVersionString = Utils.GetNormalizedVersionString(installedPackage.Version.ToString(), installedPackage.Prerelease);
+                if (!NuGetVersion.TryParse(installedVersionString, out NuGetVersion installedVersion))
                 {
                     WriteWarning($"Cannot parse nuget version in installed package '{installedPackage.Name}'. Cannot update package.");
                     continue;

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -390,7 +390,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
 
                 // If the current package is out of range, install it with the correct version.
-                string installedVersionString = Utils.GetNormalizedVersionString(installedPackage.Version.ToString(), installedPackage.Prerelease);
+                string installedVersionString = Utils.GetThreeDigitNormalizedVersionString(installedPackage.Version.ToString(), installedPackage.Prerelease);
                 if (!NuGetVersion.TryParse(installedVersionString, out NuGetVersion installedVersion))
                 {
                     WriteWarning($"Cannot parse nuget version in installed package '{installedPackage.Name}'. Cannot update package.");

--- a/test/UpdatePSResourceTests/UpdatePSResourceV2.Tests.ps1
+++ b/test/UpdatePSResourceTests/UpdatePSResourceV2.Tests.ps1
@@ -13,13 +13,14 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
         $testModuleName = "test_module"
         $testModuleName2 = "test_module2"
         $testModuleName3 = "TestModule99"
+        $testModuleName4 = "TestModulePrerelease"
         $PackageManagement = "PackageManagement"
         Get-NewPSResourceRepositoryFile
         Get-PSResourceRepository
     }
 
     AfterEach {
-       Uninstall-PSResource "test_module", "TestModule99", "TestModuleWithLicense", "test_module2", "test_script" -Version "*" -ErrorAction SilentlyContinue -SkipDependencyCheck
+       Uninstall-PSResource "test_module", "TestModule99", "TestModuleWithLicense", "test_module2", "test_script", "TestModulePrerelease" -Version "*" -ErrorAction SilentlyContinue -SkipDependencyCheck
     }
 
     AfterAll {
@@ -208,6 +209,20 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
         }
 
         $isPkgUpdated | Should -Be $true
+    }
+
+    It "Update prerelease version to next version when prerelease label is only differing factor between versions" {
+        # $testModuleName4 (TestModulePrerelease) has versions: 0.0.4-beta, 0.0.4. Updating should respect prerelease label
+        Install-PSResource -Name $testModuleName4 -Version "0.0.4-beta" -Repository $PSGalleryName -TrustRepository
+        $res = Get-InstalledPSResource -Name $testModuleName4
+        $res.Name | Should -Be $testModuleName4
+        $res.Version | Should -Contain "0.0.4"
+        $res.Prerelease | Should -Be "beta"
+
+        Update-PSResource -Name $testModuleName4 -Repository $PSGalleryName -TrustRepository
+        $res2 = Get-InstalledPSResource -Name $testModuleName4
+        $res2.Version | Should -Contain "0.0.4"
+        $res2.Prerelease | Should -BeNullOrEmpty
     }
 
     # Windows only


### PR DESCRIPTION
# PR Summary

This PR updates `Microsoft.PowerShell.PSResourceGet.Cmdlets.UpdatePSResource` to consider a locally-installed resource's prerelease string when comparing against the repository's available versions.

Fixes #1953.

## PR Context

Currently, `Update-PSResource` only considers the locally-installed resource's version component from the `PSResourceInfo.Version` field, of type `System.Version`. This struct doesn't include prerelease strings - `PSResourceInfo.Prerelease` contains those.

This means that if I have:
* A locally-installed resource, with version `1.0.1-pre`
* A remote repository resource, with version `1.0.1`
* The same version number between the two (sans prerelease - i.e. the module's prerelease "graduated")
...then `Update-PSResource` will mistakenly mark the locally-installed version as "up to date".

[JiraPS](https://www.powershellgallery.com/packages/JiraPS), which recently released `2.15.0` (having previously released `2.15.0-alpha1` in 2024), falls into this bucket.

**This behavior needs a test.** Publishing a test module to Gallery with a prerelease, then normal-release version (i.e. `1.0.1-pre` and `1.0.1`) would be enough to test this behavior. 

If someone from the Gallery team can publish a test module, I'm happy to contribute a test to `test\UpdatePSResourceTests\UpdatePSResourceV2.Tests.ps1` as part of this PR.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
