### PR TITLE
Update-PSResource: Include local-copy prerelease string when deciding update applicability

### DIFF
--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -390,7 +390,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
 
                 // If the current package is out of range, install it with the correct version.
-                if (!NuGetVersion.TryParse(installedPackage.Version.ToString(), out NuGetVersion installedVersion))
+                string installedVersionString = Utils.GetNormalizedVersionString(installedPackage.Version.ToString(), installedPackage.Prerelease);
+                if (!NuGetVersion.TryParse(installedVersionString, out NuGetVersion installedVersion))
                 {
                     WriteWarning($"Cannot parse nuget version in installed package '{installedPackage.Name}'. Cannot update package.");
                     continue;

--- a/src/code/UpdatePSResource.cs
+++ b/src/code/UpdatePSResource.cs
@@ -390,7 +390,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
 
                 // If the current package is out of range, install it with the correct version.
-                string installedVersionString = Utils.GetNormalizedVersionString(installedPackage.Version.ToString(), installedPackage.Prerelease);
+                string installedVersionString = Utils.GetThreeDigitNormalizedVersionString(installedPackage.Version.ToString(), installedPackage.Prerelease);
                 if (!NuGetVersion.TryParse(installedVersionString, out NuGetVersion installedVersion))
                 {
                     WriteWarning($"Cannot parse nuget version in installed package '{installedPackage.Name}'. Cannot update package.");

--- a/test/UpdatePSResourceTests/UpdatePSResourceV2.Tests.ps1
+++ b/test/UpdatePSResourceTests/UpdatePSResourceV2.Tests.ps1
@@ -13,13 +13,14 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
         $testModuleName = "test_module"
         $testModuleName2 = "test_module2"
         $testModuleName3 = "TestModule99"
+        $testModuleName4 = "TestModulePrerelease"
         $PackageManagement = "PackageManagement"
         Get-NewPSResourceRepositoryFile
         Get-PSResourceRepository
     }
 
     AfterEach {
-       Uninstall-PSResource "test_module", "TestModule99", "TestModuleWithLicense", "test_module2", "test_script" -Version "*" -ErrorAction SilentlyContinue -SkipDependencyCheck
+       Uninstall-PSResource "test_module", "TestModule99", "TestModuleWithLicense", "test_module2", "test_script", "TestModulePrerelease" -Version "*" -ErrorAction SilentlyContinue -SkipDependencyCheck
     }
 
     AfterAll {
@@ -208,6 +209,20 @@ Describe 'Test HTTP Update-PSResource for V2 Server Protocol' -tags 'CI' {
         }
 
         $isPkgUpdated | Should -Be $true
+    }
+
+    It "Update prerelease version to next version when prerelease label is only differing factor between versions" {
+        # $testModuleName4 (TestModulePrerelease) has versions: 0.0.4-beta, 0.0.4. Updating should respect prerelease label
+        Install-PSResource -Name $testModuleName4 -Version "0.0.4-beta" -Repository $PSGalleryName -TrustRepository
+        $res = Get-InstalledPSResource -Name $testModuleName4
+        $res.Name | Should -Be $testModuleName4
+        $res.Version | Should -Contain "0.0.4"
+        $res.Prerelease | Should -Be "beta"
+
+        Update-PSResource -Name $testModuleName4 -Repository $PSGalleryName -TrustRepository
+        $res2 = Get-InstalledPSResource -Name $testModuleName4
+        $res2.Version | Should -Contain "0.0.4"
+        $res2.Prerelease | Should -BeNullOrEmpty
     }
 
     # Windows only


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Tracking https://github.com/PowerShell/PSResourceGet/pull/1954, had to create a PR off the main remote to run tests.
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
