### PR TITLE
fix: capture cmdlet warnings to prevent stdout contamination breaking DSC JSON parsing

### DIFF
--- a/src/dsc/psresourceget.ps1
+++ b/src/dsc/psresourceget.ps1
@@ -586,7 +586,11 @@ function SetPSResourceList {
     if ($resourcesToUninstall.Count -gt 0) {
         Write-Trace -message "Uninstalling resources: $($resourcesToUninstall | ForEach-Object { "$($_.Name) - $($_.Version)" })" -level debug
         $resourcesToUninstall | ForEach-Object {
-            Uninstall-PSResource -Name $_.Name -Scope $scope -ErrorAction Stop
+            $cmdWarnings = $null
+            Uninstall-PSResource -Name $_.Name -Scope $scope -ErrorAction Stop -WarningVariable cmdWarnings
+            foreach ($w in $cmdWarnings) {
+                Write-Trace -message $w.Message -level warn
+            }
         }
         $resourcesChanged = $true
     }
@@ -614,9 +618,12 @@ function SetPSResourceList {
             $version = $_.Version
 
             try {
-                Install-PSResource -Name $_.Name -Version $_.Version -Scope $scope -Repository $repositoryName -ErrorAction Stop -TrustRepository:$inputObj.trustedRepository -Prerelease:$usePrerelease -Reinstall
-            }
-            catch {
+                $cmdWarnings = $null
+                Install-PSResource -Name $_.Name -Version $_.Version -Scope $scope -Repository $repositoryName -ErrorAction Stop -TrustRepository:$inputObj.trustedRepository -Prerelease:$usePrerelease -Reinstall -WarningVariable cmdWarnings
+                foreach ($w in $cmdWarnings) {
+                    Write-Trace -message $w.Message -level warn
+                }
+            } catch {
                 Write-Trace -level error -message "Failed to install resource '$name' with version '$version'. Error: $($_.Exception.Message)"
                 $installErrors += $_.Exception.Message
             }
@@ -824,6 +831,10 @@ if ($null -eq (Get-Module -Name Microsoft.PowerShell.PSResourceGet)) {
     Write-Trace -level trace -message "Importing Microsoft.PowerShell.PSResourceGet module from path: $path"
     Import-Module -Name $path -Force -ErrorAction Stop
 }
+
+# Suppress warnings from PSResourceGet cmdlets to prevent them from reaching stdout and
+# breaking DSC's JSON parsing. Warnings should be captured on individual cmdlets
+$WarningPreference = 'SilentlyContinue'
 
 switch ($Operation.ToLower()) {
     'get' { return (GetOperation -ResourceType $ResourceType) }

--- a/src/dsc/psresourceget.ps1
+++ b/src/dsc/psresourceget.ps1
@@ -589,7 +589,7 @@ function SetPSResourceList {
             $cmdWarnings = $null
             Uninstall-PSResource -Name $_.Name -Scope $scope -ErrorAction Stop -WarningVariable cmdWarnings
             foreach ($w in $cmdWarnings) {
-                Write-Trace -message $w.Message -level warn
+                Write-Trace -message ([string]$w) -level warn
             }
         }
         $resourcesChanged = $true
@@ -621,7 +621,7 @@ function SetPSResourceList {
                 $cmdWarnings = $null
                 Install-PSResource -Name $_.Name -Version $_.Version -Scope $scope -Repository $repositoryName -ErrorAction Stop -TrustRepository:$inputObj.trustedRepository -Prerelease:$usePrerelease -Reinstall -WarningVariable cmdWarnings
                 foreach ($w in $cmdWarnings) {
-                    Write-Trace -message $w.Message -level warn
+                    Write-Trace -message ([string]$w) -level warn
                 }
             } catch {
                 Write-Trace -level error -message "Failed to install resource '$name' with version '$version'. Error: $($_.Exception.Message)"

--- a/test/DscResource/PSResourceGetDSCResource.Tests.ps1
+++ b/test/DscResource/PSResourceGetDSCResource.Tests.ps1
@@ -243,6 +243,37 @@ Describe "PSResourceList Resource Tests" -Tags 'CI' {
         $setResult.afterState.resources[1].version | Should -Be '5.0.0'
     }
 
+    It 'Set operation stdout contains only valid JSON and is not contaminated by warning messages' {
+        # Simple regression test as it is hard to predict a warning message but we want to ensure they do not break DSC's JSON parsing. This test does not verify that warnings are emitted when expected, 
+        # only that if they are emitted they do not reach stdout.
+        Uninstall-PSResource -Name $script:testModuleName -ErrorAction SilentlyContinue
+
+        $psResourceListParams = @{
+            repositoryName    = $script:localRepo
+            trustedRepository = $true
+            resources         = @(
+                @{
+                    name    = $script:testModuleName
+                    version = '1.0.0'
+                }
+            )
+        }
+
+        $resourceInput = $psResourceListParams | ConvertTo-Json -Depth 5
+
+        # Capture only stdout; stderr carries DSC trace messages and is intentionally discarded
+        $stdoutLines = & $script:dscExe resource set --resource Microsoft.PowerShell.PSResourceGet/PSResourceList --input $resourceInput -o json 2>$null
+
+        # No stdout line should contain warning text or ANSI escape sequences
+        $stdoutLines | Where-Object { $_ } | ForEach-Object {
+            $_ | Should -Not -Match 'WARNING:'
+            $_ | Should -Not -Match '\x1b\['
+        }
+
+        # stdout must be parseable as JSON without error
+        { $stdoutLines | ConvertFrom-Json -ErrorAction Stop } | Should -Not -Throw
+    }
+
     It 'Can test a PSResourceList resource instance with resources' {
         $psResourceListParams = @{
             repositoryName = $script:localRepo


### PR DESCRIPTION
# PR Summary

Warnings emitted by `Install-PSResource` and `Uninstall-PSResource` were leaking to stdout, corrupting the JSON output that DSC parses after each set operation. This fix suppresses the warning stream globally in the DSC script and re-routes any per-cmdlet warnings through the trace (stderr) channel so they remain visible without breaking JSON parsing.

## PR Context

DSC expects each resource operation to emit only valid JSON on stdout. PowerShell warning messages (e.g. from NuGet or module compatibility checks) were being written to stdout alongside the JSON output, causing DSC to fail when parsing the response. The fix sets `$WarningPreference = 'SilentlyContinue'` at the script level to prevent any unintentional warning output, while individually capturing `-WarningVariable` on `Install-PSResource` and `Uninstall-PSResource` and forwarding those through `Write-Trace` at `warn` level so they still appear in DSC's trace/stderr stream.

> [!NOTE]
> It's difficult to reproduce a warning in the stream on the GitHub runners; thus, I added a simple regression test.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
- **User-facing changes**
    - [x] Not Applicable
- **Testing - New and feature**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.