### PR TITLE
Add `WhatIf` functionality to PSResourceList operations

### DIFF
--- a/src/dsc/psresourceget.ps1
+++ b/src/dsc/psresourceget.ps1
@@ -161,12 +161,17 @@ class PSResourceList {
     }
 
     [string] ToJson() {
-        $resourceJsonItems = if ($this.resources) {
-            @($this.resources | ForEach-Object { $_.ToJson() })
+        $resourceObjects = if ($this.resources) {
+            @($this.resources | ForEach-Object {
+                [string[]]$excludeProps = @('_inDesiredState')
+                if ($null -eq $_._metadata) { $excludeProps += '_metadata' }
+                $_ | Select-Object -ExcludeProperty $excludeProps
+            })
         } else { @() }
-        $resourcesArrayJson = '[' + ($resourceJsonItems -join ',') + ']'
-        $repoNameJson = $this.repositoryName | ConvertTo-Json -Compress
-        $retVal = "{`"repositoryName`":$repoNameJson,`"resources`":$resourcesArrayJson}"
+        $retVal = [ordered]@{
+            repositoryName = $this.repositoryName
+            resources      = [object[]]$resourceObjects
+        } | ConvertTo-Json -Compress -Depth 5 -EnumsAsStrings
         Write-Trace -message "Serializing PSResourceList to JSON. RepositoryName: $($this.repositoryName), TrustedRepository: $($this.trustedRepository), Resources count: $($this.resources.Count)" -level debug
         Write-Trace -message "Serialized JSON: $retVal" -level trace
         return $retVal
@@ -174,14 +179,19 @@ class PSResourceList {
 
     [string] ToJsonForTest() {
         Write-Trace -message "Serializing PSResourceList to JSON for test output. RepositoryName: $($this.repositoryName), TrustedRepository: $($this.trustedRepository), Resources count: $($this.resources.Count)" -level debug
-        $resourceJsonItems = if ($this.resources) {
-            @($this.resources | ForEach-Object { $_.ToJsonForTest() })
+        $resourceObjects = if ($this.resources) {
+            @($this.resources | ForEach-Object {
+                [string[]]$excludeProps = @()
+                if ($null -eq $_._metadata) { $excludeProps += '_metadata' }
+                if ($excludeProps.Count -gt 0) { $_ | Select-Object -ExcludeProperty $excludeProps } else { $_ }
+            })
         } else { @() }
-        $resourcesArrayJson = '[' + ($resourceJsonItems -join ',') + ']'
-        $repoNameJson = $this.repositoryName | ConvertTo-Json -Compress
-        $trustedStr = ($this.trustedRepository).ToString().ToLower()
-        $inDesiredStr = ($this._inDesiredState).ToString().ToLower()
-        $retVal = "{`"repositoryName`":$repoNameJson,`"resources`":$resourcesArrayJson,`"trustedRepository`":$trustedStr,`"_inDesiredState`":$inDesiredStr}"
+        $retVal = [ordered]@{
+            repositoryName    = $this.repositoryName
+            resources         = [object[]]$resourceObjects
+            trustedRepository = $this.trustedRepository
+            _inDesiredState   = $this._inDesiredState
+        } | ConvertTo-Json -Compress -Depth 5 -EnumsAsStrings
         Write-Trace -message "Serialized JSON: $retVal" -level trace
         return $retVal
     }
@@ -568,7 +578,14 @@ function WhatIfPSResourceList {
         if (-not $resourceDesiredState._exist -and $null -ne $currentResource -and $currentResource._exist) {
             $msg = "Would uninstall resource '$name'"
             Write-Trace -message "WhatIf: $msg." -level debug
-            $resource = [PSResource]::new($name)
+            $resource = [PSResource]::new(
+                $currentResource.name,
+                $currentResource.version,
+                $currentResource.scope,
+                $currentResource.repositoryName,
+                $currentResource.preRelease
+            )
+            $resource._exist = $false
             $resource._metadata = [pscustomobject]@{ whatIf = @($msg) }
             $projectedResources += $resource
         }

--- a/src/dsc/psresourceget.ps1
+++ b/src/dsc/psresourceget.ps1
@@ -10,7 +10,8 @@ param(
     [ValidateSet('get', 'set', 'test', 'delete', 'export')]
     [string]$Operation,
     [Parameter(ValueFromPipeline)]
-    $stdinput
+    $stdinput,
+    [switch]$WhatIf
 )
 
 enum Scope {
@@ -42,6 +43,7 @@ class PSResource {
     [bool]$preRelease
     [bool]$_exist
     [bool]$_inDesiredState
+    [object]$_metadata
 
     PSResource([string]$name, [string]$version, [Scope]$scope, [string]$repositoryName, [bool]$preRelease) {
         $this.name = $name
@@ -98,14 +100,18 @@ class PSResource {
     }
 
     [string] ToJson() {
-        $retVal = ($this | Select-Object -ExcludeProperty _inDesiredState | ConvertTo-Json -Compress -EnumsAsStrings)
+        [string[]]$excludeProps = @('_inDesiredState')
+        if ($null -eq $this._metadata) { $excludeProps += '_metadata' }
+        $retVal = ($this | Select-Object -ExcludeProperty $excludeProps | ConvertTo-Json -Compress -EnumsAsStrings)
         Write-Trace -message "Serializing PSResource to JSON. Name: $($this.name), Version: $($this.version), Scope: $($this.scope), RepositoryName: $($this.repositoryName), PreRelease: $($this.preRelease), _exist: $($this._exist)" -level debug
         Write-Trace -message "Serialized JSON: $retVal" -level trace
         return $retVal
     }
 
     [string] ToJsonForTest() {
-        return ($this | ConvertTo-Json -Compress -Depth 5 -EnumsAsStrings)
+        [string[]]$excludeProps = @()
+        if ($null -eq $this._metadata) { $excludeProps += '_metadata' }
+        return ($this | Select-Object -ExcludeProperty $excludeProps | ConvertTo-Json -Compress -Depth 5 -EnumsAsStrings)
     }
 }
 
@@ -155,23 +161,29 @@ class PSResourceList {
     }
 
     [string] ToJson() {
-        $resourceJson = if ($this.resources) { ($this.resources | ForEach-Object { $_.ToJson() }) -join ',' } else { '' }
-        $resourceJson = "[$resourceJson]"
-        $jsonString = "{'repositoryName': '$($this.repositoryName)','resources': $resourceJson}"
-        $jsonString = $jsonString -replace "'", '"'
-        $retVal =  $jsonString | ConvertFrom-Json | ConvertTo-Json -Compress -EnumsAsStrings
-
+        $resourceJsonItems = if ($this.resources) {
+            @($this.resources | ForEach-Object { $_.ToJson() })
+        } else { @() }
+        $resourcesArrayJson = '[' + ($resourceJsonItems -join ',') + ']'
+        $repoNameJson = $this.repositoryName | ConvertTo-Json -Compress
+        $retVal = "{`"repositoryName`":$repoNameJson,`"resources`":$resourcesArrayJson}"
         Write-Trace -message "Serializing PSResourceList to JSON. RepositoryName: $($this.repositoryName), TrustedRepository: $($this.trustedRepository), Resources count: $($this.resources.Count)" -level debug
         Write-Trace -message "Serialized JSON: $retVal" -level trace
-
         return $retVal
     }
 
     [string] ToJsonForTest() {
         Write-Trace -message "Serializing PSResourceList to JSON for test output. RepositoryName: $($this.repositoryName), TrustedRepository: $($this.trustedRepository), Resources count: $($this.resources.Count)" -level debug
-        $jsonForTest = $this | ConvertTo-Json -Compress -Depth 5 -EnumsAsStrings
-        Write-Trace -message "Serialized JSON: $jsonForTest" -level trace
-        return $jsonForTest
+        $resourceJsonItems = if ($this.resources) {
+            @($this.resources | ForEach-Object { $_.ToJsonForTest() })
+        } else { @() }
+        $resourcesArrayJson = '[' + ($resourceJsonItems -join ',') + ']'
+        $repoNameJson = $this.repositoryName | ConvertTo-Json -Compress
+        $trustedStr = ($this.trustedRepository).ToString().ToLower()
+        $inDesiredStr = ($this._inDesiredState).ToString().ToLower()
+        $retVal = "{`"repositoryName`":$repoNameJson,`"resources`":$resourcesArrayJson,`"trustedRepository`":$trustedStr,`"_inDesiredState`":$inDesiredStr}"
+        Write-Trace -message "Serialized JSON: $retVal" -level trace
+        return $retVal
     }
 }
 
@@ -538,10 +550,60 @@ function ExportOperation {
     }
 }
 
-function SetPSResourceList {
+function WhatIfPSResourceList {
     param(
         $inputObj
     )
+
+    $repositoryName = $inputObj.repositoryName
+    $currentState = GetPSResourceList -inputObj $inputObj
+    $projectedResources = @()
+    $inputObj.resources | ForEach-Object {
+        $resourceDesiredState = ConvertInputToPSResource -inputObj $_ -repositoryName $repositoryName
+        $name = $resourceDesiredState.name
+        $version = $resourceDesiredState.version
+        $scope = if ($resourceDesiredState.scope) { $resourceDesiredState.scope } else { [Scope]'CurrentUser' }
+        $currentResource = $currentState.resources | Where-Object { $_.name -eq $name } | Select-Object -First 1
+
+        if (-not $resourceDesiredState._exist -and $null -ne $currentResource -and $currentResource._exist) {
+            $msg = "Would uninstall resource '$name'"
+            Write-Trace -message "WhatIf: $msg." -level debug
+            $resource = [PSResource]::new($name)
+            $resource._metadata = [pscustomobject]@{ whatIf = @($msg) }
+            $projectedResources += $resource
+        }
+        elseif ($resourceDesiredState._exist -and ($null -eq $currentResource -or -not $currentResource._exist)) {
+            $versionStr = if ($version) { $version } else { 'latest' }
+            $msg = "Would install resource '$name' version '$versionStr'"
+            Write-Trace -message "WhatIf: $msg." -level debug
+            $resource = [PSResource]::new($name, $versionStr, [Scope]$scope, $repositoryName, $resourceDesiredState.preRelease)
+            $resource._metadata = [pscustomobject]@{ whatIf = @($msg) }
+            $projectedResources += $resource
+        }
+        else {
+            Write-Trace -message "WhatIf: Resource '$name' is already in desired state." -level debug
+            if ($null -ne $currentResource) {
+                $projectedResources += $currentResource
+            }
+            else {
+                $projectedResources += $resourceDesiredState
+            }
+        }
+    }
+
+    $list = [PSResourceList]::new($repositoryName, $projectedResources, $currentState.trustedRepository)
+    $list.ToJson()
+}
+
+function SetPSResourceList {
+    param(
+        $inputObj,
+        [switch]$WhatIf
+    )
+
+    if ($WhatIf) {
+        return WhatIfPSResourceList -inputObj $inputObj
+    }
 
     $repositoryName = $inputObj.repositoryName
     $resourcesToUninstall = @()
@@ -690,7 +752,7 @@ function SetOperation {
             Write-Trace -level error -message "Set operation is not implemented for PSResource resource."
             exit [ExitCode]::SetNotImplemented
         }
-        'psresourcelist' { return SetPSResourceList -inputObj $inputObj }
+        'psresourcelist' { return SetPSResourceList -inputObj $inputObj -WhatIf:$WhatIf }
         default {
             Write-Trace -level error -message "Unknown ResourceType: $ResourceType"
             exit [ExitCode]::UnknownResourceType

--- a/src/dsc/psresourcelist.dsc.resource.json
+++ b/src/dsc/psresourcelist.dsc.resource.json
@@ -32,10 +32,12 @@
       "-ExecutionPolicy",
       "Bypass",
       "-Command",
-      "$Input | ./psresourceget.ps1 -resourcetype 'psresourcelist' -operation set; exit $LASTEXITCODE"
+      "$Input | ./psresourceget.ps1 -resourcetype 'psresourcelist' -operation set",
+      { "whatIfArg": "-WhatIf" }
     ],
     "input": "stdin",
-    "return": "stateAndDiff"
+    "return": "stateAndDiff",
+    "whatIfReturns": "state"
   },
   "export": {
     "executable": "pwsh",
@@ -161,6 +163,20 @@
             },
             "_inDesiredState": {
               "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/resource/properties/inDesiredState.json"
+            },
+            "_metadata": {
+              "type": "object",
+              "title": "Metadata",
+              "description": "Metadata populated during what-if operations.",
+              "readOnly": true,
+              "additionalProperties": false,
+              "properties": {
+                "whatIf": {
+                  "type": "array",
+                  "description": "Messages describing what the set operation would do.",
+                  "items": { "type": "string" }
+                }
+              }
             }
           }
         },

--- a/test/DscResource/PSResourceGetDSCResource.Tests.ps1
+++ b/test/DscResource/PSResourceGetDSCResource.Tests.ps1
@@ -475,3 +475,98 @@ Describe "Error code tests" -Tags 'CI' {
         $out[-1] | Should -BeLike '*Could not install one or more resources (during set operation)*'
     }
 }
+
+Describe 'PSResourceList what-if tests' -Tags 'CI' {
+    BeforeAll {
+        SetupDsc
+        SetupTestRepos
+
+        $isOnWindowsPowerShell = $PSVersionTable.PSVersion.Major -lt 6
+        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+        $PSDefaultParameterValues['it:skip'] = $isOnWindowsPowerShell
+    }
+
+    AfterAll {
+        $global:PSDefaultParameterValues = $originalDefaultParameterValues
+        Get-RevertPSResourceRepositoryFile
+    }
+
+    It 'What-if install does not modify the system' {
+        Uninstall-PSResource -Name $script:testModuleName -ErrorAction SilentlyContinue
+        Uninstall-PSResource -Name $script:testModuleName2 -ErrorAction SilentlyContinue
+
+        $config_yaml = @"
+`$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+resources:
+- name: PSResourceList what-if install
+  type: Microsoft.PowerShell.PSResourceGet/PSResourceList
+  properties:
+    repositoryName: $script:localRepo
+    trustedRepository: true
+    resources:
+    - name: $script:testModuleName
+      version: '5.0.0'
+    - name: $script:testModuleName2
+      version: '5.0.0'
+"@
+
+        $out = & $script:dscExe config set --what-if --input $config_yaml 2>$TestDrive/error.log | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0 -Because (Get-Content -Path $TestDrive/error.log -Raw)
+
+        $result = $out.results.result[0].afterState
+        $result.repositoryName | Should -BeExactly $script:localRepo
+        $result.resources.Count | Should -Be 2
+        $result.resources[0]._metadata.whatIf[0] | Should -Match 'Would install'
+        $result.resources[1]._metadata.whatIf[0] | Should -Match 'Would install'
+
+        Get-PSResource -Name $script:testModuleName -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+        Get-PSResource -Name $script:testModuleName2 -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+    }
+
+    It 'What-if uninstall does not modify the system' {
+        Install-PSResource -Name $script:testModuleName -Version '5.0.0' -Repository $script:localRepo -TrustRepository -Reinstall
+
+        $config_yaml = @"
+`$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+resources:
+- name: PSResourceList what-if uninstall
+  type: Microsoft.PowerShell.PSResourceGet/PSResourceList
+  properties:
+    repositoryName: $script:localRepo
+    resources:
+    - name: $script:testModuleName
+      _exist: false
+"@
+
+        $out = & $script:dscExe config set --what-if --input $config_yaml 2>$TestDrive/error.log | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0 -Because (Get-Content -Path $TestDrive/error.log -Raw)
+
+        $result = $out.results.result[0].afterState
+        $result.resources[0]._exist | Should -BeFalse
+        $result.resources[0]._metadata.whatIf[0] | Should -Match 'Would uninstall'
+
+        Get-PSResource -Name $script:testModuleName -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+    }
+
+    It 'What-if returns no metadata for resources already in desired state' {
+        Install-PSResource -Name $script:testModuleName -Version '5.0.0' -Repository $script:localRepo -TrustRepository -Reinstall
+
+        $config_yaml = @"
+`$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+resources:
+- name: PSResourceList what-if in desired state
+  type: Microsoft.PowerShell.PSResourceGet/PSResourceList
+  properties:
+    repositoryName: $script:localRepo
+    resources:
+    - name: $script:testModuleName
+      version: '5.0.0'
+"@
+
+        $out = & $script:dscExe config set --what-if --input $config_yaml 2>$TestDrive/error.log | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0 -Because (Get-Content -Path $TestDrive/error.log -Raw)
+
+        $result = $out.results.result[0].afterState
+        $result.resources[0]._metadata | Should -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
# PR Summary

Adds DSC `--what-if` support to the `PSResourceList` resource. When a DSC config is run with `--what-if`, the resource now returns a projected state describing what _would_ happen (install or uninstall) without making any changes to the system. Each affected resource is annotated with a `_metadata.whatIf` array containing a human-readable description of the pending action.

## PR Context

Fixes #2003.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.