### PR TITLE
fix(repository:) Add input validation for `GetOperation`

### DIFF
--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -815,8 +815,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     return InstallParentAndDependencyPackages(parentAndDeps, currentServer, tempInstallPath, packagesHash, updatedPackagesHash, pkgToInstall);
                 }
                 else {
-                    // If we don't install dependencies, we're only installing the parent pkg so we can short circut and simply install the parent pkg. 
-                    Stream responseStream = currentServer.InstallPackage(pkgToInstall.Name, pkgVersion, true, out ErrorRecord installNameErrRecord);
+                    // If we don't install dependencies, we're only installing the parent pkg so we can short circut and simply install the parent pkg.
+                    // Dispose the stream once done: for local repositories this is a FileStream on the repository's .nupkg and leaving it open locks the file.
+                    using Stream responseStream = currentServer.InstallPackage(pkgToInstall.Name, pkgVersion, true, out ErrorRecord installNameErrRecord);
 
                     if (installNameErrRecord != null)
                     {
@@ -868,7 +869,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     verboseMsgs.Enqueue($"Installing package '{depPkgName}' version '{depPkgVersion}'");
                     //Stream responseStream = currentServer.InstallPackage(depPkgName, depPkgVersion, true, out ErrorRecord installNameErrRecord);
                     // add async
-                    Stream responseStream = currentServer.InstallPackageAsync(depPkgName, depPkgVersion, true, errorMsgs, warningMsgs, debugMsgs, verboseMsgs).GetAwaiter().GetResult();
+                    using Stream responseStream = currentServer.InstallPackageAsync(depPkgName, depPkgVersion, true, errorMsgs, warningMsgs, debugMsgs, verboseMsgs).GetAwaiter().GetResult();
 
                     if (errorMsgs.Count > 0)
                     {
@@ -906,7 +907,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     var pkgToInstallName = pkgToBeInstalled.Name;
                     var pkgToInstallVersion = Utils.GetFullVersionString(pkgToBeInstalled.Version.ToString(), pkgToBeInstalled.Prerelease);
-                    Stream responseStream = currentServer.InstallPackage(pkgToInstallName, pkgToInstallVersion, true, out ErrorRecord installNameErrRecord);
+                    using Stream responseStream = currentServer.InstallPackage(pkgToInstallName, pkgToInstallVersion, true, out ErrorRecord installNameErrRecord);
 
                     if (installNameErrRecord != null)
                     {

--- a/src/dsc/psresourceget.ps1
+++ b/src/dsc/psresourceget.ps1
@@ -376,6 +376,11 @@ function GetOperation {
         [string]$ResourceType
     )
 
+    if ([string]::IsNullOrEmpty($stdinput)) {
+        Write-Trace -level error -message "Get operation requires --input with the resource properties. No input was provided."
+        exit [ExitCode]::Error
+    }
+
     $inputObj = $stdinput | ConvertFrom-Json -ErrorAction Stop
 
     Write-Trace -message "Starting Get operation for ResourceType: $ResourceType" -level trace

--- a/test/DscResource/PSResourceGetDSCResource.Tests.ps1
+++ b/test/DscResource/PSResourceGetDSCResource.Tests.ps1
@@ -142,6 +142,12 @@ Describe 'Repository Resource Tests' -Tags 'CI' {
         }
     }
 
+    It 'Get operation without --input exits with a non-zero code and does not produce an unhandled exception' {
+        $output = & $script:dscExe resource get --resource Microsoft.PowerShell.PSResourceGet/Repository -o json 2>&1
+        $LASTEXITCODE | Should -Not -Be 0
+        ($output | Out-String) | Should -Not -Match 'Cannot bind argument to parameter'
+    }
+
     It 'Can delete a Repository resource instance' {
         # First, create a repository to delete
         Register-PSResourceRepository -Name 'TestRepoToDelete' -uri 'https://www.doesnotexist.com' -ErrorAction SilentlyContinue -APIVersion Local

--- a/test/DscResource/PSResourceGetDSCResource.Tests.ps1
+++ b/test/DscResource/PSResourceGetDSCResource.Tests.ps1
@@ -144,8 +144,12 @@ Describe 'Repository Resource Tests' -Tags 'CI' {
 
     It 'Get operation without --input exits with a non-zero code and does not produce an unhandled exception' {
         $output = & $script:dscExe resource get --resource Microsoft.PowerShell.PSResourceGet/Repository -o json 2>&1
+        $outputText = $output | Out-String
         $LASTEXITCODE | Should -Not -Be 0
-        ($output | Out-String) | Should -Not -Match 'Cannot bind argument to parameter'
+        $outputText | Should -Match '--input'
+        $outputText | Should -Match 'required'
+        $outputText | Should -Not -Match 'Cannot bind argument to parameter'
+        $outputText | Should -Not -Match 'Unhandled exception'
     }
 
     It 'Can delete a Repository resource instance' {

--- a/test/DscResource/PSResourceGetDSCResource.Tests.ps1
+++ b/test/DscResource/PSResourceGetDSCResource.Tests.ps1
@@ -147,7 +147,7 @@ Describe 'Repository Resource Tests' -Tags 'CI' {
         $outputText = $output | Out-String
         $LASTEXITCODE | Should -Not -Be 0
         $outputText | Should -Match '--input'
-        $outputText | Should -Match 'required'
+        $outputText | Should -Match 'requires'
         $outputText | Should -Not -Match 'Cannot bind argument to parameter'
         $outputText | Should -Not -Match 'Unhandled exception'
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request adds a simple input validation when it's empty for the `GetOperation` on the `Repository` resource. 

## PR Context

When `--input` is omitted, DSC closes the child process stdin without writing anything. The
resource manifest uses `"input": "stdin"` and invokes the script as `$Input | ./psresourceget.ps1 ...`, so `$Input` is an empty enumerator and the `$stdinput` pipeline parameter is never bound (keeping it $null). 

Fixes #2001

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
