### PR TITLE
Fixing the logic to determine if the current PowerShell session is Windows PowerShell or PowerShell Core

### DIFF
--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1161,7 +1161,6 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             return s_tempHome;
         }
 
-        private readonly static Version PSVersion6 = new Version(6, 0);
         private static void GetStandardPlatformPaths(
             PSCmdlet psCmdlet,
             out string localUserDir,
@@ -1169,7 +1168,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                string powerShellType = (psCmdlet.Host.Version >= PSVersion6) ? "PowerShell" : "WindowsPowerShell";
+                string powerShellType = ((psCmdlet.GetVariableValue("PSEdition") as string) == "Core") ? "PowerShell" : "WindowsPowerShell";
                 localUserDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), powerShellType);
                 allUsersDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), powerShellType);
             }
@@ -1189,7 +1188,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
         public static bool GetIsWindowsPowerShell(PSCmdlet psCmdlet)
         {
-            return psCmdlet.Host.Version < PSVersion6;
+            return ((psCmdlet.GetVariableValue("PSEdition") as string) != "Core");
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Tracking #1974, had to create a PR off the main remote to run tests.
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
