### PR TITLE
fix(psresourcelist): Get operation filters out resources on installed version

### DIFF
--- a/src/dsc/psresourceget.ps1
+++ b/src/dsc/psresourceget.ps1
@@ -342,27 +342,38 @@ function GetPSResourceList {
         )
     }
 
-    $resourcesExist = @()
+    $resolvedResources = @()
 
     foreach ($inputResource in $inputResources) {
         $matchingResources = $allPSResources | Where-Object { $_.Name -eq $inputResource.Name }
 
         if ($matchingResources) {
-            # Prefer a version that satisfies the requested range; fall back to any installed version
-            $preferred = if ($inputResource.Version) {
-                $matchingResources | Where-Object {
+            $preferred = $null
+            if ($inputResource.Version) {
+                $preferred = $matchingResources | Where-Object {
                     try { SatisfiesVersion -version $_.Version -versionRange $inputResource.Version } catch { $false }
                 } | Select-Object -First 1
+            } else {
+                $preferred = $matchingResources | Select-Object -First 1
             }
 
-            $toAdd = if ($preferred) { $preferred } else { $matchingResources | Select-Object -First 1 }
-            Write-Trace -message "Found matching resource for input: $($inputResource.Name). Returning version: $($toAdd.Version)" -level debug
-            $resourcesExist += $toAdd
+            if ($preferred) {
+                Write-Trace -message "Resource '$($inputResource.Name)' version '$($preferred.Version)' satisfies requested range '$($inputResource.Version)'." -level debug
+                $resolvedResources += $preferred
+            } else {
+                # Installed but doesn't satisfy the version range - report actual installed version with _exist = false
+                $fallback = $matchingResources | Select-Object -First 1
+                Write-Trace -message "Resource '$($inputResource.Name)' installed at '$($fallback.Version)' does not satisfy requested range '$($inputResource.Version)'. Reporting _exist = false." -level debug
+                $fallback._exist = $false
+                $resolvedResources += $fallback
+            }
+        } else {
+            Write-Trace -message "Resource '$($inputResource.Name)' is not installed. Reporting _exist = false." -level debug
+            $resolvedResources += [PSResource]::new($inputResource.Name)
         }
     }
 
-    ## For get operation we only need the first resource that exists, which is always the latest for currentUser
-    PopulatePSResourceListObjectByRepository -resourcesExist $resourcesExist -inputResources $inputResources -repositoryName $inputPSResourceList.RepositoryName -trustedRepository $inputPSResourceList.trustedRepository
+    PopulatePSResourceListObjectByRepository -resourcesExist $resolvedResources -inputResources $inputResources -repositoryName $inputPSResourceList.RepositoryName -trustedRepository $inputPSResourceList.trustedRepository
 }
 
 function GetOperation {
@@ -753,13 +764,20 @@ function PopulatePSResourceListObjectByRepository {
     }
     else {
         $resources += $resourcesExist | ForEach-Object {
-            [PSResource]::new(
-                $_.Name,
-                $_.Version.PreRelease ? $_.Version.ToString() + "-" + $_.PreRelease : $_.Version.ToString(),
-                $_.Scope,
-                $_.RepositoryName,
-                $_.PreRelease ? $true : $false
-            )
+            $srcExist = $_._exist
+            $r = if ($_.version) {
+                [PSResource]::new(
+                    $_.Name,
+                    $_.Version.ToString(),
+                    $_.Scope,
+                    $_.RepositoryName,
+                    $_.PreRelease ? $true : $false
+                )
+            } else {
+                [PSResource]::new($_.Name)
+            }
+            $r._exist = $srcExist
+            $r
         }
     }
 

--- a/src/dsc/psresourceget.ps1
+++ b/src/dsc/psresourceget.ps1
@@ -344,26 +344,20 @@ function GetPSResourceList {
 
     $resourcesExist = @()
 
-    foreach ($resource in $allPSResources) {
-        foreach ($inputResource in $inputResources) {
-            if ($resource.Name -eq $inputResource.Name) {
-                Write-Trace -message "Found matching resource for input: $($inputResource.Name). Checking version constraints. Input version: $($inputResource.Version), Resource version: $($resource.Version)" -level debug
-                if ($inputResource.Version) {
-                    # Use the NuGet.Versioning package if available, otherwise do a simple comparison
-                    try {
-                        if (SatisfiesVersion -version $resource.Version -versionRange $inputResource.Version) {
-                            $resourcesExist += $resource
-                        }
-                    }
-                    catch {
-                        Write-Trace -message "Error checking version constraints for resource: $($inputResource.Name). Error details: $($_.Exception.Message)" -level debug
-                        # Fallback: simple string comparison (not full NuGet range support)
-                        if ($resource.Version.ToString() -eq $inputResource.Version) {
-                            $resourcesExist += $resource
-                        }
-                    }
-                }
+    foreach ($inputResource in $inputResources) {
+        $matchingResources = $allPSResources | Where-Object { $_.Name -eq $inputResource.Name }
+
+        if ($matchingResources) {
+            # Prefer a version that satisfies the requested range; fall back to any installed version
+            $preferred = if ($inputResource.Version) {
+                $matchingResources | Where-Object {
+                    try { SatisfiesVersion -version $_.Version -versionRange $inputResource.Version } catch { $false }
+                } | Select-Object -First 1
             }
+
+            $toAdd = if ($preferred) { $preferred } else { $matchingResources | Select-Object -First 1 }
+            Write-Trace -message "Found matching resource for input: $($inputResource.Name). Returning version: $($toAdd.Version)" -level debug
+            $resourcesExist += $toAdd
         }
     }
 

--- a/test/DscResource/PSResourceGetDSCResource.Tests.ps1
+++ b/test/DscResource/PSResourceGetDSCResource.Tests.ps1
@@ -285,6 +285,52 @@ Describe "PSResourceList Resource Tests" -Tags 'CI' {
         $testResult = & $script:dscExe resource test --resource Microsoft.PowerShell.PSResourceGet/PSResourceList --input $resourceInput -o json | ConvertFrom-Json
         $testResult.inDesiredState | Should -BeFalse
     }
+
+    It 'Get returns actual installed version when installed version does not satisfy requested version' {
+        # Install 1.0.0 but request 5.0.0 - get should return the actual installed version (1.0.0)
+        Install-PSResource -Name $script:testModuleName -Version '1.0.0' -Repository $script:localRepo -Reinstall -TrustRepository -ErrorAction SilentlyContinue
+        Uninstall-PSResource -Name $script:testModuleName -Version '5.0.0' -ErrorAction SilentlyContinue
+
+        $psResourceListParams = @{
+            repositoryName = $script:localRepo
+            resources      = @(
+                @{
+                    name    = $script:testModuleName
+                    version = '5.0.0'
+                }
+            )
+        }
+
+        $resourceInput = $psResourceListParams | ConvertTo-Json -Depth 5
+        $getResult = & $script:dscExe resource get --resource Microsoft.PowerShell.PSResourceGet/PSResourceList --input $resourceInput -o json | ConvertFrom-Json
+        $getResult.actualState.resources.Count | Should -Be 1
+        $getResult.actualState.resources[0].name | Should -BeExactly $script:testModuleName
+        $getResult.actualState.resources[0].version | Should -BeExactly '1.0.0'
+        $getResult.actualState.resources[0]._exist | Should -BeTrue
+    }
+
+    It 'Get prefers installed version that satisfies requested version range when multiple versions are installed' {
+        # Install both 1.0.0 and 5.0.0 but request 5.0.0 - get should prefer the satisfying version (5.0.0)
+        Install-PSResource -Name $script:testModuleName -Version '1.0.0' -Repository $script:localRepo -Reinstall -TrustRepository -ErrorAction SilentlyContinue
+        Install-PSResource -Name $script:testModuleName -Version '5.0.0' -Repository $script:localRepo -Reinstall -TrustRepository -ErrorAction SilentlyContinue
+
+        $psResourceListParams = @{
+            repositoryName = $script:localRepo
+            resources      = @(
+                @{
+                    name    = $script:testModuleName
+                    version = '5.0.0'
+                }
+            )
+        }
+
+        $resourceInput = $psResourceListParams | ConvertTo-Json -Depth 5
+        $getResult = & $script:dscExe resource get --resource Microsoft.PowerShell.PSResourceGet/PSResourceList --input $resourceInput -o json | ConvertFrom-Json
+        $getResult.actualState.resources.Count | Should -Be 1
+        $getResult.actualState.resources[0].name | Should -BeExactly $script:testModuleName
+        $getResult.actualState.resources[0].version | Should -BeExactly '5.0.0'
+        $getResult.actualState.resources[0]._exist | Should -BeTrue
+    }
 }
 
 Describe 'E2E tests for Repository resource' -Tags 'CI' {

--- a/test/DscResource/PSResourceGetDSCResource.Tests.ps1
+++ b/test/DscResource/PSResourceGetDSCResource.Tests.ps1
@@ -286,8 +286,9 @@ Describe "PSResourceList Resource Tests" -Tags 'CI' {
         $testResult.inDesiredState | Should -BeFalse
     }
 
-    It 'Get returns actual installed version when installed version does not satisfy requested version' {
-        # Install 1.0.0 but request 5.0.0 - get should return the actual installed version (1.0.0)
+    It 'Get returns actual installed version with _exist false when installed version does not satisfy requested version' {
+        # Install 1.0.0 but request 5.0.0 - get should report _exist = false (requested version absent)
+        # but still surface the actually installed version (1.0.0)
         Install-PSResource -Name $script:testModuleName -Version '1.0.0' -Repository $script:localRepo -Reinstall -TrustRepository -ErrorAction SilentlyContinue
         Uninstall-PSResource -Name $script:testModuleName -Version '5.0.0' -ErrorAction SilentlyContinue
 
@@ -306,7 +307,7 @@ Describe "PSResourceList Resource Tests" -Tags 'CI' {
         $getResult.actualState.resources.Count | Should -Be 1
         $getResult.actualState.resources[0].name | Should -BeExactly $script:testModuleName
         $getResult.actualState.resources[0].version | Should -BeExactly '1.0.0'
-        $getResult.actualState.resources[0]._exist | Should -BeTrue
+        $getResult.actualState.resources[0]._exist | Should -BeFalse
     }
 
     It 'Get prefers installed version that satisfies requested version range when multiple versions are installed' {

--- a/test/DscResource/PSResourceGetDSCResource.Tests.ps1
+++ b/test/DscResource/PSResourceGetDSCResource.Tests.ps1
@@ -167,6 +167,16 @@ Describe "PSResourceList Resource Tests" -Tags 'CI' {
         SetupTestRepos
     }
     AfterAll {
+        # Remove test modules installed through DSC so they do not leak into later runs.
+        foreach ($moduleToRemove in @($script:testModuleName, $script:testModuleName2)) {
+            $cleanupInput = @{
+                repositoryName    = $script:localRepo
+                trustedRepository = $true
+                resources         = @(@{ name = $moduleToRemove; _exist = $false })
+            } | ConvertTo-Json -Depth 5
+            $null = & $script:dscExe resource set --resource Microsoft.PowerShell.PSResourceGet/PSResourceList --input $cleanupInput -o json 2>&1
+        }
+
         # Clean up the test repository
         Get-RevertPSResourceRepositoryFile
     }
@@ -288,9 +298,19 @@ Describe "PSResourceList Resource Tests" -Tags 'CI' {
 
     It 'Get returns actual installed version with _exist false when installed version does not satisfy requested version' {
         # Install 1.0.0 but request 5.0.0 - get should report _exist = false (requested version absent)
-        # but still surface the actually installed version (1.0.0)
-        Install-PSResource -Name $script:testModuleName -Version '1.0.0' -Repository $script:localRepo -Reinstall -TrustRepository -ErrorAction SilentlyContinue
-        Uninstall-PSResource -Name $script:testModuleName -Version '5.0.0' -ErrorAction SilentlyContinue
+        $removeAllInput = @{
+            repositoryName    = $script:localRepo
+            trustedRepository = $true
+            resources         = @(@{ name = $script:testModuleName; _exist = $false })
+        } | ConvertTo-Json -Depth 5
+        $null = & $script:dscExe resource set --resource Microsoft.PowerShell.PSResourceGet/PSResourceList --input $removeAllInput -o json
+
+        $installOldInput = @{
+            repositoryName    = $script:localRepo
+            trustedRepository = $true
+            resources         = @(@{ name = $script:testModuleName; version = '1.0.0' })
+        } | ConvertTo-Json -Depth 5
+        $null = & $script:dscExe resource set --resource Microsoft.PowerShell.PSResourceGet/PSResourceList --input $installOldInput -o json
 
         $psResourceListParams = @{
             repositoryName = $script:localRepo
@@ -311,9 +331,16 @@ Describe "PSResourceList Resource Tests" -Tags 'CI' {
     }
 
     It 'Get prefers installed version that satisfies requested version range when multiple versions are installed' {
-        # Install both 1.0.0 and 5.0.0 but request 5.0.0 - get should prefer the satisfying version (5.0.0)
-        Install-PSResource -Name $script:testModuleName -Version '1.0.0' -Repository $script:localRepo -Reinstall -TrustRepository -ErrorAction SilentlyContinue
-        Install-PSResource -Name $script:testModuleName -Version '5.0.0' -Repository $script:localRepo -Reinstall -TrustRepository -ErrorAction SilentlyContinue
+        # Install both 1.0.0 and 5.0.0 but request 5.0.0 - get should prefer the satisfying version (5.0.0).
+        # Setup goes through DSC for the same reason as the previous test.
+        foreach ($setupVersion in @('1.0.0', '5.0.0')) {
+            $installInput = @{
+                repositoryName    = $script:localRepo
+                trustedRepository = $true
+                resources         = @(@{ name = $script:testModuleName; version = $setupVersion })
+            } | ConvertTo-Json -Depth 5
+            $null = & $script:dscExe resource set --resource Microsoft.PowerShell.PSResourceGet/PSResourceList --input $installInput -o json
+        }
 
         $psResourceListParams = @{
             repositoryName = $script:localRepo


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix a bug in `PSResourceList` where the `get` operation silently omits installed resources whose version does not satisfy the requested version as a NuGet (minimum)-version range. The `get` operation now always returns the actual installed state, with version-range logic used only to prefer a satisfying version when multiple versions are side-by-side installed.

## PR Context

Fixes #1997.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
