### PR TITLE
Fix detection of Windows PS vs PS Core resolving module directory issues

### DIFF
--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1161,7 +1161,6 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             return s_tempHome;
         }
 
-        private readonly static Version PSVersion6 = new Version(6, 0);
         private static void GetStandardPlatformPaths(
             PSCmdlet psCmdlet,
             out string localUserDir,
@@ -1169,7 +1168,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                string powerShellType = (psCmdlet.Host.Version >= PSVersion6) ? "PowerShell" : "WindowsPowerShell";
+                string powerShellType = ((psCmdlet.GetVariableValue("PSEdition") as string) == "Core") ? "PowerShell" : "WindowsPowerShell";
                 localUserDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), powerShellType);
                 allUsersDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), powerShellType);
             }
@@ -1189,7 +1188,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
         public static bool GetIsWindowsPowerShell(PSCmdlet psCmdlet)
         {
-            return psCmdlet.Host.Version < PSVersion6;
+            return ((psCmdlet.GetVariableValue("PSEdition") as string) != "Core");
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix detection of Windows PS vs PS Core resolving module directory issues

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Switch to using PSEdition instead of Host.Version as running PowerShell under certain instances does not return correct version (e.g. VSCode, .NET Interactive, Ruby/Puppet)

- Fixes #463 
- Fixes #881 
- Fixes #1459 

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

The PSEdition variable returns $null, or 'Desktop' under Windows PowerShell, and 'Core' under PowerShell Core. The code therefore checks for 'Core' to determine if Core is in use - otherwise, it determines Windows PowerShell.

https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_editions?view=powershell-7.5

This is the method preferred by the PowerShell team for identifying the use of PowerShell Core, rather than using version numbers

https://devblogs.microsoft.com/scripting/powertip-identify-if-you-are-running-on-powershell-core/

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
