### PR TITLE
Fix V3 packageContent URL selection to compare parsed versions

### DIFF
--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -2030,7 +2030,7 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
         {
             if (!NuGetVersion.TryParse(version, out NuGetVersion requiredVersion))
             {
-                throw new PSArgumentException($"Version {version} is not a valid NuGet version.");
+                throw new PSArgumentException($"Version '{version}' is not a valid NuGet version.");
             }
 
             return Cmdlets.V3ServerAPICalls.GetPackageContentUrlForVersion(versionedResponses, requiredVersion);

--- a/src/code/PSResourceInfo.cs
+++ b/src/code/PSResourceInfo.cs
@@ -2023,6 +2023,18 @@ namespace Microsoft.PowerShell.PSResourceGet.UtilClasses
 
             throw new PSArgumentException("psObjectGetInfo argument is not a PSGetResourceInfo type.");
         }
+
+        public static string SelectV3PackageContentUrl(
+            string[] versionedResponses,
+            string version)
+        {
+            if (!NuGetVersion.TryParse(version, out NuGetVersion requiredVersion))
+            {
+                throw new PSArgumentException($"Version {version} is not a valid NuGet version.");
+            }
+
+            return Cmdlets.V3ServerAPICalls.GetPackageContentUrlForVersion(versionedResponses, requiredVersion);
+        }
     }
 
     #endregion

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -913,17 +913,7 @@ debugMsgs.Enqueue($"'{packageName}' version parsed as '{requiredVersion}'");
             }
             else
             {
-                // loop through responses to find one containing required version
-                foreach (string response in versionedResponses)
-                {
-                    // Response will be "packageContent" element value that looks like: "{packageBaseAddress}/{packageName}/{normalizedVersion}/{packageName}.{normalizedVersion}.nupkg"
-                    // Ex: https://api.nuget.org/v3-flatcontainer/test_module/1.0.0/test_module.1.0.0.nupkg
-                    if (response.Contains(version.ToNormalizedString()))
-                    {
-                        pkgContentUrl = response;
-                        break;
-                    }
-                }
+                pkgContentUrl = GetPackageContentUrlForVersion(versionedResponses, version);
             }
 
             if (String.IsNullOrEmpty(pkgContentUrl))
@@ -997,17 +987,7 @@ debugMsgs.Enqueue($"'{packageName}' version parsed as '{requiredVersion}'");
             }
             else
             {
-                // loop through responses to find one containing required version
-                foreach (string response in versionedResponses)
-                {
-                    // Response will be "packageContent" element value that looks like: "{packageBaseAddress}/{packageName}/{normalizedVersion}/{packageName}.{normalizedVersion}.nupkg"
-                    // Ex: https://api.nuget.org/v3-flatcontainer/test_module/1.0.0/test_module.1.0.0.nupkg
-                    if (response.Contains(version.ToNormalizedString()))
-                    {
-                        pkgContentUrl = response;
-                        break;
-                    }
-                }
+                pkgContentUrl = GetPackageContentUrlForVersion(versionedResponses, version);
             }
 
             if (String.IsNullOrEmpty(pkgContentUrl))
@@ -1037,6 +1017,101 @@ debugMsgs.Enqueue($"'{packageName}' version parsed as '{requiredVersion}'");
             pkgStream = await content.ReadAsStreamAsync();
 
             return pkgStream;
+        }
+
+        /// <summary>
+        /// Selects the "packageContent" entry (i.e the .nupkg download URL) matching the required version.
+        /// The version encoded in the entry is parsed and compared as a NuGetVersion, instead of searching for the version
+        /// text anywhere within the entry, as a substring search matches version prefixes too
+        /// (i.e requesting version '1.2.3' would match the entry for version '1.2.30').
+        /// </summary>
+        internal static string GetPackageContentUrlForVersion(string[] versionedResponses, NuGetVersion requiredVersion)
+        {
+            if (versionedResponses == null || requiredVersion == null)
+            {
+                return String.Empty;
+            }
+
+            foreach (string response in versionedResponses)
+            {
+                if (String.IsNullOrWhiteSpace(response))
+                {
+                    continue;
+                }
+
+                // Response will be "packageContent" element value that looks like: "{packageBaseAddress}/{packageName}/{normalizedVersion}/{packageName}.{normalizedVersion}.nupkg"
+                // Ex: https://api.nuget.org/v3-flatcontainer/test_module/1.0.0/test_module.1.0.0.nupkg
+                if (PackageContentUrlMatchesVersion(response, requiredVersion))
+                {
+                    return response;
+                }
+            }
+
+            return String.Empty;
+        }
+
+        /// <summary>
+        /// Determines whether the given "packageContent" entry refers to the required version.
+        /// </summary>
+        private static bool PackageContentUrlMatchesVersion(string packageContentUrl, NuGetVersion requiredVersion)
+        {
+            string path = packageContentUrl;
+            string query = String.Empty;
+            int queryIndex = path.IndexOfAny(new char[] { '?', '#' });
+            if (queryIndex >= 0)
+            {
+                query = path.Substring(queryIndex + 1);
+                path = path.Substring(0, queryIndex);
+            }
+
+            string[] pathSegments = path.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            string normalizedVersion = requiredVersion.ToNormalizedString();
+            for (int i = 0; i < pathSegments.Length; i++)
+            {
+                string segment = UnescapeUrlPart(pathSegments[i]);
+
+                // Path segment containing just the version, ex: ".../test_module/1.0.0/..."
+                if (NuGetVersion.TryParse(segment, out NuGetVersion segmentVersion) && segmentVersion == requiredVersion)
+                {
+                    return true;
+                }
+
+                // Last path segment is the file name, ex: "test_module.1.0.0.nupkg"
+                if (segment.EndsWith($".{normalizedVersion}.nupkg", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            // Some repositories pass the version as a query parameter, ex: "...?packageVersion=1.0.0"
+            foreach (string queryParameter in query.Split(new char[] { '&', ';' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                int separatorIndex = queryParameter.IndexOf('=');
+                if (separatorIndex < 0)
+                {
+                    continue;
+                }
+
+                string queryValue = UnescapeUrlPart(queryParameter.Substring(separatorIndex + 1));
+                if (NuGetVersion.TryParse(queryValue, out NuGetVersion queryVersion) && queryVersion == requiredVersion)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string UnescapeUrlPart(string urlPart)
+        {
+            try
+            {
+                return Uri.UnescapeDataString(urlPart);
+            }
+            catch (UriFormatException)
+            {
+                return urlPart;
+            }
         }
 
         /// <summary>

--- a/src/code/V3ServerAPICalls.cs
+++ b/src/code/V3ServerAPICalls.cs
@@ -1092,6 +1092,12 @@ debugMsgs.Enqueue($"'{packageName}' version parsed as '{requiredVersion}'");
                     continue;
                 }
 
+                string queryKey = UnescapeUrlPart(queryParameter.Substring(0, separatorIndex)).Trim();
+                if (!queryKey.EndsWith("version", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
                 string queryValue = UnescapeUrlPart(queryParameter.Substring(separatorIndex + 1));
                 if (NuGetVersion.TryParse(queryValue, out NuGetVersion queryVersion) && queryVersion == requiredVersion)
                 {
@@ -1109,6 +1115,10 @@ debugMsgs.Enqueue($"'{packageName}' version parsed as '{requiredVersion}'");
                 return Uri.UnescapeDataString(urlPart);
             }
             catch (UriFormatException)
+            {
+                return urlPart;
+            }
+            catch (ArgumentException)
             {
                 return urlPart;
             }

--- a/test/InstallPSResourceTests/InstallPSResourceV3ServerVersionSelection.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV3ServerVersionSelection.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'Test V3 packageContent url selection for a required version' -tags 'CI
         $url | Should -BeExactly "$packageBaseAddress/1.2.3/test_module.1.2.3.nupkg"
     }
 
-    It 'Should not select the url of a version which the requested version is a prefix of' {
+    It 'Should select the url for a version which another version is a prefix of' {
         $url = [Microsoft.PowerShell.PSResourceGet.UtilClasses.TestHooks]::SelectV3PackageContentUrl($versionedResponses, '1.2.30')
         $url | Should -BeExactly "$packageBaseAddress/1.2.30/test_module.1.2.30.nupkg"
     }
@@ -45,6 +45,15 @@ Describe 'Test V3 packageContent url selection for a required version' -tags 'CI
     It 'Should select the url when the version is passed as a query parameter' {
         $responses = @(
             "https://www.myget.org/api/download?packageId=test_module&packageVersion=1.2.30",
+            "https://www.myget.org/api/download?packageId=test_module&packageVersion=1.2.3"
+        )
+        $url = [Microsoft.PowerShell.PSResourceGet.UtilClasses.TestHooks]::SelectV3PackageContentUrl($responses, '1.2.3')
+        $url | Should -BeExactly "https://www.myget.org/api/download?packageId=test_module&packageVersion=1.2.3"
+    }
+
+    It 'Should not select a url where a non-version query parameter matches the version' {
+        $responses = @(
+            "https://www.myget.org/api/download?packageId=1.2.3&packageVersion=1.2.30",
             "https://www.myget.org/api/download?packageId=test_module&packageVersion=1.2.3"
         )
         $url = [Microsoft.PowerShell.PSResourceGet.UtilClasses.TestHooks]::SelectV3PackageContentUrl($responses, '1.2.3')

--- a/test/InstallPSResourceTests/InstallPSResourceV3ServerVersionSelection.Tests.ps1
+++ b/test/InstallPSResourceTests/InstallPSResourceV3ServerVersionSelection.Tests.ps1
@@ -1,0 +1,58 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Import-Module "$psscriptroot/../PSGetTestUtils.psm1" -Force
+
+Describe 'Test V3 packageContent url selection for a required version' -tags 'CI' {
+
+    BeforeAll {
+        $packageBaseAddress = 'https://api.nuget.org/v3-flatcontainer/test_module'
+        # Responses are returned in descending version order, ie the entry for 1.2.30 precedes the entry for 1.2.3
+        $versionedResponses = @(
+            "$packageBaseAddress/1.2.30/test_module.1.2.30.nupkg",
+            "$packageBaseAddress/1.2.3/test_module.1.2.3.nupkg"
+        )
+    }
+
+    It 'Should select the url for the exact version requested' {
+        $url = [Microsoft.PowerShell.PSResourceGet.UtilClasses.TestHooks]::SelectV3PackageContentUrl($versionedResponses, '1.2.3')
+        $url | Should -BeExactly "$packageBaseAddress/1.2.3/test_module.1.2.3.nupkg"
+    }
+
+    It 'Should not select the url of a version which the requested version is a prefix of' {
+        $url = [Microsoft.PowerShell.PSResourceGet.UtilClasses.TestHooks]::SelectV3PackageContentUrl($versionedResponses, '1.2.30')
+        $url | Should -BeExactly "$packageBaseAddress/1.2.30/test_module.1.2.30.nupkg"
+    }
+
+    It 'Should select the url for a version with four version parts' {
+        $responses = @(
+            "$packageBaseAddress/2024.5.20.12/test_module.2024.5.20.12.nupkg",
+            "$packageBaseAddress/2024.5.20.1/test_module.2024.5.20.1.nupkg"
+        )
+        $url = [Microsoft.PowerShell.PSResourceGet.UtilClasses.TestHooks]::SelectV3PackageContentUrl($responses, '2024.5.20.1')
+        $url | Should -BeExactly "$packageBaseAddress/2024.5.20.1/test_module.2024.5.20.1.nupkg"
+    }
+
+    It 'Should select the url for a prerelease version' {
+        $responses = @(
+            "$packageBaseAddress/2.5.0-beta10/test_module.2.5.0-beta10.nupkg",
+            "$packageBaseAddress/2.5.0-beta1/test_module.2.5.0-beta1.nupkg"
+        )
+        $url = [Microsoft.PowerShell.PSResourceGet.UtilClasses.TestHooks]::SelectV3PackageContentUrl($responses, '2.5.0-beta1')
+        $url | Should -BeExactly "$packageBaseAddress/2.5.0-beta1/test_module.2.5.0-beta1.nupkg"
+    }
+
+    It 'Should select the url when the version is passed as a query parameter' {
+        $responses = @(
+            "https://www.myget.org/api/download?packageId=test_module&packageVersion=1.2.30",
+            "https://www.myget.org/api/download?packageId=test_module&packageVersion=1.2.3"
+        )
+        $url = [Microsoft.PowerShell.PSResourceGet.UtilClasses.TestHooks]::SelectV3PackageContentUrl($responses, '1.2.3')
+        $url | Should -BeExactly "https://www.myget.org/api/download?packageId=test_module&packageVersion=1.2.3"
+    }
+
+    It 'Should not select any url when the requested version is not present' {
+        $url = [Microsoft.PowerShell.PSResourceGet.UtilClasses.TestHooks]::SelectV3PackageContentUrl($versionedResponses, '1.2.4')
+        $url | Should -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary

Install-PSResource/Save-PSResource against a V3 feed can download the payload of a different version than requested while writing it under the requested version's folder. The V3 download path picked the packageContent URL by substring match, so a requested version that is a text prefix of another version matched the wrong entry.

V3ServerAPICalls.InstallHelper and InstallHelperAsync did:
```
// versionedResponses are in descending version order, first match wins
if (response.Contains(version.ToNormalizedString()))
{
    pkgContentUrl = response;
    break;
}
```

Requesting 1.2.3 matches .../test_module/1.2.30/test_module.1.2.30.nupkg first. This also explains why exact-range syntax ([1.2.3]) doesn't help: by this point the spec is already a parsed NuGetVersion, and only the final URL selection is text-based. FindVersionHelper already compares parsed versions, which is why Find reports the right version while the downloaded content is wrong.

Closes #1657 

## Changes
src/code/V3ServerAPICalls.cs — new GetPackageContentUrlForVersion helper that extracts the version from a packageContent entry and compares it as a NuGetVersion. Recognized shapes: version path segment (.../{name}/{version}/...), .{version}.nupkg file name suffix, and version-bearing query parameters (e.g. MyGet-style ?packageVersion=). Both the sync and async install paths now use it.
src/code/PSResourceInfo.cs — TestHooks.SelectV3PackageContentUrl entry point, following the existing TestHooks pattern, so URL selection is testable without a live feed.
test/InstallPSResourceTests/InstallPSResourceV3ServerVersionSelection.Tests.ps1 — covers 1.2.3 vs 1.2.30, the reported 2024.5.20.1 vs 2024.5.20.12, prereleases (2.5.0-beta1 vs 2.5.0-beta10), query-parameter URLs, and the not-found case. The prefix cases fail against the previous substring logic.
Behavioral note
Entries whose version can't be recovered from the URL are no longer matched at all, rather than being matched on any incidental substring occurrence. Non-matching now surfaces the existing "could not be found in repository" error instead of silently downloading a neighboring version.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed]()
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and enumerated concerns in the summary.
