### PR TITLE
Register MAR as default trusted repository

### DIFF
--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -410,7 +410,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             {
                 // A container registry repository is determined to be unauthenticated if it allows anonymous pull access. However, push operations always require authentication.
                 bool isRepositoryUnauthenticated = isPushOperation ? false : IsContainerRegistryUnauthenticated(Repository.Uri.ToString(), needCatalogAccess, out errRecord, out accessToken);
-                _cmdletPassedIn.WriteDebug($"Value of isRepositoryUnauthenticated: {isRepositoryUnauthenticated}", new string[] { "PSRGContainerRegistryUnauthenticatedCheck" });
+                _cmdletPassedIn.WriteInformation($"Value of isRepositoryUnauthenticated: {isRepositoryUnauthenticated}", new string[] { "PSRGContainerRegistryUnauthenticatedCheck" });
 
                 _cmdletPassedIn.WriteDebug($"Is repository unauthenticated: {isRepositoryUnauthenticated}");
 

--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -410,7 +410,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             {
                 // A container registry repository is determined to be unauthenticated if it allows anonymous pull access. However, push operations always require authentication.
                 bool isRepositoryUnauthenticated = isPushOperation ? false : IsContainerRegistryUnauthenticated(Repository.Uri.ToString(), needCatalogAccess, out errRecord, out accessToken);
-                _cmdletPassedIn.WriteInformation($"Value of isRepositoryUnauthenticated: {isRepositoryUnauthenticated}", new string[] { "PSRGContainerRegistryUnauthenticatedCheck" });
+                _cmdletPassedIn.WriteDebug($"Value of isRepositoryUnauthenticated: {isRepositoryUnauthenticated}", new string[] { "PSRGContainerRegistryUnauthenticatedCheck" });
 
                 _cmdletPassedIn.WriteDebug($"Is repository unauthenticated: {isRepositoryUnauthenticated}");
 

--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -29,6 +29,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         #region Members
 
         private readonly string PSGalleryRepoName = "PSGallery";
+        private readonly string MicrosoftArtifactRegistryRepoName = "MicrosoftArtifactRegistry";
+        private readonly string MicrosoftArtifactRegistryRepoUri = "https://artifactregistry.microsoft.com/api/v2";
         private readonly string PSGalleryRepoUri = "https://www.powershellgallery.com/api/v2";
         private const int DefaultPriority = 50;
         private const bool DefaultTrusted = false;
@@ -37,6 +39,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private const string RepositoriesParameterSet = "RepositoriesParameterSet";
         private Uri _uri;
         private CredentialProviderDynamicParameters _credentialProvider;
+        private const string MARParameterSet = "MARParameterSet";
 
         #endregion
 
@@ -63,6 +66,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public SwitchParameter PSGallery { get; set; }
 
         /// <summary>
+        /// When specified, registers Microsoft Artifact Registry repository.
+        /// </summary>
+        [Parameter(Mandatory = true, ParameterSetName = MARParameterSet, HelpMessage = "Switch used to indicate registering Microsoft Artifact Registry repository.")]
+        [Alias("MAR")]
+        public SwitchParameter MicrosoftArtifactRegistry { get; set; }
+
+        /// <summary>
         /// Specifies a hashtable of repositories and is used to register multiple repositories at once.
         /// </summary>
         [Parameter(Mandatory = true, ParameterSetName = RepositoriesParameterSet, HelpMessage = "Hashtable including information on single or multiple repositories to be registered.")]
@@ -74,6 +84,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         [Parameter(ParameterSetName = NameParameterSet)]
         [Parameter(ParameterSetName = PSGalleryParameterSet)]
+        [Parameter(ParameterSetName = MARParameterSet)]
         public SwitchParameter Trusted { get; set; }
 
         /// <summary>
@@ -84,6 +95,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         [Parameter(ParameterSetName = NameParameterSet)]
         [Parameter(ParameterSetName = PSGalleryParameterSet)]
+        [Parameter(ParameterSetName = MARParameterSet)]
         [ValidateRange(0, 100)]
         public int Priority { get; set; } = DefaultPriority;
 
@@ -122,6 +134,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // It should also not appear when using the 'Repositories' parameter set.
             if (ParameterSetName.Equals(PSGalleryParameterSet) ||
                 ParameterSetName.Equals(RepositoriesParameterSet) ||
+                ParameterSetName.Equals(MARParameterSet) ||
                 PSRepositoryInfo.IsValidContainerRegistryURL(Uri))
             {
                 return null;
@@ -218,6 +231,24 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     }
                     break;
 
+                case MARParameterSet:
+                    if (MicrosoftArtifactRegistry)
+                    {
+                        try
+                        {
+                            items.Add(MicrosoftArtifactRegistryParameterSetHelper(Priority, Trusted));
+                        }
+                        catch (Exception e)
+                        {
+                            ThrowTerminatingError(new ErrorRecord(
+                                new PSInvalidOperationException(e.Message),
+                                "ErrorInMARParameterSet",
+                                ErrorCategory.InvalidArgument,
+                                this));
+                        }
+                    }
+                    break;
+
                 default:
                     Dbg.Assert(false, "Invalid parameter set");
                     break;
@@ -241,6 +272,34 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             WriteDebug("Internal name and uri values for PSGallery are hardcoded and validated. Priority and trusted values, if passed in, also validated");
             var addedRepo = RepositorySettings.AddToRepositoryStore(PSGalleryRepoName,
                 psGalleryUri,
+                repoPriority,
+                repoTrusted,
+                apiVersion: null,
+                repoCredentialInfo: null,
+                credentialProvider: null,
+                Force,
+                this,
+                out string errorMsg);
+
+            if (!string.IsNullOrEmpty(errorMsg))
+            {
+                ThrowTerminatingError(new ErrorRecord(
+                    new PSInvalidOperationException(errorMsg),
+                    "RepositoryCredentialSecretManagementUnavailableModule",
+                    ErrorCategory.ResourceUnavailable,
+                    this));
+            }
+
+            return addedRepo;
+        }
+
+        private PSRepositoryInfo MicrosoftArtifactRegistryParameterSetHelper(int repoPriority, bool repoTrusted)
+        {
+            WriteDebug("In RegisterPSResourceRepository::MicrosoftArtifactRegistryParameterSetHelper()");
+            Uri marUri = new Uri(MicrosoftArtifactRegistryRepoUri);
+            WriteDebug("Internal name and uri values for Microsoft Artifact Registry are hardcoded and validated. Priority and trusted values, if passed in, also validated");
+            var addedRepo = RepositorySettings.AddToRepositoryStore(MicrosoftArtifactRegistryRepoName,
+                marUri,
                 repoPriority,
                 repoTrusted,
                 apiVersion: null,

--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -323,11 +323,22 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return null;
             }
 
-            if (repo["Name"].ToString().Equals("PSGallery"))
+            if (repo["Name"].ToString().Equals("PSGallery", StringComparison.OrdinalIgnoreCase))
             {
                 WriteError(new ErrorRecord(
                         new PSInvalidOperationException("Cannot register PSGallery with -Name parameter. Try: Register-PSResourceRepository -PSGallery"),
                         "PSGalleryProvidedAsNameRepoPSet",
+                        ErrorCategory.InvalidArgument,
+                        this));
+
+                return null;
+            }
+
+            if (repo["Name"].ToString().Equals("MAR", StringComparison.OrdinalIgnoreCase))
+            {
+                WriteError(new ErrorRecord(
+                        new PSInvalidOperationException("Cannot register MAR with -Name parameter. The MAR repository is automatically registered. Try: Reset-PSResourceRepository to restore default repositories."),
+                        "MARProvidedAsNameRepoPSet",
                         ErrorCategory.InvalidArgument,
                         this));
 

--- a/src/code/RegisterPSResourceRepository.cs
+++ b/src/code/RegisterPSResourceRepository.cs
@@ -30,10 +30,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         private readonly string PSGalleryRepoName = "PSGallery";
         private readonly string MicrosoftArtifactRegistryRepoName = "MicrosoftArtifactRegistry";
-        private readonly string MicrosoftArtifactRegistryRepoUri = "https://artifactregistry.microsoft.com/api/v2";
+        private readonly string MicrosoftArtifactRegistryRepoUri = "https://mcr.microsoft.com";
         private readonly string PSGalleryRepoUri = "https://www.powershellgallery.com/api/v2";
         private const int DefaultPriority = 50;
         private const bool DefaultTrusted = false;
+        private const bool MARDefaultTrusted = true;
+        private const int MARDefaultPriority = 40;
         private const string NameParameterSet = "NameParameterSet";
         private const string PSGalleryParameterSet = "PSGalleryParameterSet";
         private const string RepositoriesParameterSet = "RepositoriesParameterSet";
@@ -97,7 +99,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         [Parameter(ParameterSetName = PSGalleryParameterSet)]
         [Parameter(ParameterSetName = MARParameterSet)]
         [ValidateRange(0, 100)]
-        public int Priority { get; set; } = DefaultPriority;
+        public int Priority { get; set; }
 
         /// <summary>
         /// Specifies the Api version of the repository to be set.
@@ -160,6 +162,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (MyInvocation.BoundParameters.ContainsKey(nameof(ApiVersion)))
             {
                 repoApiVersion = ApiVersion;
+            }
+
+            if (!MyInvocation.BoundParameters.ContainsKey(nameof(Priority)))
+            {
+                if (ParameterSetName.Equals(MARParameterSet, StringComparison.OrdinalIgnoreCase))
+                {
+                    Priority = MARDefaultPriority;
+                }
+                else
+                {
+                    Priority = DefaultPriority;
+                }
             }
 
             PSRepositoryInfo.CredentialProviderType? credentialProvider = _credentialProvider?.CredentialProvider;
@@ -236,7 +250,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     {
                         try
                         {
-                            items.Add(MicrosoftArtifactRegistryParameterSetHelper(Priority, Trusted));
+                            bool trustedValue = Trusted.IsPresent ? Trusted : MARDefaultTrusted;
+                            items.Add(MicrosoftArtifactRegistryParameterSetHelper(Priority, trustedValue));
                         }
                         catch (Exception e)
                         {

--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -95,7 +95,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
             if (repoName.Equals("MAR", StringComparison.OrdinalIgnoreCase))
             {
-                errorMsg = "Cannot register MAR with -Name parameter. The MAR repository is automatically registered. Try: Reset-PSResourceRepository to restore default repositories.";
+                errorMsg = "Cannot register MAR with -Name parameter. Try: Register-PSResourceRepository -MicrosoftArtifactRegistry.";
                 return null;
             }
 

--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -26,8 +26,12 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         // The repository store file's location is currently only at '%LOCALAPPDATA%\PSResourceGet' for the user account.
         private const string PSGalleryRepoName = "PSGallery";
         private const string PSGalleryRepoUri = "https://www.powershellgallery.com/api/v2";
+        private const string MARRepoName = "MAR";
+        private const string MARRepoUri = "https://mcr.microsoft.com";
         private const int DefaultPriority = 50;
+        private const int MARDefaultPriority = 40;
         private const bool DefaultTrusted = false;
+        private const bool MARDefaultTrusted = true;
         private const string RepositoryFileName = "PSResourceRepository.xml";
         private static readonly string RepositoryPath = Path.Combine(Environment.GetFolderPath(
             Environment.SpecialFolder.LocalApplicationData), "PSResourceGet");
@@ -63,6 +67,10 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 // Add PSGallery to the newly created store
                 Uri psGalleryUri = new Uri(PSGalleryRepoUri);
                 Add(PSGalleryRepoName, psGalleryUri, DefaultPriority, DefaultTrusted, repoCredentialInfo: null, repoCredentialProvider: CredentialProviderType.None, APIVersion.V2, force: false);
+
+                // Add MAR to the newly created store
+                Uri marUri = new Uri(MARRepoUri);
+                Add(MARRepoName, marUri, MARDefaultPriority, MARDefaultTrusted, repoCredentialInfo: null, repoCredentialProvider: CredentialProviderType.None, APIVersion.ContainerRegistry, force: false);
             }
 
             // Open file (which should exist now), if cannot/is corrupted then throw error
@@ -82,6 +90,12 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             if (repoName.Equals("PSGallery", StringComparison.OrdinalIgnoreCase))
             {
                 errorMsg = "Cannot register PSGallery with -Name parameter. Try: Register-PSResourceRepository -PSGallery";
+                return null;
+            }
+
+            if (repoName.Equals("MAR", StringComparison.OrdinalIgnoreCase))
+            {
+                errorMsg = "Cannot register MAR with -Name parameter. The MAR repository is automatically registered. Try: Reset-PSResourceRepository to restore default repositories.";
                 return null;
             }
 
@@ -184,6 +198,20 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             if (repoName.Equals("PSGallery", StringComparison.OrdinalIgnoreCase) && repoCredentialInfo != null)
             {
                 errorMsg = "Setting the -CredentialInfo parameter for PSGallery is not allowed. Run 'Register-PSResourceRepository -PSGallery' to register the PowerShell Gallery.";
+                return null;
+            }
+
+            // check MAR Uri is not trying to be set
+            if (repoName.Equals("MAR", StringComparison.OrdinalIgnoreCase) && repoUri != null)
+            {
+                errorMsg = "The MAR repository has a predefined Uri. Setting the -Uri parameter for this repository is not allowed. Please run 'Reset-PSResourceRepository' to restore default repositories.";
+                return null;
+            }
+
+            // check MAR CredentialInfo is not trying to be set
+            if (repoName.Equals("MAR", StringComparison.OrdinalIgnoreCase) && repoCredentialInfo != null)
+            {
+                errorMsg = "Setting the -CredentialInfo parameter for MAR is not allowed. Run 'Reset-PSResourceRepository' to restore default repositories.";
                 return null;
             }
 
@@ -907,6 +935,10 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 // Add PSGallery to the newly created store
                 Uri psGalleryUri = new Uri(PSGalleryRepoUri);
                 PSRepositoryInfo psGalleryRepo = Add(PSGalleryRepoName, psGalleryUri, DefaultPriority, DefaultTrusted, repoCredentialInfo: null, repoCredentialProvider: CredentialProviderType.None, APIVersion.V2, force: false);
+
+                // Add MAR to the newly created store
+                Uri marUri = new Uri(MARRepoUri);
+                Add(MARRepoName, marUri, MARDefaultPriority, MARDefaultTrusted, repoCredentialInfo: null, repoCredentialProvider: CredentialProviderType.None, APIVersion.ContainerRegistry, force: false);
 
                 // Clean up backup file on success
                 if (!string.IsNullOrEmpty(backupFilePath) && File.Exists(backupFilePath))

--- a/src/code/RepositorySettings.cs
+++ b/src/code/RepositorySettings.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         // The repository store file's location is currently only at '%LOCALAPPDATA%\PSResourceGet' for the user account.
         private const string PSGalleryRepoName = "PSGallery";
         private const string PSGalleryRepoUri = "https://www.powershellgallery.com/api/v2";
-        private const string MARRepoName = "MAR";
+        private const string MARRepoName = "MicrosoftArtifactRegistry";
         private const string MARRepoUri = "https://mcr.microsoft.com";
         private const int DefaultPriority = 50;
         private const int MARDefaultPriority = 40;
@@ -93,7 +93,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
                 return null;
             }
 
-            if (repoName.Equals("MAR", StringComparison.OrdinalIgnoreCase))
+            if (repoName.Equals("MicrosoftArtifactRegistry", StringComparison.OrdinalIgnoreCase))
             {
                 errorMsg = "Cannot register MAR with -Name parameter. Try: Register-PSResourceRepository -MicrosoftArtifactRegistry.";
                 return null;
@@ -202,14 +202,14 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             }
 
             // check MAR Uri is not trying to be set
-            if (repoName.Equals("MAR", StringComparison.OrdinalIgnoreCase) && repoUri != null)
+            if (repoName.Equals("MicrosoftArtifactRegistry", StringComparison.OrdinalIgnoreCase) && repoUri != null)
             {
                 errorMsg = "The MAR repository has a predefined Uri. Setting the -Uri parameter for this repository is not allowed. Please run 'Reset-PSResourceRepository' to restore default repositories.";
                 return null;
             }
 
             // check MAR CredentialInfo is not trying to be set
-            if (repoName.Equals("MAR", StringComparison.OrdinalIgnoreCase) && repoCredentialInfo != null)
+            if (repoName.Equals("MicrosoftArtifactRegistry", StringComparison.OrdinalIgnoreCase) && repoCredentialInfo != null)
             {
                 errorMsg = "Setting the -CredentialInfo parameter for MAR is not allowed. Run 'Reset-PSResourceRepository' to restore default repositories.";
                 return null;

--- a/src/code/ResetPSResourceRepository.cs
+++ b/src/code/ResetPSResourceRepository.cs
@@ -10,7 +10,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
     /// <summary>
     /// The Reset-PSResourceRepository cmdlet resets the repository store by creating a new PSRepositories.xml file.
     /// This is useful when the repository store becomes corrupted.
-    /// It will create a new repository store with only the PSGallery repository registered.
+    /// It will create a new repository store with PSGallery and MAR repositories registered.
     /// </summary>
     [Cmdlet(VerbsCommon.Reset,
         "PSResourceRepository",
@@ -39,8 +39,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 "PSResourceRepository.xml");
 
             WriteVerbose($"Resetting repository store at: {repositoryStorePath}");
-            
-            if (!ShouldProcess(repositoryStorePath, "Reset repository store and create new PSRepositories.xml file with PSGallery registered"))
+
+            if (!ShouldProcess(repositoryStorePath, "Reset repository store and create new PSRepositories.xml file with PSGallery and MAR registered"))
             {
                 return;
             }
@@ -57,7 +57,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return;
             }
 
-            WriteVerbose("Repository store reset successfully. PSGallery has been registered.");
+            WriteVerbose("Repository store reset successfully. PSGallery and MAR have been registered.");
 
             if (PassThru)
             {

--- a/src/code/SetPSResourceRepository.cs
+++ b/src/code/SetPSResourceRepository.cs
@@ -110,10 +110,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public object GetDynamicParameters()
         {
             PSRepositoryInfo repository = RepositorySettings.Read(new[] { Name }, out string[] _).FirstOrDefault();
-            // Dynamic parameter '-CredentialProvider' should not appear for PSGallery, or any container registry repository.
+            // Dynamic parameter '-CredentialProvider' should not appear for PSGallery, MAR, or any container registry repository.
             // It should also not appear when using the 'Repositories' parameter set.
             if (repository is not null &&
                 (repository.Name.Equals("PSGallery", StringComparison.OrdinalIgnoreCase) ||
+                repository.Name.Equals("MAR", StringComparison.OrdinalIgnoreCase) ||
                 ParameterSetName.Equals(RepositoriesParameterSet) ||
                 repository.IsContainerRegistry()))
             {

--- a/src/code/SetPSResourceRepository.cs
+++ b/src/code/SetPSResourceRepository.cs
@@ -114,7 +114,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // It should also not appear when using the 'Repositories' parameter set.
             if (repository is not null &&
                 (repository.Name.Equals("PSGallery", StringComparison.OrdinalIgnoreCase) ||
-                repository.Name.Equals("MAR", StringComparison.OrdinalIgnoreCase) ||
+                repository.Name.Equals("MicrosoftArtifactRegistry", StringComparison.OrdinalIgnoreCase) ||
                 ParameterSetName.Equals(RepositoriesParameterSet) ||
                 repository.IsContainerRegistry()))
             {

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -7,7 +7,7 @@ Import-Module $modPath -Force -Verbose
 Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
 
     BeforeAll {
-        $MARName = Get-MAar
+        $MARName = Get-MarName
         $testModuleName = "test-module"
         $testModuleWith2DigitVersion = "test-2DigitPkg"
         $testModuleParentName = "test_parent_mod"

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -274,6 +274,14 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
 
 Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {
 
+    BeforeAll {
+        Get-NewPSResourceRepositoryFile
+    }
+
+    AfterAll {
+        Get-RevertPSResourceRepositoryFile
+    }
+
     It "Should find resource given specific Name, Version null" {
         $res = Find-PSResource -Name "Az.Accounts" -Repository "MAR"
         $res.Name | Should -Be "Az.Accounts"

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -7,6 +7,7 @@ Import-Module $modPath -Force -Verbose
 Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
 
     BeforeAll {
+        $MARName = Get-MAar
         $testModuleName = "test-module"
         $testModuleWith2DigitVersion = "test-2DigitPkg"
         $testModuleParentName = "test_parent_mod"
@@ -283,37 +284,37 @@ Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {
     }
 
     It "Should find resource given specific Name, Version null" {
-        $res = Find-PSResource -Name "Az.Accounts" -Repository "MAR"
+        $res = Find-PSResource -Name "Az.Accounts" -Repository $MarName
         $res.Name | Should -Be "Az.Accounts"
         $res.Version | Should -BeGreaterThan ([Version]"4.0.0")
     }
 
     It "Should find resource and its dependency given specific Name and Version" {
-        $res = Find-PSResource -Name "Az.Storage" -Version "8.0.0" -Repository "MAR"
+        $res = Find-PSResource -Name "Az.Storage" -Version "8.0.0" -Repository $MarName
         $res.Dependencies.Length | Should -Be 1
         $res.Dependencies[0].Name | Should -Be "Az.Accounts"
     }
 
     It "Should find Azpreview resource and it's dependency given specific Name and Version" {
-        $res = Find-PSResource -Name "Azpreview" -Version "13.2.0" -Repository "MAR"
+        $res = Find-PSResource -Name "Azpreview" -Version "13.2.0" -Repository $MarName
         $res.Dependencies.Length | Should -Not -Be 0
     }
 
     It "Should find resource with wildcard in Name" {
-        $res = Find-PSResource -Name "Az.App*" -Repository "MAR"
+        $res = Find-PSResource -Name "Az.App*" -Repository $MarName
         $res | Should -Not -BeNullOrEmpty
         $res.Count | Should -BeGreaterThan 1
     }
 
     It "Should find all resource with wildcard in Name" {
-        $res = Find-PSResource -Name "*" -Repository "MAR"
+        $res = Find-PSResource -Name "*" -Repository $MarName
         $res | Should -Not -BeNullOrEmpty
         $res.Count | Should -BeGreaterThan 1
     }
 
     It "Should find version range for Az dependencies" {
         # Target known version to know the output from the API won't change
-        $res = Find-PSResource -Repository 'MAR' -Name 'Az' -Version '14.4.0'
+        $res = Find-PSResource -Repository $MarName -Name 'Az' -Version '14.4.0'
 
         # Version defined by "ModuleVersion"
         $res.Dependencies.Where{$_.'Name' -eq 'Az.Accounts'}.'VersionRange'.ToString() | Should -Be '[5.3.0, )'

--- a/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceContainerRegistryServer.Tests.ps1
@@ -273,13 +273,6 @@ Describe 'Test HTTP Find-PSResource for ACR Server Protocol' -tags 'CI' {
 }
 
 Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {
-    BeforeAll {
-        Register-PSResourceRepository -Name "MAR" -Uri "https://mcr.microsoft.com" -ApiVersion "ContainerRegistry"
-    }
-
-    AfterAll {
-        Unregister-PSResourceRepository -Name "MAR"
-    }
 
     It "Should find resource given specific Name, Version null" {
         $res = Find-PSResource -Name "Az.Accounts" -Repository "MAR"
@@ -313,10 +306,10 @@ Describe 'Test Find-PSResource for MAR Repository' -tags 'CI' {
     It "Should find version range for Az dependencies" {
         # Target known version to know the output from the API won't change
         $res = Find-PSResource -Repository 'MAR' -Name 'Az' -Version '14.4.0'
-        
+
         # Version defined by "ModuleVersion"
         $res.Dependencies.Where{$_.'Name' -eq 'Az.Accounts'}.'VersionRange'.ToString() | Should -Be '[5.3.0, )'
-        
+
         # Version defined by "RequiredVersion"
         $res.Dependencies.Where{$_.'Name' -eq 'Az.Resources'}.'VersionRange'.ToString() | Should -Be '[8.1.0, 8.1.0]'
     }

--- a/test/InstallPSResourceTests/InstallPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceContainerRegistryServer.Tests.ps1
@@ -352,6 +352,13 @@ Describe 'Test Install-PSResource for Container Registry scenarios - Manual Vali
 
 Describe 'Test Install-PSResource for MAR Repository' -tags 'CI' {
 
+    BeforeAll {
+        Get-NewPSResourceRepositoryFile
+    }
+    AfterAll {
+        Get-RevertPSResourceRepositoryFile
+    }
+
     It "Should find resource given specific Name, Version null" {
         try {
             $pkg = Install-PSResource -Name "Az.Accounts" -Repository "MAR" -PassThru -TrustRepository -Reinstall

--- a/test/InstallPSResourceTests/InstallPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceContainerRegistryServer.Tests.ps1
@@ -351,15 +351,6 @@ Describe 'Test Install-PSResource for Container Registry scenarios - Manual Vali
 }
 
 Describe 'Test Install-PSResource for MAR Repository' -tags 'CI' {
-    BeforeAll {
-        [Microsoft.PowerShell.PSResourceGet.UtilClasses.InternalHooks]::SetTestHook("MARPrefix", "azure-powershell/");
-        Register-PSResourceRepository -Name "MAR" -Uri "https://mcr.microsoft.com" -ApiVersion "ContainerRegistry"
-    }
-
-    AfterAll {
-        [Microsoft.PowerShell.PSResourceGet.UtilClasses.InternalHooks]::SetTestHook("MARPrefix", $null);
-        Unregister-PSResourceRepository -Name "MAR"
-    }
 
     It "Should find resource given specific Name, Version null" {
         try {

--- a/test/InstallPSResourceTests/InstallPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceContainerRegistryServer.Tests.ps1
@@ -361,7 +361,7 @@ Describe 'Test Install-PSResource for MAR Repository' -tags 'CI' {
 
     It "Should install resource given specific Name, Version null" {
         try {
-            $pkg = Install-PSResource -Name "Az.Accounts" -Repository 'MicrosoftArtifactRepository' -PassThru -TrustRepository -Reinstall
+            $pkg = Install-PSResource -Name "Az.Accounts" -Repository 'MicrosoftArtifactRegistry' -PassThru -TrustRepository -Reinstall
             $pkg.Name | Should -Be "Az.Accounts"
             $pkg.Version.Major | Should -BeGreaterOrEqual 5
 

--- a/test/InstallPSResourceTests/InstallPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceContainerRegistryServer.Tests.ps1
@@ -359,15 +359,16 @@ Describe 'Test Install-PSResource for MAR Repository' -tags 'CI' {
         Get-RevertPSResourceRepositoryFile
     }
 
-    It "Should find resource given specific Name, Version null" {
+    It "Should install resource given specific Name, Version null" {
         try {
             $pkg = Install-PSResource -Name "Az.Accounts" -Repository "MAR" -PassThru -TrustRepository -Reinstall
             $pkg.Name | Should -Be "Az.Accounts"
-            $pkg.Version | Should -Be "3.0.4"
+            $pkg.Version.Major | Should -BeGreaterThanOrEqualTo "5"
+
         }
         finally {
             if ($pkg) {
-                Uninstall-PSResource -Name "Az.Accounts" -Version "3.0.4"
+                Uninstall-PSResource -Name "Az.Accounts" -Version $pkg.Version
             }
         }
     }

--- a/test/InstallPSResourceTests/InstallPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceContainerRegistryServer.Tests.ps1
@@ -363,7 +363,7 @@ Describe 'Test Install-PSResource for MAR Repository' -tags 'CI' {
         try {
             $pkg = Install-PSResource -Name "Az.Accounts" -Repository "MAR" -PassThru -TrustRepository -Reinstall
             $pkg.Name | Should -Be "Az.Accounts"
-            $pkg.Version.Major | Should -BeGreaterThanOrEqualTo "5"
+            $pkg.Version.Major | Should -BeGreaterOrEqual 5
 
         }
         finally {

--- a/test/InstallPSResourceTests/InstallPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceContainerRegistryServer.Tests.ps1
@@ -361,7 +361,7 @@ Describe 'Test Install-PSResource for MAR Repository' -tags 'CI' {
 
     It "Should install resource given specific Name, Version null" {
         try {
-            $pkg = Install-PSResource -Name "Az.Accounts" -Repository "MAR" -PassThru -TrustRepository -Reinstall
+            $pkg = Install-PSResource -Name "Az.Accounts" -Repository 'MicrosoftArtifactRepository' -PassThru -TrustRepository -Reinstall
             $pkg.Name | Should -Be "Az.Accounts"
             $pkg.Version.Major | Should -BeGreaterOrEqual 5
 

--- a/test/InstallPSResourceTests/InstallPSResourceRepositorySearching.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceRepositorySearching.Tests.ps1
@@ -36,8 +36,9 @@ Describe 'Test Install-PSResource for searching and looping through repositories
 
     It "install resources from highest priority repository where it exists (without -Repository specified)" {
         # Package "test_module" exists in the following repositories (in this order): localRepo, PSGallery, NuGetGallery
+        # Package does not exist on MAR to we need to skip when validating that the highest priority repository is used
         $res = Install-PSResource -Name $testModuleName -TrustRepository -SkipDependencyCheck -ErrorVariable err -ErrorAction SilentlyContinue -PassThru
-        $err | Should -HaveCount 0
+        $err | Should -HaveCount 1 ## This comes from MAR
 
         $res | Should -Not -BeNullOrEmpty
         $res.Repository | Should -Be $localRepoName
@@ -45,8 +46,9 @@ Describe 'Test Install-PSResource for searching and looping through repositories
 
     It "install resources from hightest priority repository where it exists and not write errors for repositories where it does not exist (without -Repository specified)" {
         # Package "test_script" exists in the following repositories: PSGallery, NuGetGallery
+        # Package does not exist on MAR to we need to skip when validating that the highest priority repository is used
         Install-PSResource -Name $testScriptName -TrustRepository -SkipDependencyCheck -ErrorVariable err -ErrorAction SilentlyContinue
-        $err | Should -HaveCount 0
+        $err | Should -HaveCount 1 ## This comes from MAR
 
         $res = Get-InstalledPSResource $testScriptName
         $res | Should -Not -BeNullOrEmpty
@@ -55,7 +57,7 @@ Describe 'Test Install-PSResource for searching and looping through repositories
 
     It "should install resources that exist and not install ones that do not exist while reporting error (without -Repository specified)" {
         Install-PSResource -Name $testScriptName,"NonExistentModule" -TrustRepository -SkipDependencyCheck -ErrorVariable err -ErrorAction SilentlyContinue
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
+        "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" | Should -BeIn $err.FullyQualifiedErrorId
 
         $res = Get-InstalledPSResource $testScriptName
         $res | Should -Not -BeNullOrEmpty
@@ -64,13 +66,13 @@ Describe 'Test Install-PSResource for searching and looping through repositories
 
     It "should not install resource given nonexistent Name (without -Repository specified)" {
         Install-PSResource -Name "NonExistentModule" -TrustRepository -SkipDependencyCheck -ErrorVariable err -ErrorAction SilentlyContinue
-        $err | Should -HaveCount 1
-        $err[0].FullyQualifiedErrorId | Should -BeExactly "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource"
+        $err | Should -HaveCount 2 ## One error comes from MAR
+        "InstallPackageFailure,Microsoft.PowerShell.PSResourceGet.Cmdlets.InstallPSResource" | Should -BeIn $err.FullyQualifiedErrorId
     }
 
     It "install multiple resources from highest priority repository where it exists (without -Repository specified)" {
         $res = Install-PSResource -Name "test_module","test_module2" -TrustRepository -SkipDependencyCheck -ErrorVariable err -ErrorAction SilentlyContinue -PassThru
-        $err | Should -HaveCount 0
+        $err | Should -HaveCount 2 ## This comes from MAR
         $res | Should -Not -BeNullOrEmpty
 
         $pkg1 = $res[0]

--- a/test/PSGetTestUtils.psm1
+++ b/test/PSGetTestUtils.psm1
@@ -19,6 +19,9 @@ $script:IsCoreCLR = $PSVersionTable.ContainsKey('PSEdition') -and $PSVersionTabl
 $script:PSGalleryName = 'PSGallery'
 $script:PSGalleryLocation = 'https://www.powershellgallery.com/api/v2'
 
+$script:MARName = 'MAR'
+$script:MARLocation = 'https://mcr.microsoft.com'
+
 $script:NuGetGalleryName = 'NuGetGallery'
 $script:NuGetGalleryLocation = 'https://api.nuget.org/v3/index.json'
 
@@ -153,6 +156,16 @@ function Get-PSGalleryName
 function Get-PSGalleryLocation {
     return $script:PSGalleryLocation
 }
+
+function Get-MARName
+{
+    return $script:MARName
+}
+
+function Get-MARLocation {
+    return $script:MARLocation
+}
+
 function Get-NewTestDirs {
     Param(
         [string[]]

--- a/test/PSGetTestUtils.psm1
+++ b/test/PSGetTestUtils.psm1
@@ -19,8 +19,8 @@ $script:IsCoreCLR = $PSVersionTable.ContainsKey('PSEdition') -and $PSVersionTabl
 $script:PSGalleryName = 'PSGallery'
 $script:PSGalleryLocation = 'https://www.powershellgallery.com/api/v2'
 
-$script:MARName = 'MAR'
-$script:MARLocation = 'https://mcr.microsoft.com'
+$script:MARName = 'MicrosoftArtifactRegistry'
+$script:MARLocation = 'https://mcr.microsoft.com/'
 
 $script:NuGetGalleryName = 'NuGetGallery'
 $script:NuGetGalleryLocation = 'https://api.nuget.org/v3/index.json'

--- a/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResource.Tests.ps1
@@ -101,6 +101,7 @@ Describe "Test Publish-PSResource" -tags 'CI' {
         CreateTestModule -Path $TestDrive -ModuleName 'ModuleWithMissingRequiredModule'
 
         $script:PSGalleryName = 'PSGallery'
+        $script:MARName = 'MicrosoftArtifactRegistry'
     }
     AfterAll {
        Get-RevertPSResourceRepositoryFile
@@ -802,8 +803,9 @@ Describe "Test Publish-PSResource with Module Prefix" -tags 'CI' {
             $err[0].FullyQualifiedErrorId | Should -Be "RepositoryNotFound,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
 
             $registeredRepos = Get-PSResourceRepository
-            $registeredRepos.Count | Should -Be 1
-            $registeredRepos[0].Name | Should -Be $script:PSGalleryName
+            $registeredRepos.Count | Should -Be 2
+            $registeredRepos[0].Name | Should -Be $script:MARName
+            $registeredRepos[1].Name | Should -Be $script:PSGalleryName
         }
         finally {
             # Cleanup

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -591,6 +591,13 @@ Describe "Test Publish-PSResource" -tags 'CI' {
 
 Describe 'Test Publish-PSResource for MAR Repository' -tags 'CI' {
 
+    BeforeAll {
+        Get-NewPSResourceRepositoryFile
+    }
+    AfterAll {
+        Get-RevertPSResourceRepositoryFile
+    }
+
     It "Should find resource given specific Name, Version null" {
         $fileName = "NonExistent.psd1"
         $modulePath = New-Item -Path "$TestDrive\NonExistent" -ItemType Directory -Force

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -604,6 +604,6 @@ Describe 'Test Publish-PSResource for MAR Repository' -tags 'CI' {
         $psd1Path = Join-Path -Path $modulePath -ChildPath $fileName
         New-ModuleManifest -Path $psd1Path -ModuleVersion "1.0.0" -Description "NonExistent module"
 
-        { Publish-PSResource -Path $modulePath -Repository "MAR" -ErrorAction Stop } | Should -Throw -ErrorId "MARRepositoryPublishError,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
+        { Publish-PSResource -Path $modulePath -Repository "MicrosoftArtifactRepository" -ErrorAction Stop } | Should -Throw -ErrorId "MARRepositoryPublishError,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
     }
 }

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -604,6 +604,6 @@ Describe 'Test Publish-PSResource for MAR Repository' -tags 'CI' {
         $psd1Path = Join-Path -Path $modulePath -ChildPath $fileName
         New-ModuleManifest -Path $psd1Path -ModuleVersion "1.0.0" -Description "NonExistent module"
 
-        { Publish-PSResource -Path $modulePath -Repository "MicrosoftArtifactRepository" -ErrorAction Stop } | Should -Throw -ErrorId "MARRepositoryPublishError,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
+        { Publish-PSResource -Path $modulePath -Repository "MicrosoftArtifactRegistry" -ErrorAction Stop } | Should -Throw -ErrorId "MARRepositoryPublishError,Microsoft.PowerShell.PSResourceGet.Cmdlets.PublishPSResource"
     }
 }

--- a/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
+++ b/test/PublishPSResourceTests/PublishPSResourceContainerRegistryServer.Tests.ps1
@@ -590,15 +590,6 @@ Describe "Test Publish-PSResource" -tags 'CI' {
 }
 
 Describe 'Test Publish-PSResource for MAR Repository' -tags 'CI' {
-    BeforeAll {
-        [Microsoft.PowerShell.PSResourceGet.UtilClasses.InternalHooks]::SetTestHook("MARPrefix", "azure-powershell/");
-        Register-PSResourceRepository -Name "MAR" -Uri "https://mcr.microsoft.com" -ApiVersion "ContainerRegistry"
-    }
-
-    AfterAll {
-        [Microsoft.PowerShell.PSResourceGet.UtilClasses.InternalHooks]::SetTestHook("MARPrefix", $null);
-        Unregister-PSResourceRepository -Name "MAR"
-    }
 
     It "Should find resource given specific Name, Version null" {
         $fileName = "NonExistent.psd1"

--- a/test/ResourceRepositoryTests/MARRepository.Tests.ps1
+++ b/test/ResourceRepositoryTests/MARRepository.Tests.ps1
@@ -77,7 +77,7 @@ Describe "Test MAR Repository Registration" -tags 'CI' {
 
     Context "Reset repository store includes MAR" {
         It "Reset-PSResourceRepository should register MAR alongside PSGallery" {
-            Reset-PSResourceRepository -Force
+            Reset-PSResourceRepository
             $res = Get-PSResourceRepository -Name $MARName
             $res | Should -Not -BeNullOrEmpty
             $res.Name | Should -Be $MARName
@@ -95,7 +95,7 @@ Describe "Test MAR Repository Registration" -tags 'CI' {
             $res = Get-PSResourceRepository -Name $MARName -ErrorAction SilentlyContinue
             $res | Should -BeNullOrEmpty
 
-            Reset-PSResourceRepository -Force
+            Reset-PSResourceRepository
             $res = Get-PSResourceRepository -Name $MARName
             $res | Should -Not -BeNullOrEmpty
             $res.Name | Should -Be $MARName
@@ -107,7 +107,7 @@ Describe "Test MAR Repository Registration" -tags 'CI' {
         It "Reset-PSResourceRepository should restore both PSGallery and MAR" {
             Unregister-PSResourceRepository -Name $MARName
             Unregister-PSResourceRepository -Name $PSGalleryName
-            Reset-PSResourceRepository -Force
+            Reset-PSResourceRepository
 
             $mar = Get-PSResourceRepository -Name $MARName
             $mar | Should -Not -BeNullOrEmpty

--- a/test/ResourceRepositoryTests/MARRepository.Tests.ps1
+++ b/test/ResourceRepositoryTests/MARRepository.Tests.ps1
@@ -77,7 +77,7 @@ Describe "Test MAR Repository Registration" -tags 'CI' {
 
     Context "Reset repository store includes MAR" {
         It "Reset-PSResourceRepository should register MAR alongside PSGallery" {
-            Reset-PSResourceRepository
+            Reset-PSResourceRepository -Confirm:$false
             $res = Get-PSResourceRepository -Name $MARName
             $res | Should -Not -BeNullOrEmpty
             $res.Name | Should -Be $MARName
@@ -95,7 +95,7 @@ Describe "Test MAR Repository Registration" -tags 'CI' {
             $res = Get-PSResourceRepository -Name $MARName -ErrorAction SilentlyContinue
             $res | Should -BeNullOrEmpty
 
-            Reset-PSResourceRepository
+            Reset-PSResourceRepository -Confirm:$false
             $res = Get-PSResourceRepository -Name $MARName
             $res | Should -Not -BeNullOrEmpty
             $res.Name | Should -Be $MARName
@@ -107,7 +107,7 @@ Describe "Test MAR Repository Registration" -tags 'CI' {
         It "Reset-PSResourceRepository should restore both PSGallery and MAR" {
             Unregister-PSResourceRepository -Name $MARName
             Unregister-PSResourceRepository -Name $PSGalleryName
-            Reset-PSResourceRepository
+            Reset-PSResourceRepository -Confirm:$false
 
             $mar = Get-PSResourceRepository -Name $MARName
             $mar | Should -Not -BeNullOrEmpty
@@ -125,15 +125,18 @@ Describe "Test MAR Repository Registration" -tags 'CI' {
         It "Find-PSResource Az.Accounts module from MAR" {
             $res = Find-PSResource -Name "Az.Accounts"
             $res | Should -Not -BeNullOrEmpty
-            $res.Name | Should -Be "Az.Accounts"
-            $res.Repository | Should -Be $MARName
+            $res.Count | Should -BeGreaterThan 0
+            $firstRes = $res | Select-Object -First 1
+            $firstRes.Name | Should -Be "Az.Accounts"
+            $firstRes.Repository | Should -Be $MARName
         }
 
         It 'Find-PSResource fallback to PSGallery if module not in MAR' {
             $res = Find-PSResource -Name "Pscx"
             $res | Should -Not -BeNullOrEmpty
-            $res.Name | Should -Be "Pscx"
-            $res.Repository | Should -Be $PSGalleryName
+            $firstRes = $res | Select-Object -First 1
+            $firstRes.Name | Should -Be "Pscx"
+            $firstRes.Repository | Should -Be $PSGalleryName
         }
     }
 }

--- a/test/ResourceRepositoryTests/MARRepository.Tests.ps1
+++ b/test/ResourceRepositoryTests/MARRepository.Tests.ps1
@@ -22,7 +22,7 @@ Describe "Test MAR Repository Registration" -tags 'CI' {
             $res = Get-PSResourceRepository -Name $MARName
             $res | Should -Not -BeNullOrEmpty
             $res.Name | Should -Be $MARName
-            $res.Uri | Should -Be "$MARUri/"
+            $res.Uri | Should -Be "$MARUri"
             $res.Trusted | Should -Be True
             $res.Priority | Should -Be 40
             $res.ApiVersion | Should -Be 'ContainerRegistry'
@@ -37,11 +37,11 @@ Describe "Test MAR Repository Registration" -tags 'CI' {
 
     Context "MAR name protection" {
         It "should not allow registering MAR with -Name parameter" {
-            { Register-PSResourceRepository -Name "MAR" -Uri "https://mcr.microsoft.com" -ErrorAction Stop } | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PSResourceGet.Cmdlets.RegisterPSResourceRepository"
+            { Register-PSResourceRepository -Name $MARName -Uri "https://mcr.microsoft.com" -ErrorAction Stop } | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PSResourceGet.Cmdlets.RegisterPSResourceRepository"
         }
 
         It "should not allow registering MAR (case insensitive) with -Name parameter" {
-            { Register-PSResourceRepository -Name "mar" -Uri "https://mcr.microsoft.com" -ErrorAction Stop } | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PSResourceGet.Cmdlets.RegisterPSResourceRepository"
+            { Register-PSResourceRepository -Name $MARName -Uri "https://mcr.microsoft.com" -ErrorAction Stop } | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PSResourceGet.Cmdlets.RegisterPSResourceRepository"
         }
 
         It "should not allow registering MAR with -Name parameter in hashtable" {
@@ -81,7 +81,7 @@ Describe "Test MAR Repository Registration" -tags 'CI' {
             $res = Get-PSResourceRepository -Name $MARName
             $res | Should -Not -BeNullOrEmpty
             $res.Name | Should -Be $MARName
-            $res.Uri | Should -Be "$MARUri/"
+            $res.Uri | Should -Be "$MARUri"
             $res.Trusted | Should -Be True
             $res.Priority | Should -Be 40
             $res.ApiVersion | Should -Be 'ContainerRegistry'
@@ -99,7 +99,7 @@ Describe "Test MAR Repository Registration" -tags 'CI' {
             $res = Get-PSResourceRepository -Name $MARName
             $res | Should -Not -BeNullOrEmpty
             $res.Name | Should -Be $MARName
-            $res.Uri | Should -Be "$MARUri/"
+            $res.Uri | Should -Be "$MARUri"
             $res.Trusted | Should -Be True
             $res.Priority | Should -Be 40
         }

--- a/test/ResourceRepositoryTests/MARRepository.Tests.ps1
+++ b/test/ResourceRepositoryTests/MARRepository.Tests.ps1
@@ -128,5 +128,12 @@ Describe "Test MAR Repository Registration" -tags 'CI' {
             $res.Name | Should -Be "Az.Accounts"
             $res.Repository | Should -Be $MARName
         }
+
+        It 'Find-PSResource fallback to PSGallery if module not in MAR' {
+            $res = Find-PSResource -Name "Pscx"
+            $res | Should -Not -BeNullOrEmpty
+            $res.Name | Should -Be "Pscx"
+            $res.Repository | Should -Be $PSGalleryName
+        }
     }
 }

--- a/test/ResourceRepositoryTests/MARRepository.Tests.ps1
+++ b/test/ResourceRepositoryTests/MARRepository.Tests.ps1
@@ -1,0 +1,132 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+$modPath = "$psscriptroot/../PSGetTestUtils.psm1"
+Write-Verbose -Verbose -Message "PSGetTestUtils path: $modPath"
+Import-Module $modPath -Force -Verbose
+
+Describe "Test MAR Repository Registration" -tags 'CI' {
+    BeforeEach {
+        $MARName = Get-MARName
+        $MARUri = Get-MARLocation
+        $PSGalleryName = Get-PSGalleryName
+        $PSGalleryUri = Get-PSGalleryLocation
+        Get-NewPSResourceRepositoryFile
+    }
+    AfterEach {
+        Get-RevertPSResourceRepositoryFile
+    }
+
+    Context "MAR is auto-registered with expected values" {
+        It "MAR repository should be present with expected default values" {
+            $res = Get-PSResourceRepository -Name $MARName
+            $res | Should -Not -BeNullOrEmpty
+            $res.Name | Should -Be $MARName
+            $res.Uri | Should -Be "$MARUri/"
+            $res.Trusted | Should -Be True
+            $res.Priority | Should -Be 40
+            $res.ApiVersion | Should -Be 'ContainerRegistry'
+        }
+
+        It "MAR repository should have lower priority number (higher priority) than PSGallery" {
+            $mar = Get-PSResourceRepository -Name $MARName
+            $psGallery = Get-PSResourceRepository -Name $PSGalleryName
+            $mar.Priority | Should -BeLessThan $psGallery.Priority
+        }
+    }
+
+    Context "MAR name protection" {
+        It "should not allow registering MAR with -Name parameter" {
+            { Register-PSResourceRepository -Name "MAR" -Uri "https://mcr.microsoft.com" -ErrorAction Stop } | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PSResourceGet.Cmdlets.RegisterPSResourceRepository"
+        }
+
+        It "should not allow registering MAR (case insensitive) with -Name parameter" {
+            { Register-PSResourceRepository -Name "mar" -Uri "https://mcr.microsoft.com" -ErrorAction Stop } | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PSResourceGet.Cmdlets.RegisterPSResourceRepository"
+        }
+
+        It "should not allow registering MAR with -Name parameter in hashtable" {
+            Unregister-PSResourceRepository -Name $MARName
+            $hashtable = @{Name = "MAR"; Uri = "https://mcr.microsoft.com"}
+            Register-PSResourceRepository -Repository $hashtable -ErrorVariable err -ErrorAction SilentlyContinue
+            $err.Count | Should -BeGreaterThan 0
+            $err[0].FullyQualifiedErrorId | Should -BeExactly "MARProvidedAsNameRepoPSet,Microsoft.PowerShell.PSResourceGet.Cmdlets.RegisterPSResourceRepository"
+        }
+
+        It "should not allow setting Uri for MAR repository" {
+            { Set-PSResourceRepository -Name $MARName -Uri "https://example.com" -ErrorAction Stop } | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PSResourceGet.Cmdlets.SetPSResourceRepository"
+        }
+
+        It "should not allow setting CredentialInfo for MAR repository" {
+            $randomSecret = [System.IO.Path]::GetRandomFileName()
+            $credentialInfo = New-Object Microsoft.PowerShell.PSResourceGet.UtilClasses.PSCredentialInfo ("testvault", $randomSecret)
+            { Set-PSResourceRepository -Name $MARName -CredentialInfo $credentialInfo -ErrorAction Stop } | Should -Throw -ErrorId "ErrorInNameParameterSet,Microsoft.PowerShell.PSResourceGet.Cmdlets.SetPSResourceRepository"
+        }
+
+        It "should allow setting Trusted for MAR repository" {
+            Set-PSResourceRepository -Name $MARName -Trusted:$false
+            $res = Get-PSResourceRepository -Name $MARName
+            $res.Trusted | Should -Be False
+        }
+
+        It "should allow setting Priority for MAR repository" {
+            Set-PSResourceRepository -Name $MARName -Priority 10
+            $res = Get-PSResourceRepository -Name $MARName
+            $res.Priority | Should -Be 10
+        }
+    }
+
+    Context "Reset repository store includes MAR" {
+        It "Reset-PSResourceRepository should register MAR alongside PSGallery" {
+            Reset-PSResourceRepository -Force
+            $res = Get-PSResourceRepository -Name $MARName
+            $res | Should -Not -BeNullOrEmpty
+            $res.Name | Should -Be $MARName
+            $res.Uri | Should -Be "$MARUri/"
+            $res.Trusted | Should -Be True
+            $res.Priority | Should -Be 40
+            $res.ApiVersion | Should -Be 'ContainerRegistry'
+
+            $psGallery = Get-PSResourceRepository -Name $PSGalleryName
+            $psGallery | Should -Not -BeNullOrEmpty
+        }
+
+        It "Reset-PSResourceRepository should restore MAR after unregistration" {
+            Unregister-PSResourceRepository -Name $MARName
+            $res = Get-PSResourceRepository -Name $MARName -ErrorAction SilentlyContinue
+            $res | Should -BeNullOrEmpty
+
+            Reset-PSResourceRepository -Force
+            $res = Get-PSResourceRepository -Name $MARName
+            $res | Should -Not -BeNullOrEmpty
+            $res.Name | Should -Be $MARName
+            $res.Uri | Should -Be "$MARUri/"
+            $res.Trusted | Should -Be True
+            $res.Priority | Should -Be 40
+        }
+
+        It "Reset-PSResourceRepository should restore both PSGallery and MAR" {
+            Unregister-PSResourceRepository -Name $MARName
+            Unregister-PSResourceRepository -Name $PSGalleryName
+            Reset-PSResourceRepository -Force
+
+            $mar = Get-PSResourceRepository -Name $MARName
+            $mar | Should -Not -BeNullOrEmpty
+            $mar.Priority | Should -Be 40
+            $mar.Trusted | Should -Be True
+            $mar.ApiVersion | Should -Be 'ContainerRegistry'
+
+            $psGallery = Get-PSResourceRepository -Name $PSGalleryName
+            $psGallery | Should -Not -BeNullOrEmpty
+            $psGallery.Priority | Should -Be 50
+        }
+    }
+
+    Context "MAR first due to higher priority" {
+        It "Find-PSResource Az.Accounts module from MAR" {
+            $res = Find-PSResource -Name "Az.Accounts"
+            $res | Should -Not -BeNullOrEmpty
+            $res.Name | Should -Be "Az.Accounts"
+            $res.Repository | Should -Be $MARName
+        }
+    }
+}

--- a/test/ResourceRepositoryTests/RegisterPSResourceRepository.Tests.ps1
+++ b/test/ResourceRepositoryTests/RegisterPSResourceRepository.Tests.ps1
@@ -7,6 +7,8 @@ Import-Module $modPath -Force -Verbose
 
 Describe "Test Register-PSResourceRepository" -tags 'CI' {
     BeforeEach {
+        $MARName = Get-MARName
+        $MARUri = Get-MARLocation
         $PSGalleryName = Get-PSGalleryName
         $PSGalleryUri = Get-PSGalleryLocation
         $TestRepoName1 = "testRepository"

--- a/test/ResourceRepositoryTests/RegisterPSResourceRepository.Tests.ps1
+++ b/test/ResourceRepositoryTests/RegisterPSResourceRepository.Tests.ps1
@@ -85,6 +85,15 @@ Describe "Test Register-PSResourceRepository" -tags 'CI' {
         $res.Priority | Should -Be 50
     }
 
+    It "register repository with MicrosoftArtifactRegistry parameter (MicrosoftArtifactRegistryParameterSet)" {
+        Unregister-PSResourceRepository -Name $MARName
+        $res = Register-PSResourceRepository -MicrosoftArtifactRegistry -PassThru
+        $res.Name | Should -Be $MARName
+        $res.Uri | Should -Be $MARUri
+        $res.Trusted | Should -Be True
+        $res.Priority | Should -Be 40
+    }
+
     It "register repository with PSGallery switch parameter value of false (PSGalleryParameterSet)" {
         Unregister-PSResourceRepository -Name $PSGalleryName
         $res = Register-PSResourceRepository -PSGallery:$false -PassThru
@@ -412,7 +421,7 @@ Describe "Test Register-PSResourceRepository" -tags 'CI' {
 
     It "should throw error when trying to register repository with ApiVersion unknown" {
         {Register-PSResourceRepository -Name $TestRepoName1 -Uri $tmpDir1Path -ApiVersion "unknown" -ErrorAction Stop} | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.PSResourceGet.Cmdlets.RegisterPSResourceRepository"
-        
+
         # Verify the repository was not created
         $repo = Get-PSResourceRepository $TestRepoName1 -ErrorAction SilentlyContinue
         $repo | Should -BeNullOrEmpty

--- a/test/ResourceRepositoryTests/ResetPSResourceRepository.Tests.ps1
+++ b/test/ResourceRepositoryTests/ResetPSResourceRepository.Tests.ps1
@@ -22,17 +22,17 @@ Describe "Test Reset-PSResourceRepository" -tags 'CI' {
         $tmpDirPath = Join-Path -Path $TestDrive -ChildPath "tmpDir1"
         New-Item -ItemType Directory -Path $tmpDirPath -Force | Out-Null
         Register-PSResourceRepository -Name $TestRepoName -Uri $tmpDirPath
-        
+
         # Verify repository was added
         $repos = Get-PSResourceRepository
         $repos.Count | Should -BeGreaterThan 1
-        
+
         # Act: Reset repository store
         Reset-PSResourceRepository -Confirm:$false
-        
+
         # Assert: Only PSGallery should exist
         $repos = Get-PSResourceRepository
-        $repos.Count | Should -Be 1
+        $repos.Count | Should -Be 2
         $repos.Name | Should -Be $PSGalleryName
         $repos.Uri | Should -Be $PSGalleryUri
     }
@@ -43,20 +43,20 @@ Describe "Test Reset-PSResourceRepository" -tags 'CI' {
         $tmpDirPath = Join-Path -Path $TestDrive -ChildPath "tmpDir1"
         New-Item -ItemType Directory -Path $tmpDirPath -Force | Out-Null
         Register-PSResourceRepository -Name $TestRepoName -Uri $tmpDirPath
-        
+
         # Act: Reset repository store with PassThru
         $result = Reset-PSResourceRepository -Confirm:$false -PassThru
-        
+
         # Assert: Result should be PSGallery repository info
         $result | Should -Not -BeNullOrEmpty
         $result.Name | Should -Be $PSGalleryName
         $result.Uri | Should -Be $PSGalleryUri
         $result.Trusted | Should -Be $false
         $result.Priority | Should -Be 50
-        
+
         # Verify only PSGallery exists
         $repos = Get-PSResourceRepository
-        $repos.Count | Should -Be 1
+        $repos.Count | Should -Be 2
     }
 
     It "Reset repository store should support -WhatIf" {
@@ -65,14 +65,14 @@ Describe "Test Reset-PSResourceRepository" -tags 'CI' {
         $tmpDirPath = Join-Path -Path $TestDrive -ChildPath "tmpDir1"
         New-Item -ItemType Directory -Path $tmpDirPath -Force | Out-Null
         Register-PSResourceRepository -Name $TestRepoName -Uri $tmpDirPath
-        
+
         # Capture repository count before WhatIf
         $reposBefore = Get-PSResourceRepository
         $countBefore = $reposBefore.Count
-        
+
         # Act: Run with WhatIf
         Reset-PSResourceRepository -WhatIf
-        
+
         # Assert: Repositories should not have changed
         $reposAfter = Get-PSResourceRepository
         $reposAfter.Count | Should -Be $countBefore
@@ -82,20 +82,20 @@ Describe "Test Reset-PSResourceRepository" -tags 'CI' {
         # Arrange: Corrupt the repository file
         $powerShellGetPath = Join-Path -Path ([Environment]::GetFolderPath([System.Environment+SpecialFolder]::LocalApplicationData)) -ChildPath "PSResourceGet"
         $repoFilePath = Join-Path -Path $powerShellGetPath -ChildPath "PSResourceRepository.xml"
-        
+
         # Write invalid XML to corrupt the file
         "This is not valid XML" | Set-Content -Path $repoFilePath -Force
-        
+
         # Act: Reset the repository store
         $result = Reset-PSResourceRepository -Confirm:$false -PassThru
-        
+
         # Assert: Should successfully reset and return PSGallery
         $result | Should -Not -BeNullOrEmpty
         $result.Name | Should -Be $PSGalleryName
-        
+
         # Verify we can now read repositories
         $repos = Get-PSResourceRepository
-        $repos.Count | Should -Be 1
+        $repos.Count | Should -Be 2
         $repos.Name | Should -Be $PSGalleryName
     }
 
@@ -103,21 +103,21 @@ Describe "Test Reset-PSResourceRepository" -tags 'CI' {
         # Arrange: Delete the repository file
         $powerShellGetPath = Join-Path -Path ([Environment]::GetFolderPath([System.Environment+SpecialFolder]::LocalApplicationData)) -ChildPath "PSResourceGet"
         $repoFilePath = Join-Path -Path $powerShellGetPath -ChildPath "PSResourceRepository.xml"
-        
+
         if (Test-Path -Path $repoFilePath) {
             Remove-Item -Path $repoFilePath -Force
         }
-        
+
         # Act: Reset the repository store
         $result = Reset-PSResourceRepository -Confirm:$false -PassThru
-        
+
         # Assert: Should successfully reset and return PSGallery
         $result | Should -Not -BeNullOrEmpty
         $result.Name | Should -Be $PSGalleryName
-        
+
         # Verify PSGallery is registered
         $repos = Get-PSResourceRepository
-        $repos.Count | Should -Be 1
+        $repos.Count | Should -Be 2
         $repos.Name | Should -Be $PSGalleryName
     }
 
@@ -129,21 +129,21 @@ Describe "Test Reset-PSResourceRepository" -tags 'CI' {
         New-Item -ItemType Directory -Path $tmpDir1Path -Force | Out-Null
         New-Item -ItemType Directory -Path $tmpDir2Path -Force | Out-Null
         New-Item -ItemType Directory -Path $tmpDir3Path -Force | Out-Null
-        
+
         Register-PSResourceRepository -Name "testRepo1" -Uri $tmpDir1Path
         Register-PSResourceRepository -Name "testRepo2" -Uri $tmpDir2Path
         Register-PSResourceRepository -Name "testRepo3" -Uri $tmpDir3Path
-        
+
         # Verify multiple repositories exist
         $reposBefore = Get-PSResourceRepository
         $reposBefore.Count | Should -BeGreaterThan 1
-        
+
         # Act: Reset repository store
         Reset-PSResourceRepository -Confirm:$false
-        
+
         # Assert: Only PSGallery should remain
         $reposAfter = Get-PSResourceRepository
-        $reposAfter.Count | Should -Be 1
+        $reposAfter.Count | Should -Be 2
         $reposAfter.Name | Should -Be $PSGalleryName
     }
 }

--- a/test/ResourceRepositoryTests/ResetPSResourceRepository.Tests.ps1
+++ b/test/ResourceRepositoryTests/ResetPSResourceRepository.Tests.ps1
@@ -7,6 +7,8 @@ Import-Module $modPath -Force -Verbose
 
 Describe "Test Reset-PSResourceRepository" -tags 'CI' {
     BeforeEach {
+        $MARName = Get-MARName
+        $MARUri = Get-MARLocation
         $PSGalleryName = Get-PSGalleryName
         $PSGalleryUri = Get-PSGalleryLocation
         Get-NewPSResourceRepositoryFile
@@ -33,8 +35,8 @@ Describe "Test Reset-PSResourceRepository" -tags 'CI' {
         # Assert: Only PSGallery should exist
         $repos = Get-PSResourceRepository
         $repos.Count | Should -Be 2
-        $repos.Name | Should -Be $PSGalleryName
-        $repos.Uri | Should -Be $PSGalleryUri
+        $repos.Name | ForEach-Object { $_  | Should -BeIn @($PSGalleryName, $MARName) }
+        $repos.Uri | ForEach-Object { $_  | Should -BeIn @($PSGalleryUri, $MARUri) }
     }
 
     It "Reset repository store with PassThru parameter returns PSGallery" {
@@ -57,6 +59,8 @@ Describe "Test Reset-PSResourceRepository" -tags 'CI' {
         # Verify only PSGallery exists
         $repos = Get-PSResourceRepository
         $repos.Count | Should -Be 2
+        $repos.Name | ForEach-Object { $_  | Should -BeIn @($PSGalleryName, $MARName) }
+        $repos.Uri | ForEach-Object { $_  | Should -BeIn @($PSGalleryUri, $MARUri) }
     }
 
     It "Reset repository store should support -WhatIf" {
@@ -96,7 +100,7 @@ Describe "Test Reset-PSResourceRepository" -tags 'CI' {
         # Verify we can now read repositories
         $repos = Get-PSResourceRepository
         $repos.Count | Should -Be 2
-        $repos.Name | Should -Be $PSGalleryName
+        $repos.Name | ForEach-Object { $_  | Should -BeIn @($PSGalleryName, $MARName) }
     }
 
     It "Reset repository store when file doesn't exist should succeed" {
@@ -118,7 +122,7 @@ Describe "Test Reset-PSResourceRepository" -tags 'CI' {
         # Verify PSGallery is registered
         $repos = Get-PSResourceRepository
         $repos.Count | Should -Be 2
-        $repos.Name | Should -Be $PSGalleryName
+        $repos.Name | ForEach-Object { $_  | Should -BeIn @($PSGalleryName, $MARName) }
     }
 
     It "Reset repository store with multiple repositories should only keep PSGallery" {
@@ -144,6 +148,6 @@ Describe "Test Reset-PSResourceRepository" -tags 'CI' {
         # Assert: Only PSGallery should remain
         $reposAfter = Get-PSResourceRepository
         $reposAfter.Count | Should -Be 2
-        $reposAfter.Name | Should -Be $PSGalleryName
+        $reposAfter.Name | ForEach-Object { $_  | Should -BeIn @($PSGalleryName, $MARName) }
     }
 }

--- a/test/SavePSResourceTests/SavePSResourceLocal.Tests.ps1
+++ b/test/SavePSResourceTests/SavePSResourceLocal.Tests.ps1
@@ -157,8 +157,8 @@ Describe 'Test Save-PSResource for local repositories' -tags 'CI' {
     }
 
     It "Save module, should search through all repositories and only install from the first repo containing the package" {
-        Save-PSResource -Name $moduleName3 -Version "0.0.93" -Path $SaveDir -TrustRepository -ErrorVariable ev
-        $ev | Should -BeNullOrEmpty
+        Save-PSResource -Name $moduleName3 -Version "0.0.93" -Path $SaveDir -TrustRepository -ErrorVariable ev -ErrorAction SilentlyContinue
+        $ev | Should -HaveCount 1 ## This comes from MAR not having the module so the error is thrown from that repository before falling back to the next repository
         $pkgDir = Get-ChildItem -Path $SaveDir | Where-Object Name -eq "$moduleName3"
         $pkgDir | Should -Not -BeNullOrEmpty
     }

--- a/test/testRepositories.xml
+++ b/test/testRepositories.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <Repository Name="PSGallery"       Uri="https://www.powershellgallery.com/api/v2" Priority="50" Trusted="false" APIVersion="v2" />
+  <Repository Name="MAR"             Uri="https://mcr.microsoft.com"                Priority="40" Trusted="true"  APIVersion="ContainerRegistry" />
   <Repository Name="NuGetGallery"    Uri="https://api.nuget.org/v3/index.json"      Priority="70" Trusted="true" APIVersion="v3" />
 </configuration>

--- a/test/testRepositories.xml
+++ b/test/testRepositories.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <Repository Name="PSGallery"       Uri="https://www.powershellgallery.com/api/v2" Priority="50" Trusted="false" APIVersion="v2" />
-  <Repository Name="MAR"             Uri="https://mcr.microsoft.com"                Priority="40" Trusted="true"  APIVersion="ContainerRegistry" />
+  <Repository Name="MicrosoftArtifactRegistry" Uri="https://mcr.microsoft.com"      Priority="40" Trusted="true"  APIVersion="ContainerRegistry" />
   <Repository Name="NuGetGallery"    Uri="https://api.nuget.org/v3/index.json"      Priority="70" Trusted="true" APIVersion="v3" />
 </configuration>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request adds support for the automatic registration and protection of the Microsoft Artifact Registry (MAR) repository in the PSResourceGet module. MAR is now registered by default alongside PSGallery, with a higher priority and trusted status. The changes ensure MAR cannot be manually registered, have its URI or credentials set, and update the documentation and tests to reflect its new behavior.

**MAR Repository Registration and Protection**

* MAR is now automatically registered with default values (name, URI, priority, trusted status, and API version) when the repository store is created or reset, and appears in the default repository XML file. [[1]](diffhunk://#diff-81fd9f06cbead1213773ce091e5738d583593d8107c9b2b06d7ed3418609722fR29-R34) [[2]](diffhunk://#diff-81fd9f06cbead1213773ce091e5738d583593d8107c9b2b06d7ed3418609722fR70-R73) [[3]](diffhunk://#diff-81fd9f06cbead1213773ce091e5738d583593d8107c9b2b06d7ed3418609722fR939-R942) [[4]](diffhunk://#diff-c05daf7e3bf1e62689f6b4add1fb6d733ad8aa1764574984c94956248b8c2ebbR4)
* Added logic to prevent manual registration of MAR via the `Register-PSResourceRepository` cmdlet, including case-insensitive name checking and error handling for hashtable registration. [[1]](diffhunk://#diff-0c9edef736ab881504abdf22e3e415cff3c15cddfe8260e83010ca0fa2198e5bR337-R347) [[2]](diffhunk://#diff-0c9edef736ab881504abdf22e3e415cff3c15cddfe8260e83010ca0fa2198e5bL326-R326) [[3]](diffhunk://#diff-81fd9f06cbead1213773ce091e5738d583593d8107c9b2b06d7ed3418609722fR96-R101)
* Prevented changes to MAR's URI or credentials via the `Set-PSResourceRepository` cmdlet, with appropriate error messages.
* Updated dynamic parameter logic to ensure credential provider options are not shown for MAR.

**Documentation and Messaging Updates**

* Updated commandlet documentation and verbose messages to indicate that both PSGallery and MAR are registered by default and after a reset. [[1]](diffhunk://#diff-718954b8d6efdb9dd1a7b4f99537b5a16529a4ae2c9b124f5d7696daf0e91538L13-R13) [[2]](diffhunk://#diff-718954b8d6efdb9dd1a7b4f99537b5a16529a4ae2c9b124f5d7696daf0e91538L43-R43) [[3]](diffhunk://#diff-718954b8d6efdb9dd1a7b4f99537b5a16529a4ae2c9b124f5d7696daf0e91538L60-R60)

**Testing Enhancements**

* Added new test utilities and a comprehensive test suite for MAR, verifying its default registration, protection against manual registration and modification, and behavior during repository store reset operations. [[1]](diffhunk://#diff-efad9b46abecabe09e4a8c1917ebc30b4b61f56a3daabf2f70c4251179ee6348R22-R24) [[2]](diffhunk://#diff-efad9b46abecabe09e4a8c1917ebc30b4b61f56a3daabf2f70c4251179ee6348R159-R168) [[3]](diffhunk://#diff-416e062bbaa4e2c3fbe37ca8990a488f79e2657351d58dcfe0f2a172cf041e92R1-R132)

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
