### PR TITLE
Add concurrency for parent packages

### DIFF
--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -343,6 +343,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             Stream results = new MemoryStream();
             if (string.IsNullOrEmpty(packageVersion))
             {
+                errRecord = new ErrorRecord(
                     exception: new ArgumentNullException($"Package version could not be found for {packageName}"),
                     "PackageVersionNullOrEmptyError",
                     ErrorCategory.InvalidArgument,

--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -368,12 +368,20 @@ namespace Microsoft.PowerShell.PSResourceGet
         public override Task<Stream> InstallPackageAsync(string packageName, string packageVersion, bool includePrerelease, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
             debugMsgs.Enqueue("In ContainerRegistryServerAPICalls::InstallPackageAsync()");
-            Stream results = InstallPackage(packageName, packageVersion, includePrerelease, out ErrorRecord errRecord);
-            if (errRecord != null)
+            Stream results = new MemoryStream();
+            if (string.IsNullOrEmpty(packageVersion))
             {
-                errorMsgs.Enqueue(errRecord);
+                errorMsgs.Enqueue(new ErrorRecord(
+                    exception: new ArgumentNullException($"Package version could not be found for {packageName}"),
+                    "PackageVersionNullOrEmptyError",
+                    ErrorCategory.InvalidArgument,
+                    _cmdletPassedIn));
+
+                return Task.FromResult(results);
             }
 
+            string packageNameForInstall = PrependMARPrefix(packageName);
+            results = InstallVersion(packageNameForInstall, packageVersion, errorMsgs, debugMsgs, verboseMsgs);
             return Task.FromResult(results);
         }
 
@@ -438,6 +446,76 @@ namespace Microsoft.PowerShell.PSResourceGet
                     "InstallVersionGetContainerRegistryBlobAsyncError",
                     ErrorCategory.InvalidResult,
                     _cmdletPassedIn);
+
+                return null;
+            }
+
+            return responseContent.ReadAsStreamAsync().Result;
+        }
+
+        /// <summary>
+        /// Installs a package with version specified using concurrent queues for output instead of cmdlet streams.
+        /// Used by the async install path to avoid cross-thread cmdlet stream writes.
+        /// </summary>
+        private Stream InstallVersion(
+            string packageName,
+            string packageVersion,
+            ConcurrentQueue<ErrorRecord> errorMsgs,
+            ConcurrentQueue<string> debugMsgs,
+            ConcurrentQueue<string> verboseMsgs)
+        {
+            debugMsgs.Enqueue("In ContainerRegistryServerAPICalls::InstallVersion()");
+            string packageNameLowercase = packageName.ToLower();
+            string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                Directory.CreateDirectory(tempPath);
+            }
+            catch (Exception e)
+            {
+                errorMsgs.Enqueue(new ErrorRecord(
+                    exception: e,
+                    "InstallVersionTempDirCreationError",
+                    ErrorCategory.InvalidResult,
+                    _cmdletPassedIn));
+
+                return null;
+            }
+
+            string containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: false, isPushOperation: false, out ErrorRecord errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+                return null;
+            }
+
+            verboseMsgs.Enqueue($"Getting manifest for {packageNameLowercase} - {packageVersion}");
+            var manifest = GetContainerRegistryRepositoryManifest(packageNameLowercase, packageVersion, containerRegistryAccessToken, out errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+                return null;
+            }
+            string digest = GetDigestFromManifest(manifest, out errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+                return null;
+            }
+
+            verboseMsgs.Enqueue($"Downloading blob for {packageNameLowercase} - {packageVersion}");
+            HttpContent responseContent;
+            try
+            {
+                responseContent = GetContainerRegistryBlobAsync(packageNameLowercase, digest, containerRegistryAccessToken).Result;
+            }
+            catch (Exception e)
+            {
+                errorMsgs.Enqueue(new ErrorRecord(
+                    exception: e,
+                    "InstallVersionGetContainerRegistryBlobAsyncError",
+                    ErrorCategory.InvalidResult,
+                    _cmdletPassedIn));
 
                 return null;
             }

--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -343,7 +343,6 @@ namespace Microsoft.PowerShell.PSResourceGet
             Stream results = new MemoryStream();
             if (string.IsNullOrEmpty(packageVersion))
             {
-                errRecord = new ErrorRecord(
                     exception: new ArgumentNullException($"Package version could not be found for {packageName}"),
                     "PackageVersionNullOrEmptyError",
                     ErrorCategory.InvalidArgument,
@@ -381,7 +380,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             }
 
             string packageNameForInstall = PrependMARPrefix(packageName);
-            results = InstallVersion(packageNameForInstall, packageVersion, errorMsgs, debugMsgs, verboseMsgs);
+            results = InstallVersionAsync(packageNameForInstall, packageVersion, errorMsgs, debugMsgs, verboseMsgs);
             return Task.FromResult(results);
         }
 
@@ -457,14 +456,14 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// Installs a package with version specified using concurrent queues for output instead of cmdlet streams.
         /// Used by the async install path to avoid cross-thread cmdlet stream writes.
         /// </summary>
-        private Stream InstallVersion(
+        private Stream InstallVersionAsync(
             string packageName,
             string packageVersion,
             ConcurrentQueue<ErrorRecord> errorMsgs,
             ConcurrentQueue<string> debugMsgs,
             ConcurrentQueue<string> verboseMsgs)
         {
-            debugMsgs.Enqueue("In ContainerRegistryServerAPICalls::InstallVersion()");
+            debugMsgs.Enqueue("In ContainerRegistryServerAPICalls::InstallVersionAsync()");
             string packageNameLowercase = packageName.ToLower();
             string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             try

--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -82,14 +82,40 @@ namespace Microsoft.PowerShell.PSResourceGet
 
         #region Overridden Methods
 
+        /// <summary>
+        /// Async find method which allows for searching for single name with specific version.
+        /// Name: no wildcard support
+        /// Version: no wildcard support
+        /// This is the concurrent (parallel) counterpart of FindVersion().
+        /// </summary>
         public override Task<FindResults> FindVersionAsync(string packageName, string version, ResourceType type, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            throw new NotImplementedException("FindVersionAsync is not implemented for ContainerRegistryServerAPICalls.");
+            debugMsgs.Enqueue("In ContainerRegistryServerAPICalls::FindVersionAsync()");
+            FindResults findResponse = FindVersion(packageName, version, type, out ErrorRecord errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+            }
+
+            return Task.FromResult(findResponse);
         }
 
+        /// <summary>
+        /// Async find method which allows for searching for single name with version range.
+        /// Name: no wildcard support
+        /// Version: supports wildcards
+        /// This is the concurrent (parallel) counterpart of FindVersionGlobbing().
+        /// </summary>
         public override Task<FindResults> FindVersionGlobbingAsync(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            throw new NotImplementedException("FindVersionGlobbingAsync is not implemented for ContainerRegistryServerAPICalls.");   
+            debugMsgs.Enqueue("In ContainerRegistryServerAPICalls::FindVersionGlobbingAsync()");
+            FindResults findResponse = FindVersionGlobbing(packageName, versionRange, includePrerelease, type, getOnlyLatest, out ErrorRecord errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+            }
+
+            return Task.FromResult(findResponse);
         }
 
         /// <summary>
@@ -158,9 +184,21 @@ namespace Microsoft.PowerShell.PSResourceGet
         }
 
 
+        /// <summary>
+        /// Async find method which allows for searching for single name and returns latest version.
+        /// Name: no wildcard support
+        /// This is the concurrent (parallel) counterpart of FindName().
+        /// </summary>
         public override Task<FindResults> FindNameAsync(string packageName, bool includePrerelease, ResourceType type, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            throw new NotImplementedException("FindNameAsync is not implemented for ContainerRegistryServerAPICalls.");
+            debugMsgs.Enqueue("In ContainerRegistryServerAPICalls::FindNameAsync()");
+            FindResults findResponse = FindName(packageName, includePrerelease, type, out ErrorRecord errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+            }
+
+            return Task.FromResult(findResponse);
         }
 
         /// <summary>
@@ -329,7 +367,14 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// </summary>
         public override Task<Stream> InstallPackageAsync(string packageName, string packageVersion, bool includePrerelease, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            throw new NotImplementedException("FindNameAsync is not implemented for ContainerRegistryServerAPICalls.");
+            debugMsgs.Enqueue("In ContainerRegistryServerAPICalls::InstallPackageAsync()");
+            Stream results = InstallPackage(packageName, packageVersion, includePrerelease, out ErrorRecord errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+            }
+
+            return Task.FromResult(results);
         }
 
         /// <summary>

--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -579,7 +579,7 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// Note: Access token can be empty if the repository is unauthenticated
         /// Note: ConcurrentQueues default to null because the method calls both concurrent methods and synchronous methods. Synchronous methods may not have queues to pass in.
         /// </summary>
-        internal string GetContainerRegistryAccessToken(bool needCatalogAccess, bool isPushOperation, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
+        internal string GetContainerRegistryAccessToken(bool needCatalogAccess, bool isPushOperation, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null, ConcurrentQueue<InformationRecord> informationMsgs = null)
         {
             debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::GetContainerRegistryAccessToken()");
             string accessToken = string.Empty;
@@ -610,6 +610,9 @@ namespace Microsoft.PowerShell.PSResourceGet
                 // A container registry repository is determined to be unauthenticated if it allows anonymous pull access. However, push operations always require authentication.
                 bool isRepositoryUnauthenticated = isPushOperation ? false : IsContainerRegistryUnauthenticated(Repository.Uri.ToString(), needCatalogAccess, out errRecord, out accessToken, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                 verboseMsgs?.Enqueue($"Value of isRepositoryUnauthenticated: {isRepositoryUnauthenticated}");
+                var informationRecord = new InformationRecord($"Value of isRepositoryUnauthenticated: {isRepositoryUnauthenticated}", "PSResourceGet");
+                informationRecord.Tags.Add("PSRGContainerRegistryUnauthenticatedCheck");
+                informationMsgs?.Enqueue(informationRecord);
 
                 debugMsgs?.Enqueue($"Is repository unauthenticated: {isRepositoryUnauthenticated}");
 
@@ -1549,8 +1552,9 @@ namespace Microsoft.PowerShell.PSResourceGet
             ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
             ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
             ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
-            var containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: false, isPushOperation: true, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
-            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+            ConcurrentQueue<InformationRecord> informationMsgs = new ConcurrentQueue<InformationRecord>();
+            var containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: false, isPushOperation: true, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs, informationMsgs);
+            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs, informationMsgs);
             if (errRecord != null)
             {
                 return false;

--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -577,6 +577,7 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// If a credential is provided when registering the repository, retrieve the token from SecretsManagement.
         /// If no credential provided at registration then, check if the ACR endpoint can be accessed without a token. If not, try using Azure.Identity to get the az access token, then ACR refresh token and then ACR access token.
         /// Note: Access token can be empty if the repository is unauthenticated
+        /// Note: ConcurrentQueues default to null because the method calls both concurrent methods and synchronous methods. Synchronous methods may not have queues to pass in.
         /// </summary>
         internal string GetContainerRegistryAccessToken(bool needCatalogAccess, bool isPushOperation, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
@@ -664,6 +665,7 @@ namespace Microsoft.PowerShell.PSResourceGet
 
         /// <summary>
         /// Checks if container registry repository is unauthenticated.
+        /// Note: ConcurrentQueues default to null because the method calls both concurrent methods and synchronous methods. Synchronous methods may not have queues to pass in.
         /// </summary>
         internal bool IsContainerRegistryUnauthenticated(string containerRegistryUrl, bool needCatalogAccess, out ErrorRecord errRecord, out string anonymousAccessToken, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
@@ -763,6 +765,7 @@ namespace Microsoft.PowerShell.PSResourceGet
 
         /// <summary>
         /// Given the access token retrieved from credentials, gets the refresh token.
+        /// Note: ConcurrentQueues default to null because the method calls both concurrent methods and synchronous methods. Synchronous methods may not have queues to pass in.
         /// </summary>
         internal string GetContainerRegistryRefreshToken(string tenant, string accessToken, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
@@ -781,6 +784,7 @@ namespace Microsoft.PowerShell.PSResourceGet
 
         /// <summary>
         /// Given the refresh token, gets the new access token with appropriate scope access permissions.
+        /// Note: ConcurrentQueues default to null because the method calls both concurrent methods and synchronous methods. Synchronous methods may not have queues to pass in.
         /// </summary>
         internal string GetContainerRegistryAccessTokenByRefreshToken(string refreshToken, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
@@ -803,6 +807,7 @@ namespace Microsoft.PowerShell.PSResourceGet
 
         /// <summary>
         /// Parses package manifest JObject to find digest entry, which is the SHA needed to identify and get the package.
+        /// Note: ConcurrentQueues default to null because the method calls both concurrent methods and synchronous methods. Synchronous methods may not have queues to pass in.
         /// </summary>
         private string GetDigestFromManifest(JObject manifest, out ErrorRecord errRecord, ConcurrentQueue<string> debugMsgs = null)
         {
@@ -847,6 +852,7 @@ namespace Microsoft.PowerShell.PSResourceGet
 
         /// <summary>
         /// Gets the manifest for a package (ie repository in container registry terms) from the repository (ie registry in container registry terms)
+        /// Note: ConcurrentQueues default to null because the method calls both concurrent methods and synchronous methods. Synchronous methods may not have queues to pass in.
         /// </summary>
         internal JObject GetContainerRegistryRepositoryManifest(string packageName, string version, string containerRegistryAccessToken, out ErrorRecord errRecord, ConcurrentQueue<string> debugMsgs = null)
         {
@@ -860,6 +866,7 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// <summary>
         /// Get the blob for the package (ie repository in container registry terms) from the repository (ie registry in container registry terms)
         /// Used when installing the package
+        /// Note: ConcurrentQueues default to null because the method calls both concurrent methods and synchronous methods. Synchronous methods may not have queues to pass in.
         /// </summary>
         internal async Task<HttpContent> GetContainerRegistryBlobAsync(string packageName, string digest, string containerRegistryAccessToken, ConcurrentQueue<string> debugMsgs = null)
         {
@@ -872,6 +879,7 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// <summary>
         /// Gets the image tags associated with the package (i.e repository in container registry terms), where the tag corresponds to the package's versions.
         /// If the package version is specified search for that specific tag for the image, if the package version is "*" search for all tags for the image.
+        /// Note: ConcurrentQueues default to null because the method calls both concurrent methods and synchronous methods. Synchronous methods may not have queues to pass in.
         /// </summary>
         internal JObject FindContainerRegistryImageTags(string packageName, string version, string containerRegistryAccessToken, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
@@ -908,6 +916,7 @@ namespace Microsoft.PowerShell.PSResourceGet
 
         /// <summary>
         /// Get metadata for a package version.
+        /// Note: ConcurrentQueues default to null because the method calls both concurrent methods and synchronous methods. Synchronous methods may not have queues to pass in.
         /// </summary>
         internal Hashtable GetContainerRegistryMetadata(string packageName, string exactTagVersion, string containerRegistryAccessToken, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
@@ -1027,6 +1036,7 @@ namespace Microsoft.PowerShell.PSResourceGet
 
         /// <summary>
         /// Get the manifest associated with the package version.
+        /// Note: ConcurrentQueues default to null because the method calls both concurrent methods and synchronous methods. Synchronous methods may not have queues to pass in.
         /// </summary>
         internal JObject FindContainerRegistryManifest(string packageName, string version, string containerRegistryAccessToken, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
@@ -1040,6 +1050,7 @@ namespace Microsoft.PowerShell.PSResourceGet
 
         /// <summary>
         /// Get metadata for the package by parsing its manifest.
+        /// Note: ConcurrentQueues default to null because the method calls both concurrent methods and synchronous methods. Synchronous methods may not have queues to pass in.
         /// </summary>
         internal ContainerRegistryInfo GetMetadataProperty(JObject foundTags, string packageName, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
@@ -1136,6 +1147,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             }
         }
 
+        /// Note: ConcurrentQueues default to null because the method calls both concurrent methods and synchronous methods. Synchronous methods may not have queues to pass in.
         internal async Task<HttpContent> GetHttpContentResponseJObject(string url, Collection<KeyValuePair<string, string>> defaultHeaders, ConcurrentQueue<string> debugMsgs = null)
         {
             debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::GetHttpContentResponseJObject()");
@@ -1153,6 +1165,7 @@ namespace Microsoft.PowerShell.PSResourceGet
 
         /// <summary>
         /// Get response object when using default headers in the request.
+        /// Note: ConcurrentQueues default to null because the method calls both concurrent methods and synchronous methods. Synchronous methods may not have queues to pass in.
         /// </summary>
         internal JObject GetHttpResponseJObjectUsingDefaultHeaders(string url, HttpMethod method, Collection<KeyValuePair<string, string>> defaultHeaders, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null, bool usePagination = false)
         {
@@ -1204,6 +1217,7 @@ namespace Microsoft.PowerShell.PSResourceGet
 
         /// <summary>
         /// Get response object when using content headers in the request.
+        /// Note: ConcurrentQueues default to null because the method calls both concurrent methods and synchronous methods. Synchronous methods may not have queues to pass in.
         /// </summary>
         internal JObject GetHttpResponseJObjectUsingContentHeaders(string url, HttpMethod method, string content, Collection<KeyValuePair<string, string>> contentHeaders, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
@@ -1991,6 +2005,7 @@ namespace Microsoft.PowerShell.PSResourceGet
 
         /// <summary>
         /// Helper method for find scenarios.
+        /// Note: ConcurrentQueues default to null because the method calls both concurrent methods and synchronous methods. Synchronous methods may not have queues to pass in.
         /// </summary>
         private Hashtable[] FindPackagesWithVersionHelper(string packageName, VersionType versionType, VersionRange versionRange, NuGetVersion requiredVersion, bool includePrerelease, bool getOnlyLatest, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
@@ -2047,6 +2062,7 @@ namespace Microsoft.PowerShell.PSResourceGet
 
         /// <summary>
         /// Helper method used for find scenarios that resolves versions required from all versions found.
+        /// Note: ConcurrentQueues default to null because the method calls both concurrent methods and synchronous methods. Synchronous methods may not have queues to pass in.
         /// </summary>
         private SortedDictionary<NuGet.Versioning.SemanticVersion, string> GetPackagesWithRequiredVersion(List<JToken> allPkgVersions, VersionType versionType, VersionRange versionRange, NuGetVersion specificVersion, string packageName, bool includePrerelease, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {

--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -91,12 +91,29 @@ namespace Microsoft.PowerShell.PSResourceGet
         public override Task<FindResults> FindVersionAsync(string packageName, string version, ResourceType type, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
             debugMsgs.Enqueue("In ContainerRegistryServerAPICalls::FindVersionAsync()");
-            FindResults findResponse = FindVersion(packageName, version, type, out ErrorRecord errRecord);
+            if (!NuGetVersion.TryParse(version, out NuGetVersion requiredVersion))
+            {
+                errorMsgs.Enqueue(new ErrorRecord(
+                    new ArgumentException($"Version {version} to be found is not a valid NuGet version."),
+                    "FindNameFailure",
+                    ErrorCategory.InvalidArgument,
+                    this));
+
+                return Task.FromResult(emptyResponseResults);
+            }
+
+            debugMsgs.Enqueue($"'{packageName}' version parsed as '{requiredVersion}'");
+            bool includePrereleaseVersions = requiredVersion.IsPrerelease;
+
+            // for FindVersion(), need to consider the specific required version (hence VersionType.SpecificVersion and no version range)
+            Hashtable[] pkgResult = FindPackagesWithVersionHelper(packageName, VersionType.SpecificVersion, versionRange: VersionRange.None, requiredVersion: requiredVersion, includePrereleaseVersions, getOnlyLatest: false, out ErrorRecord errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);
+                return Task.FromResult(emptyResponseResults);
             }
 
+            FindResults findResponse = new FindResults(stringResponse: new string[] { }, hashtableResponse: pkgResult.ToArray(), responseType: containerRegistryFindResponseType);
             return Task.FromResult(findResponse);
         }
 
@@ -109,12 +126,16 @@ namespace Microsoft.PowerShell.PSResourceGet
         public override Task<FindResults> FindVersionGlobbingAsync(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
             debugMsgs.Enqueue("In ContainerRegistryServerAPICalls::FindVersionGlobbingAsync()");
-            FindResults findResponse = FindVersionGlobbing(packageName, versionRange, includePrerelease, type, getOnlyLatest, out ErrorRecord errRecord);
+
+            // for FindVersionGlobbing(), need to consider all versions that match version range criteria (hence VersionType.VersionRange and no requiredVersion)
+            Hashtable[] pkgResults = FindPackagesWithVersionHelper(packageName, VersionType.VersionRange, versionRange: versionRange, requiredVersion: null, includePrerelease, getOnlyLatest: false, out ErrorRecord errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);
+                return Task.FromResult(emptyResponseResults);
             }
 
+            FindResults findResponse = new FindResults(stringResponse: new string[] { }, hashtableResponse: pkgResults.ToArray(), responseType: containerRegistryFindResponseType);
             return Task.FromResult(findResponse);
         }
 
@@ -172,9 +193,14 @@ namespace Microsoft.PowerShell.PSResourceGet
         public override FindResults FindName(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::FindName()");
+            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
 
             // for FindName(), need to consider all versions (hence VersionType.VersionRange and VersionRange.All, and no requiredVersion) but only pick latest (hence getOnlyLatest: true)
-            Hashtable[] pkgResult = FindPackagesWithVersionHelper(packageName, VersionType.VersionRange, versionRange: VersionRange.All, requiredVersion: null, includePrerelease, getOnlyLatest: true, out errRecord);
+            Hashtable[] pkgResult = FindPackagesWithVersionHelper(packageName, VersionType.VersionRange, versionRange: VersionRange.All, requiredVersion: null, includePrerelease, getOnlyLatest: true, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return emptyResponseResults;
@@ -192,12 +218,16 @@ namespace Microsoft.PowerShell.PSResourceGet
         public override Task<FindResults> FindNameAsync(string packageName, bool includePrerelease, ResourceType type, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
             debugMsgs.Enqueue("In ContainerRegistryServerAPICalls::FindNameAsync()");
-            FindResults findResponse = FindName(packageName, includePrerelease, type, out ErrorRecord errRecord);
+
+            // for FindName(), need to consider all versions (hence VersionType.VersionRange and VersionRange.All, and no requiredVersion) but only pick latest (hence getOnlyLatest: true)
+            Hashtable[] pkgResult = FindPackagesWithVersionHelper(packageName, VersionType.VersionRange, versionRange: VersionRange.All, requiredVersion: null, includePrerelease, getOnlyLatest: true, out ErrorRecord errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);
+                return Task.FromResult(emptyResponseResults);
             }
 
+            FindResults findResponse = new FindResults(stringResponse: new string[] { }, hashtableResponse: pkgResult.ToArray(), responseType: containerRegistryFindResponseType);
             return Task.FromResult(findResponse);
         }
 
@@ -265,9 +295,14 @@ namespace Microsoft.PowerShell.PSResourceGet
         public override FindResults FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::FindVersionGlobbing()");
+            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
 
             // for FindVersionGlobbing(), need to consider all versions that match version range criteria (hence VersionType.VersionRange and no requiredVersion)
-            Hashtable[] pkgResults = FindPackagesWithVersionHelper(packageName, VersionType.VersionRange, versionRange: versionRange, requiredVersion: null, includePrerelease, getOnlyLatest: false, out errRecord);
+            Hashtable[] pkgResults = FindPackagesWithVersionHelper(packageName, VersionType.VersionRange, versionRange: versionRange, requiredVersion: null, includePrerelease, getOnlyLatest: false, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return emptyResponseResults;
@@ -298,9 +333,14 @@ namespace Microsoft.PowerShell.PSResourceGet
 
             _cmdletPassedIn.WriteDebug($"'{packageName}' version parsed as '{requiredVersion}'");
             bool includePrereleaseVersions = requiredVersion.IsPrerelease;
+            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
 
             // for FindVersion(), need to consider the specific required version (hence VersionType.SpecificVersion and no version range)
-            Hashtable[] pkgResult = FindPackagesWithVersionHelper(packageName, VersionType.SpecificVersion, versionRange: VersionRange.None, requiredVersion: requiredVersion, includePrereleaseVersions, getOnlyLatest: false, out errRecord);
+            Hashtable[] pkgResult = FindPackagesWithVersionHelper(packageName, VersionType.SpecificVersion, versionRange: VersionRange.None, requiredVersion: requiredVersion, includePrereleaseVersions, getOnlyLatest: false, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return emptyResponseResults;
@@ -399,6 +439,10 @@ namespace Microsoft.PowerShell.PSResourceGet
             string packageNameLowercase = packageName.ToLower();
             string accessToken = string.Empty;
             string tenantID = string.Empty;
+            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
             string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             try
             {
@@ -415,7 +459,8 @@ namespace Microsoft.PowerShell.PSResourceGet
                 return null;
             }
 
-            string containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: false, isPushOperation: false, out errRecord);
+            string containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: false, isPushOperation: false, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return null;
@@ -482,7 +527,7 @@ namespace Microsoft.PowerShell.PSResourceGet
                 return null;
             }
 
-            string containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: false, isPushOperation: false, out ErrorRecord errRecord);
+            string containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: false, isPushOperation: false, out ErrorRecord errRecord, errorMsgs, warningMsgs: null, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);
@@ -533,9 +578,9 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// If no credential provided at registration then, check if the ACR endpoint can be accessed without a token. If not, try using Azure.Identity to get the az access token, then ACR refresh token and then ACR access token.
         /// Note: Access token can be empty if the repository is unauthenticated
         /// </summary>
-        internal string GetContainerRegistryAccessToken(bool needCatalogAccess, bool isPushOperation, out ErrorRecord errRecord)
+        internal string GetContainerRegistryAccessToken(bool needCatalogAccess, bool isPushOperation, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
-            _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::GetContainerRegistryAccessToken()");
+            debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::GetContainerRegistryAccessToken()");
             string accessToken = string.Empty;
             string containerRegistryAccessToken = string.Empty;
             string tenantID = string.Empty;
@@ -543,7 +588,7 @@ namespace Microsoft.PowerShell.PSResourceGet
 
             if (!string.IsNullOrEmpty(_cachedContainterRegistryToken))
             {
-                _cmdletPassedIn.WriteVerbose("Using cached container registry access token.");
+                verboseMsgs?.Enqueue("Using cached container registry access token.");
                 return _cachedContainterRegistryToken;
             }
 
@@ -555,17 +600,17 @@ namespace Microsoft.PowerShell.PSResourceGet
                     repositoryCredentialInfo,
                     _cmdletPassedIn);
 
-                _cmdletPassedIn.WriteVerbose("Access token retrieved.");
+                verboseMsgs?.Enqueue("Access token retrieved.");
 
                 tenantID = repositoryCredentialInfo.SecretName;
             }
             else
             {
                 // A container registry repository is determined to be unauthenticated if it allows anonymous pull access. However, push operations always require authentication.
-                bool isRepositoryUnauthenticated = isPushOperation ? false : IsContainerRegistryUnauthenticated(Repository.Uri.ToString(), needCatalogAccess, out errRecord, out accessToken);
-                _cmdletPassedIn.WriteInformation($"Value of isRepositoryUnauthenticated: {isRepositoryUnauthenticated}", new string[] { "PSRGContainerRegistryUnauthenticatedCheck" });
+                bool isRepositoryUnauthenticated = isPushOperation ? false : IsContainerRegistryUnauthenticated(Repository.Uri.ToString(), needCatalogAccess, out errRecord, out accessToken, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+                verboseMsgs?.Enqueue($"Value of isRepositoryUnauthenticated: {isRepositoryUnauthenticated}");
 
-                _cmdletPassedIn.WriteDebug($"Is repository unauthenticated: {isRepositoryUnauthenticated}");
+                debugMsgs?.Enqueue($"Is repository unauthenticated: {isRepositoryUnauthenticated}");
 
                 if (errRecord != null)
                 {
@@ -574,7 +619,7 @@ namespace Microsoft.PowerShell.PSResourceGet
 
                 if (!string.IsNullOrEmpty(accessToken))
                 {
-                    _cmdletPassedIn.WriteVerbose("Anonymous access token retrieved.");
+                    verboseMsgs?.Enqueue("Anonymous access token retrieved.");
                     return accessToken;
                 }
 
@@ -594,24 +639,24 @@ namespace Microsoft.PowerShell.PSResourceGet
                 }
                 else
                 {
-                    _cmdletPassedIn.WriteVerbose("Repository is unauthenticated");
+                    verboseMsgs?.Enqueue("Repository is unauthenticated");
                     return null;
                 }
             }
 
-            var containerRegistryRefreshToken = GetContainerRegistryRefreshToken(tenantID, accessToken, out errRecord);
+            var containerRegistryRefreshToken = GetContainerRegistryRefreshToken(tenantID, accessToken, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return null;
             }
 
-            containerRegistryAccessToken = GetContainerRegistryAccessTokenByRefreshToken(containerRegistryRefreshToken, out errRecord);
+            containerRegistryAccessToken = GetContainerRegistryAccessTokenByRefreshToken(containerRegistryRefreshToken, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return null;
             }
 
-            _cmdletPassedIn.WriteVerbose("Container registry access token retrieved.");
+            verboseMsgs?.Enqueue("Container registry access token retrieved.");
             _cachedContainterRegistryToken = containerRegistryAccessToken;
 
             return containerRegistryAccessToken;
@@ -620,9 +665,9 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// <summary>
         /// Checks if container registry repository is unauthenticated.
         /// </summary>
-        internal bool IsContainerRegistryUnauthenticated(string containerRegistryUrl, bool needCatalogAccess, out ErrorRecord errRecord, out string anonymousAccessToken)
+        internal bool IsContainerRegistryUnauthenticated(string containerRegistryUrl, bool needCatalogAccess, out ErrorRecord errRecord, out string anonymousAccessToken, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
-            _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::IsContainerRegistryUnauthenticated()");
+            debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::IsContainerRegistryUnauthenticated()");
             errRecord = null;
             anonymousAccessToken = string.Empty;
             string endpoint = $"{containerRegistryUrl}/v2/";
@@ -664,24 +709,24 @@ namespace Microsoft.PowerShell.PSResourceGet
 
                                 string url = needCatalogAccess ? String.Format(authUrlTemplate, realm, service, catalogScope) : String.Format(authUrlTemplate, realm, service, defaultScope);
 
-                                _cmdletPassedIn.WriteDebug($"Getting anonymous access token from the realm: {url}");
+                                debugMsgs?.Enqueue($"Getting anonymous access token from the realm: {url}");
 
                                 // we don't check the error record here because we want to return false if we get a 401 and not throw an error
-                                _cmdletPassedIn.WriteDebug($"Getting anonymous access token from the realm: {url}");
+                                debugMsgs?.Enqueue($"Getting anonymous access token from the realm: {url}");
                                 ErrorRecord errRecordTemp = null;
 
-                                var results = GetHttpResponseJObjectUsingContentHeaders(url, HttpMethod.Get, content, contentHeaders, out errRecordTemp);
+                                var results = GetHttpResponseJObjectUsingContentHeaders(url, HttpMethod.Get, content, contentHeaders, out errRecordTemp, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
 
                                 if (results == null)
                                 {
-                                    _cmdletPassedIn.WriteDebug("Failed to get access token from the realm. results is null.");
-                                    _cmdletPassedIn.WriteDebug($"ErrorRecord: {errRecordTemp}");
+                                    debugMsgs?.Enqueue("Failed to get access token from the realm. results is null.");
+                                    debugMsgs?.Enqueue($"ErrorRecord: {errRecordTemp}");
                                     return false;
                                 }
 
                                 if (results["access_token"] == null)
                                 {
-                                    _cmdletPassedIn.WriteDebug($"Failed to get access token from the realm. access_token is null. results: {results}");
+                                    debugMsgs?.Enqueue($"Failed to get access token from the realm. access_token is null. results: {results}");
                                     return false;
                                 }
 
@@ -719,13 +764,13 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// <summary>
         /// Given the access token retrieved from credentials, gets the refresh token.
         /// </summary>
-        internal string GetContainerRegistryRefreshToken(string tenant, string accessToken, out ErrorRecord errRecord)
+        internal string GetContainerRegistryRefreshToken(string tenant, string accessToken, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
-            _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::GetContainerRegistryRefreshToken()");
+            debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::GetContainerRegistryRefreshToken()");
             string content = string.Format(containerRegistryRefreshTokenTemplate, Registry, tenant, accessToken);
             var contentHeaders = new Collection<KeyValuePair<string, string>> { new KeyValuePair<string, string>("Content-Type", "application/x-www-form-urlencoded") };
             string exchangeUrl = string.Format(containerRegistryOAuthExchangeUrlTemplate, Registry);
-            var results = GetHttpResponseJObjectUsingContentHeaders(exchangeUrl, HttpMethod.Post, content, contentHeaders, out errRecord);
+            var results = GetHttpResponseJObjectUsingContentHeaders(exchangeUrl, HttpMethod.Post, content, contentHeaders, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null || results == null || results["refresh_token"] == null)
             {
                 return string.Empty;
@@ -737,13 +782,13 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// <summary>
         /// Given the refresh token, gets the new access token with appropriate scope access permissions.
         /// </summary>
-        internal string GetContainerRegistryAccessTokenByRefreshToken(string refreshToken, out ErrorRecord errRecord)
+        internal string GetContainerRegistryAccessTokenByRefreshToken(string refreshToken, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
-            _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::GetContainerRegistryAccessTokenByRefreshToken()");
+            debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::GetContainerRegistryAccessTokenByRefreshToken()");
             string content = string.Format(containerRegistryAccessTokenTemplate, Registry, refreshToken);
             var contentHeaders = new Collection<KeyValuePair<string, string>> { new KeyValuePair<string, string>("Content-Type", "application/x-www-form-urlencoded") };
             string tokenUrl = string.Format(containerRegistryOAuthTokenUrlTemplate, Registry);
-            var results = GetHttpResponseJObjectUsingContentHeaders(tokenUrl, HttpMethod.Post, content, contentHeaders, out errRecord);
+            var results = GetHttpResponseJObjectUsingContentHeaders(tokenUrl, HttpMethod.Post, content, contentHeaders, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null || results == null || results["access_token"] == null)
             {
                 return string.Empty;
@@ -828,7 +873,7 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// Gets the image tags associated with the package (i.e repository in container registry terms), where the tag corresponds to the package's versions.
         /// If the package version is specified search for that specific tag for the image, if the package version is "*" search for all tags for the image.
         /// </summary>
-        internal JObject FindContainerRegistryImageTags(string packageName, string version, string containerRegistryAccessToken, out ErrorRecord errRecord)
+        internal JObject FindContainerRegistryImageTags(string packageName, string version, string containerRegistryAccessToken, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
             /*
             {
@@ -844,7 +889,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             string resolvedVersion = string.Equals(version, "*", StringComparison.OrdinalIgnoreCase) ? null : $"/{version}";
             string findImageUrl = string.Format(containerRegistryFindImageVersionUrlTemplate, Registry, packageName);
             var defaultHeaders = GetDefaultHeaders(containerRegistryAccessToken);
-            return GetHttpResponseJObjectUsingDefaultHeaders(findImageUrl, HttpMethod.Get, defaultHeaders, out errRecord);
+            return GetHttpResponseJObjectUsingDefaultHeaders(findImageUrl, HttpMethod.Get, defaultHeaders, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
         }
 
         /// <summary>
@@ -864,12 +909,12 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// <summary>
         /// Get metadata for a package version.
         /// </summary>
-        internal Hashtable GetContainerRegistryMetadata(string packageName, string exactTagVersion, string containerRegistryAccessToken, out ErrorRecord errRecord)
+        internal Hashtable GetContainerRegistryMetadata(string packageName, string exactTagVersion, string containerRegistryAccessToken, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
-            _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::GetContainerRegistryMetadata()");
+            debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::GetContainerRegistryMetadata()");
             Hashtable requiredVersionResponse = new();
 
-            JObject foundTags = FindContainerRegistryManifest(packageName, exactTagVersion, containerRegistryAccessToken, out errRecord);
+            JObject foundTags = FindContainerRegistryManifest(packageName, exactTagVersion, containerRegistryAccessToken, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return requiredVersionResponse;
@@ -898,7 +943,7 @@ namespace Microsoft.PowerShell.PSResourceGet
                 }
             */
 
-            ContainerRegistryInfo serverPkgInfo = GetMetadataProperty(foundTags, packageName, out errRecord);
+            ContainerRegistryInfo serverPkgInfo = GetMetadataProperty(foundTags, packageName, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return requiredVersionResponse;
@@ -959,7 +1004,7 @@ namespace Microsoft.PowerShell.PSResourceGet
                         return requiredVersionResponse;
                     }
 
-                    _cmdletPassedIn.WriteDebug($"'{packageName}' version parsed as '{pkgVersion}'");
+                    debugMsgs?.Enqueue($"'{packageName}' version parsed as '{pkgVersion}'");
                     if (pkgVersion.ToNormalizedString() == requiredVersion.ToNormalizedString())
                     {
                         requiredVersionResponse = serverPkgInfo.ToHashtable();
@@ -983,22 +1028,22 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// <summary>
         /// Get the manifest associated with the package version.
         /// </summary>
-        internal JObject FindContainerRegistryManifest(string packageName, string version, string containerRegistryAccessToken, out ErrorRecord errRecord)
+        internal JObject FindContainerRegistryManifest(string packageName, string version, string containerRegistryAccessToken, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
-            _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::FindContainerRegistryManifest()");
+            debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::FindContainerRegistryManifest()");
             var createManifestUrl = string.Format(containerRegistryManifestUrlTemplate, Registry, packageName, version);
-            _cmdletPassedIn.WriteDebug($"GET manifest url:  {createManifestUrl}");
+            debugMsgs?.Enqueue($"GET manifest url:  {createManifestUrl}");
 
             var defaultHeaders = GetDefaultHeaders(containerRegistryAccessToken);
-            return GetHttpResponseJObjectUsingDefaultHeaders(createManifestUrl, HttpMethod.Get, defaultHeaders, out errRecord);
+            return GetHttpResponseJObjectUsingDefaultHeaders(createManifestUrl, HttpMethod.Get, defaultHeaders, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
         }
 
         /// <summary>
         /// Get metadata for the package by parsing its manifest.
         /// </summary>
-        internal ContainerRegistryInfo GetMetadataProperty(JObject foundTags, string packageName, out ErrorRecord errRecord)
+        internal ContainerRegistryInfo GetMetadataProperty(JObject foundTags, string packageName, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
-            _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::GetMetadataProperty()");
+            debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::GetMetadataProperty()");
             errRecord = null;
             ContainerRegistryInfo serverPkgInfo = null;
 
@@ -1109,9 +1154,9 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// <summary>
         /// Get response object when using default headers in the request.
         /// </summary>
-        internal JObject GetHttpResponseJObjectUsingDefaultHeaders(string url, HttpMethod method, Collection<KeyValuePair<string, string>> defaultHeaders, out ErrorRecord errRecord, bool usePagination = false)
+        internal JObject GetHttpResponseJObjectUsingDefaultHeaders(string url, HttpMethod method, Collection<KeyValuePair<string, string>> defaultHeaders, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null, bool usePagination = false)
         {
-            _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::GetHttpResponseJObjectUsingDefaultHeaders()");
+            debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::GetHttpResponseJObjectUsingDefaultHeaders()");
             try
             {
                 errRecord = null;
@@ -1160,9 +1205,9 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// <summary>
         /// Get response object when using content headers in the request.
         /// </summary>
-        internal JObject GetHttpResponseJObjectUsingContentHeaders(string url, HttpMethod method, string content, Collection<KeyValuePair<string, string>> contentHeaders, out ErrorRecord errRecord)
+        internal JObject GetHttpResponseJObjectUsingContentHeaders(string url, HttpMethod method, string content, Collection<KeyValuePair<string, string>> contentHeaders, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
-            _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::GetHttpResponseJObjectUsingContentHeaders()");
+            debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::GetHttpResponseJObjectUsingContentHeaders()");
             errRecord = null;
             try
             {
@@ -1486,7 +1531,12 @@ namespace Microsoft.PowerShell.PSResourceGet
 
             // Get access token (includes refresh tokens)
             _cmdletPassedIn.WriteVerbose($"Get access token for container registry server.");
-            var containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: false, isPushOperation: true, out errRecord);
+            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
+            var containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: false, isPushOperation: true, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return false;
@@ -1942,22 +1992,22 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// <summary>
         /// Helper method for find scenarios.
         /// </summary>
-        private Hashtable[] FindPackagesWithVersionHelper(string packageName, VersionType versionType, VersionRange versionRange, NuGetVersion requiredVersion, bool includePrerelease, bool getOnlyLatest, out ErrorRecord errRecord)
+        private Hashtable[] FindPackagesWithVersionHelper(string packageName, VersionType versionType, VersionRange versionRange, NuGetVersion requiredVersion, bool includePrerelease, bool getOnlyLatest, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
-            _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::FindPackagesWithVersionHelper()");
+            debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::FindPackagesWithVersionHelper()");
             string accessToken = string.Empty;
             string tenantID = string.Empty;
             string registryUrl = Repository.Uri.ToString();
             string packageNameLowercase = packageName.ToLower();
 
             string packageNameForFind = PrependMARPrefix(packageNameLowercase);
-            string containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: false, isPushOperation: false,out errRecord);
+            string containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: false, isPushOperation: false, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return emptyHashResponses;
             }
 
-            var foundTags = FindContainerRegistryImageTags(packageNameForFind, "*", containerRegistryAccessToken, out errRecord);
+            var foundTags = FindContainerRegistryImageTags(packageNameForFind, "*", containerRegistryAccessToken, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null || foundTags == null)
             {
                 return emptyHashResponses;
@@ -1966,10 +2016,10 @@ namespace Microsoft.PowerShell.PSResourceGet
             List<Hashtable> latestVersionResponse = new List<Hashtable>();
             List<JToken> allVersionsList = foundTags["tags"].ToList();
 
-            SortedDictionary<NuGet.Versioning.SemanticVersion, string> sortedQualifyingPkgs = GetPackagesWithRequiredVersion(allVersionsList, versionType, versionRange, requiredVersion, packageNameForFind, includePrerelease, out errRecord);
+            SortedDictionary<NuGet.Versioning.SemanticVersion, string> sortedQualifyingPkgs = GetPackagesWithRequiredVersion(allVersionsList, versionType, versionRange, requiredVersion, packageNameForFind, includePrerelease, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null && sortedQualifyingPkgs?.Count == 0)
             {
-                _cmdletPassedIn.WriteDebug("No qualifying packages found for the specified criteria.");
+                debugMsgs?.Enqueue("No qualifying packages found for the specified criteria.");
                 return emptyHashResponses;
             }
 
@@ -1978,7 +2028,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             foreach (var pkgVersionTag in pkgsInDescendingOrder)
             {
                 string exactTagVersion = pkgVersionTag.Value.ToString();
-                Hashtable metadata = GetContainerRegistryMetadata(packageNameForFind, exactTagVersion, containerRegistryAccessToken, out errRecord);
+                Hashtable metadata = GetContainerRegistryMetadata(packageNameForFind, exactTagVersion, containerRegistryAccessToken, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                 if (errRecord != null || metadata.Count == 0)
                 {
                     return emptyHashResponses;
@@ -1998,9 +2048,9 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// <summary>
         /// Helper method used for find scenarios that resolves versions required from all versions found.
         /// </summary>
-        private SortedDictionary<NuGet.Versioning.SemanticVersion, string> GetPackagesWithRequiredVersion(List<JToken> allPkgVersions, VersionType versionType, VersionRange versionRange, NuGetVersion specificVersion, string packageName, bool includePrerelease, out ErrorRecord errRecord)
+        private SortedDictionary<NuGet.Versioning.SemanticVersion, string> GetPackagesWithRequiredVersion(List<JToken> allPkgVersions, VersionType versionType, VersionRange versionRange, NuGetVersion specificVersion, string packageName, bool includePrerelease, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs = null, ConcurrentQueue<string> warningMsgs = null, ConcurrentQueue<string> debugMsgs = null, ConcurrentQueue<string> verboseMsgs = null)
         {
-            _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::GetPackagesWithRequiredVersion()");
+            debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::GetPackagesWithRequiredVersion()");
             errRecord = null;
             // we need NuGetVersion to sort versions by order, and string pkgVersionString (which is the exact tag from the server) to call GetContainerRegistryMetadata() later with exact version tag.
             SortedDictionary<NuGet.Versioning.SemanticVersion, string> sortedPkgs = new SortedDictionary<SemanticVersion, string>(VersionComparer.Default);
@@ -2018,12 +2068,12 @@ namespace Microsoft.PowerShell.PSResourceGet
                         ErrorCategory.InvalidArgument,
                         this);
 
-                    _cmdletPassedIn.WriteError(errRecord);
-                    _cmdletPassedIn.WriteDebug($"Skipping package '{packageName}' with version '{pkgVersionString}' as it is not a valid NuGet version.");
+                    errorMsgs?.Enqueue(errRecord);
+                    debugMsgs?.Enqueue($"Skipping package '{packageName}' with version '{pkgVersionString}' as it is not a valid NuGet version.");
                     continue; // skip this version and continue with the next one
                 }
 
-                _cmdletPassedIn.WriteDebug($"'{packageName}' version parsed as '{pkgVersion}'");
+                debugMsgs?.Enqueue($"'{packageName}' version parsed as '{pkgVersion}'");
 
                 if (isSpecificVersionSearch)
                 {
@@ -2063,7 +2113,12 @@ namespace Microsoft.PowerShell.PSResourceGet
         {
             _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::FindPackages()");
             errRecord = null;
-            string containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: true, isPushOperation: false, out errRecord);
+            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
+            string containerRegistryAccessToken = GetContainerRegistryAccessToken(needCatalogAccess: true, isPushOperation: false, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return emptyResponseResults;
@@ -2100,7 +2155,8 @@ namespace Microsoft.PowerShell.PSResourceGet
 
                 _cmdletPassedIn.WriteDebug($"Found repository: {repositoryName}");
 
-                repositoriesList.AddRange(FindPackagesWithVersionHelper(repositoryName, VersionType.VersionRange, versionRange: VersionRange.All, requiredVersion: null, includePrerelease, getOnlyLatest: true, out errRecord));
+                repositoriesList.AddRange(FindPackagesWithVersionHelper(repositoryName, VersionType.VersionRange, versionRange: VersionRange.All, requiredVersion: null, includePrerelease, getOnlyLatest: true, out errRecord, errorMsgs, warningMsgs, debugMsgs, verboseMsgs));
+                Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                 if (errRecord != null)
                 {
                     return emptyResponseResults;

--- a/src/code/ContainerRegistryServerAPICalls.cs
+++ b/src/code/ContainerRegistryServerAPICalls.cs
@@ -535,13 +535,13 @@ namespace Microsoft.PowerShell.PSResourceGet
             }
 
             verboseMsgs.Enqueue($"Getting manifest for {packageNameLowercase} - {packageVersion}");
-            var manifest = GetContainerRegistryRepositoryManifest(packageNameLowercase, packageVersion, containerRegistryAccessToken, out errRecord);
+            var manifest = GetContainerRegistryRepositoryManifest(packageNameLowercase, packageVersion, containerRegistryAccessToken, out errRecord, debugMsgs);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);
                 return null;
             }
-            string digest = GetDigestFromManifest(manifest, out errRecord);
+            string digest = GetDigestFromManifest(manifest, out errRecord, debugMsgs);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);
@@ -552,7 +552,7 @@ namespace Microsoft.PowerShell.PSResourceGet
             HttpContent responseContent;
             try
             {
-                responseContent = GetContainerRegistryBlobAsync(packageNameLowercase, digest, containerRegistryAccessToken).Result;
+                responseContent = GetContainerRegistryBlobAsync(packageNameLowercase, digest, containerRegistryAccessToken, debugMsgs).Result;
             }
             catch (Exception e)
             {
@@ -804,9 +804,9 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// <summary>
         /// Parses package manifest JObject to find digest entry, which is the SHA needed to identify and get the package.
         /// </summary>
-        private string GetDigestFromManifest(JObject manifest, out ErrorRecord errRecord)
+        private string GetDigestFromManifest(JObject manifest, out ErrorRecord errRecord, ConcurrentQueue<string> debugMsgs = null)
         {
-            _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::GetDigestFromManifest()");
+            debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::GetDigestFromManifest()");
             errRecord = null;
             string digest = String.Empty;
 
@@ -848,25 +848,25 @@ namespace Microsoft.PowerShell.PSResourceGet
         /// <summary>
         /// Gets the manifest for a package (ie repository in container registry terms) from the repository (ie registry in container registry terms)
         /// </summary>
-        internal JObject GetContainerRegistryRepositoryManifest(string packageName, string version, string containerRegistryAccessToken, out ErrorRecord errRecord)
+        internal JObject GetContainerRegistryRepositoryManifest(string packageName, string version, string containerRegistryAccessToken, out ErrorRecord errRecord, ConcurrentQueue<string> debugMsgs = null)
         {
-            _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::GetContainerRegistryRepositoryManifest()");
+            debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::GetContainerRegistryRepositoryManifest()");
             // example of manifestUrl: https://psgetregistry.azurecr.io/hello-world:3.0.0
             string manifestUrl = string.Format(containerRegistryManifestUrlTemplate, Registry, packageName, version);
             var defaultHeaders = GetDefaultHeaders(containerRegistryAccessToken);
-            return GetHttpResponseJObjectUsingDefaultHeaders(manifestUrl, HttpMethod.Get, defaultHeaders, out errRecord);
+            return GetHttpResponseJObjectUsingDefaultHeaders(manifestUrl, HttpMethod.Get, defaultHeaders, out errRecord, debugMsgs: debugMsgs);
         }
 
         /// <summary>
         /// Get the blob for the package (ie repository in container registry terms) from the repository (ie registry in container registry terms)
         /// Used when installing the package
         /// </summary>
-        internal async Task<HttpContent> GetContainerRegistryBlobAsync(string packageName, string digest, string containerRegistryAccessToken)
+        internal async Task<HttpContent> GetContainerRegistryBlobAsync(string packageName, string digest, string containerRegistryAccessToken, ConcurrentQueue<string> debugMsgs = null)
         {
-            _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::GetContainerRegistryBlobAsync()");
+            debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::GetContainerRegistryBlobAsync()");
             string blobUrl = string.Format(containerRegistryBlobDownloadUrlTemplate, Registry, packageName, digest);
             var defaultHeaders = GetDefaultHeaders(containerRegistryAccessToken);
-            return await GetHttpContentResponseJObject(blobUrl, defaultHeaders);
+            return await GetHttpContentResponseJObject(blobUrl, defaultHeaders, debugMsgs);
         }
 
         /// <summary>
@@ -885,7 +885,7 @@ namespace Microsoft.PowerShell.PSResourceGet
                   ]
                 }
             */
-            _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::FindContainerRegistryImageTags()");
+            debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::FindContainerRegistryImageTags()");
             string resolvedVersion = string.Equals(version, "*", StringComparison.OrdinalIgnoreCase) ? null : $"/{version}";
             string findImageUrl = string.Format(containerRegistryFindImageVersionUrlTemplate, Registry, packageName);
             var defaultHeaders = GetDefaultHeaders(containerRegistryAccessToken);
@@ -1136,9 +1136,9 @@ namespace Microsoft.PowerShell.PSResourceGet
             }
         }
 
-        internal async Task<HttpContent> GetHttpContentResponseJObject(string url, Collection<KeyValuePair<string, string>> defaultHeaders)
+        internal async Task<HttpContent> GetHttpContentResponseJObject(string url, Collection<KeyValuePair<string, string>> defaultHeaders, ConcurrentQueue<string> debugMsgs = null)
         {
-            _cmdletPassedIn.WriteDebug("In ContainerRegistryServerAPICalls::GetHttpContentResponseJObject()");
+            debugMsgs?.Enqueue("In ContainerRegistryServerAPICalls::GetHttpContentResponseJObject()");
             try
             {
                 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -1419,7 +1419,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             ConcurrentDictionary<string, Task<FindResults>> cachedNetworkCalls = new ConcurrentDictionary<string, Task<FindResults>>();
             debugMsgs.Enqueue("In FindHelper::FindDependencyWithUpperBound()");
-            // See if the network call we're making is already caced, if not, call FindNameAsync() and cache results
+            // See if the network call we're making is already cached, if not, call FindNameAsync() and cache results
             string key = $"{dep.Name}|{dep.VersionRange.MaxVersion.ToString()}|{_type}";
             debugMsgs.Enqueue("Checking if network call is cached.");
             response = cachedNetworkCalls.GetOrAdd(key, _ => currentServer.FindVersionGlobbingAsync(dep.Name, dep.VersionRange, includePrerelease: true, ResourceType.None, getOnlyLatest: true, errorMsgs, warningMsgs, debugMsgs, verboseMsgs));

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -1282,12 +1282,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             debugMsgs.Enqueue("In FindHelper::FindDependencyWithSpecificVersion()");
 
             
-            // See if the network call we're making is already cached, if not, call FindNameAsync() and cache results
+            // Call FindVersionAsync() for dependency with specific version.
             string key = $"{dep.Name}|{dep.VersionRange.MaxVersion.ToString()}|{_type}";
-            debugMsgs.Enqueue("Checking if network call is cached.");
-            response = _cachedNetworkCalls.GetOrAdd(key, _ => currentServer.FindVersionAsync(dep.Name, dep.VersionRange.MaxVersion.ToString(), _type, errorMsgs, warningMsgs, debugMsgs, verboseMsgs));
-            
-            responses = response.GetAwaiter().GetResult();
+            responses = currentServer.FindVersionAsync(dep.Name, dep.VersionRange.MaxVersion.ToString(), _type, errorMsgs, warningMsgs, debugMsgs, verboseMsgs).GetAwaiter().GetResult();
+            errorMsgs.TryPeek(out errRecord);
 
             // Error handling and Convert to PSResource object
             if (errRecord != null)

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -1278,14 +1278,41 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             PSResourceInfo depPkg = null;
             ErrorRecord errRecord = null;
             FindResults responses = null;
-            Task<FindResults> response = null;
             debugMsgs.Enqueue("In FindHelper::FindDependencyWithSpecificVersion()");
 
-            
+            ConcurrentQueue<ErrorRecord> operationErrorMsgs = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> operationWarningMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> operationDebugMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> operationVerboseMsgs = new ConcurrentQueue<string>();
+
             // Call FindVersionAsync() for dependency with specific version.
             string key = $"{dep.Name}|{dep.VersionRange.MaxVersion.ToString()}|{_type}";
-            responses = currentServer.FindVersionAsync(dep.Name, dep.VersionRange.MaxVersion.ToString(), _type, errorMsgs, warningMsgs, debugMsgs, verboseMsgs).GetAwaiter().GetResult();
-            errorMsgs.TryPeek(out errRecord);
+            responses = currentServer.FindVersionAsync(dep.Name, dep.VersionRange.MaxVersion.ToString(), _type, operationErrorMsgs, operationWarningMsgs, operationDebugMsgs, operationVerboseMsgs).GetAwaiter().GetResult();
+
+            while (operationErrorMsgs.TryDequeue(out ErrorRecord queuedError))
+            {
+                if (errRecord == null)
+                {
+                    errRecord = queuedError;
+                }
+
+                errorMsgs.Enqueue(queuedError);
+            }
+
+            while (operationWarningMsgs.TryDequeue(out string queuedWarning))
+            {
+                warningMsgs.Enqueue(queuedWarning);
+            }
+
+            while (operationDebugMsgs.TryDequeue(out string queuedDebug))
+            {
+                debugMsgs.Enqueue(queuedDebug);
+            }
+
+            while (operationVerboseMsgs.TryDequeue(out string queuedVerbose))
+            {
+                verboseMsgs.Enqueue(queuedVerbose);
+            }
 
             // Error handling and Convert to PSResource object
             if (errRecord != null)

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -984,6 +984,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         // Example: Find-PSResource -Name "Az" -Version "[1.0.0.0, 3.0.0.0]"
                         _cmdletPassedIn.WriteDebug("Version range and package name are specified");
 
+                        errRecord = null;
                         FindResults responses = null;
                         if (_tag.Length == 0)
                         {
@@ -993,6 +994,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             response = cachedNetworkCalls.GetOrAdd(key, _ => currentServer.FindVersionGlobbingAsync(pkgName, _versionRange, _prerelease, _type, getOnlyLatest: false, errorMsgs, warningMsgs, debugMsgs, verboseMsgs));
                             
                             responses = response.GetAwaiter().GetResult();
+
+                            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                         }
                         else
                         {

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -912,17 +912,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         
                             ConcurrentDictionary<string, Task<FindResults>> cachedNetworkCalls = new ConcurrentDictionary<string, Task<FindResults>>();
                             Task<FindResults> response = null;
-                            if (currentServer.Repository.ApiVersion == PSRepositoryInfo.APIVersion.V2) {       
-                                string key = $"{pkgName}|{_nugetVersion.ToNormalizedString()}|{_type}";
-                                response = cachedNetworkCalls.GetOrAdd(key, _ => currentServer.FindVersionAsync(pkgName, _nugetVersion.ToNormalizedString(), _type, errorMsgs, warningMsgs, debugMsgs, verboseMsgs));
-                    
-                                responses = response.GetAwaiter().GetResult();
+                            string key = $"{pkgName}|{_nugetVersion.ToNormalizedString()}|{_type}";
+                            response = cachedNetworkCalls.GetOrAdd(key, _ => currentServer.FindVersionAsync(pkgName, _nugetVersion.ToNormalizedString(), _type, errorMsgs, warningMsgs, debugMsgs, verboseMsgs));
+                
+                            responses = response.GetAwaiter().GetResult();
 
-                                Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
-                            }
-                            else {         
-                                responses = currentServer.FindVersion(pkgName, _nugetVersion.ToNormalizedString(), _type, out errRecord);
-                            }
+                            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                         }
                         else
                         {
@@ -996,15 +991,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         {
                             ConcurrentDictionary<string, Task<FindResults>> cachedNetworkCalls = new ConcurrentDictionary<string, Task<FindResults>>();
                             Task<FindResults> response = null;
-                            if (currentServer.Repository.ApiVersion == PSRepositoryInfo.APIVersion.V2) {       
-                                string key = $"{pkgName}|{_versionRange.ToString()}|{_type}";
-                                response = cachedNetworkCalls.GetOrAdd(key, _ => currentServer.FindVersionGlobbingAsync(pkgName, _versionRange, _prerelease, _type, getOnlyLatest: false, errorMsgs, warningMsgs, debugMsgs, verboseMsgs));
-                                
-                                responses = response.GetAwaiter().GetResult();
-                            }
-                            else {         
-                               responses = currentServer.FindVersionGlobbing(pkgName, _versionRange, _prerelease, _type, getOnlyLatest: false, out errRecord);    
-                            }
+                            string key = $"{pkgName}|{_versionRange.ToString()}|{_type}";
+                            response = cachedNetworkCalls.GetOrAdd(key, _ => currentServer.FindVersionGlobbingAsync(pkgName, _versionRange, _prerelease, _type, getOnlyLatest: false, errorMsgs, warningMsgs, debugMsgs, verboseMsgs));
+                            
+                            responses = response.GetAwaiter().GetResult();
                         }
                         else
                         {
@@ -1189,7 +1179,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 //const int PARALLEL_THRESHOLD = 5; // TODO: Trottle limit from user, defaults to 5; 
                 int processorCount = Environment.ProcessorCount;
                 int maxDegreeOfParallelism = processorCount * 4;
-                if (currentServer.Repository.ApiVersion == PSRepositoryInfo.APIVersion.V2 && currentPkg.Dependencies.Length > processorCount)
+                if (currentPkg.Dependencies.Length > processorCount)
                 {
                     Parallel.ForEach(currentPkg.Dependencies, new ParallelOptions { MaxDegreeOfParallelism = maxDegreeOfParallelism }, dep =>
                     {
@@ -1293,20 +1283,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             Task<FindResults> response = null;
             debugMsgs.Enqueue("In FindHelper::FindDependencyWithSpecificVersion()");
 
-            if (currentServer.Repository.ApiVersion == PSRepositoryInfo.APIVersion.V2)
-            {
-                // See if the network call we're making is already cached, if not, call FindNameAsync() and cache results
-                string key = $"{dep.Name}|{dep.VersionRange.MaxVersion.ToString()}|{_type}";
-                debugMsgs.Enqueue("Checking if network call is cached.");
-                response = _cachedNetworkCalls.GetOrAdd(key, _ => currentServer.FindVersionAsync(dep.Name, dep.VersionRange.MaxVersion.ToString(), _type, errorMsgs, warningMsgs, debugMsgs, verboseMsgs));
-                
-                responses = response.GetAwaiter().GetResult();
-            }
-            else
-            {
-                responses = currentServer.FindVersion(dep.Name, dep.VersionRange.MaxVersion.ToString(), _type, out errRecord);
-            }
-
+            
+            // See if the network call we're making is already cached, if not, call FindNameAsync() and cache results
+            string key = $"{dep.Name}|{dep.VersionRange.MaxVersion.ToString()}|{_type}";
+            debugMsgs.Enqueue("Checking if network call is cached.");
+            response = _cachedNetworkCalls.GetOrAdd(key, _ => currentServer.FindVersionAsync(dep.Name, dep.VersionRange.MaxVersion.ToString(), _type, errorMsgs, warningMsgs, debugMsgs, verboseMsgs));
+            
+            responses = response.GetAwaiter().GetResult();
 
             // Error handling and Convert to PSResource object
             if (errRecord != null)
@@ -1369,19 +1352,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             Task<FindResults> response = null;
             debugMsgs.Enqueue("In FindHelper::FindDependencyWithLowerBound()");
 
-            if (currentServer.Repository.ApiVersion == PSRepositoryInfo.APIVersion.V2)
-            {
-                // See if the network call we're making is already cached, if not, call FindNameAsync() and cache results
-                string key = $"{dep.Name}|*|{_type}";
-                debugMsgs.Enqueue("Checking if network call is cached.");
-                response = _cachedNetworkCalls.GetOrAdd(key, _ => currentServer.FindNameAsync(dep.Name, includePrerelease: true, _type, errorMsgs, warningMsgs, debugMsgs, verboseMsgs));
-                
-                responses = response.GetAwaiter().GetResult();
-            }
-            else
-            {
-                responses = currentServer.FindName(dep.Name, includePrerelease: true, _type, out errRecord);
-            }
+            // See if the network call we're making is already cached, if not, call FindNameAsync() and cache results
+            string key = $"{dep.Name}|*|{_type}";
+            debugMsgs.Enqueue("Checking if network call is cached.");
+            response = _cachedNetworkCalls.GetOrAdd(key, _ => currentServer.FindNameAsync(dep.Name, includePrerelease: true, _type, errorMsgs, warningMsgs, debugMsgs, verboseMsgs));
+            
+            responses = response.GetAwaiter().GetResult();
 
             // Error handling and Convert to PSResource object
             if (errRecord != null)
@@ -1445,21 +1421,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             ConcurrentDictionary<string, Task<FindResults>> cachedNetworkCalls = new ConcurrentDictionary<string, Task<FindResults>>();
             debugMsgs.Enqueue("In FindHelper::FindDependencyWithUpperBound()");
+            // See if the network call we're making is already caced, if not, call FindNameAsync() and cache results
+            string key = $"{dep.Name}|{dep.VersionRange.MaxVersion.ToString()}|{_type}";
+            debugMsgs.Enqueue("Checking if network call is cached.");
+            response = cachedNetworkCalls.GetOrAdd(key, _ => currentServer.FindVersionGlobbingAsync(dep.Name, dep.VersionRange, includePrerelease: true, ResourceType.None, getOnlyLatest: true, errorMsgs, warningMsgs, debugMsgs, verboseMsgs));
 
-            if (currentServer.Repository.ApiVersion == PSRepositoryInfo.APIVersion.V2)
-            {
-                // See if the network call we're making is already caced, if not, call FindNameAsync() and cache results
-                string key = $"{dep.Name}|{dep.VersionRange.MaxVersion.ToString()}|{_type}";
-                debugMsgs.Enqueue("Checking if network call is cached.");
-                response = cachedNetworkCalls.GetOrAdd(key, _ => currentServer.FindVersionGlobbingAsync(dep.Name, dep.VersionRange, includePrerelease: true, ResourceType.None, getOnlyLatest: true, errorMsgs, warningMsgs, debugMsgs, verboseMsgs));
+            responses = response.GetAwaiter().GetResult();
 
-                responses = response.GetAwaiter().GetResult();
-
-            }
-            else
-            {
-                responses = currentServer.FindVersionGlobbing(dep.Name, dep.VersionRange, includePrerelease: true, ResourceType.None, getOnlyLatest: true, out errRecord);
-            }
 
             // Error handling and Convert to PSResource object
             if (errRecord != null)

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -904,15 +904,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         // Example: Find-PSResource -Name "Az" -Version "3.0.0.0"
                         // Example: Find-PSResource -Name "Az" -Version "3.0.0.0" -Tag "Windows"
                         _cmdletPassedIn.WriteDebug("Exact version and package name are specified");
-
+                        string key = string.Empty;
                         FindResults responses = null;
                         if (_tag.Length == 0)
                         {
-
-                        
                             ConcurrentDictionary<string, Task<FindResults>> cachedNetworkCalls = new ConcurrentDictionary<string, Task<FindResults>>();
                             Task<FindResults> response = null;
-                            string key = $"{pkgName}|{_nugetVersion.ToNormalizedString()}|{_type}";
+                            key = $"{pkgName}|{_nugetVersion.ToNormalizedString()}|{_type}";
                             response = cachedNetworkCalls.GetOrAdd(key, _ => currentServer.FindVersionAsync(pkgName, _nugetVersion.ToNormalizedString(), _type, errorMsgs, warningMsgs, debugMsgs, verboseMsgs));
                 
                             responses = response.GetAwaiter().GetResult();
@@ -1318,7 +1316,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                     string pkgVersion = FormatPkgVersionString(depPkg);
                     debugMsgs.Enqueue($"Found dependency '{depPkg.Name}' version '{pkgVersion}'");
-                    string key = $"{depPkg.Name}{pkgVersion}";
+                    key = $"{depPkg.Name}{pkgVersion}";
                     if (!depPkgsFound.ContainsKey(key))
                     {
                         // Add pkg to collection of packages found then find dependencies
@@ -1386,7 +1384,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                     string pkgVersion = FormatPkgVersionString(depPkg);
                     debugMsgs.Enqueue($"Found dependency '{depPkg.Name}' version '{pkgVersion}'");
-                    string key = $"{depPkg.Name}{pkgVersion}";
+                    key = $"{depPkg.Name}{pkgVersion}";
                     if (!depPkgsFound.ContainsKey(key))
                     {
                         // Add pkg to collection of packages found then find dependencies
@@ -1457,7 +1455,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                     string pkgVersion = FormatPkgVersionString(depPkg);
                     debugMsgs.Enqueue($"Found dependency '{depPkg.Name}' version '{pkgVersion}'");
-                    string key = $"{depPkg.Name}{pkgVersion}";
+                    key = $"{depPkg.Name}{pkgVersion}";
                     if (!depPkgsFound.ContainsKey(key))
                     {
                         // Add pkg to collection of packages found then find dependencies

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -30,6 +30,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private CancellationToken _cancellationToken;
         private readonly PSCmdlet _cmdletPassedIn;
         private HashSet<string> _pkgsLeftToFind;
+        private string[] _packageNamesToFind;
         private List<string> _tagsLeftToFind;
         private ResourceType _type;
         private string _version;
@@ -114,7 +115,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 yield break;
             }
 
-            _pkgsLeftToFind = new HashSet<string>(name, StringComparer.InvariantCultureIgnoreCase);
+            _packageNamesToFind = name.Distinct(StringComparer.InvariantCultureIgnoreCase).ToArray();
+            _pkgsLeftToFind = new HashSet<string>(_packageNamesToFind, StringComparer.InvariantCultureIgnoreCase);
             HashSet<string> pkgsDiscovered = GetPackageNamesPopulated(_pkgsLeftToFind.ToArray());
 
             _tagsLeftToFind = tag == null ? new List<string>() : new List<string>(tag);
@@ -713,7 +715,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             bool isV2Resource = currentResponseUtil is V2ResponseUtil;
 
             _cmdletPassedIn.WriteDebug("In FindHelper::SearchByNames()");
-            foreach (string pkgName in _pkgsLeftToFind.ToArray())
+            string[] packageNames = _packageNamesToFind;
+            if (_tag.Length == 0 && packageNames.Length > 1 && packageNames.All(packageName => !packageName.Contains("*")))
+            {
+                foreach (PSResourceInfo package in SearchExplicitNamesConcurrently(currentServer, currentResponseUtil, repository, shouldReportErrorForEachRepo, packageNames))
+                {
+                    yield return package;
+                }
+
+                yield break;
+            }
+
+            foreach (string pkgName in packageNames)
             {
                 if (_versionType == VersionType.NoVersion)
                 {
@@ -1087,6 +1100,167 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     yield return pkgDep;
                 }
             }
+        }
+
+        /// <summary>
+        /// Searches explicit package names and version concurrently, then writes logs
+        /// and returns results in the original package-name order. 
+        /// Dependencies are also resolved concurrently when the -IncludeDependencies parameter is specified.
+        /// </summary>
+        private IEnumerable<PSResourceInfo> SearchExplicitNamesConcurrently(
+            ServerApiCall currentServer,
+            ResponseUtil currentResponseUtil,
+            PSRepositoryInfo repository,
+            bool shouldReportErrorForEachRepo,
+            string[] packageNames)
+        {
+            // After parallel work finishes, workItems are processed sequentially in the original package-name order
+            ParentFindWorkItem[] workItems = packageNames.Select(packageName => new ParentFindWorkItem(packageName)).ToArray();
+            int maxDegreeOfParallelism = Environment.ProcessorCount * 4;
+
+            Parallel.ForEach(workItems, new ParallelOptions { MaxDegreeOfParallelism = maxDegreeOfParallelism }, workItem =>
+            {
+                switch (_versionType)
+                {
+                    case VersionType.SpecificVersion:
+                        workItem.Results = currentServer.FindVersionAsync(
+                            workItem.PackageName,
+                            _nugetVersion.ToNormalizedString(),
+                            _type,
+                            workItem.ErrorMsgs,
+                            workItem.WarningMsgs,
+                            workItem.DebugMsgs,
+                            workItem.VerboseMsgs).GetAwaiter().GetResult();
+                        break;
+
+                    case VersionType.VersionRange:
+                        workItem.Results = currentServer.FindVersionGlobbingAsync(
+                            workItem.PackageName,
+                            _versionRange,
+                            _prerelease,
+                            _type,
+                            getOnlyLatest: false,
+                            workItem.ErrorMsgs,
+                            workItem.WarningMsgs,
+                            workItem.DebugMsgs,
+                            workItem.VerboseMsgs).GetAwaiter().GetResult();
+                        break;
+
+                    default:
+                        workItem.Results = currentServer.FindNameAsync(
+                            workItem.PackageName,
+                            _prerelease,
+                            _type,
+                            workItem.ErrorMsgs,
+                            workItem.WarningMsgs,
+                            workItem.DebugMsgs,
+                            workItem.VerboseMsgs).GetAwaiter().GetResult();
+                        break;
+                }
+            });
+
+            List<PSResourceInfo> parentPkgs = new List<PSResourceInfo>();
+            foreach (ParentFindWorkItem workItem in workItems)
+            {
+                bool lookupFailed = !workItem.ErrorMsgs.IsEmpty;
+                WriteParentFindMessagesForRepository(workItem, shouldReportErrorForEachRepo);
+                if (lookupFailed)
+                {
+                    continue;
+                }
+
+                IEnumerable<PSResourceResult> convertedResults = currentResponseUtil.ConvertToPSResourceResult(workItem.Results);
+                if (_versionType != VersionType.VersionRange)
+                {
+                    convertedResults = convertedResults.Take(1);
+                }
+
+                foreach (PSResourceResult currentResult in convertedResults)
+                {
+                    if (currentResult.exception != null && !currentResult.exception.Message.Equals(string.Empty))
+                    {
+                        _cmdletPassedIn.WriteError(new ErrorRecord(
+                            currentResult.exception,
+                            _versionType == VersionType.SpecificVersion ? "FindVersionConvertToPSResourceFailure" : "FindNameConvertToPSResourceFailure",
+                            ErrorCategory.ObjectNotFound,
+                            this));
+                        continue;
+                    }
+
+                    PSResourceInfo foundPkg = currentResult.returnedObject;
+                    if (_versionType == VersionType.VersionRange)
+                    {
+                        string versionString = FormatPkgVersionString(foundPkg);
+                        if (!NuGetVersion.TryParse(versionString, out NuGetVersion version) || !_versionRange.Satisfies(version))
+                        {
+                            continue;
+                        }
+                    }
+
+                    parentPkgs.Add(foundPkg);
+                    TryAddToPackagesFound(foundPkg);
+                    yield return foundPkg;
+                }
+            }
+
+            if (!_includeDependencies)
+            {
+                yield break;
+            }
+
+            ConcurrentBag<PSResourceInfo> dependencyPkgs = new ConcurrentBag<PSResourceInfo>();
+            ConcurrentQueue<ErrorRecord> dependencyErrors = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> dependencyWarnings = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> dependencyDebug = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> dependencyVerbose = new ConcurrentQueue<string>();
+
+            Parallel.ForEach(parentPkgs, new ParallelOptions { MaxDegreeOfParallelism = maxDegreeOfParallelism }, parentPkg =>
+            {
+                foreach (PSResourceInfo dependency in FindDependencyPackages(
+                    currentServer,
+                    currentResponseUtil,
+                    parentPkg,
+                    repository,
+                    dependencyErrors,
+                    dependencyWarnings,
+                    dependencyDebug,
+                    dependencyVerbose))
+                {
+                    dependencyPkgs.Add(dependency);
+                }
+            });
+
+            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, dependencyErrors, dependencyWarnings, dependencyDebug, dependencyVerbose);
+            foreach (PSResourceInfo dependency in dependencyPkgs)
+            {
+                yield return dependency;
+            }
+        }
+
+        /// <summary>
+        /// Writes diagnostics from a parent package lookup on the pipeline thread, reporting queued errors
+        /// as errors for explicitly selected repositories or as verbose messages otherwise.
+        /// This is specifically needed to preserve the existing multi-repository behavior:
+        ///     - when 'ShouldReportErrorForEachRepo' is true, it write the error normally
+        ///     - Otherwise, it downgrades repository specific lookup failures to verbose messages
+        ///     - A final 'PackageNotFound' error is emitted only if every repository fails
+        ///     - Lastly, it uses Utils.WriteOutConcurrentQueue to write out any remaining queued messages (warnings, debug, verbose)
+        /// </summary>
+        private void WriteParentFindMessagesForRepository(ParentFindWorkItem workItem, bool shouldReportErrorForEachRepo)
+        {
+            while (workItem.ErrorMsgs.TryDequeue(out ErrorRecord error))
+            {
+                if (shouldReportErrorForEachRepo)
+                {
+                    _cmdletPassedIn.WriteError(error);
+                }
+                else
+                {
+                    _cmdletPassedIn.WriteVerbose(error.Exception.Message);
+                }
+            }
+
+            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, workItem.ErrorMsgs, workItem.WarningMsgs, workItem.DebugMsgs, workItem.VerboseMsgs);
         }
 
         /// <summary>
@@ -1550,5 +1724,26 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         }
 
         #endregion
+
+        /// </summary>
+        /// ParentFindWorkItem class bundles all mutable states for a single parent package search, 
+        /// so that we can run multiple parent package searches concurrently without racing on shared state.
+        /// Specificially it is keeping track of the package name, the search results, and the error/warning/debug/verbose 
+        /// messages for that search. After parallel work finishes, workItems are processed sequentially in the original package-name order
+        /// </summary>
+        private sealed class ParentFindWorkItem
+        {
+            public ParentFindWorkItem(string packageName)
+            {
+                PackageName = packageName;
+            }
+
+            public string PackageName { get; }
+            public FindResults Results { get; set; }
+            public readonly ConcurrentQueue<ErrorRecord> ErrorMsgs = new ConcurrentQueue<ErrorRecord>();
+            public readonly ConcurrentQueue<string> WarningMsgs = new ConcurrentQueue<string>();
+            public readonly ConcurrentQueue<string> DebugMsgs = new ConcurrentQueue<string>();
+            public readonly ConcurrentQueue<string> VerboseMsgs = new ConcurrentQueue<string>();
+        }
     }
 }

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -1177,22 +1177,50 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         internal IEnumerable<PSResourceInfo> FindDependencyPackages(ServerApiCall currentServer, ResponseUtil currentResponseUtil, PSResourceInfo currentPkg, PSRepositoryInfo repository)
         {
+            // Pipeline-thread callers: collect diagnostics locally and drain them to the cmdlet on this thread.
+            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
+
+            var depPkgs = FindDependencyPackages(currentServer, currentResponseUtil, currentPkg, repository, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+
+            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+            return depPkgs;
+        }
+
+        // Overload for worker-thread callers: diagnostics are routed to the caller-provided queues and drained by the caller on the pipeline thread.
+        internal IEnumerable<PSResourceInfo> FindDependencyPackages(
+            ServerApiCall currentServer,
+            ResponseUtil currentResponseUtil,
+            PSResourceInfo currentPkg,
+            PSRepositoryInfo repository,
+            ConcurrentQueue<ErrorRecord> errorMsgs,
+            ConcurrentQueue<string> warningMsgs,
+            ConcurrentQueue<string> debugMsgs,
+            ConcurrentQueue<string> verboseMsgs)
+        {
             // Use a local instance so multiple parent packages can resolve their dependency closures concurrently
             // without racing on shared state.
             ConcurrentDictionary<string, PSResourceInfo> depPkgsFound = new ConcurrentDictionary<string, PSResourceInfo>();
-            _cmdletPassedIn.WriteDebug($"In FindHelper::FindDependencyPackages() - {currentPkg.Name}");            
-            FindDependencyPackagesHelper(currentServer, currentResponseUtil, currentPkg, repository, depPkgsFound); 
+            debugMsgs.Enqueue($"In FindHelper::FindDependencyPackages() - {currentPkg.Name}");
+            FindDependencyPackagesHelper(currentServer, currentResponseUtil, currentPkg, repository, depPkgsFound, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
 
             return depPkgsFound.Values.ToList();
         }
 
         // Method 2 
-        internal void FindDependencyPackagesHelper(ServerApiCall currentServer, ResponseUtil currentResponseUtil, PSResourceInfo currentPkg, PSRepositoryInfo repository, ConcurrentDictionary<string, PSResourceInfo> depPkgsFound)
+        internal void FindDependencyPackagesHelper(
+            ServerApiCall currentServer,
+            ResponseUtil currentResponseUtil,
+            PSResourceInfo currentPkg,
+            PSRepositoryInfo repository,
+            ConcurrentDictionary<string, PSResourceInfo> depPkgsFound,
+            ConcurrentQueue<ErrorRecord> errorMsgs,
+            ConcurrentQueue<string> warningMsgs,
+            ConcurrentQueue<string> debugMsgs,
+            ConcurrentQueue<string> verboseMsgs)
         {
-            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
-            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
-            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
-            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
             debugMsgs.Enqueue("In FindHelper::FindDependencyPackagesHelper()");
 
             if (currentPkg.Dependencies.Length > 0)
@@ -1217,8 +1245,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         FindDependencyPackageVersion(dep, currentServer, currentResponseUtil, currentPkg, repository, depPkgsFound, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                     }
                 }
-
-                Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
             }
         }
 
@@ -1374,7 +1400,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         // This will eventually return the PSResourceInfo object to the main cmdlet class.
                         debugMsgs.Enqueue($"Adding'{key}' to list of dependency packages found");
                         depPkgsFound.TryAdd(key, depPkg);
-                        FindDependencyPackagesHelper(currentServer, currentResponseUtil, depPkg, repository, depPkgsFound);
+                        FindDependencyPackagesHelper(currentServer, currentResponseUtil, depPkg, repository, depPkgsFound, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                     }
                 }
             }
@@ -1443,7 +1469,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         // This will eventually return the PSResourceInfo object to the main cmdlet class.
                         debugMsgs.Enqueue($"Adding'{key}' to list of dependency packages found");
                         depPkgsFound.TryAdd(key, depPkg);
-                        FindDependencyPackagesHelper(currentServer, currentResponseUtil, depPkg, repository, depPkgsFound);
+                        FindDependencyPackagesHelper(currentServer, currentResponseUtil, depPkg, repository, depPkgsFound, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                     }
                 }
             }
@@ -1515,7 +1541,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         // This will eventually return the PSResourceInfo object to the main cmdlet class.
                         debugMsgs.Enqueue($"Adding'{key}' to list of dependency packages found");
                         depPkgsFound.TryAdd(key, depPkg);
-                        FindDependencyPackagesHelper(currentServer, currentResponseUtil, depPkg, repository, depPkgsFound);
+                        FindDependencyPackagesHelper(currentServer, currentResponseUtil, depPkg, repository, depPkgsFound, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                     }
                 }
             }

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -1289,7 +1289,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             ConcurrentQueue<string> operationVerboseMsgs = new ConcurrentQueue<string>();
 
             // Call FindVersionAsync() for dependency with specific version.
-            string key = $"{dep.Name}|{dep.VersionRange.MaxVersion.ToString()}|{_type}";
             responses = currentServer.FindVersionAsync(dep.Name, dep.VersionRange.MaxVersion.ToString(), _type, operationErrorMsgs, operationWarningMsgs, operationDebugMsgs, operationVerboseMsgs).GetAwaiter().GetResult();
 
             while (operationErrorMsgs.TryDequeue(out ErrorRecord queuedError))
@@ -1344,7 +1343,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                     string pkgVersion = FormatPkgVersionString(depPkg);
                     debugMsgs.Enqueue($"Found dependency '{depPkg.Name}' version '{pkgVersion}'");
-                    key = $"{depPkg.Name}{pkgVersion}";
+                    string key = $"{depPkg.Name}{pkgVersion}";
                     if (!depPkgsFound.ContainsKey(key))
                     {
                         // Add pkg to collection of packages found then find dependencies

--- a/src/code/FindHelper.cs
+++ b/src/code/FindHelper.cs
@@ -46,10 +46,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         // If running 'Install-PSResource Az, TestModule, NewTestModule', it will contain one parent and its dependencies.
         private ConcurrentDictionary<string, List<string>> _packagesFound;
 
-        // Creates a new instance of depPkgsFound each time FindDependencyPackages() is called.
-        // This will eventually return the PSResourceInfo object to the main cmdlet class.
-        private ConcurrentDictionary<string, PSResourceInfo> depPkgsFound;
-        
         // Contains the latest found version of a particular package.
         private ConcurrentDictionary<string, PSResourceInfo> _knownLatestPkgVersion;
 
@@ -1060,12 +1056,35 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // After retrieving all packages find their dependencies
             if (_includeDependencies)
             {
-                foreach (PSResourceInfo currentPkg in parentPkgs)
+                // Resolving each parent package's dependency closure is independent work, so do it concurrently.
+                // yield return cannot be used inside Parallel.ForEach, so collect results into a thread-safe bag first.
+                ConcurrentBag<PSResourceInfo> dependencyPkgs = new ConcurrentBag<PSResourceInfo>();
+                int processorCount = Environment.ProcessorCount;
+                int maxDegreeOfParallelism = processorCount * 4;
+                if (parentPkgs.Count > processorCount)
                 {
-                    foreach (PSResourceInfo pkgDep in FindDependencyPackages(currentServer, currentResponseUtil, currentPkg, repository))
+                    Parallel.ForEach(parentPkgs, new ParallelOptions { MaxDegreeOfParallelism = maxDegreeOfParallelism }, currentPkg =>
                     {
-                        yield return pkgDep;
+                        foreach (PSResourceInfo pkgDep in FindDependencyPackages(currentServer, currentResponseUtil, currentPkg, repository))
+                        {
+                            dependencyPkgs.Add(pkgDep);
+                        }
+                    });
+                }
+                else
+                {
+                    foreach (PSResourceInfo currentPkg in parentPkgs)
+                    {
+                        foreach (PSResourceInfo pkgDep in FindDependencyPackages(currentServer, currentResponseUtil, currentPkg, repository))
+                        {
+                            dependencyPkgs.Add(pkgDep);
+                        }
                     }
+                }
+
+                foreach (PSResourceInfo pkgDep in dependencyPkgs)
+                {
+                    yield return pkgDep;
                 }
             }
         }
@@ -1158,15 +1177,17 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         internal IEnumerable<PSResourceInfo> FindDependencyPackages(ServerApiCall currentServer, ResponseUtil currentResponseUtil, PSResourceInfo currentPkg, PSRepositoryInfo repository)
         {
-            depPkgsFound = new ConcurrentDictionary<string, PSResourceInfo>();
+            // Use a local instance so multiple parent packages can resolve their dependency closures concurrently
+            // without racing on shared state.
+            ConcurrentDictionary<string, PSResourceInfo> depPkgsFound = new ConcurrentDictionary<string, PSResourceInfo>();
             _cmdletPassedIn.WriteDebug($"In FindHelper::FindDependencyPackages() - {currentPkg.Name}");            
-            FindDependencyPackagesHelper(currentServer, currentResponseUtil, currentPkg, repository); 
+            FindDependencyPackagesHelper(currentServer, currentResponseUtil, currentPkg, repository, depPkgsFound); 
 
             return depPkgsFound.Values.ToList();
         }
 
         // Method 2 
-        internal void FindDependencyPackagesHelper(ServerApiCall currentServer, ResponseUtil currentResponseUtil, PSResourceInfo currentPkg, PSRepositoryInfo repository)
+        internal void FindDependencyPackagesHelper(ServerApiCall currentServer, ResponseUtil currentResponseUtil, PSResourceInfo currentPkg, PSRepositoryInfo repository, ConcurrentDictionary<string, PSResourceInfo> depPkgsFound)
         {
             ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
             ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
@@ -1185,7 +1206,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     Parallel.ForEach(currentPkg.Dependencies, new ParallelOptions { MaxDegreeOfParallelism = maxDegreeOfParallelism }, dep =>
                     {
                         debugMsgs.Enqueue($"Finding dependency '{dep.Name}' version range '{dep.VersionRange}'");
-                        FindDependencyPackageVersion(dep, currentServer, currentResponseUtil, currentPkg, repository, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+                        FindDependencyPackageVersion(dep, currentServer, currentResponseUtil, currentPkg, repository, depPkgsFound, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                     });
                 }
                 else
@@ -1193,7 +1214,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     foreach (var dep in currentPkg.Dependencies)
                     {
                         debugMsgs.Enqueue($"Finding dependency '{dep.Name}' version range '{dep.VersionRange}'");
-                        FindDependencyPackageVersion(dep, currentServer, currentResponseUtil, currentPkg, repository, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+                        FindDependencyPackageVersion(dep, currentServer, currentResponseUtil, currentPkg, repository, depPkgsFound, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                     }
                 }
 
@@ -1208,6 +1229,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             ResponseUtil currentResponseUtil, 
             PSResourceInfo currentPkg, 
             PSRepositoryInfo repository, 
+            ConcurrentDictionary<string, PSResourceInfo> depPkgsFound,
             ConcurrentQueue<ErrorRecord> errorMsgs, 
             ConcurrentQueue<string> warningMsgs,
             ConcurrentQueue<string> debugMsgs,
@@ -1228,7 +1250,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     else
                     {
                         // Find this version from the server
-                        depPkg = FindDependencyWithLowerBound(dep, currentServer, currentResponseUtil, currentPkg, repository, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+                        depPkg = FindDependencyWithLowerBound(dep, currentServer, currentResponseUtil, currentPkg, repository, depPkgsFound, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                     }
             }
             else if (dep.VersionRange.HasLowerBound && dep.VersionRange.MinVersion.Equals(dep.VersionRange.MaxVersion))
@@ -1245,7 +1267,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
                 else
                 {
-                    depPkg = FindDependencyWithSpecificVersion(dep, currentServer, currentResponseUtil, currentPkg, repository, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+                    depPkg = FindDependencyWithSpecificVersion(dep, currentServer, currentResponseUtil, currentPkg, repository, depPkgsFound, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                 }
             }
             else
@@ -1261,7 +1283,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 }
                 else
                 {
-                    depPkg = FindDependencyWithUpperBound(dep, currentServer, currentResponseUtil, currentPkg, repository, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+                    depPkg = FindDependencyWithUpperBound(dep, currentServer, currentResponseUtil, currentPkg, repository, depPkgsFound, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                 }
             }
         }
@@ -1273,6 +1295,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             ResponseUtil currentResponseUtil, 
             PSResourceInfo currentPkg, 
             PSRepositoryInfo repository, 
+            ConcurrentDictionary<string, PSResourceInfo> depPkgsFound,
             ConcurrentQueue<ErrorRecord> errorMsgs, 
             ConcurrentQueue<string> warningMsgs,
             ConcurrentQueue<string> debugMsgs,
@@ -1351,7 +1374,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         // This will eventually return the PSResourceInfo object to the main cmdlet class.
                         debugMsgs.Enqueue($"Adding'{key}' to list of dependency packages found");
                         depPkgsFound.TryAdd(key, depPkg);
-                        FindDependencyPackagesHelper(currentServer, currentResponseUtil, depPkg, repository);
+                        FindDependencyPackagesHelper(currentServer, currentResponseUtil, depPkg, repository, depPkgsFound);
                     }
                 }
             }
@@ -1366,6 +1389,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             ResponseUtil currentResponseUtil, 
             PSResourceInfo currentPkg, 
             PSRepositoryInfo repository, 
+            ConcurrentDictionary<string, PSResourceInfo> depPkgsFound,
             ConcurrentQueue<ErrorRecord> errorMsgs, 
             ConcurrentQueue<string> warningMsgs,
             ConcurrentQueue<string> debugMsgs,
@@ -1419,7 +1443,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         // This will eventually return the PSResourceInfo object to the main cmdlet class.
                         debugMsgs.Enqueue($"Adding'{key}' to list of dependency packages found");
                         depPkgsFound.TryAdd(key, depPkg);
-                        FindDependencyPackagesHelper(currentServer, currentResponseUtil, depPkg, repository);
+                        FindDependencyPackagesHelper(currentServer, currentResponseUtil, depPkg, repository, depPkgsFound);
                     }
                 }
             }
@@ -1434,6 +1458,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             ResponseUtil currentResponseUtil, 
             PSResourceInfo currentPkg, 
             PSRepositoryInfo repository, 
+            ConcurrentDictionary<string, PSResourceInfo> depPkgsFound,
             ConcurrentQueue<ErrorRecord> errorMsgs, 
             ConcurrentQueue<string> warningMsgs,
             ConcurrentQueue<string> debugMsgs,
@@ -1490,7 +1515,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         // This will eventually return the PSResourceInfo object to the main cmdlet class.
                         debugMsgs.Enqueue($"Adding'{key}' to list of dependency packages found");
                         depPkgsFound.TryAdd(key, depPkg);
-                        FindDependencyPackagesHelper(currentServer, currentResponseUtil, depPkg, repository);
+                        FindDependencyPackagesHelper(currentServer, currentResponseUtil, depPkg, repository, depPkgsFound);
                     }
                 }
             }

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -801,7 +801,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             else
             {
-                // Concurrent updates, currently only implemented for v2 server repositories
+                // Concurrent updates
                 // Find all dependencies
                 if (!skipDependencyCheck)
                 {
@@ -853,7 +853,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // TODO: figure out a good threshold and parallel count
             int processorCount = Environment.ProcessorCount;
             _cmdletPassedIn.WriteDebug($"parentAndDeps.Count is {parentAndDeps.Count}, processor count is: {processorCount}");
-            if (currentServer.Repository.ApiVersion == PSRepositoryInfo.APIVersion.V2 && parentAndDeps.Count > processorCount)
+            if (parentAndDeps.Count > processorCount)
             {
                  _cmdletPassedIn.WriteDebug($"parentAndDeps.Count is greater than processor count");
                 // Set the maximum degree of parallelism to 32? (Invoke-Command has default of 32, that's where we got this number from)

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -516,73 +516,123 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             FindHelper findHelper)
         {
             _cmdletPassedIn.WriteDebug("In InstallHelper::InstallPackages()");
-            
+
             List<PSResourceInfo> pkgsSuccessfullyInstalled = new();
 
-            // Install parent package to the temp directory,
-            // Get the dependencies from the installed package,
-            // Install all dependencies to temp directory.
-            // If a single dependency fails to install, roll back by deleting the temp directory.
+            // ---------- Phase 1 (pipeline thread): resolve each parent package and evaluate ShouldProcess ----------
+            // ShouldProcess / -WhatIf / -Confirm and Write* must run on the pipeline thread, so all gating happens
+            // here, before any parallel download work begins. Packages that pass the gate become work items.
+            List<ParentInstallWorkItem> workItems = new();
             foreach (var parentPackage in pkgNamesToInstall)
             {
-                string tempInstallPath = CreateInstallationTempPath();
+                PSResourceInfo pkgToInstall = FindParentPackage(
+                    searchVersionType: _versionType,
+                    specificVersion: _nugetVersion,
+                    versionRange: _versionRange,
+                    pkgNameToInstall: parentPackage,
+                    repository: repository,
+                    currentServer: currentServer,
+                    currentResponseUtil: currentResponseUtil,
+                    pkgVersion: out string pkgVersion,
+                    errRecord: out ErrorRecord findErrRecord);
 
+                if (findErrRecord != null)
+                {
+                    if (findErrRecord.FullyQualifiedErrorId.Equals("PackageNotFound"))
+                    {
+                        _cmdletPassedIn.WriteVerbose(findErrRecord.Exception.Message);
+                    }
+                    else
+                    {
+                        _cmdletPassedIn.WriteError(findErrRecord);
+                    }
+
+                    continue;
+                }
+
+                if (pkgToInstall == null)
+                {
+                    continue;
+                }
+
+                // Check to see if the pkg is already installed (unless -Reinstall was specified).
+                if (!_reinstall && _packagesOnMachine.Contains($"{pkgToInstall.Name}{pkgVersion}"))
+                {
+                    _cmdletPassedIn.WriteWarning($"Resource '{pkgToInstall.Name}' with version '{pkgVersion}' is already installed.  If you would like to reinstall, please run the cmdlet again with the -Reinstall parameter");
+
+                    // Remove from tracking list of packages to install.
+                    _pkgNamesToInstall.RemoveAll(x => x.Equals(pkgToInstall.Name, StringComparison.InvariantCultureIgnoreCase));
+
+                    continue;
+                }
+
+                // ShouldProcess gate (handles -WhatIf / -Confirm) on the pipeline thread.
+                string shouldProcessTarget = _savePkg
+                    ? $"Package to save: '{pkgToInstall.Name}', version: '{pkgVersion}'"
+                    : $"Package to install: '{pkgToInstall.Name}', version: '{pkgVersion}'";
+                if (!_cmdletPassedIn.ShouldProcess(shouldProcessTarget))
+                {
+                    continue;
+                }
+
+                workItems.Add(new ParentInstallWorkItem
+                {
+                    PkgToInstall = pkgToInstall,
+                    PkgVersion = pkgVersion,
+                    TempInstallPath = CreateInstallationTempPath()
+                });
+            }
+
+            if (workItems.Count == 0)
+            {
+                return pkgsSuccessfullyInstalled;
+            }
+
+            // ---------- Phase 2 (parallel): download each parent + its dependencies to its own temp path ----------
+            // This is network-bound work. No pipeline-thread calls are made here; all host messages are queued
+            // per work item and drained in Phase 3. Each work item downloads into its own temp path and its own
+            // packagesHash, so there is no shared mutable state between parents.
+            int processorCount = Environment.ProcessorCount;
+            if (workItems.Count > 1)
+            {
+                int maxDegreeOfParallelism = processorCount * 4;
+                Parallel.ForEach(workItems, new ParallelOptions { MaxDegreeOfParallelism = maxDegreeOfParallelism }, workItem =>
+                {
+                    workItem.PackagesHash = DownloadParentAndDeps(
+                        workItem.PkgToInstall, workItem.PkgVersion, workItem.TempInstallPath, repository,
+                        currentServer, currentResponseUtil, skipDependencyCheck,
+                        workItem.ErrorMsgs, workItem.WarningMsgs, workItem.DebugMsgs, workItem.VerboseMsgs,
+                        out bool succeeded);
+                    workItem.Succeeded = succeeded;
+                });
+            }
+            else
+            {
+                ParentInstallWorkItem workItem = workItems[0];
+                workItem.PackagesHash = DownloadParentAndDeps(
+                    workItem.PkgToInstall, workItem.PkgVersion, workItem.TempInstallPath, repository,
+                    currentServer, currentResponseUtil, skipDependencyCheck,
+                    workItem.ErrorMsgs, workItem.WarningMsgs, workItem.DebugMsgs, workItem.VerboseMsgs,
+                    out bool succeeded);
+                workItem.Succeeded = succeeded;
+            }
+
+            // ---------- Phase 3 (pipeline thread): drain messages, move content to final location, record results ----------
+            // If a single dependency fails to install, roll back that parent by deleting its temp directory.
+            foreach (ParentInstallWorkItem workItem in workItems)
+            {
                 try
                 {
-                    // Hashtable has the key as the package name
-                    // and value as a Hashtable of specific package info:
-                    //     packageName, { version = "", isScript = "", isModule = "", pkg = "", etc. }
-                    // Install parent package to the temp directory.
-                    ConcurrentDictionary<string, Hashtable> packagesHash = BeginPackageInstall(
-                                                        searchVersionType: _versionType,
-                                                        specificVersion: _nugetVersion,
-                                                        versionRange: _versionRange,
-                                                        pkgNameToInstall: parentPackage,
-                                                        repository: repository,
-                                                        currentServer: currentServer,
-                                                        currentResponseUtil: currentResponseUtil,
-                                                        tempInstallPath: tempInstallPath,
-                                                        skipDependencyCheck: skipDependencyCheck,
-                                                        packagesHash: new ConcurrentDictionary<string, Hashtable>(StringComparer.InvariantCultureIgnoreCase),
-                                                        warning: out string warning,
-                                                        errRecord: out ErrorRecord errRecord);
+                    Utils.WriteOutConcurrentQueue(_cmdletPassedIn, workItem.ErrorMsgs, workItem.WarningMsgs, workItem.DebugMsgs, workItem.VerboseMsgs);
 
-                    // At this point all packages are installed to temp path.
-                    if (errRecord != null)
-                    {
-                        if (errRecord.FullyQualifiedErrorId.Equals("PackageNotFound"))
-                        {
-                            _cmdletPassedIn.WriteVerbose(errRecord.Exception.Message);
-                        }
-                        else
-                        {
-                            _cmdletPassedIn.WriteError(errRecord);
-                        }
-
-                        continue;
-                    }
-                    if (warning != null)
-                    {
-                        _cmdletPassedIn.WriteWarning(warning);
-                    }
-
-                    if (packagesHash.Count == 0)
+                    if (!workItem.Succeeded || workItem.PackagesHash == null || workItem.PackagesHash.Count == 0)
                     {
                         continue;
-                    }
-
-                    Hashtable parentPkgInfo = packagesHash[parentPackage] as Hashtable;
-                    PSResourceInfo parentPkgObj = parentPkgInfo["psResourceInfoPkg"] as PSResourceInfo;
-
-                    // If -WhatIf is passed in, early out.
-                    if (_cmdletPassedIn.MyInvocation.BoundParameters.ContainsKey("WhatIf") && (SwitchParameter)_cmdletPassedIn.MyInvocation.BoundParameters["WhatIf"] == true)
-                    {
-                        return pkgsSuccessfullyInstalled;
                     }
 
                     // Parent package and dependencies are now installed to temp directory.
                     // Try to move all package directories from temp directory to final destination.
-                    if (!TryMoveInstallContent(tempInstallPath, scope, packagesHash))
+                    if (!TryMoveInstallContent(workItem.TempInstallPath, scope, workItem.PackagesHash))
                     {
                         _cmdletPassedIn.WriteError(new ErrorRecord(
                             new InvalidOperationException(),
@@ -592,9 +642,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     }
                     else
                     {
-                        foreach (string pkgName in packagesHash.Keys)
+                        foreach (string pkgName in workItem.PackagesHash.Keys)
                         {
-                            Hashtable pkgInfo = packagesHash[pkgName] as Hashtable;
+                            Hashtable pkgInfo = workItem.PackagesHash[pkgName] as Hashtable;
                             pkgsSuccessfullyInstalled.Add(pkgInfo["psResourceInfoPkg"] as PSResourceInfo);
 
                             // Add each pkg to _packagesOnMachine (ie pkgs fully installed on the machine).
@@ -610,11 +660,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             ErrorCategory.InvalidOperation,
                             _cmdletPassedIn));
 
-                    throw e;
+                    throw;
                 }
                 finally
                 {
-                    DeleteInstallationTempPath(tempInstallPath);
+                    DeleteInstallationTempPath(workItem.TempInstallPath);
                 }
             }
 
@@ -622,9 +672,27 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         }
 
         /// <summary>
-        /// Installs a single package to the temporary path.
+        /// Tracks the per-parent state used to parallelize parent-package installation across the three phases.
+        /// Each parent has its own temp path, result hash, and message queues so there is no shared mutable state
+        /// during the parallel download phase.
         /// </summary>
-        private ConcurrentDictionary<string, Hashtable> BeginPackageInstall(
+        private sealed class ParentInstallWorkItem
+        {
+            public PSResourceInfo PkgToInstall;
+            public string PkgVersion;
+            public string TempInstallPath;
+            public ConcurrentDictionary<string, Hashtable> PackagesHash;
+            public bool Succeeded;
+            public readonly ConcurrentQueue<ErrorRecord> ErrorMsgs = new();
+            public readonly ConcurrentQueue<string> WarningMsgs = new();
+            public readonly ConcurrentQueue<string> DebugMsgs = new();
+            public readonly ConcurrentQueue<string> VerboseMsgs = new();
+        }
+
+        /// <summary>
+        /// Resolves the parent package to install (find + version selection). Must run on the pipeline thread.
+        /// </summary>
+        private PSResourceInfo FindParentPackage(
             VersionType searchVersionType,
             NuGetVersion specificVersion,
             VersionRange versionRange,
@@ -632,15 +700,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             PSRepositoryInfo repository,
             ServerApiCall currentServer,
             ResponseUtil currentResponseUtil,
-            string tempInstallPath,
-            bool skipDependencyCheck,
-            ConcurrentDictionary<string, Hashtable> packagesHash,
-            out string warning,
+            out string pkgVersion,
             out ErrorRecord errRecord)
         {
-            _cmdletPassedIn.WriteDebug("In InstallHelper::BeginPackageInstall()");
+            _cmdletPassedIn.WriteDebug("In InstallHelper::FindParentPackage()");
             FindResults responses = null;
-            warning = null;
+            pkgVersion = null;
             errRecord = null;
 
             // Find the parent package that needs to be installed
@@ -652,7 +717,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (findVersionGlobbingErrRecord != null || responses.IsFindResultsEmpty())
                     {
                         errRecord = findVersionGlobbingErrRecord;
-                        return packagesHash;
+                        return null;
                     }
 
                     break;
@@ -664,7 +729,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (findVersionErrRecord != null)
                     {
                         errRecord = findVersionErrRecord;
-                        return packagesHash;
+                        return null;
                     }
 
                     break;
@@ -675,7 +740,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     if (findNameErrRecord != null)
                     {
                         errRecord = findNameErrRecord;
-                        return packagesHash;
+                        return null;
                     }
 
                     break;
@@ -721,11 +786,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (pkgToInstall == null)
             {
-                return packagesHash;
+                return null;
             }
 
             pkgToInstall.RepositorySourceLocation = repository.Uri.ToString();
-            pkgToInstall.AdditionalMetadata.TryGetValue("NormalizedVersion", out string pkgVersion);
+            pkgToInstall.AdditionalMetadata.TryGetValue("NormalizedVersion", out pkgVersion);
             if (pkgVersion == null)
             {
                 // Not all NuGet providers (e.g. Artifactory, possibly others) send NormalizedVersion in NuGet package responses.
@@ -745,117 +810,67 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             
             // Check to see if the pkg is already installed (ie the pkg is installed and the version satisfies the version range provided via param)
-            // TODO:  can use cache for this
-            if (!_reinstall)
+            // Note: the already-installed check and ShouldProcess gate are handled by the caller on the pipeline thread.
+            return pkgToInstall;
+        }
+
+        /// <summary>
+        /// Downloads the parent package and its dependencies to the temporary path. Safe to run on worker threads:
+        /// all host messages are routed to the provided queues and drained by the caller on the pipeline thread.
+        /// </summary>
+        private ConcurrentDictionary<string, Hashtable> DownloadParentAndDeps(
+            PSResourceInfo pkgToInstall,
+            string pkgVersion,
+            string tempInstallPath,
+            PSRepositoryInfo repository,
+            ServerApiCall currentServer,
+            ResponseUtil currentResponseUtil,
+            bool skipDependencyCheck,
+            ConcurrentQueue<ErrorRecord> errorMsgs,
+            ConcurrentQueue<string> warningMsgs,
+            ConcurrentQueue<string> debugMsgs,
+            ConcurrentQueue<string> verboseMsgs,
+            out bool success)
+        {
+            debugMsgs.Enqueue("In InstallHelper::DownloadParentAndDeps()");
+            ConcurrentDictionary<string, Hashtable> packagesHash = new ConcurrentDictionary<string, Hashtable>(StringComparer.InvariantCultureIgnoreCase);
+
+            List<PSResourceInfo> parentAndDeps = new List<PSResourceInfo>();
+            if (!skipDependencyCheck)
             {
-                string currPkgNameVersion = $"{pkgToInstall.Name}{pkgVersion}";
-                // Use HashSet lookup instead of Contains for O(1) performance
-                if (_packagesOnMachine.Contains(currPkgNameVersion))
-                {
-                    _cmdletPassedIn.WriteWarning($"Resource '{pkgToInstall.Name}' with version '{pkgVersion}' is already installed.  If you would like to reinstall, please run the cmdlet again with the -Reinstall parameter");
-
-                    // Remove from tracking list of packages to install.
-                    _pkgNamesToInstall.RemoveAll(x => x.Equals(pkgToInstall.Name, StringComparison.InvariantCultureIgnoreCase));
-
-                    return packagesHash;
-                }
+                // List returned only includes dependencies, so we'll add the parent pkg to this list to pass on to installation method.
+                parentAndDeps.AddRange(_findHelper.FindDependencyPackages(currentServer, currentResponseUtil, pkgToInstall, repository));
+                debugMsgs.Enqueue("In InstallHelper::DownloadParentAndDeps(), found all dependencies");
             }
 
-            if (packagesHash.ContainsKey(pkgToInstall.Name))
-            {
-                return packagesHash;
-            }
+            parentAndDeps.Add(pkgToInstall);
 
+            ConcurrentDictionary<string, Hashtable> updatedPackagesHash = InstallParentAndDependencyPackages(
+                parentAndDeps, currentServer, tempInstallPath, packagesHash, packagesHash, pkgToInstall,
+                errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
 
-            ConcurrentDictionary<string, Hashtable> updatedPackagesHash = packagesHash;
-  
-            // -WhatIf processing.
-            if (_savePkg && !_cmdletPassedIn.ShouldProcess($"Package to save: '{pkgToInstall.Name}', version: '{pkgVersion}'"))
-            {               
-                updatedPackagesHash.TryAdd(pkgToInstall.Name, new Hashtable(StringComparer.InvariantCultureIgnoreCase)
-                {
-                    { "isModule", "" },
-                    { "isScript", "" },
-                    { "psResourceInfoPkg", pkgToInstall },
-                    { "tempDirNameVersionPath", tempInstallPath },
-                    { "pkgVersion", "" },
-                    { "scriptPath", ""  },
-                    { "installPath", "" }
-                });
-            }
-            else if (!_cmdletPassedIn.ShouldProcess($"Package to install: '{pkgToInstall.Name}', version: '{pkgVersion}'"))
-            {
-                if (!updatedPackagesHash.ContainsKey(pkgToInstall.Name))
-                {
-                    updatedPackagesHash.TryAdd(pkgToInstall.Name, new Hashtable(StringComparer.InvariantCultureIgnoreCase)
-                    {
-                        { "isModule", "" },
-                        { "isScript", "" },
-                        { "psResourceInfoPkg", pkgToInstall },
-                        { "tempDirNameVersionPath", tempInstallPath },
-                        { "pkgVersion", "" },
-                        { "scriptPath", ""  },
-                        { "installPath", "" }
-                    });
-                }
-            }
-            else
-            {
-                // Concurrent updates
-                // Find all dependencies
-                if (!skipDependencyCheck)
-                {
-                    // concurrency updates 
-                    List<PSResourceInfo> parentAndDeps = _findHelper.FindDependencyPackages(currentServer, currentResponseUtil, pkgToInstall, repository).ToList();
-                    // List returned only includes dependencies, so we'll add the parent pkg to this list to pass on to installation method
-                    parentAndDeps.Add(pkgToInstall);
-
-                    _cmdletPassedIn.WriteDebug("In InstallHelper::BeginPackageInstall(), found all dependencies");
-
-                    return InstallParentAndDependencyPackages(parentAndDeps, currentServer, tempInstallPath, packagesHash, updatedPackagesHash, pkgToInstall);
-                }
-                else {
-                    // If we don't install dependencies, we're only installing the parent pkg so we can short circut and simply install the parent pkg. 
-                    Stream responseStream = currentServer.InstallPackage(pkgToInstall.Name, pkgVersion, true, out ErrorRecord installNameErrRecord);
-
-                    if (installNameErrRecord != null)
-                    {
-                        errRecord = installNameErrRecord;
-                        return packagesHash;
-                    }
-                    ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
-                    ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
-                    ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
-                    ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
-
-                    bool installedToTempPathSuccessfully = _asNupkg ? TrySaveNupkgToTempPath(responseStream, tempInstallPath, pkgToInstall.Name, pkgVersion, pkgToInstall, packagesHash, out updatedPackagesHash, errorMsgs, warningMsgs, debugMsgs, verboseMsgs) :
-                        TryInstallToTempPath(responseStream, tempInstallPath, pkgToInstall.Name, pkgVersion, pkgToInstall, packagesHash, out updatedPackagesHash, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
-                    
-                    Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
-                    if (!installedToTempPathSuccessfully)
-                    {
-                        return packagesHash;
-                    }
-                }
-            }
-
+            success = errorMsgs.IsEmpty;
             return updatedPackagesHash;
         }
 
-        private ConcurrentDictionary<string, Hashtable> InstallParentAndDependencyPackages(List<PSResourceInfo> parentAndDeps, ServerApiCall currentServer, string tempInstallPath, ConcurrentDictionary<string, Hashtable> packagesHash, ConcurrentDictionary<string, Hashtable> updatedPackagesHash, PSResourceInfo pkgToInstall)
+        private ConcurrentDictionary<string, Hashtable> InstallParentAndDependencyPackages(
+            List<PSResourceInfo> parentAndDeps,
+            ServerApiCall currentServer,
+            string tempInstallPath,
+            ConcurrentDictionary<string, Hashtable> packagesHash,
+            ConcurrentDictionary<string, Hashtable> updatedPackagesHash,
+            PSResourceInfo pkgToInstall,
+            ConcurrentQueue<ErrorRecord> errorMsgs,
+            ConcurrentQueue<string> warningMsgs,
+            ConcurrentQueue<string> debugMsgs,
+            ConcurrentQueue<string> verboseMsgs)
         {
-            string warning = string.Empty;
-            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
-            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
-            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
-            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
-
             // TODO: figure out a good threshold and parallel count
             int processorCount = Environment.ProcessorCount;
-            _cmdletPassedIn.WriteDebug($"parentAndDeps.Count is {parentAndDeps.Count}, processor count is: {processorCount}");
+            debugMsgs.Enqueue($"parentAndDeps.Count is {parentAndDeps.Count}, processor count is: {processorCount}");
             if (parentAndDeps.Count > processorCount)
             {
-                 _cmdletPassedIn.WriteDebug($"parentAndDeps.Count is greater than processor count");
+                 debugMsgs.Enqueue($"parentAndDeps.Count is greater than processor count");
                 // Set the maximum degree of parallelism to 32? (Invoke-Command has default of 32, that's where we got this number from)
                 // If installing more than 3 packages, do so concurrently
                 // If the number of dependencies is very small (e.g., ≤ CPU cores), parallelism may add overhead instead of improving speed.
@@ -891,8 +906,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     }
                 });
 
-                Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
-                if (errorMsgs.Count > 0)
+                if (!errorMsgs.IsEmpty)
                 {
                     return packagesHash;
                 }
@@ -910,15 +924,12 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                     if (installNameErrRecord != null)
                     {
-                        _cmdletPassedIn.WriteError(installNameErrRecord);
+                        errorMsgs.Enqueue(installNameErrRecord);
                         return packagesHash;
                     }
 
-                    //ErrorRecord tempSaveErrRecord = null, tempInstallErrRecord = null;
                     bool installedToTempPathSuccessfully = _asNupkg ? TrySaveNupkgToTempPath(responseStream, tempInstallPath, pkgToInstallName, pkgToInstallVersion, pkgToBeInstalled, packagesHash, out updatedPackagesHash, errorMsgs, warningMsgs, debugMsgs, verboseMsgs) :
                         TryInstallToTempPath(responseStream, tempInstallPath, pkgToInstallName, pkgToInstallVersion, pkgToBeInstalled, packagesHash, out updatedPackagesHash, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
-
-                    Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
 
                     if (!installedToTempPathSuccessfully)
                     {

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -920,11 +920,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 {
                     var pkgToInstallName = pkgToBeInstalled.Name;
                     var pkgToInstallVersion = Utils.GetFullVersionString(pkgToBeInstalled.Version.ToString(), pkgToBeInstalled.Prerelease);
-                    Stream responseStream = currentServer.InstallPackage(pkgToInstallName, pkgToInstallVersion, true, out ErrorRecord installNameErrRecord);
+                    // Runs on worker threads when parent installs are parallelized; use the async overload to avoid cross-thread cmdlet stream writes.
+                    Stream responseStream = currentServer.InstallPackageAsync(pkgToInstallName, pkgToInstallVersion, true, errorMsgs, warningMsgs, debugMsgs, verboseMsgs).GetAwaiter().GetResult();
 
-                    if (installNameErrRecord != null)
+                    if (!errorMsgs.IsEmpty)
                     {
-                        errorMsgs.Enqueue(installNameErrRecord);
                         return packagesHash;
                     }
 

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -885,7 +885,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     // add async
                     Stream responseStream = currentServer.InstallPackageAsync(depPkgName, depPkgVersion, true, errorMsgs, warningMsgs, debugMsgs, verboseMsgs).GetAwaiter().GetResult();
 
-                    if (errorMsgs.Count > 0)
+                    if (!errorMsgs.IsEmpty)
                     {
                         verboseMsgs.Enqueue($"Error installing package '{depPkgName}'");
                     }

--- a/src/code/InstallHelper.cs
+++ b/src/code/InstallHelper.cs
@@ -839,7 +839,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (!skipDependencyCheck)
             {
                 // List returned only includes dependencies, so we'll add the parent pkg to this list to pass on to installation method.
-                parentAndDeps.AddRange(_findHelper.FindDependencyPackages(currentServer, currentResponseUtil, pkgToInstall, repository));
+                parentAndDeps.AddRange(_findHelper.FindDependencyPackages(currentServer, currentResponseUtil, pkgToInstall, repository, errorMsgs, warningMsgs, debugMsgs, verboseMsgs));
                 debugMsgs.Enqueue("In InstallHelper::DownloadParentAndDeps(), found all dependencies");
             }
 

--- a/src/code/LocalServerApiCalls.cs
+++ b/src/code/LocalServerApiCalls.cs
@@ -41,14 +41,40 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         #region Overridden Methods
 
+        /// <summary>
+        /// Async find method which allows for searching for single name with specific version.
+        /// Name: no wildcard support
+        /// Version: no wildcard support
+        /// This is the concurrent (parallel) counterpart of FindVersion().
+        /// </summary>
         public override Task<FindResults> FindVersionAsync(string packageName, string version, ResourceType type, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            throw new NotImplementedException();
+            debugMsgs.Enqueue("In LocalServerApiCalls::FindVersionAsync()");
+            FindResults findResponse = FindVersionHelper(packageName, version, tags: Utils.EmptyStrArray, type, out ErrorRecord errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+            }
+
+            return Task.FromResult(findResponse);
         }
 
+        /// <summary>
+        /// Async find method which allows for searching for single name with version range.
+        /// Name: no wildcard support
+        /// Version: supports wildcards
+        /// This is the concurrent (parallel) counterpart of FindVersionGlobbing().
+        /// </summary>
         public override Task<FindResults> FindVersionGlobbingAsync(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            throw new NotImplementedException();
+            debugMsgs.Enqueue("In LocalServerApiCalls::FindVersionGlobbingAsync()");
+            FindResults findResponse = FindVersionGlobbing(packageName, versionRange, includePrerelease, type, getOnlyLatest, out ErrorRecord errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+            }
+
+            return Task.FromResult(findResponse);
         }
         /// <summary>
         /// Find method which allows for searching for all packages from a repository and returns latest version for each.
@@ -124,9 +150,21 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             return FindNameHelper(packageName, Utils.EmptyStrArray, includePrerelease, type, out errRecord);
         }
 
+        /// <summary>
+        /// Async find method which allows for searching for single name and returns latest version.
+        /// Name: no wildcard support
+        /// This is the concurrent (parallel) counterpart of FindName().
+        /// </summary>
         public override Task<FindResults> FindNameAsync(string packageName, bool includePrerelease, ResourceType type, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            throw new NotImplementedException();
+            debugMsgs.Enqueue("In LocalServerApiCalls::FindNameAsync()");
+            FindResults findResponse = FindNameHelper(packageName, tags: Utils.EmptyStrArray, includePrerelease, type, out ErrorRecord errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+            }
+
+            return Task.FromResult(findResponse);
         }
 
         /// <summary>
@@ -278,7 +316,26 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override Task<Stream> InstallPackageAsync(string packageName, string packageVersion, bool includePrerelease, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            throw new NotImplementedException("InstallPackageAsync is not implemented for LocalServerAPICalls.");
+            debugMsgs.Enqueue("In LocalServerApiCalls::InstallPackageAsync()");
+            Stream results = new MemoryStream();
+            if (string.IsNullOrEmpty(packageVersion))
+            {
+                errorMsgs.Enqueue(new ErrorRecord(
+                    exception: new ArgumentNullException($"Package version could not be found for {packageName}"),
+                    "PackageVersionNullOrEmptyError",
+                    ErrorCategory.InvalidArgument,
+                    _cmdletPassedIn));
+
+                return Task.FromResult(results);
+            }
+
+            results = InstallVersion(packageName, packageVersion, out ErrorRecord errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+            }
+
+            return Task.FromResult(results);
         }
 
         #endregion

--- a/src/code/NuGetServerAPICalls.cs
+++ b/src/code/NuGetServerAPICalls.cs
@@ -58,7 +58,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override Task<FindResults> FindVersionAsync(string packageName, string version, ResourceType type, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
             debugMsgs.Enqueue("In NuGetServerAPICalls::FindVersionAsync()");
-            FindResults findResponse = FindVersion(packageName, version, type, out ErrorRecord errRecord);
+            var queryBuilder = new NuGetV2QueryBuilder(new Dictionary<string, string>{
+                { "id", $"'{packageName}'" },
+            });
+            var filterBuilder = queryBuilder.FilterBuilder;
+
+            // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
+            filterBuilder.AddCriterion($"Id eq '{packageName}'");
+            filterBuilder.AddCriterion($"NormalizedVersion eq '{packageName}'");
+
+            var requestUrl = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
+            string response = HttpRequestCallAsync(requestUrl, debugMsgs, out ErrorRecord errRecord);
+            FindResults findResponse = new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: FindResponseType);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);
@@ -615,6 +626,55 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             return content;
+        }
+
+        /// <summary>
+        /// Helper method that makes the HTTP request for the NuGet server protocol url passed in for async find APIs.
+        /// This helper writes diagnostics to the provided debug queue and avoids cmdlet stream writes.
+        /// </summary>
+        private string HttpRequestCallAsync(string requestUrl, ConcurrentQueue<string> debugMsgs, out ErrorRecord errRecord)
+        {
+            debugMsgs.Enqueue("In NuGetServerAPICalls::HttpRequestCallAsync()");
+            errRecord = null;
+            string response = string.Empty;
+
+            try
+            {
+                debugMsgs.Enqueue($"Request url is: '{requestUrl}'");
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+                response = SendRequestAsync(request, _sessionClient).GetAwaiter().GetResult();
+            }
+            catch (HttpRequestException e)
+            {
+                errRecord = new ErrorRecord(
+                    exception: e,
+                    "HttpRequestFallFailure",
+                    ErrorCategory.ConnectionError,
+                    this);
+            }
+            catch (ArgumentNullException e)
+            {
+                errRecord = new ErrorRecord(
+                    exception: e,
+                    "HttpRequestFallFailure",
+                    ErrorCategory.ConnectionError,
+                    this);
+            }
+            catch (InvalidOperationException e)
+            {
+                errRecord = new ErrorRecord(
+                    exception: e,
+                    "HttpRequestFallFailure",
+                    ErrorCategory.ConnectionError,
+                    this);
+            }
+
+            if (string.IsNullOrEmpty(response))
+            {
+                debugMsgs.Enqueue("Response is empty");
+            }
+
+            return response;
         }
 
         #endregion

--- a/src/code/NuGetServerAPICalls.cs
+++ b/src/code/NuGetServerAPICalls.cs
@@ -49,14 +49,40 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         #region Overridden Methods
 
+        /// <summary>
+        /// Async find method which allows for searching for single name with specific version.
+        /// Name: no wildcard support
+        /// Version: no wildcard support
+        /// This is the concurrent (parallel) counterpart of FindVersion().
+        /// </summary>
         public override Task<FindResults> FindVersionAsync(string packageName, string version, ResourceType type, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            throw new NotImplementedException("FindVersionAsync is not implemented for NuGetServerAPICalls.");
+            debugMsgs.Enqueue("In NuGetServerAPICalls::FindVersionAsync()");
+            FindResults findResponse = FindVersion(packageName, version, type, out ErrorRecord errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+            }
+
+            return Task.FromResult(findResponse);
         }
 
+        /// <summary>
+        /// Async find method which allows for searching for single name with version range.
+        /// Name: no wildcard support
+        /// Version: supports wildcards
+        /// This is the concurrent (parallel) counterpart of FindVersionGlobbing().
+        /// </summary>
         public override Task<FindResults> FindVersionGlobbingAsync(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            throw new NotImplementedException("FindVersionGlobbingAsync is not implemented for NuGetServerAPICalls.");
+            debugMsgs.Enqueue("In NuGetServerAPICalls::FindVersionGlobbingAsync()");
+            FindResults findResponse = FindVersionGlobbing(packageName, versionRange, includePrerelease, type, getOnlyLatest, out ErrorRecord errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+            }
+
+            return Task.FromResult(findResponse);
         }
         /// <summary>
         /// Find method which allows for searching for all packages from a repository and returns latest version for each.
@@ -193,9 +219,21 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             return new FindResults(stringResponse: new string[]{ response }, hashtableResponse: emptyHashResponses, responseType: FindResponseType);
         }
 
+        /// <summary>
+        /// Async find method which allows for searching for single name and returns latest version.
+        /// Name: no wildcard support
+        /// This is the concurrent (parallel) counterpart of FindName().
+        /// </summary>
         public override Task<FindResults> FindNameAsync(string packageName, bool includePrerelease, ResourceType type, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            throw new NotImplementedException("FindNameAsync is not implemented for NuGetServerAPICalls.");
+            debugMsgs.Enqueue("In NuGetServerAPICalls::FindNameAsync()");
+            FindResults findResponse = FindName(packageName, includePrerelease, type, out ErrorRecord errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+            }
+
+            return Task.FromResult(findResponse);
         }
 
         /// <summary>
@@ -471,7 +509,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override Task<Stream> InstallPackageAsync(string packageName, string packageVersion, bool includePrerelease, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            throw new NotImplementedException("InstallPackageAsync is not implemented for NuGetServerAPICalls.");
+            debugMsgs.Enqueue("In NuGetServerAPICalls::InstallPackageAsync()");
+            Stream results = InstallPackage(packageName, packageVersion, includePrerelease, out ErrorRecord errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+            }
+
+            return Task.FromResult(results);
         }
 
         /// <summary>

--- a/src/code/NuGetServerAPICalls.cs
+++ b/src/code/NuGetServerAPICalls.cs
@@ -122,7 +122,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: FindResponseType);
             }
 
-            int count = initialCount / 6000;
+            int count = (int)Math.Ceiling((double)initialCount / 6000) - 1;
             // if more than 100 count, loop and add response to list
             while (count > 0)
             {
@@ -166,7 +166,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: FindResponseType);
             }
 
-            int count = initialCount / 100;
+            int count = (int)Math.Ceiling((double)initialCount / 100) - 1;
             // if more than 100 count, loop and add response to list
             while (count > 0)
             {
@@ -310,7 +310,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: FindResponseType);
             }
 
-            int count = initialCount / 100;
+            int count = (int)Math.Ceiling((double)initialCount / 100) - 1;
             // if more than 100 count, loop and add response to list
             while (count > 0)
             {
@@ -355,7 +355,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: FindResponseType);
             }
 
-            int count = initialCount / 100;
+            int count = (int)Math.Ceiling((double)initialCount / 100) - 1;
             // if more than 100 count, loop and add response to list
             while (count > 0)
             {
@@ -404,7 +404,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     return new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: FindResponseType);
                 }
 
-                int count = initialCount / 100;
+                int count = (int)Math.Ceiling((double)initialCount / 100) - 1;
 
                 while (count > 0)
                 {

--- a/src/code/NuGetServerAPICalls.cs
+++ b/src/code/NuGetServerAPICalls.cs
@@ -87,13 +87,46 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override Task<FindResults> FindVersionGlobbingAsync(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
             debugMsgs.Enqueue("In NuGetServerAPICalls::FindVersionGlobbingAsync()");
-            FindResults findResponse = FindVersionGlobbing(packageName, versionRange, includePrerelease, type, getOnlyLatest, out ErrorRecord errRecord);
+            List<string> responses = new List<string>();
+            int skip = 0;
+
+            var initialResponse = FindVersionGlobbingFromEndpointAsync(packageName, versionRange, includePrerelease, skip, getOnlyLatest, debugMsgs, out ErrorRecord errRecord);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);
+                return Task.FromResult(new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: FindResponseType));
             }
 
-            return Task.FromResult(findResponse);
+            responses.Add(initialResponse);
+
+            if (!getOnlyLatest)
+            {
+                int initialCount = GetCountFromResponse(initialResponse, out errRecord);
+                if (errRecord != null)
+                {
+                    errorMsgs.Enqueue(errRecord);
+                    return Task.FromResult(new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: FindResponseType));
+                }
+
+                int count = (int)Math.Ceiling((double)initialCount / 100) - 1;
+
+                while (count > 0)
+                {
+                    // skip 100
+                    skip += 100;
+                    var tmpResponse = FindVersionGlobbingFromEndpointAsync(packageName, versionRange, includePrerelease, skip, getOnlyLatest, debugMsgs, out errRecord);
+                    if (errRecord != null)
+                    {
+                        errorMsgs.Enqueue(errRecord);
+                        return Task.FromResult(new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: FindResponseType));
+                    }
+
+                    responses.Add(tmpResponse);
+                    count--;
+                }
+            }
+
+            return Task.FromResult(new FindResults(stringResponse: responses.ToArray(), hashtableResponse: emptyHashResponses, responseType: FindResponseType));
         }
         /// <summary>
         /// Find method which allows for searching for all packages from a repository and returns latest version for each.
@@ -985,6 +1018,25 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         private string FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, int skip, bool getOnlyLatest, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::FindVersionGlobbing()");
+            var requestUrl = GetVersionGlobbingRequestUrl(packageName, versionRange, includePrerelease, skip, getOnlyLatest);
+            return HttpRequestCall(requestUrl, out errRecord);
+        }
+
+        /// <summary>
+        /// Worker-thread counterpart of FindVersionGlobbing(); enqueues diagnostics instead of writing to cmdlet streams.
+        /// </summary>
+        private string FindVersionGlobbingFromEndpointAsync(string packageName, VersionRange versionRange, bool includePrerelease, int skip, bool getOnlyLatest, ConcurrentQueue<string> debugMsgs, out ErrorRecord errRecord)
+        {
+            debugMsgs.Enqueue("In NuGetServerAPICalls::FindVersionGlobbingFromEndpointAsync()");
+            var requestUrl = GetVersionGlobbingRequestUrl(packageName, versionRange, includePrerelease, skip, getOnlyLatest);
+            return HttpRequestCallAsync(requestUrl, debugMsgs, out errRecord);
+        }
+
+        /// <summary>
+        /// Builds the FindPackagesById() request url for version-globbing searches.
+        /// </summary>
+        private string GetVersionGlobbingRequestUrl(string packageName, VersionRange versionRange, bool includePrerelease, int skip, bool getOnlyLatest)
+        {
             //https://www.powershellgallery.com/api/v2//FindPackagesById()?id='blah'&includePrerelease=false&$filter= NormalizedVersion gt '1.0.0' and NormalizedVersion lt '2.2.5' and substringof('PSModule', Tags) eq true
             //https://www.powershellgallery.com/api/v2//FindPackagesById()?id='PowerShellGet'&includePrerelease=false&$filter= NormalizedVersion gt '1.1.1' and NormalizedVersion lt '2.2.5'
             // NormalizedVersion doesn't include trailing zeroes
@@ -1053,9 +1105,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
             filterBuilder.AddCriterion($"Id eq '{packageName}'");
 
-            var requestUrl = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
-
-            return HttpRequestCall(requestUrl, out errRecord);
+            return $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
         }
 
         /// <summary>

--- a/src/code/NuGetServerAPICalls.cs
+++ b/src/code/NuGetServerAPICalls.cs
@@ -89,7 +89,7 @@ filterBuilder.AddCriterion($"NormalizedVersion eq '{version}'");
             List<string> responses = new List<string>();
             int skip = 0;
 
-            var initialResponse = FindVersionGlobbingFromEndpointAsync(packageName, versionRange, includePrerelease, skip, getOnlyLatest, debugMsgs, out ErrorRecord errRecord);
+            var initialResponse = FindVersionGlobbingAsync(packageName, versionRange, includePrerelease, skip, getOnlyLatest, debugMsgs, out ErrorRecord errRecord);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);
@@ -113,7 +113,7 @@ filterBuilder.AddCriterion($"NormalizedVersion eq '{version}'");
                 {
                     // skip 100
                     skip += 100;
-                    var tmpResponse = FindVersionGlobbingFromEndpointAsync(packageName, versionRange, includePrerelease, skip, getOnlyLatest, debugMsgs, out errRecord);
+                    var tmpResponse = FindVersionGlobbingAsync(packageName, versionRange, includePrerelease, skip, getOnlyLatest, debugMsgs, out errRecord);
                     if (errRecord != null)
                     {
                         errorMsgs.Enqueue(errRecord);
@@ -1024,9 +1024,9 @@ filterBuilder.AddCriterion($"NormalizedVersion eq '{version}'");
         /// <summary>
         /// Worker-thread counterpart of FindVersionGlobbing(); enqueues diagnostics instead of writing to cmdlet streams.
         /// </summary>
-        private string FindVersionGlobbingFromEndpointAsync(string packageName, VersionRange versionRange, bool includePrerelease, int skip, bool getOnlyLatest, ConcurrentQueue<string> debugMsgs, out ErrorRecord errRecord)
+        private string FindVersionGlobbingAsync(string packageName, VersionRange versionRange, bool includePrerelease, int skip, bool getOnlyLatest, ConcurrentQueue<string> debugMsgs, out ErrorRecord errRecord)
         {
-            debugMsgs.Enqueue("In NuGetServerAPICalls::FindVersionGlobbingFromEndpointAsync()");
+            debugMsgs.Enqueue("In NuGetServerAPICalls::FindVersionGlobbingAsync()");
             var requestUrl = GetVersionGlobbingRequestUrl(packageName, versionRange, includePrerelease, skip, getOnlyLatest);
             return HttpRequestCallAsync(requestUrl, debugMsgs, out errRecord);
         }

--- a/src/code/NuGetServerAPICalls.cs
+++ b/src/code/NuGetServerAPICalls.cs
@@ -521,7 +521,19 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override Task<Stream> InstallPackageAsync(string packageName, string packageVersion, bool includePrerelease, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
             debugMsgs.Enqueue("In NuGetServerAPICalls::InstallPackageAsync()");
-            Stream results = InstallPackage(packageName, packageVersion, includePrerelease, out ErrorRecord errRecord);
+            Stream results = new MemoryStream();
+            if (string.IsNullOrEmpty(packageVersion))
+            {
+                errorMsgs.Enqueue(new ErrorRecord(
+                    exception: new ArgumentNullException($"Package version could not be found for {packageName}"),
+                    "PackageVersionNullOrEmptyError",
+                    ErrorCategory.InvalidArgument,
+                    _cmdletPassedIn));
+
+                return Task.FromResult(results);
+            }
+
+            results = InstallVersionAsync(packageName, packageVersion, debugMsgs, out ErrorRecord errRecord);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);
@@ -623,6 +635,55 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (string.IsNullOrEmpty(content.ToString()))
             {
                 _cmdletPassedIn.WriteDebug("Response is empty");
+            }
+
+            return content;
+        }
+
+        /// <summary>
+        /// Helper method that makes the HTTP request for install APIs on worker threads; enqueues diagnostics instead of writing to cmdlet streams.
+        /// </summary>
+        private HttpContent HttpRequestCallForContentAsync(string requestUrl, ConcurrentQueue<string> debugMsgs, out ErrorRecord errRecord)
+        {
+            debugMsgs.Enqueue("In NuGetServerAPICalls::HttpRequestCallForContentAsync()");
+            errRecord = null;
+            HttpContent content = null;
+
+            try
+            {
+                debugMsgs.Enqueue($"Request url is: '{requestUrl}'");
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+
+                content = SendRequestForContentAsync(request, _sessionClient).GetAwaiter().GetResult();
+            }
+            catch (HttpRequestException e)
+            {
+                errRecord = new ErrorRecord(
+                    exception: e,
+                    "HttpRequestFailure",
+                    ErrorCategory.ConnectionError ,
+                    this);
+            }
+            catch (ArgumentNullException e)
+            {
+                errRecord = new ErrorRecord(
+                    exception: e,
+                    "HttpRequestFailure",
+                    ErrorCategory.InvalidData,
+                    this);
+            }
+            catch (InvalidOperationException e)
+            {
+                errRecord = new ErrorRecord(
+                    exception: e,
+                    "HttpRequestFailure",
+                    ErrorCategory.InvalidOperation,
+                    this);
+            }
+
+            if (string.IsNullOrEmpty(content?.ToString()))
+            {
+                debugMsgs.Enqueue("Response is empty");
             }
 
             return content;
@@ -1025,6 +1086,29 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             _cmdletPassedIn.WriteDebug("In NuGetServerAPICalls::InstallVersion()");
             var requestUrl = $"{Repository.Uri}/Packages(Id='{packageName}',Version='{version}')/Download";
             var response = HttpRequestCallForContent(requestUrl, out errRecord);
+
+            if (response is null)
+            {
+                errRecord = new ErrorRecord(
+                    new Exception($"No content was returned by repository '{Repository.Name}'"),
+                    "InstallFailureContentNullNuGetServer",
+                    ErrorCategory.InvalidResult,
+                    this);
+
+                return null;
+            }
+
+            return response.ReadAsStreamAsync().Result;
+        }
+
+        /// <summary>
+        /// Worker-thread counterpart of InstallVersion(); enqueues diagnostics instead of writing to cmdlet streams.
+        /// </summary>
+        private Stream InstallVersionAsync(string packageName, string version, ConcurrentQueue<string> debugMsgs, out ErrorRecord errRecord)
+        {
+            debugMsgs.Enqueue("In NuGetServerAPICalls::InstallVersionAsync()");
+            var requestUrl = $"{Repository.Uri}/Packages(Id='{packageName}',Version='{version}')/Download";
+            var response = HttpRequestCallForContentAsync(requestUrl, debugMsgs, out errRecord);
 
             if (response is null)
             {

--- a/src/code/NuGetServerAPICalls.cs
+++ b/src/code/NuGetServerAPICalls.cs
@@ -238,7 +238,19 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override Task<FindResults> FindNameAsync(string packageName, bool includePrerelease, ResourceType type, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
             debugMsgs.Enqueue("In NuGetServerAPICalls::FindNameAsync()");
-            FindResults findResponse = FindName(packageName, includePrerelease, type, out ErrorRecord errRecord);
+            var queryBuilder = new NuGetV2QueryBuilder(new Dictionary<string, string>{
+                { "id", $"'{packageName}'" },
+            });
+            var filterBuilder = queryBuilder.FilterBuilder;
+
+            filterBuilder.AddCriterion(includePrerelease ? "IsAbsoluteLatestVersion" : "IsLatestVersion");
+
+            // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
+            filterBuilder.AddCriterion($"Id eq '{packageName}'");
+
+            var requestUrl = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
+            string response = HttpRequestCallAsync(requestUrl, debugMsgs, out ErrorRecord errRecord);
+            FindResults findResponse = new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: FindResponseType);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);

--- a/src/code/NuGetServerAPICalls.cs
+++ b/src/code/NuGetServerAPICalls.cs
@@ -63,10 +63,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             });
             var filterBuilder = queryBuilder.FilterBuilder;
 
-            // We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
-            filterBuilder.AddCriterion($"Id eq '{packageName}'");
-            filterBuilder.AddCriterion($"NormalizedVersion eq '{packageName}'");
-
+// We need to explicitly add 'Id eq <packageName>' whenever $filter is used, otherwise arbitrary results are returned.
+filterBuilder.AddCriterion($"Id eq '{packageName}'");
+filterBuilder.AddCriterion($"NormalizedVersion eq '{version}'");
             var requestUrl = $"{Repository.Uri}/FindPackagesById()?{queryBuilder.BuildQueryString()}";
             string response = HttpRequestCallAsync(requestUrl, debugMsgs, out ErrorRecord errRecord);
             FindResults findResponse = new FindResults(stringResponse: new string[] { response }, hashtableResponse: emptyHashResponses, responseType: FindResponseType);

--- a/src/code/Utils.cs
+++ b/src/code/Utils.cs
@@ -1737,7 +1737,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         }
 
 
-        public static void WriteOutConcurrentQueue(PSCmdlet cmdletPassedIn, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
+        public static void WriteOutConcurrentQueue(PSCmdlet cmdletPassedIn, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs, ConcurrentQueue<InformationRecord> informationMsgs = null)
         {
 
             while (errorMsgs.TryDequeue(out ErrorRecord error))
@@ -1755,6 +1755,10 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
             while (verboseMsgs.TryDequeue(out string verboseMsg))
             {
                 cmdletPassedIn.WriteVerbose(verboseMsg);
+            }
+            while (informationMsgs?.TryDequeue(out InformationRecord informationRecord) == true)
+            {
+                cmdletPassedIn.WriteInformation(informationRecord);
             }
         }
 

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -206,7 +206,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (initialScriptCount != 0)
                 {
                     responses.Add(initialScriptResponse);
-                    int count = initialScriptCount / 100;
+                    int count = (int)Math.Ceiling((double)initialScriptCount / 100) - 1;
                     // if more than 100 count, loop and add response to list
                     while (count > 0)
                     {
@@ -242,7 +242,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 if (initialModuleCount != 0)
                 {
                     responses.Add(initialModuleResponse);
-                    int count = initialModuleCount / 100;
+                    int count = (int)Math.Ceiling((double)initialModuleCount / 100) - 1;
                     // if more than 100 count, loop and add response to list
                     while (count > 0)
                     {
@@ -296,7 +296,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             if (initialCount != 0)
             {
                 responses.Add(initialResponse);
-                int count = (int)Math.Ceiling((double)(initialCount / 100));
+                int count = (int)Math.Ceiling((double)initialCount / 100) - 1;
 
                 while (count > 0)
                 {
@@ -596,7 +596,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
 
-            int count = (int)Math.Ceiling((double)(initialCount / 100));
+            int count = (int)Math.Ceiling((double)initialCount / 100) - 1;
             // if more than 100 count, loop and add response to list
             while (count > 0)
             {
@@ -648,7 +648,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
             }
 
-            int count = (int)Math.Ceiling((double)(initialCount / 100));
+            int count = (int)Math.Ceiling((double)initialCount / 100) - 1;
             // if more than 100 count, loop and add response to list
             while (count > 0)
             {
@@ -704,7 +704,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (!getOnlyLatest)
             {
-                int count = (int)Math.Ceiling((double)(initialCount / 100));
+                int count = (int)Math.Ceiling((double)initialCount / 100) - 1;
 
                 while (count > 0)
                 {
@@ -1735,7 +1735,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (!getOnlyLatest)
             {
-                int count = (int)Math.Ceiling((double)(initialCount / 100));
+                int count = (int)Math.Ceiling((double)initialCount / 100) - 1;
 
                 while (count > 0)
                 {

--- a/src/code/V2ServerAPICalls.cs
+++ b/src/code/V2ServerAPICalls.cs
@@ -1074,7 +1074,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private async Task<string> HttpRequestCallAsync(string requestUrlV2, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            // TODO: Async methods cannot have out ref, so currently handling errorRecords as thrown exceptions.
             debugMsgs.Enqueue("In V2ServerAPICalls::HttpRequestCallAsync()");
             string response = string.Empty;
 
@@ -1131,7 +1130,6 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private async Task<HttpContent> HttpRequestCallForContentAsync(string requestUrlV2, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            // TODO: Async methods cannot have out ref, so need to handle errorRecords a different way.
             debugMsgs.Enqueue("In V2ServerAPICalls::HttpRequestCallForContentAsync()");
             HttpContent content = null;
 
@@ -1744,13 +1742,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     debugMsgs.Enqueue($"Count is '{count}'");
                     // skip 100
                     skip += 100;
-                    // TODO: this should be an async method
-                    var tmpResponse = FindVersionGlobbing(packageName, versionRange, includePrerelease, type, skip, getOnlyLatest, out ErrorRecord errRecord);
-                    if (errRecord != null)
-                    {
-                        Utils.EnqueueIfNotNull(errorMsgs, errRecord);
-                        return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v2FindResponseType);
-                    }
+                    var tmpResponse = await FindVersionGlobbingAsync(packageName, versionRange, includePrerelease, type, skip, getOnlyLatest, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                     responses.Add(tmpResponse);
                     count--;
                 }

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override Task<FindResults> FindVersionAsync(string packageName, string version, ResourceType type, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
             debugMsgs.Enqueue("In V3ServerAPICalls::FindVersionAsync()");
-            FindResults findResponse = FindVersionHelper(packageName, version, tags: Utils.EmptyStrArray, type, out ErrorRecord errRecord);
+            FindResults findResponse = FindVersionHelper(packageName, version, tags: Utils.EmptyStrArray, type, out ErrorRecord errRecord, debugMsgs);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);
@@ -119,7 +119,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override Task<FindResults> FindVersionGlobbingAsync(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
             debugMsgs.Enqueue("In V3ServerAPICalls::FindVersionGlobbingAsync()");
-            FindResults findResponse = FindVersionGlobbing(packageName, versionRange, includePrerelease, type, getOnlyLatest, out ErrorRecord errRecord);
+            FindResults findResponse = FindVersionGlobbingHelper(packageName, versionRange, includePrerelease, type, getOnlyLatest, out ErrorRecord errRecord, debugMsgs);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);
@@ -204,7 +204,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override Task<FindResults> FindNameAsync(string packageName, bool includePrerelease, ResourceType type, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
             debugMsgs.Enqueue("In V3ServerAPICalls::FindNameAsync()");
-            FindResults findResponse = FindNameHelper(packageName, tags: Utils.EmptyStrArray, includePrerelease, type, out ErrorRecord errRecord);
+            FindResults findResponse = FindNameHelper(packageName, tags: Utils.EmptyStrArray, includePrerelease, type, out ErrorRecord errRecord, debugMsgs);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);
@@ -281,9 +281,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ErrorRecord errRecord)
         {
-            // TODO: pass in ConcurrentQueue for debug messages so this is thread-safe when called from FindVersionGlobbingAsync().
-            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindVersionGlobbing()");
-            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord);
+            return FindVersionGlobbingHelper(packageName, versionRange, includePrerelease, type, getOnlyLatest, out errRecord);
+        }
+
+        private FindResults FindVersionGlobbingHelper(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ErrorRecord errRecord, ConcurrentQueue<string> debugMsgs = null)
+        {
+            WriteDebug("In V3ServerAPICalls::FindVersionGlobbing()", debugMsgs);
+            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord, debugMsgs);
             if (errRecord != null)
             {
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -310,8 +314,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         if (NuGetVersion.TryParse(pkgVersionElement.ToString(), out NuGetVersion pkgVersion) && versionRange.Satisfies(pkgVersion))
                         {
-                            // TODO: pass in ConcurrentQueue for debug messages so this is thread-safe when called from FindVersionGlobbingAsync(). ?
-                            _cmdletPassedIn.WriteDebug($"Package version parsed as '{pkgVersion}' satisfies the version range");
+                            WriteDebug($"Package version parsed as '{pkgVersion}' satisfies the version range", debugMsgs);
                             if (!pkgVersion.IsPrerelease || includePrerelease)
                             {
                                 satisfyingVersions.Add(response);
@@ -581,11 +584,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method called by FindName() and FindNameWithTag()
         /// <summary>
-        private FindResults FindNameHelper(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
+        private FindResults FindNameHelper(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord, ConcurrentQueue<string> debugMsgs = null)
         {
-            // TODO: pass in ConcurrentQueue for debug messages so this is thread-safe when called from FindNameAsync(). ?
-            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindNameHelper()");
-            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord);
+            WriteDebug("In V3ServerAPICalls::FindNameHelper()", debugMsgs);
+            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord, debugMsgs);
             if (errRecord != null)
             {
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -623,8 +625,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         if (NuGetVersion.TryParse(pkgVersionElement.ToString(), out NuGetVersion pkgVersion))
                         {
-                            // ?
-                            _cmdletPassedIn.WriteDebug($"'{packageName}' version parsed as '{pkgVersion}'");
+                            WriteDebug($"'{packageName}' version parsed as '{pkgVersion}'", debugMsgs);
                             if (!pkgVersion.IsPrerelease || includePrerelease)
                             {
                                 // Versions are always in descending order i.e 5.0.0, 3.0.0, 1.0.0 so grabbing the first match suffices
@@ -679,10 +680,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method called by FindVersion() and FindVersionWithTag()
         /// </summary>
-        private FindResults FindVersionHelper(string packageName, string version, string[] tags, ResourceType type, out ErrorRecord errRecord)
+        private FindResults FindVersionHelper(string packageName, string version, string[] tags, ResourceType type, out ErrorRecord errRecord, ConcurrentQueue<string> debugMsgs = null)
         {
-            // TODO: pass in ConcurrentQueue for debug messages so this is thread-safe when called from FindVersionAsync(). ?
-            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindVersionHelper()");
+            WriteDebug("In V3ServerAPICalls::FindVersionHelper()", debugMsgs);
             if (!NuGetVersion.TryParse(version, out NuGetVersion requiredVersion))
             {
                 errRecord = new ErrorRecord(
@@ -695,7 +695,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             //_cmdletPassedIn.WriteDebug($"'{packageName}' version parsed as '{requiredVersion}'");
 
-            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord);
+            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord, debugMsgs);
             if (errRecord != null)
             {
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -989,7 +989,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// i.e when the package Name being searched for does not contain wildcard
         /// This is called by FindNameHelper(), FindVersionHelper(), FindVersionGlobbing(), InstallHelper()
         /// </summary>
-        private string[] GetVersionedPackageEntriesFromRegistrationsResource(string packageName, string propertyName, bool isSearch, out ErrorRecord errRecord)
+        private string[] GetVersionedPackageEntriesFromRegistrationsResource(string packageName, string propertyName, bool isSearch, out ErrorRecord errRecord, ConcurrentQueue<string> debugMsgs = null)
         {
             // TODO: pass in ConcurrentQueue to write out debug message.
             //_cmdletPassedIn.WriteDebug("In V3ServerAPICalls::GetVersionedPackageEntriesFromRegistrationsResource()");
@@ -1006,7 +1006,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return responses;
             }
 
-            responses = GetVersionedResponsesFromRegistrationsResource(registrationsBaseUrl, packageName, propertyName, isSearch, out errRecord);
+            responses = GetVersionedResponsesFromRegistrationsResource(registrationsBaseUrl, packageName, propertyName, isSearch, out errRecord, debugMsgs);
             if (errRecord != null)
             {
                 return Utils.EmptyStrArray;
@@ -1452,7 +1452,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         ///     The "packageContent" property is used for download, and the value is a URI for the .nupkg file.
         /// </param>
         /// <summary>
-        private string[] GetVersionedResponsesFromRegistrationsResource(string registrationsBaseUrl, string packageName, string property, bool isSearch, out ErrorRecord errRecord)
+        private string[] GetVersionedResponsesFromRegistrationsResource(string registrationsBaseUrl, string packageName, string property, bool isSearch, out ErrorRecord errRecord, ConcurrentQueue<string> debugMsgs = null)
         {
             // TODO: pass in ConcurrentQueue to write out debug message.
             //_cmdletPassedIn.WriteDebug("In V3ServerAPICalls::GetVersionedResponsesFromRegistrationsResource()");
@@ -1490,7 +1490,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (isSearch)
             {
-                if (!IsLatestVersionFirstForSearch(versionedResponseArr, out errRecord))
+                if (!IsLatestVersionFirstForSearch(versionedResponseArr, out errRecord, debugMsgs))
                 {
                     Array.Reverse(versionedResponseArr);
                 }
@@ -1511,10 +1511,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// ADO feeds usually return version entries in descending order, but Nuget.org repository returns them in ascending order.
         /// Package versions will reflect prerelease preference, but upper version and lower version would not so we don't use them for comparison.
         /// </summary>
-        private bool IsLatestVersionFirstForSearch(string[] versionedResponses, out ErrorRecord errRecord)
+        private bool IsLatestVersionFirstForSearch(string[] versionedResponses, out ErrorRecord errRecord, ConcurrentQueue<string> debugMsgs = null)
         {
-            // TODO: pass in ConcurrentQueue for debug messages so this is thread-safe when reached from the async find methods. ?
-            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::IsLatestVersionFirstForSearch()");
+            WriteDebug("In V3ServerAPICalls::IsLatestVersionFirstForSearch()", debugMsgs);
             errRecord = null;
             bool latestVersionFirst = true;
             int versionResponsesCount = versionedResponses.Length;
@@ -1604,6 +1603,18 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             return latestVersionFirst;
+        }
+
+        private void WriteDebug(string message, ConcurrentQueue<string> debugMsgs = null)
+        {
+            if (debugMsgs == null)
+            {
+                _cmdletPassedIn.WriteDebug(message);
+            }
+            else
+            {
+                debugMsgs.Enqueue(message);
+            }
         }
 
         /// <summary>

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -89,14 +89,43 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
         #region Overridden Methods
 
+        /// <summary>
+        /// Async find method which allows for searching for single name with specific version.
+        /// Name: no wildcard support
+        /// Version: no wildcard support
+        /// Examples: Search "NuGet.Server.Core" "3.0.0-beta"
+        /// This is the concurrent (parallel) counterpart of FindVersion().
+        /// </summary>
         public override Task<FindResults> FindVersionAsync(string packageName, string version, ResourceType type, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            throw new NotImplementedException("FindVersionAsync is not implemented for V3ServerAPICalls.");
+            debugMsgs.Enqueue("In V3ServerAPICalls::FindVersionAsync()");
+            FindResults findResponse = FindVersionHelper(packageName, version, tags: Utils.EmptyStrArray, type, out ErrorRecord errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+            }
+
+            return Task.FromResult(findResponse);
         }
 
+        /// <summary>
+        /// Async find method which allows for searching for single name with version range.
+        /// Name: no wildcard support
+        /// Version: supports wildcards
+        /// Examples: Search "NuGet.Server.Core" "[1.0.0.0, 5.0.0.0]"
+        ///           Search "NuGet.Server.Core" "3.*"
+        /// This is the concurrent (parallel) counterpart of FindVersionGlobbing().
+        /// </summary>
         public override Task<FindResults> FindVersionGlobbingAsync(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            throw new NotImplementedException("FindVersionAsync is not implemented for V3ServerAPICalls.");
+            debugMsgs.Enqueue("In V3ServerAPICalls::FindVersionGlobbingAsync()");
+            FindResults findResponse = FindVersionGlobbing(packageName, versionRange, includePrerelease, type, getOnlyLatest, out ErrorRecord errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+            }
+
+            return Task.FromResult(findResponse);
         }
 
         /// <summary>
@@ -166,9 +195,22 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             return FindNameHelper(packageName, tags: Utils.EmptyStrArray, includePrerelease, type, out errRecord);
         }
 
+        /// <summary>
+        /// Async find method which allows for searching for single name and returns latest version.
+        /// Name: no wildcard support
+        /// Examples: Search "Newtonsoft.Json"
+        /// This is the concurrent (parallel) counterpart of FindName().
+        /// </summary>
         public override Task<FindResults> FindNameAsync(string packageName, bool includePrerelease, ResourceType type, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            throw new NotImplementedException("FindVersionAsync is not implemented for V3ServerAPICalls.");
+            debugMsgs.Enqueue("In V3ServerAPICalls::FindNameAsync()");
+            FindResults findResponse = FindNameHelper(packageName, tags: Utils.EmptyStrArray, includePrerelease, type, out ErrorRecord errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+            }
+
+            return Task.FromResult(findResponse);
         }
 
         /// <summary>
@@ -239,6 +281,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ErrorRecord errRecord)
         {
+            // TODO: pass in ConcurrentQueue for debug messages so this is thread-safe when called from FindVersionGlobbingAsync().
             _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindVersionGlobbing()");
             string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord);
             if (errRecord != null)
@@ -267,6 +310,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         if (NuGetVersion.TryParse(pkgVersionElement.ToString(), out NuGetVersion pkgVersion) && versionRange.Satisfies(pkgVersion))
                         {
+                            // TODO: pass in ConcurrentQueue for debug messages so this is thread-safe when called from FindVersionGlobbingAsync(). ?
                             _cmdletPassedIn.WriteDebug($"Package version parsed as '{pkgVersion}' satisfies the version range");
                             if (!pkgVersion.IsPrerelease || includePrerelease)
                             {
@@ -353,9 +397,34 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Install "PowerShellGet" -Version "3.5.0-alpha"
         ///           Install "PowerShellGet" -Version "3.0.0"
         /// </summary>
-        public override Task<Stream> InstallPackageAsync(string packageName, string packageVersion, bool includePrerelease, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
+        public override async Task<Stream> InstallPackageAsync(string packageName, string packageVersion, bool includePrerelease, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            throw new NotImplementedException("InstallPackageAsync is not implemented for NuGetServerAPICalls.");
+            debugMsgs.Enqueue("In V3ServerAPICalls::InstallPackageAsync()");
+            Stream results = new MemoryStream();
+            if (string.IsNullOrEmpty(packageVersion))
+            {
+                errorMsgs.Enqueue(new ErrorRecord(
+                    exception: new ArgumentNullException($"Package version could not be found for {packageName}"),
+                    "PackageVersionNullOrEmptyError",
+                    ErrorCategory.InvalidArgument,
+                    this));
+
+                return results;
+            }
+
+            if (!NuGetVersion.TryParse(packageVersion, out NuGetVersion requiredVersion))
+            {
+                errorMsgs.Enqueue(new ErrorRecord(
+                    new ArgumentException($"Version {packageVersion} to be installed is not a valid NuGet version."),
+                    "InstallVersionFailure",
+                    ErrorCategory.InvalidArgument,
+                    this));
+
+                return results;
+            }
+
+            results = await InstallHelperAsync(packageName, requiredVersion, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+            return results;
         }
 
         #endregion
@@ -514,6 +583,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         private FindResults FindNameHelper(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
+            // TODO: pass in ConcurrentQueue for debug messages so this is thread-safe when called from FindNameAsync(). ?
             _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindNameHelper()");
             string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord);
             if (errRecord != null)
@@ -553,6 +623,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         if (NuGetVersion.TryParse(pkgVersionElement.ToString(), out NuGetVersion pkgVersion))
                         {
+                            // ?
                             _cmdletPassedIn.WriteDebug($"'{packageName}' version parsed as '{pkgVersion}'");
                             if (!pkgVersion.IsPrerelease || includePrerelease)
                             {
@@ -610,6 +681,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private FindResults FindVersionHelper(string packageName, string version, string[] tags, ResourceType type, out ErrorRecord errRecord)
         {
+            // TODO: pass in ConcurrentQueue for debug messages so this is thread-safe when called from FindVersionAsync(). ?
             _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindVersionHelper()");
             if (!NuGetVersion.TryParse(version, out NuGetVersion requiredVersion))
             {
@@ -621,7 +693,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
-            _cmdletPassedIn.WriteDebug($"'{packageName}' version parsed as '{requiredVersion}'");
+            //_cmdletPassedIn.WriteDebug($"'{packageName}' version parsed as '{requiredVersion}'");
 
             string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord);
             if (errRecord != null)
@@ -828,6 +900,88 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             return content.ReadAsStreamAsync().GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Helper method that is called by InstallPackageAsync()
+        /// For InstallName() we want latest version installed (so version parameter passed in will be null), for InstallVersion() we want specified, non-null version installed.
+        /// This is the async counterpart of InstallHelper() used for concurrent (parallel) installation workflows.
+        /// </summary>
+        private async Task<Stream> InstallHelperAsync(string packageName, NuGetVersion version, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
+        {
+            debugMsgs.Enqueue("In V3ServerAPICalls::InstallHelperAsync()");
+            Stream pkgStream = null;
+            bool getLatestVersion = true;
+            if (version != null)
+            {
+                getLatestVersion = false;
+            }
+
+            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, packageContentProperty, isSearch: false, out ErrorRecord errRecord);
+            if (errRecord != null)
+            {
+                errorMsgs.Enqueue(errRecord);
+                return pkgStream;
+            }
+
+            if (versionedResponses.Length == 0)
+            {
+                errorMsgs.Enqueue(new ErrorRecord(
+                    new Exception($"Package with name '{packageName}' and version '{version}' could not be found in repository '{Repository.Name}'"),
+                    "InstallFailure",
+                    ErrorCategory.InvalidResult,
+                    this));
+
+                return null;
+            }
+
+            string pkgContentUrl = String.Empty;
+            if (getLatestVersion)
+            {
+                pkgContentUrl = versionedResponses[0];
+            }
+            else
+            {
+                // loop through responses to find one containing required version
+                foreach (string response in versionedResponses)
+                {
+                    // Response will be "packageContent" element value that looks like: "{packageBaseAddress}/{packageName}/{normalizedVersion}/{packageName}.{normalizedVersion}.nupkg"
+                    // Ex: https://api.nuget.org/v3-flatcontainer/test_module/1.0.0/test_module.1.0.0.nupkg
+                    if (response.Contains(version.ToNormalizedString()))
+                    {
+                        pkgContentUrl = response;
+                        break;
+                    }
+                }
+            }
+
+            if (String.IsNullOrEmpty(pkgContentUrl))
+            {
+                errorMsgs.Enqueue(new ErrorRecord(
+                    new Exception($"Package with name '{packageName}' and version '{version}' could not be found in repository '{Repository.Name}'"),
+                    "InstallFailure",
+                    ErrorCategory.InvalidResult,
+                    this));
+
+                return null;
+            }
+
+            var content = await HttpRequestCallForContentAsync(pkgContentUrl, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+
+            if (content is null)
+            {
+                errorMsgs.Enqueue(new ErrorRecord(
+                    new Exception($"No content was returned by repository '{Repository.Name}'"),
+                    "InstallFailureContentNullv3Async",
+                    ErrorCategory.InvalidResult,
+                    this));
+
+                return new MemoryStream();
+            }
+
+            pkgStream = await content.ReadAsStreamAsync();
+
+            return pkgStream;
         }
 
         /// <summary>
@@ -1060,6 +1214,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private JsonElement[] GetMetadataElementFromIdLinkElement(JsonElement idLinkElement, string packageName, out string upperVersion, out ErrorRecord errRecord)
         {
+            // TODO: pass in ConcurrentQueue to write out debug message. Called from the concurrent install metadata chain so cmdlet methods cannot be used here. ?
             _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::GetMetadataElementFromIdLinkElement()");
             upperVersion = String.Empty;
             JsonElement[] innerItems = new JsonElement[]{};
@@ -1102,6 +1257,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     }
                     else
                     {
+                        // TODO: pass in ConcurrentQueue to write out debug message. Called from the concurrent install metadata chain so cmdlet methods cannot be used here. ?
                         _cmdletPassedIn.WriteDebug($"Package with name '{packageName}' did not have 'upper' property so package versions may not be in descending order.");
                     }
 
@@ -1228,6 +1384,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         }
                         else
                         {
+                            // TODO: pass in ConcurrentQueue to write out debug message. Called from the concurrent install metadata chain so cmdlet methods cannot be used here. ?
                             _cmdletPassedIn.WriteDebug($"Metadata for package with name '{packageName}' did not have inner 'items' or '@Id' properties.");
                         }
                     }
@@ -1267,6 +1424,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         }
                         else
                         {
+                            // TODO: pass in ConcurrentQueue to write out debug message. Called from the concurrent install metadata chain so cmdlet methods cannot be used here. ?
                             _cmdletPassedIn.WriteDebug($"Metadata for package with name '{packageName}' was not of value kind type string or object.");
                         }
                     }
@@ -1355,6 +1513,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         private bool IsLatestVersionFirstForSearch(string[] versionedResponses, out ErrorRecord errRecord)
         {
+            // TODO: pass in ConcurrentQueue for debug messages so this is thread-safe when reached from the async find methods. ?
             _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::IsLatestVersionFirstForSearch()");
             errRecord = null;
             bool latestVersionFirst = true;
@@ -1670,6 +1829,40 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 // TODO: pass in ConcurrentQueue to write out debug message.
                 //_cmdletPassedIn.WriteDebug("Response is empty");
+            }
+
+            return content;
+        }
+
+        /// <summary>
+        /// Helper method that makes the HTTP request for the V3 server protocol url passed in for install APIs asynchronously.
+        /// This is the async counterpart of HttpRequestCallForContent() used for concurrent (parallel) installation workflows.
+        /// </summary>
+        private async Task<HttpContent> HttpRequestCallForContentAsync(string requestUrlV3, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
+        {
+            debugMsgs.Enqueue("In V3ServerAPICalls::HttpRequestCallForContentAsync()");
+            HttpContent content = null;
+            try
+            {
+                debugMsgs.Enqueue($"Request url is '{requestUrlV3}'");
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUrlV3);
+
+                content = await SendV3RequestForContentAsync(request, _sessionClient);
+            }
+            catch (Exception e)
+            {
+                errorMsgs.Enqueue(new ErrorRecord(
+                    exception: e,
+                    "HttpRequestCallForContentFailure",
+                    ErrorCategory.InvalidResult,
+                    this));
+
+                return null;
+            }
+
+            if (string.IsNullOrEmpty(content?.ToString()))
+            {
+                debugMsgs.Enqueue("Response is empty");
             }
 
             return content;

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -1097,8 +1097,8 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             // Get responses for all packages that contain the required tags
             pkgEntries.AddRange(GetJsonElementArr(query, dataName, out int initialCount, out errRecord, errorMsgs, debugMsgs, verboseMsgs).ToList());
 
-            // check count (ie "totalHits") 425 ==> count/100  ~~> 4 calls ~~> + 1 = 5 calls
-            int count = initialCount / 100 + 1;
+            // check count (ie "totalHits") 425 ==> ceil(425/100) - 1 ~~> 4 more calls (initial page already fetched)
+            int count = (int)Math.Ceiling((double)initialCount / 100) - 1;
             // if more than 100 count, loop and add response to list
             while (count > 0)
             {

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override Task<FindResults> FindVersionAsync(string packageName, string version, ResourceType type, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
             debugMsgs.Enqueue("In V3ServerAPICalls::FindVersionAsync()");
-            FindResults findResponse = FindVersionHelper(packageName, version, tags: Utils.EmptyStrArray, type, out ErrorRecord errRecord, debugMsgs);
+            FindResults findResponse = FindVersionHelper(packageName, version, tags: Utils.EmptyStrArray, type, out ErrorRecord errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);
@@ -119,7 +119,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override Task<FindResults> FindVersionGlobbingAsync(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
             debugMsgs.Enqueue("In V3ServerAPICalls::FindVersionGlobbingAsync()");
-            FindResults findResponse = FindVersionGlobbingHelper(packageName, versionRange, includePrerelease, type, getOnlyLatest, out ErrorRecord errRecord, debugMsgs);
+            FindResults findResponse = FindVersionGlobbingHelper(packageName, versionRange, includePrerelease, type, getOnlyLatest, out ErrorRecord errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);
@@ -151,9 +151,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override FindResults FindTags(string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindTags()");
+            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
             if (_isNuGetRepo || _isJFrogRepo)
             {
-                return FindTagsFromNuGetRepo(tags, includePrerelease, out errRecord);
+                FindResults findResults = FindTagsFromNuGetRepo(tags, includePrerelease, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
+                Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+                return findResults;
             }
             else
             {
@@ -163,6 +169,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     ErrorCategory.InvalidOperation,
                     this);
 
+                Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
         }
@@ -192,7 +199,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override FindResults FindName(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindName()");
-            return FindNameHelper(packageName, tags: Utils.EmptyStrArray, includePrerelease, type, out errRecord);
+            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
+            FindResults findResults = FindNameHelper(packageName, tags: Utils.EmptyStrArray, includePrerelease, type, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
+            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+            return findResults;
         }
 
         /// <summary>
@@ -204,7 +217,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override Task<FindResults> FindNameAsync(string packageName, bool includePrerelease, ResourceType type, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> warningMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
             debugMsgs.Enqueue("In V3ServerAPICalls::FindNameAsync()");
-            FindResults findResponse = FindNameHelper(packageName, tags: Utils.EmptyStrArray, includePrerelease, type, out ErrorRecord errRecord, debugMsgs);
+            FindResults findResponse = FindNameHelper(packageName, tags: Utils.EmptyStrArray, includePrerelease, type, out ErrorRecord errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);
@@ -222,7 +235,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override FindResults FindNameWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindNameWithTag()");
-            return FindNameHelper(packageName, tags, includePrerelease, type, out errRecord);
+            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
+            FindResults findResults = FindNameHelper(packageName, tags, includePrerelease, type, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
+            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+            return findResults;
         }
 
         /// <summary>
@@ -232,9 +251,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override FindResults FindNameGlobbing(string packageName, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindNameGlobbing()");
+            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
             if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo || _isMyGetRepo)
             {
-                return FindNameGlobbingFromNuGetRepo(packageName, tags: Utils.EmptyStrArray, includePrerelease, out errRecord);
+                FindResults findResults = FindNameGlobbingFromNuGetRepo(packageName, tags: Utils.EmptyStrArray, includePrerelease, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
+                Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+                return findResults;
             }
             else
             {
@@ -244,6 +269,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     ErrorCategory.InvalidOperation,
                     this);
 
+                Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
         }
@@ -255,9 +281,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override FindResults FindNameGlobbingWithTag(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindNameGlobbingWithTag()");
+            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
             if (_isNuGetRepo || _isJFrogRepo || _isGHPkgsRepo || _isMyGetRepo)
             {
-                return FindNameGlobbingFromNuGetRepo(packageName, tags, includePrerelease, out errRecord);
+                FindResults findResults = FindNameGlobbingFromNuGetRepo(packageName, tags, includePrerelease, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
+                Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+                return findResults;
             }
             else
             {
@@ -267,6 +299,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     ErrorCategory.InvalidOperation,
                     this);
 
+                Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
         }
@@ -281,13 +314,19 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override FindResults FindVersionGlobbing(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ErrorRecord errRecord)
         {
-            return FindVersionGlobbingHelper(packageName, versionRange, includePrerelease, type, getOnlyLatest, out errRecord);
+            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
+            FindResults findResults = FindVersionGlobbingHelper(packageName, versionRange, includePrerelease, type, getOnlyLatest, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
+            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+            return findResults;
         }
 
-        private FindResults FindVersionGlobbingHelper(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ErrorRecord errRecord, ConcurrentQueue<string> debugMsgs = null)
+        private FindResults FindVersionGlobbingHelper(string packageName, VersionRange versionRange, bool includePrerelease, ResourceType type, bool getOnlyLatest, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            WriteDebug("In V3ServerAPICalls::FindVersionGlobbing()", debugMsgs);
-            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord, debugMsgs);
+            debugMsgs.Enqueue("In V3ServerAPICalls::FindVersionGlobbing()");
+            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -314,7 +353,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         if (NuGetVersion.TryParse(pkgVersionElement.ToString(), out NuGetVersion pkgVersion) && versionRange.Satisfies(pkgVersion))
                         {
-                            WriteDebug($"Package version parsed as '{pkgVersion}' satisfies the version range", debugMsgs);
+                            debugMsgs.Enqueue($"Package version parsed as '{pkgVersion}' satisfies the version range");
                             if (!pkgVersion.IsPrerelease || includePrerelease)
                             {
                                 satisfyingVersions.Add(response);
@@ -347,7 +386,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override FindResults FindVersion(string packageName, string version, ResourceType type, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindVersion()");
-            return FindVersionHelper(packageName, version, tags: Utils.EmptyStrArray, type, out errRecord);
+            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
+            FindResults findResults = FindVersionHelper(packageName, version, tags: Utils.EmptyStrArray, type, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
+            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+            return findResults;
         }
 
         /// <summary>
@@ -360,7 +405,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         public override FindResults FindVersionWithTag(string packageName, string version, string[] tags, ResourceType type, out ErrorRecord errRecord)
         {
             _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindVersionWithTag()");
-            return FindVersionHelper(packageName, version, tags: tags, type, out errRecord);
+            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
+            FindResults findResults = FindVersionHelper(packageName, version, tags: tags, type, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
+            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+            return findResults;
         }
 
         /**  INSTALL APIS **/
@@ -375,8 +426,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// </summary>
         public override Stream InstallPackage(string packageName, string packageVersion, bool includePrerelease, out ErrorRecord errRecord)
         {
-            // TODO: pass in ConcurrentQueue to write out debug message.
-            //_cmdletPassedIn.WriteDebug("In V3ServerAPICalls::InstallPackage()");
+            ConcurrentQueue<ErrorRecord> errorMsgs = new ConcurrentQueue<ErrorRecord>();
+            ConcurrentQueue<string> warningMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> debugMsgs = new ConcurrentQueue<string>();
+            ConcurrentQueue<string> verboseMsgs = new ConcurrentQueue<string>();
+            debugMsgs.Enqueue("In V3ServerAPICalls::InstallPackage()");
             Stream results = new MemoryStream();
             if (string.IsNullOrEmpty(packageVersion))
             {
@@ -386,10 +440,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     ErrorCategory.InvalidArgument,
                     _cmdletPassedIn);
 
+                Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
                 return results;
             }
 
-            return InstallVersion(packageName, packageVersion, out errRecord);
+            Stream installResults = InstallVersion(packageName, packageVersion, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
+            Utils.WriteOutConcurrentQueue(_cmdletPassedIn, errorMsgs, warningMsgs, debugMsgs, verboseMsgs);
+            return installResults;
         }
 
         /// <summary>
@@ -437,9 +494,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method called by FindNameGlobbing() and FindNameGlobbingWithTag() for special case where repository is NuGet.org repository.
         /// </summary>
-        private FindResults FindNameGlobbingFromNuGetRepo(string packageName, string[] tags, bool includePrerelease, out ErrorRecord errRecord)
+        private FindResults FindNameGlobbingFromNuGetRepo(string packageName, string[] tags, bool includePrerelease, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindNameGlobbingFromNuGetRepo()");
+            debugMsgs.Enqueue("In V3ServerAPICalls::FindNameGlobbingFromNuGetRepo()");
             var names = packageName.Split(new char[] { '*' }, StringSplitOptions.RemoveEmptyEntries);
             string querySearchTerm;
 
@@ -475,7 +532,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
 
-            var matchingPkgEntries = GetVersionedPackageEntriesFromSearchQueryResource(querySearchTerm, includePrerelease, out errRecord);
+            var matchingPkgEntries = GetVersionedPackageEntriesFromSearchQueryResource(querySearchTerm, includePrerelease, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -549,13 +606,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method called by FindTags() for special case where repository is NuGet.org repository.
         /// </summary>
-        private FindResults FindTagsFromNuGetRepo(string[] tags, bool includePrerelease, out ErrorRecord errRecord)
+        private FindResults FindTagsFromNuGetRepo(string[] tags, bool includePrerelease, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindTagsFromNuGetRepo()");
+            debugMsgs.Enqueue("In V3ServerAPICalls::FindTagsFromNuGetRepo()");
             string tagsQueryTerm = $"tags:{String.Join(" ", tags)}";
             // Get responses for all packages that contain the required tags
             // example query:
-            var tagPkgEntries = GetVersionedPackageEntriesFromSearchQueryResource(tagsQueryTerm, includePrerelease, out errRecord);
+            var tagPkgEntries = GetVersionedPackageEntriesFromSearchQueryResource(tagsQueryTerm, includePrerelease, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -584,10 +641,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method called by FindName() and FindNameWithTag()
         /// <summary>
-        private FindResults FindNameHelper(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord, ConcurrentQueue<string> debugMsgs = null)
+        private FindResults FindNameHelper(string packageName, string[] tags, bool includePrerelease, ResourceType type, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            WriteDebug("In V3ServerAPICalls::FindNameHelper()", debugMsgs);
-            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord, debugMsgs);
+            debugMsgs.Enqueue("In V3ServerAPICalls::FindNameHelper()");
+            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -625,7 +682,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                         if (NuGetVersion.TryParse(pkgVersionElement.ToString(), out NuGetVersion pkgVersion))
                         {
-                            WriteDebug($"'{packageName}' version parsed as '{pkgVersion}'", debugMsgs);
+                            debugMsgs.Enqueue($"'{packageName}' version parsed as '{pkgVersion}'");
                             if (!pkgVersion.IsPrerelease || includePrerelease)
                             {
                                 // Versions are always in descending order i.e 5.0.0, 3.0.0, 1.0.0 so grabbing the first match suffices
@@ -680,9 +737,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method called by FindVersion() and FindVersionWithTag()
         /// </summary>
-        private FindResults FindVersionHelper(string packageName, string version, string[] tags, ResourceType type, out ErrorRecord errRecord, ConcurrentQueue<string> debugMsgs = null)
+        private FindResults FindVersionHelper(string packageName, string version, string[] tags, ResourceType type, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            WriteDebug("In V3ServerAPICalls::FindVersionHelper()", debugMsgs);
+            debugMsgs.Enqueue("In V3ServerAPICalls::FindVersionHelper()");
             if (!NuGetVersion.TryParse(version, out NuGetVersion requiredVersion))
             {
                 errRecord = new ErrorRecord(
@@ -695,7 +752,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
             //_cmdletPassedIn.WriteDebug($"'{packageName}' version parsed as '{requiredVersion}'");
 
-            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord, debugMsgs);
+            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
@@ -788,10 +845,10 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Name: no wildcard support.
         /// Examples: Install "Newtonsoft.json"
         /// </summary>
-        private Stream InstallName(string packageName, out ErrorRecord errRecord)
+        private Stream InstallName(string packageName, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::InstallName()");
-            return InstallHelper(packageName, version: null, out errRecord);
+            debugMsgs.Enqueue("In V3ServerAPICalls::InstallName()");
+            return InstallHelper(packageName, version: null, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
         }
 
         /// <summary>
@@ -801,10 +858,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Examples: Install "Newtonsoft.json" -Version "1.0.0.0"
         ///           Install "Newtonsoft.json" -Version "2.5.0-beta"
         /// </summary>
-        private Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord)
+        private Stream InstallVersion(string packageName, string version, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            // TODO: pass in ConcurrentQueue to write out debug message.
-            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::InstallVersion()");
+            debugMsgs.Enqueue("In V3ServerAPICalls::InstallVersion()");
             if (!NuGetVersion.TryParse(version, out NuGetVersion requiredVersion))
             {
                 errRecord = new ErrorRecord(
@@ -816,17 +872,16 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return null;
             }
 
-            return InstallHelper(packageName, requiredVersion, out errRecord);
+            return InstallHelper(packageName, requiredVersion, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
         }
 
         /// <summary>
         /// Helper method that is called by InstallName() and InstallVersion()
         /// For InstallName() we want latest version installed (so version parameter passed in will be null), for InstallVersion() we want specified, non-null version installed.
         /// </summary>
-        private Stream InstallHelper(string packageName, NuGetVersion version, out ErrorRecord errRecord)
+        private Stream InstallHelper(string packageName, NuGetVersion version, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            // TODO: pass in ConcurrentQueue to write out debug message.
-            //_cmdletPassedIn.WriteDebug("In V3ServerAPICalls::InstallHelper()");
+            debugMsgs.Enqueue("In V3ServerAPICalls::InstallHelper()");
             Stream pkgStream = null;
             bool getLatestVersion = true;
             if (version != null)
@@ -834,7 +889,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 getLatestVersion = false;
             }
 
-            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, packageContentProperty, isSearch: false, out errRecord);
+            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, packageContentProperty, isSearch: false, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return pkgStream;
@@ -882,7 +937,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 return null;
             }
 
-            var content = HttpRequestCallForContent(pkgContentUrl, out errRecord);
+            var content = HttpRequestCallForContent(pkgContentUrl, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return null;
@@ -917,7 +972,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                 getLatestVersion = false;
             }
 
-            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, packageContentProperty, isSearch: false, out ErrorRecord errRecord);
+            string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, packageContentProperty, isSearch: false, out ErrorRecord errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 errorMsgs.Enqueue(errRecord);
@@ -989,24 +1044,23 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// i.e when the package Name being searched for does not contain wildcard
         /// This is called by FindNameHelper(), FindVersionHelper(), FindVersionGlobbing(), InstallHelper()
         /// </summary>
-        private string[] GetVersionedPackageEntriesFromRegistrationsResource(string packageName, string propertyName, bool isSearch, out ErrorRecord errRecord, ConcurrentQueue<string> debugMsgs = null)
+        private string[] GetVersionedPackageEntriesFromRegistrationsResource(string packageName, string propertyName, bool isSearch, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            // TODO: pass in ConcurrentQueue to write out debug message.
-            //_cmdletPassedIn.WriteDebug("In V3ServerAPICalls::GetVersionedPackageEntriesFromRegistrationsResource()");
+            debugMsgs.Enqueue("In V3ServerAPICalls::GetVersionedPackageEntriesFromRegistrationsResource()");
             string[] responses = Utils.EmptyStrArray;
-            Dictionary<string, string> resources = GetResourcesFromServiceIndex(out errRecord);
+            Dictionary<string, string> resources = GetResourcesFromServiceIndex(out errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return responses;
             }
 
-            string registrationsBaseUrl = FindRegistrationsBaseUrl(resources, out errRecord);
+            string registrationsBaseUrl = FindRegistrationsBaseUrl(resources, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return responses;
             }
 
-            responses = GetVersionedResponsesFromRegistrationsResource(registrationsBaseUrl, packageName, propertyName, isSearch, out errRecord, debugMsgs);
+            responses = GetVersionedResponsesFromRegistrationsResource(registrationsBaseUrl, packageName, propertyName, isSearch, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return Utils.EmptyStrArray;
@@ -1020,11 +1074,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// i.e when the package Name being searched for contains wildcards or a Tag query search is performed
         /// This is called by FindNameGlobbingFromNuGetRepo() and FindTagsFromNuGetRepo()
         /// </summary>
-        private List<JsonElement> GetVersionedPackageEntriesFromSearchQueryResource(string queryTerm, bool includePrerelease, out ErrorRecord errRecord)
+        private List<JsonElement> GetVersionedPackageEntriesFromSearchQueryResource(string queryTerm, bool includePrerelease, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::GetVersionedPackageEntriesFromSearchQueryResource()");
+            debugMsgs.Enqueue("In V3ServerAPICalls::GetVersionedPackageEntriesFromSearchQueryResource()");
             List<JsonElement> pkgEntries = new();
-            Dictionary<string, string> resources = GetResourcesFromServiceIndex(out errRecord);
+            Dictionary<string, string> resources = GetResourcesFromServiceIndex(out errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return pkgEntries;
@@ -1041,7 +1095,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             string query = $"{searchQueryServiceUrl}?q={queryTerm}&prerelease={includePrerelease}&semVerLevel=2.0.0&skip={skip}&take=100";
 
             // Get responses for all packages that contain the required tags
-            pkgEntries.AddRange(GetJsonElementArr(query, dataName, out int initialCount, out errRecord).ToList());
+            pkgEntries.AddRange(GetJsonElementArr(query, dataName, out int initialCount, out errRecord, errorMsgs, debugMsgs, verboseMsgs).ToList());
 
             // check count (ie "totalHits") 425 ==> count/100  ~~> 4 calls ~~> + 1 = 5 calls
             int count = initialCount / 100 + 1;
@@ -1050,7 +1104,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             {
                 skip += 100;
                 query = $"{searchQueryServiceUrl}?q={queryTerm}&prerelease={includePrerelease}&semVerLevel=2.0.0&skip={skip}&take=100";
-                pkgEntries.AddRange(GetJsonElementArr(query, dataName, out int unneededCount, out errRecord).ToList());
+                pkgEntries.AddRange(GetJsonElementArr(query, dataName, out int unneededCount, out errRecord, errorMsgs, debugMsgs, verboseMsgs).ToList());
                 count--;
             }
 
@@ -1061,12 +1115,11 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Finds all resources present in the repository's service index.
         /// For example: https://api.nuget.org/v3/index.json
         /// </summary>
-        private Dictionary<string, string> GetResourcesFromServiceIndex(out ErrorRecord errRecord)
+        private Dictionary<string, string> GetResourcesFromServiceIndex(out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            // TODO: pass in ConcurrentQueue to write out debug message.
-            //_cmdletPassedIn.WriteDebug("In V3ServerAPICalls::GetResourcesFromServiceIndex()");
+            debugMsgs.Enqueue("In V3ServerAPICalls::GetResourcesFromServiceIndex()");
             Dictionary<string, string> resources = new Dictionary<string, string>();
-            JsonElement[] resourcesArray = GetJsonElementArr($"{Repository.Uri}", resourcesName, out int totalHits, out errRecord);
+            JsonElement[] resourcesArray = GetJsonElementArr($"{Repository.Uri}", resourcesName, out int totalHits, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return resources;
@@ -1122,10 +1175,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// Gets the resource of type "RegistrationBaseUrl" from the repository's resources.
         /// A repository can have multiple resources of type "RegistrationsBaseUrl" so it finds the best match according to the guideline comment in the method.
         /// </summary>
-        private string FindRegistrationsBaseUrl(Dictionary<string, string> resources, out ErrorRecord errRecord)
+        private string FindRegistrationsBaseUrl(Dictionary<string, string> resources, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            // TODO: pass in ConcurrentQueue to write out debug message.
-            //_cmdletPassedIn.WriteDebug("In V3ServerAPICalls::FindRegistrationsBaseUrl()");
+            debugMsgs.Enqueue("In V3ServerAPICalls::FindRegistrationsBaseUrl()");
             errRecord = null;
             string registrationsBaseUrl = String.Empty;
 
@@ -1212,16 +1264,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// For some packages (that we know of: JFrog repo and some packages on NuGet.org), the metadata is located under outer "items" element > "@id" element > inner "items" element
         /// This requires a different search.
         /// </summary>
-        private JsonElement[] GetMetadataElementFromIdLinkElement(JsonElement idLinkElement, string packageName, out string upperVersion, out ErrorRecord errRecord)
+        private JsonElement[] GetMetadataElementFromIdLinkElement(JsonElement idLinkElement, string packageName, out string upperVersion, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            // TODO: pass in ConcurrentQueue to write out debug message. Called from the concurrent install metadata chain so cmdlet methods cannot be used here. ?
-            _cmdletPassedIn.WriteDebug("In V3ServerAPICalls::GetMetadataElementFromIdLinkElement()");
+            debugMsgs.Enqueue("In V3ServerAPICalls::GetMetadataElementFromIdLinkElement()");
             upperVersion = String.Empty;
             JsonElement[] innerItems = new JsonElement[]{};
             List<JsonElement> innerItemsList = new List<JsonElement>();
 
             string metadataUri = idLinkElement.ToString();
-            string response = HttpRequestCall(metadataUri, out errRecord);
+            string response = HttpRequestCall(metadataUri, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 if (errRecord.Exception is ResourceNotFoundException) {
@@ -1257,8 +1308,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                     }
                     else
                     {
-                        // TODO: pass in ConcurrentQueue to write out debug message. Called from the concurrent install metadata chain so cmdlet methods cannot be used here. ?
-                        _cmdletPassedIn.WriteDebug($"Package with name '{packageName}' did not have 'upper' property so package versions may not be in descending order.");
+                        debugMsgs.Enqueue($"Package with name '{packageName}' did not have 'upper' property so package versions may not be in descending order.");
                     }
 
                     foreach(JsonElement entry in innerItemsElement.EnumerateArray())
@@ -1283,10 +1333,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         ///  For most packages returned from V3 server protocol responses, the metadata is located under outer "items" element > inner "items" element.
         /// </summary>
-        private JsonElement[] GetMetadataElementFromItemsElement(JsonElement itemsElement, string packageName, out ErrorRecord errRecord)
+        private JsonElement[] GetMetadataElementFromItemsElement(JsonElement itemsElement, string packageName, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            // TODO: pass in ConcurrentQueue to write out debug message.
-            //_cmdletPassedIn.WriteDebug("In V3ServerAPICalls::GetMetadataElementFromItemsElement()");
+            debugMsgs.Enqueue("In V3ServerAPICalls::GetMetadataElementFromItemsElement()");
             errRecord = null;
             List<JsonElement> innerItemsList = new List<JsonElement>();
 
@@ -1316,10 +1365,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         ///  under outer "items" element > inner "items" element (for which we call helper method GetMetadataElementFromItemsElement()), OR
         ///  under outer "items" element > "@Id" element > inner "items" element (for which we call helper method GetMetadataElementFromIdLinkElement)
         /// </summary>
-        private string[] GetMetadataElementsFromResponse(string response, string property, string packageName, out string upperVersion, out ErrorRecord errRecord)
+        private string[] GetMetadataElementsFromResponse(string response, string property, string packageName, out string upperVersion, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            // TODO: pass in ConcurrentQueue to write out debug message.
-            //_cmdletPassedIn.WriteDebug("In V3ServerAPICalls::GetMetadataElementsFromResponse()");
+            debugMsgs.Enqueue("In V3ServerAPICalls::GetMetadataElementsFromResponse()");
             errRecord = null;
             upperVersion = String.Empty;
             List<string> versionedPkgResponses = new List<string>();
@@ -1353,7 +1401,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         if (currentItem.TryGetProperty(itemsName, out JsonElement currentInnerItemsElement))
                         {
                             // Scenarios: NuGet.org majority responses
-                            JsonElement[] innerItemsFromItemsElement = GetMetadataElementFromItemsElement(currentInnerItemsElement, packageName, out errRecord);
+                            JsonElement[] innerItemsFromItemsElement = GetMetadataElementFromItemsElement(currentInnerItemsElement, packageName, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
                             if (errRecord != null)
                             {
                                 continue;
@@ -1365,8 +1413,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                             }
                             else
                             {
-                               // TODO: pass in ConcurrentQueue to write out debug message.
-                               // _cmdletPassedIn.WriteDebug($"Package with name '{packageName}' did not have 'upper' property so package versions may not be in descending order.");
+                                debugMsgs.Enqueue($"Package with name '{packageName}' did not have 'upper' property so package versions may not be in descending order.");
                             }
 
                             innerItemsElements.AddRange(innerItemsFromItemsElement);
@@ -1374,7 +1421,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         else if (currentItem.TryGetProperty(idLinkName, out JsonElement idLinkElement))
                         {
                             // Scenarios: JFrog responses, some NuGet.org responses
-                            JsonElement[] innerItemsFromIdElement = GetMetadataElementFromIdLinkElement(idLinkElement, packageName, out upperVersion, out errRecord);
+                            JsonElement[] innerItemsFromIdElement = GetMetadataElementFromIdLinkElement(idLinkElement, packageName, out upperVersion, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
                             if (errRecord != null)
                             {
                                 continue;
@@ -1384,8 +1431,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         }
                         else
                         {
-                            // TODO: pass in ConcurrentQueue to write out debug message. Called from the concurrent install metadata chain so cmdlet methods cannot be used here. ?
-                            _cmdletPassedIn.WriteDebug($"Metadata for package with name '{packageName}' did not have inner 'items' or '@Id' properties.");
+                            debugMsgs.Enqueue($"Metadata for package with name '{packageName}' did not have inner 'items' or '@Id' properties.");
                         }
                     }
 
@@ -1424,8 +1470,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
                         }
                         else
                         {
-                            // TODO: pass in ConcurrentQueue to write out debug message. Called from the concurrent install metadata chain so cmdlet methods cannot be used here. ?
-                            _cmdletPassedIn.WriteDebug($"Metadata for package with name '{packageName}' was not of value kind type string or object.");
+                            debugMsgs.Enqueue($"Metadata for package with name '{packageName}' was not of value kind type string or object.");
                         }
                     }
                 }
@@ -1452,14 +1497,13 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         ///     The "packageContent" property is used for download, and the value is a URI for the .nupkg file.
         /// </param>
         /// <summary>
-        private string[] GetVersionedResponsesFromRegistrationsResource(string registrationsBaseUrl, string packageName, string property, bool isSearch, out ErrorRecord errRecord, ConcurrentQueue<string> debugMsgs = null)
+        private string[] GetVersionedResponsesFromRegistrationsResource(string registrationsBaseUrl, string packageName, string property, bool isSearch, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            // TODO: pass in ConcurrentQueue to write out debug message.
-            //_cmdletPassedIn.WriteDebug("In V3ServerAPICalls::GetVersionedResponsesFromRegistrationsResource()");
+            debugMsgs.Enqueue("In V3ServerAPICalls::GetVersionedResponsesFromRegistrationsResource()");
             List<string> versionedResponses = new List<string>();
             var requestPkgMapping = registrationsBaseUrl.EndsWith("/") ? $"{registrationsBaseUrl}{packageName.ToLower()}/index.json" : $"{registrationsBaseUrl}/{packageName.ToLower()}/index.json";
 
-            string pkgMappingResponse = HttpRequestCall(requestPkgMapping, out errRecord);
+            string pkgMappingResponse = HttpRequestCall(requestPkgMapping, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 if (errRecord.Exception is ResourceNotFoundException)
@@ -1475,7 +1519,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             }
 
             string upperVersion = String.Empty;
-            string[] versionedResponseArr = GetMetadataElementsFromResponse(pkgMappingResponse, property, packageName, out upperVersion, out errRecord);
+            string[] versionedResponseArr = GetMetadataElementsFromResponse(pkgMappingResponse, property, packageName, out upperVersion, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)
             {
                 return Utils.EmptyStrArray;
@@ -1490,14 +1534,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (isSearch)
             {
-                if (!IsLatestVersionFirstForSearch(versionedResponseArr, out errRecord, debugMsgs))
+                if (!IsLatestVersionFirstForSearch(versionedResponseArr, out errRecord, errorMsgs, debugMsgs, verboseMsgs))
                 {
                     Array.Reverse(versionedResponseArr);
                 }
             }
             else
             {
-                if (!IsLatestVersionFirstForInstall(versionedResponseArr, upperVersion, out errRecord))
+                if (!IsLatestVersionFirstForInstall(versionedResponseArr, upperVersion, out errRecord, errorMsgs, debugMsgs, verboseMsgs))
                 {
                     Array.Reverse(versionedResponseArr);
                 }
@@ -1511,9 +1555,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// ADO feeds usually return version entries in descending order, but Nuget.org repository returns them in ascending order.
         /// Package versions will reflect prerelease preference, but upper version and lower version would not so we don't use them for comparison.
         /// </summary>
-        private bool IsLatestVersionFirstForSearch(string[] versionedResponses, out ErrorRecord errRecord, ConcurrentQueue<string> debugMsgs = null)
+        private bool IsLatestVersionFirstForSearch(string[] versionedResponses, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            WriteDebug("In V3ServerAPICalls::IsLatestVersionFirstForSearch()", debugMsgs);
+            debugMsgs.Enqueue("In V3ServerAPICalls::IsLatestVersionFirstForSearch()");
             errRecord = null;
             bool latestVersionFirst = true;
             int versionResponsesCount = versionedResponses.Length;
@@ -1605,27 +1649,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
             return latestVersionFirst;
         }
 
-        private void WriteDebug(string message, ConcurrentQueue<string> debugMsgs = null)
-        {
-            if (debugMsgs == null)
-            {
-                _cmdletPassedIn.WriteDebug(message);
-            }
-            else
-            {
-                debugMsgs.Enqueue(message);
-            }
-        }
-
         /// <summary>
         /// Returns true if the nupkg URI entries for each package version are arranged in descending order with respect to the package's version.
         /// ADO feeds usually return version entries in descending order, but Nuget.org repository returns them in ascending order.
         /// Entries do not reflect prerelease preference so all versions (including prerelease) are being considered here, so upper version (including prerelease) can be used for comparison.
         /// </summary>
-        private bool IsLatestVersionFirstForInstall(string[] versionedResponses, string upperVersion, out ErrorRecord errRecord)
+        private bool IsLatestVersionFirstForInstall(string[] versionedResponses, string upperVersion, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            // TODO: pass in ConcurrentQueue to write out debug message.
-            //_cmdletPassedIn.WriteDebug("In V3ServerAPICalls::IsLatestVersionFirstForInstall()");
+            debugMsgs.Enqueue("In V3ServerAPICalls::IsLatestVersionFirstForInstall()");
             errRecord = null;
             bool latestVersionFirst = true;
 
@@ -1701,14 +1732,14 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method that parses response for given property and returns result for that property as a JsonElement array.
         /// </summary>
-        private JsonElement[] GetJsonElementArr(string request, string propertyName, out int totalHits, out ErrorRecord errRecord)
+        private JsonElement[] GetJsonElementArr(string request, string propertyName, out int totalHits, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
             List<JsonElement> responseEntries = new List<JsonElement>();
             JsonElement[] entries = new JsonElement[0];
             totalHits = 0;
             try
             {
-                string response = HttpRequestCall(request, out errRecord);
+                string response = HttpRequestCall(request, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
                 if (errRecord != null)
                 {
                     return new JsonElement[]{};
@@ -1759,17 +1790,15 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method that makes the HTTP request for the V3 server protocol url passed in for find APIs.
         /// </summary>
-        private string HttpRequestCall(string requestUrlV3, out ErrorRecord errRecord)
+        private string HttpRequestCall(string requestUrlV3, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            // TODO: pass in ConcurrentQueue to write out debug message.
-            //_cmdletPassedIn.WriteDebug("In V3ServerAPICalls::HttpRequestCall()");
+            debugMsgs.Enqueue("In V3ServerAPICalls::HttpRequestCall()");
             errRecord = null;
             string response = string.Empty;
 
             try
             {
-                // TODO: pass in ConcurrentQueue to write out debug message.
-                //_cmdletPassedIn.WriteDebug($"Request url is '{requestUrlV3}'");
+                debugMsgs.Enqueue($"Request url is '{requestUrlV3}'");
                 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUrlV3);
 
                 response = SendV3RequestAsync(request, _sessionClient).GetAwaiter().GetResult();
@@ -1813,10 +1842,9 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
         /// <summary>
         /// Helper method that makes the HTTP request for the V3 server protocol url passed in for install APIs.
         /// </summary>
-        private HttpContent HttpRequestCallForContent(string requestUrlV3, out ErrorRecord errRecord)
+        private HttpContent HttpRequestCallForContent(string requestUrlV3, out ErrorRecord errRecord, ConcurrentQueue<ErrorRecord> errorMsgs, ConcurrentQueue<string> debugMsgs, ConcurrentQueue<string> verboseMsgs)
         {
-            // TODO: pass in ConcurrentQueue to write out debug message.
-            //_cmdletPassedIn.WriteDebug("In V3ServerAPICalls::HttpRequestCallForContent()");
+            debugMsgs.Enqueue("In V3ServerAPICalls::HttpRequestCallForContent()");
             errRecord = null;
             HttpContent content = null;
             try
@@ -1838,8 +1866,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
             if (string.IsNullOrEmpty(content?.ToString()))
             {
-                // TODO: pass in ConcurrentQueue to write out debug message.
-                //_cmdletPassedIn.WriteDebug("Response is empty");
+                debugMsgs.Enqueue("Response is empty");
             }
 
             return content;

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -750,7 +750,7 @@ namespace Microsoft.PowerShell.PSResourceGet.Cmdlets
 
                 return new FindResults(stringResponse: Utils.EmptyStrArray, hashtableResponse: emptyHashResponses, responseType: v3FindResponseType);
             }
-            //_cmdletPassedIn.WriteDebug($"'{packageName}' version parsed as '{requiredVersion}'");
+debugMsgs.Enqueue($"'{packageName}' version parsed as '{requiredVersion}'");
 
             string[] versionedResponses = GetVersionedPackageEntriesFromRegistrationsResource(packageName, catalogEntryProperty, isSearch: true, out errRecord, errorMsgs, debugMsgs, verboseMsgs);
             if (errRecord != null)

--- a/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
+++ b/test/FindPSResourceTests/FindPSResourceLocal.Tests.ps1
@@ -53,6 +53,14 @@ Describe 'Test Find-PSResource for local repositories' -tags 'CI' {
         $res.Version | Should -Be "5.0.0"
     }
 
+    It "find resources given multiple explicit Names" {
+        $res = @(Find-PSResource -Name $testModuleName,$testModuleName2 -Repository $localRepo)
+
+        $res | Should -HaveCount 2
+        $res[0].Name | Should -Be $testModuleName
+        $res[1].Name | Should -Be $testModuleName2
+    }
+
     It "find resource given specific Name with incorrect casing (should return correct casing)" {
         # FindName()
         $res = Find-PSResource -Name "test_local_mod3" -Repository $localRepo


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add concurrent processing for explicit parent package operations in `Find-PSResource`, `Install-PSResource`, and `Save-PSResource`.  This PR builds off of the PR https://github.com/PowerShell/PSResourceGet/pull/1950 and PR https://github.com/PowerShell/PSResourceGet/pull/2012.


## PR Context

Operations that specify multiple explicit package names currently process each parent package serially. This can make find, install, and save operations unnecessarily slow, especially when packages and their dependency graphs require network requests.

This change parallelizes independent parent-package lookups and downloads while preserving the pipeline-thread requirements for ShouldProcess, -WhatIf, -Confirm, and cmdlet stream output.


Changes
- Run explicit multi-package `Find-PSResource` queries concurrently when names do not contain wildcards or tags. This preserves the original requested package name order when emitting results.
- Resolve dependencies concurrently for multiple parent packages when `-IncludeDependencies` is specified.
- Run parent package downloads concurrently for `Install-PSResource` and `Save-PSResource`.
- Route all appropriate errors, warnings, debug, and verbose output through concurrent queues.
- Add async find/install implementations for NuGet and container registry repositories.
- Slightly tangential bug fix:  correct paging calculations so that follow-up requests account for the initially retrieved page across V2, V3, NuGet, and container registry search paths.
- Add coverage for finding multiple explicit package names from a local repository.


Installation is split into three main phases:
1. Resolve parent packages and evaluate ShouldProcess on the pipeline thread.
2. Download each parent package and its dependencies concurrently into isolated temporary directories.
3. Drain messages, move completed content to the destination, and record results on the pipeline thread.
Rollback behavior is preserved for a parent package when one of its dependencies fails.


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
